### PR TITLE
fix: add retry to worker initialization

### DIFF
--- a/src/lib/workerPool.js
+++ b/src/lib/workerPool.js
@@ -2,9 +2,10 @@ import { BufferPacker } from './bufferPacker'
 import { Constants } from './constants'
 import OptimizerWorker from './worker/optimizerWorker?worker'
 
-let poolSize = (navigator.hardwareConcurrency || 4) - 1
-let initialized = 0
+let poolSize = Math.max(1, (navigator.hardwareConcurrency || 4) - 1)
+let initializedWorkers = 0
 console.log('Using pool size ' + poolSize)
+
 // Reuse workers and buffers
 let workers = []
 let buffers = []
@@ -12,11 +13,11 @@ let taskQueue = []
 let taskStatus = {}
 
 export const WorkerPool = {
-  initialize: () => {
-    if (initialized < poolSize) {
+  initializeWorker: () => {
+    if (initializedWorkers < poolSize) {
       const worker = new OptimizerWorker()
       workers.push(worker)
-      initialized++
+      initializedWorkers++
     }
   },
 
@@ -26,11 +27,15 @@ export const WorkerPool = {
     WorkerPool.execute(task, callback)
   },
 
-  execute: (task, callback, id) => {
+  execute: async (task, callback, id) => {
     if (taskStatus[id] == undefined) taskStatus[id] = true
     if (taskStatus[id] == false) return
 
-    WorkerPool.initialize()
+    // Dont keep looping if a task keeps failing
+    if (task.attempts == undefined) task.attempts = 0
+    if (task.attempts > 10) return console.log('Too many failures, abandoning task')
+
+    WorkerPool.initializeWorker()
 
     if (workers.length > 0) {
       const worker = workers.pop()
@@ -46,11 +51,28 @@ export const WorkerPool = {
       task.buffer = buffer
 
       worker.onmessage = (message) => {
-        // console.log('worker message', message)
+        // console.log('Worker message', message)
         if (callback) callback(message.data)
         workers.push(worker)
         buffers.push(message.data.buffer)
         WorkerPool.nextTask()
+      }
+
+      // Workers in Vite seem to have a chance to fail to initialize and die silently on Chromium browsers, when too many
+      // new workers are created at once. Using some bandaid retry logic while we investigate the root cause
+      worker.onerror = (e) => {
+        console.warn('Worker error', e)
+
+        initializedWorkers--
+        task.attempts++
+
+        // We don't try to reuse this worker - kill it and start a new one and requeue the task
+        taskQueue.push({ task, callback })
+        worker.terminate()
+        setTimeout(() => {
+          WorkerPool.initializeWorker()
+          WorkerPool.nextTask()
+        }, 100)
       }
 
       worker.postMessage(task, [task.buffer])


### PR DESCRIPTION
# Pull Request

## Description

Workers in Vite seem to have a chance to fail to initialize and die silently on Chromium browsers, when too many new workers are created at once. Using some bandaid retry logic while we investigate the root cause

## Related Issue

N/A

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.
