### PR TITLE
Feature: Add simple progress bar to optimizer search

### DIFF
--- a/src/components/optimizerTab/Sidebar.js
+++ b/src/components/optimizerTab/Sidebar.js
@@ -1,4 +1,4 @@
-import { Button, Divider, Flex, Typography } from "antd";
+import { Button, Divider, Flex, Progress, Typography } from "antd";
 import React from 'react';
 import FormCard from "./FormCard";
 import { HeaderText } from "../HeaderText";
@@ -45,7 +45,7 @@ export default function Sidebar() {
   return (
     <Flex vertical style={{overflow: 'clip'}}>
       <Flex style={{position: 'sticky', top: '50%', transform: 'translateY(-50%)', paddingLeft: 10}}>
-        <FormCard height={500}>
+        <FormCard height={550}>
           <Flex vertical gap={10}>
             <Flex justify='space-between' align='center'>
               <HeaderText>Permutations</HeaderText>
@@ -65,6 +65,11 @@ export default function Sidebar() {
               <PermutationDisplay left='Perms' right={permutations} />
               <PermutationDisplay left='Searched' right={permutationsSearched} />
               <PermutationDisplay left='Results' right={permutationsResults} />
+            </Flex>
+
+            <Flex vertical>
+              <HeaderText>Progress</HeaderText>
+              <Progress percent={Math.ceil(Number(permutationsSearched) / Number(permutations) * 100)} size="small" />
             </Flex>
 
             <Flex justify='space-between' align='center' style={{marginTop: 10}}>


### PR DESCRIPTION
# Pull Request

## Description
Added a simple progress bar to be more visual in search optimizer progress.

## Type of Changes

### Added
- Added simple progress bar to reflect the current search/permutation status.

### Changed
- Changed the optimizer control component to have 550px height to fit the new progress bar.

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots (if applicable)

![image](https://github.com/fribbels/hsr-optimizer/assets/12674637/88f83214-98cc-4b4c-99c7-499ffd182970)

![image](https://github.com/fribbels/hsr-optimizer/assets/12674637/438bf8a4-3dcf-4046-a43b-5eac5c27b05c)

![image](https://github.com/fribbels/hsr-optimizer/assets/12674637/91a8ec2d-1536-4c4e-9d0f-1f754787b235)
