### PR TITLE
qol: clarify enemy hp logic, deprecate fribbels scanner, fix char tab refresh bug

### DIFF
--- a/src/components/ImportTab.jsx
+++ b/src/components/ImportTab.jsx
@@ -401,7 +401,7 @@ function KelZImporterTab() {
   }
 
   function confirmRelicMerge() {
-    if (!currentRelics || !currentRelics.length) {
+    if (!currentRelics) {
       return (
         <Flex style={{ minHeight: 100 }}>
           <Flex vertical gap={10} style={{ display: current >= 1 ? 'flex' : 'none' }}>
@@ -695,11 +695,11 @@ export default function ImportTab() {
               key: 0,
               children: KelZImporterTab(),
             },
-            {
-              label: 'Fribbels scanner importer',
-              key: 1,
-              children: FribbelsImporterTab(),
-            },
+            // {
+            //   label: 'Fribbels scanner importer',
+            //   key: 1,
+            //   children: FribbelsImporterTab(),
+            // },
             {
               label: 'Save optimizer data',
               key: 2,

--- a/src/lib/conditionals/lightcone/4star/TheBirthOfTheSelf.ts
+++ b/src/lib/conditionals/lightcone/4star/TheBirthOfTheSelf.ts
@@ -43,7 +43,7 @@ export default (s: SuperImpositionLevel): LightConeConditional => {
       const r = request.lightConeConditionals
 
       x.FUA_BOOST += sValues[s]
-      x.FUA_BOOST += (r.enemyHp50FuaBuff && request.enemyHpPercent < 0.50) ? sValues[s] : 0
+      x.FUA_BOOST += (r.enemyHp50FuaBuff) ? sValues[s] : 0
     },
     calculatePassives: (/* c, request */) => { },
     calculateBaseMultis: (/* c, request */) => { },

--- a/src/lib/conditionals/lightcone/5star/CruisingInTheStellarSea.ts
+++ b/src/lib/conditionals/lightcone/5star/CruisingInTheStellarSea.ts
@@ -62,7 +62,7 @@ export default (s: SuperImpositionLevel): LightConeConditional => {
     precomputeEffects: (x: PrecomputedCharacterConditional, request: Form) => {
       const r = request.lightConeConditionals
 
-      x[Stats.CR] += (r.enemyHp50CrBoost && request.enemyHpPercent <= 0.50) ? sValuesCr[s] : 0
+      x[Stats.CR] += (r.enemyHp50CrBoost) ? sValuesCr[s] : 0
       x[Stats.ATK_P] += (r.enemyDefeatedAtkBuff) ? sValuesAtk[s] : 0
     },
     calculatePassives: (/* c, request */) => { },

--- a/src/lib/db.js
+++ b/src/lib/db.js
@@ -401,6 +401,10 @@ export const DB = {
     }
 
     let replacementRelics = []
+    // In case the user tries to import a characters only file, we do this
+    if (newRelics.length == 0) {
+      replacementRelics = oldRelics
+    }
     for (let newRelic of newRelics) {
       let hash = hashRelic(newRelic)
 

--- a/src/lib/relicModalController.ts
+++ b/src/lib/relicModalController.ts
@@ -17,6 +17,7 @@ export const RelicModalController = {
     DB.setRelic(updatedRelic)
     window.setRelicRows(DB.getRelics())
     SaveState.save()
+    window.forceCharacterTabUpdate()
 
     Message.success('Successfully edited relic')
     console.log('onEditOk', updatedRelic)

--- a/src/window.d.ts
+++ b/src/window.d.ts
@@ -54,6 +54,7 @@ declare global {
     optimizerForm: FormInstance
 
     forceOptimizerBuildPreviewUpdate: DispatchWithoutAction
+    forceCharacterTabUpdate: DispatchWithoutAction
 
     WorkerPool: typeof WorkerPool
     Constants: typeof Constants


### PR DESCRIPTION
# Pull Request

## Description

Various QOLs/fixes:
* Allowing non-relic imports, just update characters in that case
  * No longer rejects the file
* Deprecate Fribbels scanner 
* Removing cases where user's input contradicts the enemy options `r.enemyHp50FuaBuff && request.enemyHpPercent < 0.50` 
* Fix bug where character tab didnt update on relic modal OK

## Related Issue

https://github.com/fribbels/hsr-optimizer/issues/118

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

![image](https://github.com/fribbels/hsr-optimizer/assets/7908525/beb3e501-5200-4e0b-84b5-19ff486fb575)
