### PR TITLE
refactor: tab rendering optimization fixes, update tests with new tab rendering

### DIFF
--- a/src/components/CharacterPreview.js
+++ b/src/components/CharacterPreview.js
@@ -5,11 +5,17 @@ import { RelicScorer } from 'lib/relicScorer.ts';
 import { StatCalculator } from 'lib/statCalculator';
 import { DB } from 'lib/db';
 import { Assets } from 'lib/assets';
-import { Message } from 'lib/message';
 import { Constants } from 'lib/constants.ts';
 import {
-  defaultGap, parentH, parentW, middleColumnWidth, innerW,
-  lcParentW, lcParentH, lcInnerW, lcInnerH,
+  defaultGap,
+  innerW,
+  lcInnerH,
+  lcInnerW,
+  lcParentH,
+  lcParentW,
+  middleColumnWidth,
+  parentH,
+  parentW,
 } from 'lib/constantsUi';
 
 import Rarity from 'components/characterPreview/Rarity';
@@ -17,6 +23,7 @@ import StatRow from 'components/characterPreview/StatRow';
 import StatText from 'components/characterPreview/StatText';
 import RelicModal from 'components/RelicModal';
 import RelicPreview from 'components/RelicPreview';
+import { RelicModalController } from "../lib/relicModalController";
 
 export function CharacterPreview(props) {
   console.log('@CharacterPreview')
@@ -30,23 +37,9 @@ export function CharacterPreview(props) {
   const [selectedRelic, setSelectedRelic] = useState();
   const [editModalOpen, setEditModalOpen] = useState(false);
 
-  // DRY this up (CharacterPreview.js, OptimizerBuildPreview.js, RelicsTab.js)
   function onEditOk(relic) {
-    relic.id = selectedRelic.id
-
-    const updatedRelic = { ...selectedRelic, ...relic }
-
-    if (updatedRelic.equippedBy) {
-      DB.equipRelic(updatedRelic, updatedRelic.equippedBy)
-    } else {
-      DB.unequipRelicById(updatedRelic.id);
-    }
-
-    DB.setRelic(updatedRelic)
+    const updatedRelic = RelicModalController.onEditOk(selectedRelic, relic)
     setSelectedRelic(updatedRelic)
-
-    Message.success('Successfully edited relic')
-    console.log('onEditOk', updatedRelic)
   }
 
   if (!character) {

--- a/src/components/OptimizerBuildPreview.js
+++ b/src/components/OptimizerBuildPreview.js
@@ -5,32 +5,16 @@ import { Flex } from 'antd';
 import RelicModal from 'components/RelicModal';
 import RelicPreview from 'components/RelicPreview';
 import DB from "lib/db";
-import { Message } from 'lib/message';
 import { OptimizerTabController } from "lib/optimizerTabController";
 import { RelicScorer } from 'lib/relicScorer.ts';
+import { RelicModalController } from "../lib/relicModalController";
 
 export default function OptimizerBuildPreview(props) {
   console.log('OptimizerBuildPreview', props);
 
-  // DRY this up (CharacterPreview.js, OptimizerBuildPreview.js, RelicsTab.js)
   function onEditOk(relic) {
-    relic.id = selectedRelic.id
-    const updatedRelic = { ...selectedRelic, ...relic }
-
-    if (updatedRelic.equippedBy) {
-      DB.equipRelic(updatedRelic, updatedRelic.equippedBy)
-    } else {
-      DB.unequipRelicById(updatedRelic.id);
-    }
-
-    DB.setRelic(updatedRelic);
+    const updatedRelic = RelicModalController.onEditOk(selectedRelic, relic);
     setSelectedRelic(updatedRelic)
-
-    // window.forceOptimizerBuildPreviewUpdate()
-    // window.forceCharacterTabUpdate()
-
-    Message.success('Successfully edited relic')
-    console.log('onEditOk', updatedRelic)
   }
 
   // TODO: Force update was a band-aid fix, revisit if we actually need to

--- a/src/components/OptimizerTab.js
+++ b/src/components/OptimizerTab.js
@@ -30,7 +30,6 @@ export default function OptimizerTab() {
   }, []);
   gridOptions.datasource = datasource;
 
-
   return (
     <div>
       <Flex style={{ marginBottom: 10 }}>

--- a/src/components/RelicsTab.js
+++ b/src/components/RelicsTab.js
@@ -14,6 +14,7 @@ import { Renderer } from "../lib/renderer";
 import { SaveState } from "../lib/saveState";
 import { Hint } from "../lib/hint";
 import PropTypes from "prop-types";
+import { RelicModalController } from "../lib/relicModalController";
 
 const GradeFilter = forwardRef((props, ref) => {
   const [model, setModel] = useState(null);
@@ -84,7 +85,7 @@ export default function RelicsTab() {
   global.relicsGrid = gridRef;
 
   const [relicRows, setRelicRows] = useState(DB.getRelics());
-  window.setRelicRows = setRelicRows
+  global.setRelicRows = setRelicRows
 
   const [selectedRelic, setSelectedRelic] = useState();
   const [editModalOpen, setEditModalOpen] = useState(false);
@@ -248,24 +249,8 @@ export default function RelicsTab() {
 
   // DRY this up (CharacterPreview.js, OptimizerBuildPreview.js, RelicsTab.js)
   function onEditOk(relic) {
-    relic.id = selectedRelic.id
-
-    const updatedRelic = { ...selectedRelic, ...relic }
-
-    if (updatedRelic.equippedBy) {
-      DB.equipRelic(updatedRelic, updatedRelic.equippedBy)
-    } else {
-      DB.unequipRelicById(updatedRelic.id);
-    }
-
-    DB.setRelic(updatedRelic)
-    setRelicRows(DB.getRelics())
-    SaveState.save()
-
+    const updatedRelic = RelicModalController.onEditOk(selectedRelic, relic)
     setSelectedRelic(updatedRelic)
-
-    Message.success('Successfully edited relic')
-    console.log('onEditOk', updatedRelic)
   }
 
   function editClicked() {

--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -47,7 +47,7 @@ export default Tabs;
 function TabRenderer(props) {
   return (
     <ErrorBoundary fallback={defaultError}>
-      <div style={{display: props.activeKey === props.tabKey ? 'contents' : 'none'}}>
+      <div style={{display: props.activeKey === props.tabKey ? 'contents' : 'none'}} id={props.tabKey}>
         {props.content}
       </div>
     </ErrorBoundary >

--- a/src/lib/characterConditionals.js
+++ b/src/lib/characterConditionals.js
@@ -2792,7 +2792,7 @@ export const CharacterConditionals = {
     return characterFn(request.characterEidolon)
   },
   getDisplayForCharacter: (id, eidolon) => {
-    // console.log('getDisplayForCharacter', id)
+    console.log('getDisplayForCharacter', id)
     if (!id || !characterOptionMapping[id]) {
       return (
         <Flex justify='space-between' align='center'>

--- a/src/lib/relicModalController.ts
+++ b/src/lib/relicModalController.ts
@@ -1,0 +1,26 @@
+import DB from "./db.js";
+import { SaveState } from "./saveState.js";
+import { Message } from "./message.js";
+
+export const RelicModalController = {
+  onEditOk: (selectedRelic, relic) => {
+    relic.id = selectedRelic.id
+
+    const updatedRelic = { ...selectedRelic, ...relic }
+
+    if (updatedRelic.equippedBy) {
+      DB.equipRelic(updatedRelic, updatedRelic.equippedBy)
+    } else {
+      DB.unequipRelicById(updatedRelic.id);
+    }
+
+    DB.setRelic(updatedRelic)
+    global.setRelicRows(DB.getRelics())
+    SaveState.save()
+
+    Message.success('Successfully edited relic')
+    console.log('onEditOk', updatedRelic)
+
+    return updatedRelic;
+  }
+}

--- a/tests/CharacterPreview/delete-character.spec.ts
+++ b/tests/CharacterPreview/delete-character.spec.ts
@@ -5,7 +5,7 @@ test('Delete character from Characters tab', async ({ page }) => {
 
   // dbl-click kafka TEXT
   await page.getByRole('menuitem', { name: 'Characters' }).click();
-  await page.getByText('Jingliu').click();
+  await page.locator('#characterGrid').getByText('Jingliu').click();
   await page.getByRole('button', { name: 'Remove' }).click();
   await page.getByRole('button', { name: 'Yes' }).click();
 

--- a/tests/CharacterPreview/double-click-to-optimizer.spec.ts
+++ b/tests/CharacterPreview/double-click-to-optimizer.spec.ts
@@ -1,12 +1,12 @@
-import { test, expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 test('Double-clicking character renders Optimizer with character in focus.', async ({ page }) => {
   await page.goto('/');
 
   // dbl-click kafka TEXT
   await page.getByRole('menuitem', { name: 'Characters' }).click();
-  await page.getByText('Kafka').dblclick();
-  await expect(page.locator('.ant-image-img')).toBeVisible();
+  await page.locator('#characterGrid').getByText('Kafka').dblclick();
+  await expect(page.locator('#optimizerGridContainer')).toBeVisible();
   await expect(page.getByRole('main')).toContainText('Kafka');
   // chacater passives rendered
   await expect(page.getByRole('main')).toContainText('E1 dot dmg debuff');

--- a/tests/CharacterPreview/edit-main-stat-loads-maxed-stat.spec.ts
+++ b/tests/CharacterPreview/edit-main-stat-loads-maxed-stat.spec.ts
@@ -4,8 +4,8 @@ test('Editing relics show the correct main stat at maxed value', async ({ page }
   // navigate to Relics tab
   await page.goto('/');
 
-  await page.getByText('Characters').click();
-  await page.getByText('Jingliu').click()
+  await page.getByRole('menuitem', { name: 'Characters' }).click();
+  await page.locator('#characterGrid').getByText('Jingliu').click()
 
   await page.getByText('CRIT DMG64.8%').click();
   await expect(page.locator('#mainStatValue').first()).toHaveValue('64.8');

--- a/tests/RelicModal/1-edit-from-optimizer-tab.spec.ts
+++ b/tests/RelicModal/1-edit-from-optimizer-tab.spec.ts
@@ -1,11 +1,11 @@
-import { test, expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 test('Open RelicModal in edit mode from the Optimizer tab', async ({ page }) => {
   await page.goto('/');
 
   await page.getByRole('menuitem', { name: 'Optimizer' }).click();
 
-  await page.getByText('Jingliu').click();
+  await page.getByTitle('Jingliu').click();
   await page.getByText('Himeko').click();
 
   // start filter

--- a/tests/RelicModal/2-edit-from-character-preview-tab.spec.ts
+++ b/tests/RelicModal/2-edit-from-character-preview-tab.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 test('Open RelicModal in edit mode from the CharacterPreview tab', async ({ page }) => {
   await page.goto('/');
@@ -12,12 +12,11 @@ test('Open RelicModal in edit mode from the CharacterPreview tab', async ({ page
   await expect(page.getByRole('main')).toContainText('Lv80 E0');
   await expect(page.getByRole('main')).toContainText('Cruising in the Stellar Sea');
 
-  // click on 2nd relic (hands)
-  await page.locator('div:nth-child(3) > div > .ant-card-body > div > div').first().click();
+  // click on 1st relic (head)
+  await page.getByRole('img', { name: 'Genius of Brilliant Stars' }).first().click();
 
   // edit modal visible with expected value
   await expect(page.getByRole('dialog').locator('div').filter({ hasText: 'Equipped bySeelePartSetGenius' }).first()).toBeVisible();
-  await expect(page.locator('label:nth-child(2) > span:nth-child(2) > .ant-image > .ant-image-img')).toBeVisible();
   await expect(page.getByRole('dialog')).toContainText('Equipped by');
   await expect(page.getByRole('dialog')).toContainText('+15');
   await expect(page.getByRole('dialog')).toContainText('5 star');

--- a/tests/RelicModal/3-edit-from-relics-tab.spec.ts
+++ b/tests/RelicModal/3-edit-from-relics-tab.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 test('Open RelicModal in edit mode from the CharacterPreview tab', async ({ page }) => {
   // navigate to Relics tab
@@ -6,9 +6,8 @@ test('Open RelicModal in edit mode from the CharacterPreview tab', async ({ page
 
   // got relics tab
   await page.getByRole('menuitem', { name: 'Relics' }).click();
-
-  await page.locator('.ag-cell').first().click();
-  await page.locator('.ant-card-body > div > div').first().click();
+  await page.locator('div').filter({ hasText: /^Head15HP70511\.010\.43\.55\.2000$/ }).getByRole('img').first().click();
+  await page.getByText('+15HP705CRIT Rate11.0%CRIT').click();
 
   await expect(page.getByRole('dialog')).toContainText('Equipped by');
   await expect(page.getByRole('dialog')).toContainText('+15');

--- a/tests/RelicsTab/add-new-relic.spec.ts
+++ b/tests/RelicsTab/add-new-relic.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 test('Add new relic from RelicsTab', async ({ page }) => {
   await page.goto('/');
@@ -27,7 +27,7 @@ test('Add new relic from RelicsTab', async ({ page }) => {
   await expect(page.getByRole('dialog')).toContainText('Musketeer of Wild Wheat');
 
   // set to +12
-  await page.getByTitle('+').click();
+  await page.getByRole('dialog').getByText('+').click();
   await page.getByTitle('+12').locator('div').click();
 
   // assert main stat is flat atk
@@ -35,36 +35,39 @@ test('Add new relic from RelicsTab', async ({ page }) => {
 
   // set substats
   await page.locator('#substatType0').click();
-  await page.getByTitle('CRIT DMG').locator('div').click();
+  await page.locator('#substatType0').fill('crit dmg');
+  await page.locator('#substatType0').press('Enter');
   await page.locator('#substatValue0').fill('10');
 
   await page.locator('#substatType1').click();
-  await page.getByText('Effect Hit Rate').nth(2).click();
+  await page.locator('#substatType1').fill('effect hit rate');
+  await page.locator('#substatType1').press('Enter');
   await page.locator('#substatValue1').fill('10');
 
   await page.locator('#substatType2').click();
-  await page.getByText('ATK%').nth(3).click();
+  await page.locator('#substatType2').fill('atk%');
+  await page.locator('#substatType2').press('Enter');
   await page.locator('#substatValue2').fill('10');
 
   await page.locator('#substatType3').click();
-  // await page.getByText('DEF%').nth(3).click(); // wtf why nth(3) again?
-  await page.getByTitle('DEF%').locator('div').nth(3).click();
+  await page.locator('#substatType3').fill('def%');
+  await page.locator('#substatType3').press('Enter');
   await page.locator('#substatValue3').fill('10');
 
   await page.getByRole('button', { name: 'Submit' }).click();
 
   // assert relic added
 
-  await expect(page.locator('.ant-card-body')).toContainText('+12');
-  await expect(page.locator('.ant-card-body')).toContainText('+12ATK293CRIT DMG10.0%Effect Hit Rate10.0%ATK %10.0%DEF %10.0%');
-  await expect(page.locator('.ant-card-body')).toContainText('ATK293');
-  await expect(page.locator('.ant-card-body')).toContainText('CRIT DMG10.0%');
-  await expect(page.locator('.ant-card-body')).toContainText('Effect Hit Rate10.0%');
-  await expect(page.locator('.ant-card-body')).toContainText('ATK %10.0%');
-  await expect(page.locator('.ant-card-body')).toContainText('DEF %10.0%');
+  await expect(page.locator('#relics').locator('.ant-card-body')).toContainText('+12');
+  await expect(page.locator('#relics').locator('.ant-card-body')).toContainText('+12ATK293CRIT DMG10.0%Effect Hit Rate10.0%ATK %10.0%DEF %10.0%');
+  await expect(page.locator('#relics').locator('.ant-card-body')).toContainText('ATK293');
+  await expect(page.locator('#relics').locator('.ant-card-body')).toContainText('CRIT DMG10.0%');
+  await expect(page.locator('#relics').locator('.ant-card-body')).toContainText('Effect Hit Rate10.0%');
+  await expect(page.locator('#relics').locator('.ant-card-body')).toContainText('ATK %10.0%');
+  await expect(page.locator('#relics').locator('.ant-card-body')).toContainText('DEF %10.0%');
 
   // // re-edit relic - assert values carried over
-  await page.locator('img:nth-child(3)').click();
+  await page.locator('#relics').locator('.ant-card-body').click();
   await expect(page.getByRole('dialog').locator('div').filter({ hasText: 'Equipped' }).first()).toBeVisible();
   await expect(page.getByRole('dialog')).toContainText('Nobody');
   await expect(page.getByRole('dialog')).toContainText('Musketeer of Wild Wheat');


### PR DESCRIPTION
refactor: tab rendering optimization fixes, update tests with new tab rendering

update tests, update component rerender triggers since tabs dont fully rerender now

# Pull Request

## Description
Fixed a few bugs from the original rendering refactor. Now most components should update correctly when changes are made across tabs. 

Updated the tests to reflect the new changes - mostly selectors are different since things are not unmounted anymore.

Cleaned up the 'DRY this up (CharacterPreview.js, OptimizerBuildPreview.js, RelicsTab.js)' on onEditOk() 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.


## Additional Notes
I think there may still be cases where relic updates don't immediately reflect until the user clicks some stuff but those seem to be minor / rare
