### PR TITLE
Bugfix: skillAtkBoostScaling calculation and description in Tingyun.tsx

### DIFF
--- a/src/lib/conditionals/character/Tingyun.tsx
+++ b/src/lib/conditionals/character/Tingyun.tsx
@@ -14,7 +14,7 @@ const Tingyun = (e: Eidolon) => {
   const ultDmgBoost = ult(e, 0.50, 0.56);
   const skillAtkBoostScaling = skill(e, 0.50, 0.55);
   const skillLightningDmgBoostScaling = skill(e, 0.40, 0.44) + ((e >= 4) ? 0.20 : 0);
-  // const talentScaling = talent(e, 0.60, 0.66) + ((e >= 4) ? 0.20 : 0);
+  const talentScaling = talent(e, 0.60, 0.66) + ((e >= 4) ? 0.20 : 0);
 
   const basicScaling = basic(e, 1.00, 1.10);
   const skillScaling = skill(e, 0, 0);
@@ -76,7 +76,7 @@ const Tingyun = (e: Eidolon) => {
       // Boost
       x.BASIC_BOOST += 0.40
       x.ELEMENTAL_DMG += (r.ultDmgBuff) ? ultDmgBoost : 0
-      x.BENEDICTION_LIGHTNING_DMG = (r.benedictionBuff) ? skillLightningDmgBoostScaling : 0
+      x.BENEDICTION_LIGHTNING_DMG = (r.benedictionBuff) ? skillLightningDmgBoostScaling + talentScaling : 0
 
       return x;
     },

--- a/src/lib/conditionals/character/Tingyun.tsx
+++ b/src/lib/conditionals/character/Tingyun.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Stats } from "lib/constants";
 import { baseComputedStatsObject } from "lib/conditionals/constants";
-import { basic, precisionRound, skill, ult } from "lib/conditionals/utils";
+import { basic, precisionRound, skill, ult, talent } from "lib/conditionals/utils";
 import { Eidolon } from "types/Character";
 
 import DisplayFormControl from "components/optimizerForm/conditionals/DisplayFormControl";

--- a/src/lib/conditionals/character/Tingyun.tsx
+++ b/src/lib/conditionals/character/Tingyun.tsx
@@ -12,7 +12,8 @@ import { Form } from "types/CharacterConditional";
 const Tingyun = (e: Eidolon) => {
   const skillAtkBoostMax = skill(e, 0.25, 0.27);
   const ultDmgBoost = ult(e, 0.50, 0.56);
-  const skillAtkBoostScaling = skill(e, 0.50, 0.55) + ((e >= 4) ? 0.20 : 0);
+  const skillAtkBoostScaling = skill(e, 0.50, 0.55);
+  const skillLightningDmgBoostScaling = skill(e, 0.40, 0.44) + ((e >= 4) ? 0.20 : 0);
   // const talentScaling = talent(e, 0.60, 0.66) + ((e >= 4) ? 0.20 : 0);
 
   const basicScaling = basic(e, 1.00, 1.10);
@@ -25,7 +26,7 @@ const Tingyun = (e: Eidolon) => {
     name: 'benedictionBuff',
     text: 'Benediction buff',
     title: 'Benediction buff',
-    content: `Grants a single ally with Benediction to increase their ATK by ${precisionRound(skillAtkBoostScaling * 100)}%, up to ${precisionRound(skillAtkBoostMax * 100)}% of Tingyun's current ATK.`,
+    content: `Grants a single ally with Benediction to increase their ATK by ${precisionRound(skillAtkBoostScaling * 100)}%, up to ${precisionRound(skillAtkBoostMax * 100)}% of Tingyun's current ATK. When the ally with Benediction attacks, it deals lightning damage equal to ${precisionRound(skillLightningDmgBoostScaling * 100)}% of that ally's ATK. This effect lasts for 3 turns.`,
   }, {
     formItem: FormSwitchWithPopover,
     id: 'skillSpdBuff',
@@ -75,13 +76,14 @@ const Tingyun = (e: Eidolon) => {
       // Boost
       x.BASIC_BOOST += 0.40
       x.ELEMENTAL_DMG += (r.ultDmgBuff) ? ultDmgBoost : 0
+      x.BENEDICTION_LIGHTNING_DMG = (r.benedictionBuff) ? skillLightningDmgBoostScaling : 0
 
       return x;
     },
     calculateBaseMultis: (c) => {
       const x = c.x
 
-      x.BASIC_DMG += x.BASIC_SCALING * x[Stats.ATK]
+      x.BASIC_DMG += x.BASIC_SCALING * x[Stats.ATK] + x.BENEDICTION_LIGHTNING_DMG * x[Stats.ATK]
       x.SKILL_DMG += x.SKILL_SCALING * x[Stats.ATK]
       x.ULT_DMG += x.ULT_SCALING * x[Stats.ATK]
     }


### PR DESCRIPTION
# Pull Request

## Description
Bugfixes the skill damage increase calculation, skill description and adds the flat lightning dmg to basic atk (only tingyun damaging skill). The skill dmg buff only applies to the flat Lightning dmg buff Benediction provides, with E4 only buffing +20% in this damage, not the atk scaling.

## Type of Changes

### Added
- Add `skillLightningDmgBoostScaling` separately from `skillAtkBoostScaling`
- Add `x.BENEDICTION_LIGHTNING_DMG * x[Stats.ATK]` to `x.BASIC_DMG`

### Fixed
- Fix `skillAtkBoostScaling`
- Tingyun skill description tip

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots

Before:
![image](https://github.com/fribbels/hsr-optimizer/assets/12674637/15cd8699-1d93-4e86-9209-d87e728b39b3)

After:
![image](https://github.com/fribbels/hsr-optimizer/assets/12674637/63e376db-1274-46b0-9c46-586efa932e3b)

