### PR TITLE
fix: relic scorer tab scrolling to top on swapping characters

### DIFF
--- a/src/components/CharacterPreview.js
+++ b/src/components/CharacterPreview.js
@@ -141,7 +141,7 @@ export function CharacterPreview(props) {
               width: innerW,
               filter: (characterTabBlur && !isScorer) ? 'blur(20px)' : ''
             }}
-            onLoad={() => setTimeout(() => setCharacterTabBlur(false), 100)}
+            onLoad={() => setTimeout(() => setCharacterTabBlur(false), 50)}
           />
         </div>
       </div>


### PR DESCRIPTION
# Pull Request

## Description
fix: relic scorer tab scrolling to top on swapping characters

The state management in the relic scorer was kinda tied up, causing some weird scrolling behavior. Did a minor refactor and fixed the scrolling and the Divided animation

## Related Issue

n/a

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots (if applicable)

animation changes - n/a
