### PR TITLE
removing the (if applicable) from PR screenshot section

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,7 +24,7 @@
 - [ ] I have tested the changes locally.
 - [ ] I have reviewed the code changes.
 
-## Screenshots (if applicable)
+## Screenshots
 <!-- If the changes include any visual updates, please provide screenshots here. -->
 
 ## Additional Notes


### PR DESCRIPTION
# Pull Request

## Description
Removing the `(if applicable)` from screenshot section for PR templates.

## Type of Changes

### Changed
- Removed the `(if applicable)` from screenshot section for PR templates

