### PR TITLE
Bugfix: Conditional Rendering in RelicPreview.js

### DIFF
--- a/src/components/RelicPreview.js
+++ b/src/components/RelicPreview.js
@@ -95,7 +95,7 @@ const RelicPreview = ({
             </Text>
           </Flex>
           <Text>
-            {(scored) && `${score.score} (${score.rating})${score.meta.modified ? ' *' : ''}`}
+            {(scored) && `${score.score} (${score.rating})${score.meta?.modified ? ' *' : ''}`}
           </Text>
         </Flex>
       </Flex>


### PR DESCRIPTION
# Pull Request

## Description
Fixes rendering when only partially equipped relics for build.

## Type of Changes

### Fixed
- Fixes the undefined error when accessing `score.meta.modified` prop.

## Checklist
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots

Before:
![image](https://github.com/fribbels/hsr-optimizer/assets/12674637/8e9a73b3-7cd2-4f47-b30a-ae97d43fbe28)

After:
![image](https://github.com/fribbels/hsr-optimizer/assets/12674637/14ea7d60-b76a-4062-805b-7348fb2a3f0b)


