### PR TITLE
Fix mainStatType selection in RelicModal

### DIFF
--- a/src/components/RelicModal.js
+++ b/src/components/RelicModal.js
@@ -136,9 +136,15 @@ export default function RelicModal(props) {
 
   useEffect(() => {
     if (mainStatOptions.length > 0) {
-      relicForm.setFieldValue('mainStatType', mainStatOptions[0].value);
+      const mainStatValues = mainStatOptions.map(item => item.value);
+      if (mainStatValues.includes(props.selectedRelic?.main?.stat)) {
+        relicForm.setFieldValue('mainStatType', props.selectedRelic?.main?.stat);
+      }
+      else {
+        relicForm.setFieldValue('mainStatType', mainStatOptions[0].value);
+      }
     }
-  }, [relicForm.part]);
+  }, [relicForm, mainStatOptions, props.selectedRelic?.main?.stat]);
 
   const onFinish = (x) => {
     console.log('Form finished', x);


### PR DESCRIPTION
# Pull Request

## Description
Hotfix: Main Stat now checks if there's any previous selected main stat when clicking edit relic

## Type of Changes

### Fixed
- mainStatOptions useEffect now checks if the currently selected relic has already any mainstattype selected to avoid being reset for the mainStatOptions[0] for edit relic modal

## Checklist
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots (if applicable)
Before this change:
When selecting any relic to edit that already has a mainStatType selected:
![image](https://github.com/fribbels/hsr-optimizer/assets/12674637/076ae366-b3ba-4296-94e8-7aaf0232bcb7)
the modal opens with the mainStatOptions[0] (hp% in this example) as the default selection:
![image](https://github.com/fribbels/hsr-optimizer/assets/12674637/1973964a-995f-4d01-b9db-d63283b0a13a)

After this change:
When selecting the same relic to edit:
![image](https://github.com/fribbels/hsr-optimizer/assets/12674637/26e97c48-6bf5-4d6f-a695-8fb15bb222c0)
the modal now opens with the previously mainStatType selected (SPD in this example) as the default selection:
![image](https://github.com/fribbels/hsr-optimizer/assets/12674637/07c0d291-2bb0-4a36-88aa-135717f3c57c)

## Additional Notes
Please merge this change back to beta branch, so both will be fixed :)
