### PR TITLE
hotfix: Only Silence Remains Light Cone Crit Rate passive

### DIFF
--- a/src/lib/lightConeConditionals.js
+++ b/src/lib/lightConeConditionals.js
@@ -1473,7 +1473,7 @@ function MemoriesOfThePast(s) {
 }
 
 function OnlySilenceRemains(s) {
-  let sValues = [0.08, 0.09, 0.10, 0.11, 0.12]
+  let sValues = [0.12, 0.15, 0.18, 0.21, 0.24]
   s = s - 1
 
   return {


### PR DESCRIPTION
Only Silence Remains Crit Rate Passives correction:
S1: 12%
S2: 15%
S3: 18%
S4: 21%
S5: 24%

Reference: https://hsr.yatta.top/en/archive/equipment/21003/only-silence-remains