### PR TITLE
Hotfix: Remove redundant code for redrawing rows in DB.js

### DIFF
--- a/src/lib/db.js
+++ b/src/lib/db.js
@@ -339,15 +339,6 @@ export const DB = {
     let relicsById = global.store.getState().relicsById
     delete relicsById[id]
     global.store.getState().setRelicsById(relicsById)
-    // only valid when on relics tab
-    if (global.relicsGrid?.current?.api) {
-      global.relicsGrid.current.api.redrawRows()
-    }
-
-    // only valid when on character tab
-    if (global.characterGrid?.current?.api) {
-      global.characterGrid.current.api.redrawRows()
-    }
   },
 
   // These relics are missing speed decimals from OCR importer


### PR DESCRIPTION
# Pull Request

## Description
Hotfixes the relic delete screen flashing by removing the redraw method.

## Type of Changes

### Fixed
- Deleted redundant redrawRows() method for relic delete flow.

## Checklist
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.
