### PR TITLE
feat: sort and filter relics by verified status

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
-        "ag-grid-react": "^31.0.1",
+        "ag-grid-react": "^31.0.2",
         "antd": "^5.12.7",
         "btoa": "^1.2.1",
         "fast-sort": "^3.4.0",
@@ -6882,16 +6882,16 @@
       }
     },
     "node_modules/ag-grid-community": {
-      "version": "31.0.1",
-      "resolved": "https://registry.npmjs.org/ag-grid-community/-/ag-grid-community-31.0.1.tgz",
-      "integrity": "sha512-RZQlW1DTOJHsUR/tnbnTJQKgAnDlHi05YYyTe5AgNor/1TlX1hoYdcqrGsJjvcHQgTjeEgzWOL0yf+KcqXZzxg=="
+      "version": "31.0.2",
+      "resolved": "https://registry.npmjs.org/ag-grid-community/-/ag-grid-community-31.0.2.tgz",
+      "integrity": "sha512-gxUdHeAZUV2TDHqnDax5QSQgUxIvJ1zaFxUuPzcfiiPwbN6btz6kxg/KNrDfEjQi70JBfJV46BMR9KTG6iAVmQ=="
     },
     "node_modules/ag-grid-react": {
-      "version": "31.0.1",
-      "resolved": "https://registry.npmjs.org/ag-grid-react/-/ag-grid-react-31.0.1.tgz",
-      "integrity": "sha512-9nmYPsgH1YUDUDOTiyaFsysoNAx/y72ovFJKuOffZC1V7OrQMadyP6DbqGFWCqzzoLJOY7azOr51dDQzAIXLpw==",
+      "version": "31.0.2",
+      "resolved": "https://registry.npmjs.org/ag-grid-react/-/ag-grid-react-31.0.2.tgz",
+      "integrity": "sha512-QAC5Rsr4AaE+vCafyrnEJa7JWcmoXNzJyzZmln0T6QCLG43IuT2hZ3ULmce/IqwP2Kxf+B4hVJOVitVT9SdXkg==",
       "dependencies": {
-        "ag-grid-community": "~31.0.1",
+        "ag-grid-community": "~31.0.2",
         "prop-types": "^15.8.1"
       },
       "peerDependencies": {
@@ -30651,16 +30651,16 @@
       }
     },
     "ag-grid-community": {
-      "version": "31.0.1",
-      "resolved": "https://registry.npmjs.org/ag-grid-community/-/ag-grid-community-31.0.1.tgz",
-      "integrity": "sha512-RZQlW1DTOJHsUR/tnbnTJQKgAnDlHi05YYyTe5AgNor/1TlX1hoYdcqrGsJjvcHQgTjeEgzWOL0yf+KcqXZzxg=="
+      "version": "31.0.2",
+      "resolved": "https://registry.npmjs.org/ag-grid-community/-/ag-grid-community-31.0.2.tgz",
+      "integrity": "sha512-gxUdHeAZUV2TDHqnDax5QSQgUxIvJ1zaFxUuPzcfiiPwbN6btz6kxg/KNrDfEjQi70JBfJV46BMR9KTG6iAVmQ=="
     },
     "ag-grid-react": {
-      "version": "31.0.1",
-      "resolved": "https://registry.npmjs.org/ag-grid-react/-/ag-grid-react-31.0.1.tgz",
-      "integrity": "sha512-9nmYPsgH1YUDUDOTiyaFsysoNAx/y72ovFJKuOffZC1V7OrQMadyP6DbqGFWCqzzoLJOY7azOr51dDQzAIXLpw==",
+      "version": "31.0.2",
+      "resolved": "https://registry.npmjs.org/ag-grid-react/-/ag-grid-react-31.0.2.tgz",
+      "integrity": "sha512-QAC5Rsr4AaE+vCafyrnEJa7JWcmoXNzJyzZmln0T6QCLG43IuT2hZ3ULmce/IqwP2Kxf+B4hVJOVitVT9SdXkg==",
       "requires": {
-        "ag-grid-community": "~31.0.1",
+        "ag-grid-community": "~31.0.2",
         "prop-types": "^15.8.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
-    "ag-grid-react": "^31.0.1",
+    "ag-grid-react": "^31.0.2",
     "antd": "^5.12.7",
     "btoa": "^1.2.1",
     "fast-sort": "^3.4.0",

--- a/src/components/RelicFilterBar.js
+++ b/src/components/RelicFilterBar.js
@@ -8,6 +8,7 @@ import { Utils } from "../lib/utils";
 import { Constants } from "../lib/constants.ts";
 import { Assets } from "../lib/assets";
 import PropTypes from "prop-types";
+import { Renderer } from "lib/renderer.js";
 
 const { Text } = Typography;
 
@@ -57,6 +58,26 @@ export default function RelicFilterBar() {
     })
   }
 
+  function generateGradeTags(arr) {
+    return arr.map(x => {
+      return {
+        key: x,
+        display: Renderer.renderGrade({ grade: x })
+      }
+    })
+  }
+
+  function generateVerifiedTags(arr) {
+    return arr.map(x => {
+      return {
+        key: x,
+        display: Renderer.renderGrade({ grade: -1, verified: x })
+      }
+    })
+  }
+
+  let gradeData = generateGradeTags([2,3,4,5])
+  let verifiedData = generateVerifiedTags([false,true])
   let setsData = generateImageTags(Object.values(Constants.SetsRelics).concat(Object.values(Constants.SetsOrnaments)), (x) => Assets.getSetImage(x, Constants.Parts.PlanarSphere), true)
   let partsData = generateImageTags(Object.values(Constants.Parts), (x) => Assets.getPart(x), false)
   let mainStatsData = generateImageTags(Constants.MainStats, (x) => Assets.getStatIcon(x, true), true)
@@ -146,6 +167,8 @@ export default function RelicFilterBar() {
       enhance: [],
       mainStats: [],
       subStats: [],
+      grade: [],
+      verified: []
     })
   }
 
@@ -184,11 +207,21 @@ export default function RelicFilterBar() {
             </Button>
           </Flex>
         </Flex>
-        <Flex vertical style={{ height: '100%' }} flex={1}>
+        <Flex vertical style={{ height: '100%' }} flex={0.5}>
           <HeaderText>Filter actions</HeaderText>
-          <Button onClick={clearClicked}>
-            Clear filters
-          </Button>
+          <Flex gap={10}>
+            <Button onClick={clearClicked} style={{flexGrow: 1}}>
+              Clear filters
+            </Button>
+          </Flex>
+        </Flex>
+        <Flex vertical flex={0.5}>
+          <HeaderText>Grade</HeaderText>
+          <FilterRow name='grade' tags={gradeData} flexBasis='25%' />
+        </Flex>
+        <Flex vertical flex={0.25}>
+          <HeaderText>Verified</HeaderText>
+          <FilterRow name='verified' tags={verifiedData} flexBasis='15%' />
         </Flex>
       </Flex>
 

--- a/src/components/RelicsTab.js
+++ b/src/components/RelicsTab.js
@@ -110,7 +110,13 @@ export default function RelicsTab(props) {
   const columnDefs = useMemo(() => [
     { field: 'equippedBy', headerName: 'Owner', cellRenderer: Renderer.characterIcon },
     { field: 'set', cellRenderer: Renderer.anySet, width: 50, headerName: 'Set', filter: 'agTextColumnFilter' },
-    { field: 'grade', width: 60, cellRenderer: Renderer.renderGradeCell, filter: 'agNumberColumnFilter' },
+    { field: 'grade', width: 60, cellRenderer: Renderer.renderGradeCell, filter: 'agNumberColumnFilter', comparator: (a, b, nodeA, nodeB) => {
+      if (a === b) {
+        return (nodeA.data.verified ?? false) - (nodeB.data.verified ?? false)
+      } else {
+        return a - b
+      }
+    } },
     { field: 'part', valueFormatter: Renderer.readablePart, width: 80, filter: 'agTextColumnFilter' },
     { field: 'enhance', width: 60, filter: 'agNumberColumnFilter' },
     { field: 'main.stat', valueFormatter: Renderer.readableStat, headerName: 'Main', width: 100, filter: 'agTextColumnFilter' },

--- a/src/components/RelicsTab.js
+++ b/src/components/RelicsTab.js
@@ -1,5 +1,5 @@
 import { Button, Flex, Popconfirm } from 'antd';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState, forwardRef, useImperativeHandle } from 'react';
 import { AgGridReact } from 'ag-grid-react';
 
 import RelicPreview from './RelicPreview';
@@ -14,6 +14,69 @@ import { Renderer } from "../lib/renderer";
 import { SaveState } from "../lib/saveState";
 import { Hint } from "../lib/hint";
 import PropTypes from "prop-types";
+
+const GradeFilter = forwardRef((props, ref) => {
+  const [model, setModel] = useState(null);
+
+  const isFilterActive = useCallback(() => {
+    return model != null && (model.grade.length > 0 || model.verified.length > 0);
+  }, [model])
+
+  // expose AG Grid Filter Lifecycle callbacks
+  useImperativeHandle(ref, () => {
+    return {
+      doesFilterPass(params) {
+        if (model.grade.length > 0) {
+          if (!model.grade.includes(params.data.grade)) {
+            return false;
+          }
+        }
+
+        if (model.verified.length > 0) {
+          if (!model.verified.includes(params.data.verified ?? false)) {
+            return false;
+          }
+        }
+
+        return true;
+      },
+
+      isFilterActive,
+
+      getModel() {
+        return model;
+      },
+
+      setModel(model) {
+        setModel(model);
+      }
+    }
+  });
+
+  useEffect(() => {
+    props.filterChangedCallback()
+  }, [model]);
+
+  let filterMessage = "No Filters Applied";
+  if (isFilterActive()) {
+    let gradeFilter = model.grade.length > 0 ? `Grade ${model.grade.sort().join(" or ")}` : null;
+    let verifiedFilter = model.verified.length > 0 ? `${model.verified.sort().reverse().map(x => x ? "Verified" : "not Verified").join(" or ")}` : null;
+    
+    let filters = [gradeFilter, verifiedFilter].filter(x => x);
+    filterMessage = `Filtering by ${filters.join(" and ")}`;
+  }
+
+  return (
+    <div style={{ padding: "8px" }}>
+      { filterMessage }
+    </div>
+  );
+});
+
+GradeFilter.displayName = 'GradeFilter';
+GradeFilter.propTypes = {
+  filterChangedCallback: PropTypes.func,
+}
 
 export default function RelicsTab(props) {
   const gridRef = useRef();
@@ -60,6 +123,10 @@ export default function RelicsTab(props) {
       operator: 'OR'
     }
 
+    filterModel.grade = {
+      grade: relicTabFilters.grade,
+      verified: relicTabFilters.verified,
+    }
 
     filterModel['main.stat'] = {
       conditions: relicTabFilters.mainStats.map(x => ({
@@ -110,7 +177,7 @@ export default function RelicsTab(props) {
   const columnDefs = useMemo(() => [
     { field: 'equippedBy', headerName: 'Owner', cellRenderer: Renderer.characterIcon },
     { field: 'set', cellRenderer: Renderer.anySet, width: 50, headerName: 'Set', filter: 'agTextColumnFilter' },
-    { field: 'grade', width: 60, cellRenderer: Renderer.renderGradeCell, filter: 'agNumberColumnFilter', comparator: (a, b, nodeA, nodeB) => {
+    { field: 'grade', width: 60, cellRenderer: Renderer.renderGradeCell, filter: GradeFilter, comparator: (a, b, nodeA, nodeB) => {
       if (a === b) {
         return (nodeA.data.verified ?? false) - (nodeB.data.verified ?? false)
       } else {

--- a/src/lib/db.js
+++ b/src/lib/db.js
@@ -98,6 +98,8 @@ window.store = create((set) => ({
     enhance: [],
     mainStats: [],
     subStats: [],
+    grade: [],
+    verified: [],
   },
   setRelicTabFilters: (x) => set(() => ({ relicTabFilters: x })),
   setFilteredRelics: (relics) => set(() => ({ filteredRelics: relics })),

--- a/src/lib/renderer.js
+++ b/src/lib/renderer.js
@@ -182,6 +182,8 @@ let gradeToColor = {
   4: '#cc52f1',
   3: '#58beed',
   2: '#63e0ac',
+
+  [-1]: '#ffffff'
 }
 
 function SetDisplay(props) {


### PR DESCRIPTION
## Description
Previously, the grade column in the relic table only sorted by grade, even though that is where the "verified" status is also surfaced. This PR adds a custom comparator to enable sorting and filtering by verified status.

## Checklist
- [X] I have added commit messages that are descriptive and meaningful.
- [X] I have tested the changes locally.
- [X] I have reviewed the code changes.

![Screenshot of relics page showing the new filter UI](https://its-em.ma/and-her-nostalgic-ticket.png)

