### PR TITLE
feat: loading spinner while optimizer in progress, scroll to grid, fi…

### DIFF
--- a/src/components/OptimizerForm.jsx
+++ b/src/components/OptimizerForm.jsx
@@ -66,6 +66,7 @@ export default function OptimizerForm() {
   const lightConeOptions = useMemo(() => Utils.generateLightConeOptions(), [])
   const optimizerTabFocusCharacter = window.store((s) => s.optimizerTabFocusCharacter)
   const setOptimizerTabFocusCharacter = window.store((s) => s.setOptimizerTabFocusCharacter)
+  const setOptimizationInProgress = window.store((s) => s.setOptimizationInProgress)
 
   useEffect(() => {
     OptimizerTabController.changeCharacter(optimizerTabFocusCharacter, setSelectedLightCone)
@@ -191,6 +192,7 @@ export default function OptimizerForm() {
 
   function cancelClicked() {
     console.log('Cancel clicked')
+    setOptimizationInProgress(false)
     Optimizer.cancel(optimizationId)
   }
   window.optimizerCancelClicked = cancelClicked
@@ -221,6 +223,8 @@ export default function OptimizerForm() {
       return
     }
 
+    document.getElementById('optimizerGridContainer').scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+
     DB.addFromForm(form)
     SaveState.save()
     console.log('Form finished', form)
@@ -229,6 +233,7 @@ export default function OptimizerForm() {
     setOptimizationId(optimizationId)
     form.optimizationId = optimizationId
 
+    setOptimizationInProgress(true)
     Optimizer.optimize(form)
   }
   window.optimizerStartClicked = startClicked

--- a/src/components/optimizerTab/Sidebar.jsx
+++ b/src/components/optimizerTab/Sidebar.jsx
@@ -3,8 +3,8 @@ import React from 'react'
 import FormCard from 'components/optimizerTab/FormCard'
 import { HeaderText } from '../HeaderText'
 import { TooltipImage } from '../TooltipImage'
-import { OptimizerTabController } from '../../lib/optimizerTabController'
-import { Hint } from '../../lib/hint'
+import { OptimizerTabController } from 'lib/optimizerTabController'
+import { Hint } from 'lib/hint'
 import PropTypes from 'prop-types'
 
 const { Text } = Typography
@@ -39,6 +39,8 @@ export default function Sidebar() {
   const permutations = window.store((s) => s.permutations)
   const permutationsSearched = window.store((s) => s.permutationsSearched)
   const permutationsResults = window.store((s) => s.permutationsResults)
+
+  const optimizationInProgress = window.store((s) => s.optimizationInProgress)
 
   return (
     <Flex vertical style={{ overflow: 'clip' }}>
@@ -81,7 +83,7 @@ export default function Sidebar() {
 
             <Flex gap={defaultGap} style={{ marginBottom: 2 }} vertical>
               <Flex gap={defaultGap}>
-                <Button type="primary" onClick={window.optimizerStartClicked} style={{ width: '205px' }}>
+                <Button type="primary" loading={optimizationInProgress} onClick={window.optimizerStartClicked} style={{ width: '205px' }}>
                   Start
                 </Button>
               </Flex>

--- a/src/lib/conditionals/lightcone/4star/CarveTheMoonWeaveTheClouds.ts
+++ b/src/lib/conditionals/lightcone/4star/CarveTheMoonWeaveTheClouds.ts
@@ -56,11 +56,7 @@ export default (s: SuperImpositionLevel): LightConeConditional => {
       atkBuffActive: true,
       cdBuffActive: false,
     }),
-    precomputeEffects: (x: ComputedStatsObject, request: Form) => {
-      const r = request.lightConeConditionals
-
-      x[Stats.ATK_P] += (r.atkBuffActive) ? sValuesAtk[s] : 0
-      x[Stats.CD] += (r.cdBuffActive) ? sValuesCd[s] : 0
+    precomputeEffects: (_x: ComputedStatsObject, _request: Form) => {
     },
     precomputeMutualEffects: (x: ComputedStatsObject, request: Form) => {
       const m = request.lightConeConditionals

--- a/src/lib/db.js
+++ b/src/lib/db.js
@@ -55,6 +55,7 @@ window.store = create((set) => ({
   scorerId: undefined,
   scoringMetadataOverrides: {},
   statDisplay: 'base',
+  optimizationInProgress: false,
 
   permutationDetails: {
     Head: 0,
@@ -106,6 +107,7 @@ window.store = create((set) => ({
   setScoringMetadataOverrides: (x) => set(() => ({ scoringMetadataOverrides: x })),
   setStatDisplay: (x) => set(() => ({ statDisplay: x })),
   setOptimizerMenuState: (x) => set(() => ({ optimizerMenuState: x })),
+  setOptimizationInProgress: (x) => set(() => ({ optimizationInProgress: x })),
 }))
 
 export const DB = {

--- a/src/lib/optimizer.js
+++ b/src/lib/optimizer.js
@@ -127,13 +127,17 @@ export const Optimizer = {
     console.log(`Optimization permutations: ${permutations}, blocksize: ${Constants.THREAD_BUFFER_LENGTH}`)
 
     if (permutations == 0) {
+      window.store.getState().setOptimizationInProgress(false)
       Message.error('No possible permutations match your filters - please check the Permutations panel for details, and adjust your filter values', 10)
       OptimizerTabController.setRows([])
       OptimizerTabController.resetDataSource()
       return
     }
 
-    if (CANCEL) return
+    if (CANCEL) {
+      window.store.getState().setOptimizationInProgress(false)
+      return
+    }
 
     window.optimizerGrid.current.api.showLoadingOverlay()
 
@@ -233,6 +237,7 @@ export const Optimizer = {
         window.store.getState().setPermutationsSearched(Math.min(permutations, searched))
 
         if (inProgress == 0 || CANCEL) {
+          window.store.getState().setOptimizationInProgress(false)
           OptimizerTabController.setRows(results)
 
           window.optimizerGrid.current.api.updateGridOptions({ datasource: OptimizerTabController.getDataSource() })

--- a/src/lib/worker/optimizerWorker.js
+++ b/src/lib/worker/optimizerWorker.js
@@ -211,6 +211,8 @@ self.onmessage = function(e) {
 
     if (teammateCharacterConditionals.precomputeMutualEffects) teammateCharacterConditionals.precomputeMutualEffects(precomputedX, teammateRequest)
     if (teammateCharacterConditionals.precomputeTeammateEffects) teammateCharacterConditionals.precomputeTeammateEffects(precomputedX, teammateRequest)
+
+    if (teammateLightConeConditionals.precomputeMutualEffects) teammateLightConeConditionals.precomputeMutualEffects(precomputedX, teammateRequest)
     if (teammateLightConeConditionals.precomputeTeammateEffects) teammateLightConeConditionals.precomputeTeammateEffects(precomputedX, teammateRequest)
 
     switch (teammateRequest.teamOrnamentSet) {

--- a/src/lib/worker/optimizerWorker.js
+++ b/src/lib/worker/optimizerWorker.js
@@ -210,8 +210,8 @@ self.onmessage = function(e) {
     const teammateLightConeConditionals = LightConeConditionals.get(teammateRequest)
 
     if (teammateCharacterConditionals.precomputeMutualEffects) teammateCharacterConditionals.precomputeMutualEffects(precomputedX, teammateRequest)
-    if (teammateCharacterConditionals.precomputeTeammateEffects) teammateCharacterConditionals.precomputeTeammateEffects(precomputedX, request, teammateRequest)
-    if (teammateLightConeConditionals.precomputeTeammateEffects) teammateLightConeConditionals.precomputeTeammateEffects(precomputedX, request, teammateRequest)
+    if (teammateCharacterConditionals.precomputeTeammateEffects) teammateCharacterConditionals.precomputeTeammateEffects(precomputedX, teammateRequest)
+    if (teammateLightConeConditionals.precomputeTeammateEffects) teammateLightConeConditionals.precomputeTeammateEffects(precomputedX, teammateRequest)
 
     switch (teammateRequest.teamOrnamentSet) {
       case Sets.BrokenKeel:


### PR DESCRIPTION
# Pull Request

Some QOLs & fixes for team calc

## Description

* Fixed teammate effects calc
* Fixed teammate mutual effects not getting added
* Optimization in progress now has a spinner
* Clicking start will scroll to the optimizer grid now

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots

![image](https://github.com/fribbels/hsr-optimizer/assets/7908525/8a0e373b-bd81-4cbf-92df-adc77f6a9ba0)

