### PR TITLE
feat: autoload teammate data, sync button, move stat display to sidebar

### DIFF
--- a/src/components/CharacterModal.jsx
+++ b/src/components/CharacterModal.jsx
@@ -19,10 +19,10 @@ export default function CharacterModal(props) {
     const defaultValues = {
       characterId: props.initialCharacter?.form.characterId,
       characterLevel: 80,
-      characterEidolon: 0,
+      characterEidolon: props.initialCharacter?.form.characterEidolon || 0,
       lightCone: props.initialCharacter?.form.lightCone,
       lightConeLevel: 80,
-      lightConeSuperimposition: 1,
+      lightConeSuperimposition: props.initialCharacter?.form.lightConeSuperimposition || 1,
     }
 
     characterForm.setFieldsValue(defaultValues)

--- a/src/components/CharacterTab.jsx
+++ b/src/components/CharacterTab.jsx
@@ -413,7 +413,7 @@ export default function CharacterTab() {
               <Dropdown
                 placement="topLeft"
                 menu={actionsMenuProps}
-                trigger={['click']}
+                trigger={['hover']}
               >
                 <Button style={{ width: '100%' }} icon={<UserOutlined />}>
                   Character actions

--- a/src/components/OptimizerBuildPreview.jsx
+++ b/src/components/OptimizerBuildPreview.jsx
@@ -12,6 +12,9 @@ import { RelicModalController } from 'lib/relicModalController'
 export default function OptimizerBuildPreview(props) {
   console.log('OptimizerBuildPreview', props)
 
+  const [optimizerBuild, setOptimizerBuild] = useState()
+  window.setOptimizerBuild = setOptimizerBuild
+
   function onEditOk(relic) {
     const updatedRelic = RelicModalController.onEditOk(selectedRelic, relic)
     setSelectedRelic(updatedRelic)
@@ -28,22 +31,22 @@ export default function OptimizerBuildPreview(props) {
   const relicsById = DB.getRelicsById()
   const characterId = OptimizerTabController.getForm().characterId
 
-  const headScore = props.build ? RelicScorer.score(relicsById[props.build?.Head], characterId) : undefined
-  const handsScore = props.build ? RelicScorer.score(relicsById[props.build?.Hands], characterId) : undefined
-  const bodyScore = props.build ? RelicScorer.score(relicsById[props.build?.Body], characterId) : undefined
-  const feetScore = props.build ? RelicScorer.score(relicsById[props.build?.Feet], characterId) : undefined
-  const planarSphereScore = props.build ? RelicScorer.score(relicsById[props.build?.PlanarSphere], characterId) : undefined
-  const linkRopeScore = props.build ? RelicScorer.score(relicsById[props.build?.LinkRope], characterId) : undefined
+  const headScore = optimizerBuild ? RelicScorer.score(relicsById[optimizerBuild?.Head], characterId) : undefined
+  const handsScore = optimizerBuild ? RelicScorer.score(relicsById[optimizerBuild?.Hands], characterId) : undefined
+  const bodyScore = optimizerBuild ? RelicScorer.score(relicsById[optimizerBuild?.Body], characterId) : undefined
+  const feetScore = optimizerBuild ? RelicScorer.score(relicsById[optimizerBuild?.Feet], characterId) : undefined
+  const planarSphereScore = optimizerBuild ? RelicScorer.score(relicsById[optimizerBuild?.PlanarSphere], characterId) : undefined
+  const linkRopeScore = optimizerBuild ? RelicScorer.score(relicsById[optimizerBuild?.LinkRope], characterId) : undefined
 
   return (
     <div>
       <Flex gap={5} id="optimizerBuildPreviewContainer">
-        <RelicPreview setEditModalOpen={setEditModalOpen} setSelectedRelic={setSelectedRelic} relic={relicsById[props.build?.Head]} score={headScore} />
-        <RelicPreview setEditModalOpen={setEditModalOpen} setSelectedRelic={setSelectedRelic} relic={relicsById[props.build?.Hands]} score={handsScore} />
-        <RelicPreview setEditModalOpen={setEditModalOpen} setSelectedRelic={setSelectedRelic} relic={relicsById[props.build?.Body]} score={bodyScore} />
-        <RelicPreview setEditModalOpen={setEditModalOpen} setSelectedRelic={setSelectedRelic} relic={relicsById[props.build?.Feet]} score={feetScore} />
-        <RelicPreview setEditModalOpen={setEditModalOpen} setSelectedRelic={setSelectedRelic} relic={relicsById[props.build?.PlanarSphere]} score={planarSphereScore} />
-        <RelicPreview setEditModalOpen={setEditModalOpen} setSelectedRelic={setSelectedRelic} relic={relicsById[props.build?.LinkRope]} score={linkRopeScore} />
+        <RelicPreview setEditModalOpen={setEditModalOpen} setSelectedRelic={setSelectedRelic} relic={relicsById[optimizerBuild?.Head]} score={headScore} />
+        <RelicPreview setEditModalOpen={setEditModalOpen} setSelectedRelic={setSelectedRelic} relic={relicsById[optimizerBuild?.Hands]} score={handsScore} />
+        <RelicPreview setEditModalOpen={setEditModalOpen} setSelectedRelic={setSelectedRelic} relic={relicsById[optimizerBuild?.Body]} score={bodyScore} />
+        <RelicPreview setEditModalOpen={setEditModalOpen} setSelectedRelic={setSelectedRelic} relic={relicsById[optimizerBuild?.Feet]} score={feetScore} />
+        <RelicPreview setEditModalOpen={setEditModalOpen} setSelectedRelic={setSelectedRelic} relic={relicsById[optimizerBuild?.PlanarSphere]} score={planarSphereScore} />
+        <RelicPreview setEditModalOpen={setEditModalOpen} setSelectedRelic={setSelectedRelic} relic={relicsById[optimizerBuild?.LinkRope]} score={linkRopeScore} />
       </Flex>
       <RelicModal selectedRelic={selectedRelic} type="edit" onOk={onEditOk} setOpen={setEditModalOpen} open={editModalOpen} />
     </div>

--- a/src/components/OptimizerForm.jsx
+++ b/src/components/OptimizerForm.jsx
@@ -58,9 +58,9 @@ export default function OptimizerForm() {
 
   // hooks
   const characterEidolon = Form.useWatch('characterEidolon', optimizerForm)
+  const lightCone = Form.useWatch('lightCone', optimizerForm)
   const lightConeSuperimposition = Form.useWatch('lightConeSuperimposition', optimizerForm)
   const setConditionalSetEffectsDrawerOpen = window.store((s) => s.setConditionalSetEffectsDrawerOpen)
-  const [optimizationId, setOptimizationId] = useState()
   const [selectedLightCone, setSelectedLightCone] = useState({ id: 'None', name: 'Light Cone' })
   const characterOptions = useMemo(() => Utils.generateCharacterOptions(), [])
   const lightConeOptions = useMemo(() => Utils.generateLightConeOptions(), [])
@@ -81,7 +81,7 @@ export default function OptimizerForm() {
     OptimizerTabController.changeCharacter(optimizerTabFocusCharacter, setSelectedLightCone, id)
   }, [lightConeOptions, optimizerTabFocusCharacter])
 
-  useMemo(() => {
+  useEffect(() => {
     let lcFn = LightConeConditionals.get(optimizerForm.getFieldsValue())
     let form = optimizerForm.getFieldsValue()
     let defaults = lcFn.defaults()
@@ -96,7 +96,7 @@ export default function OptimizerForm() {
     // if (Object.values(defaults).includes(undefined)) {
     optimizerForm.setFieldValue('lightConeConditionals', lcFn.defaults())
     // }
-  }, [optimizerForm])
+  }, [lightCone, lightConeSuperimposition])
 
   const initialCharacter = useMemo(() => {
     let characters = DB.getCharacters() // retrieve instance localStore saved chars
@@ -193,7 +193,7 @@ export default function OptimizerForm() {
   function cancelClicked() {
     console.log('Cancel clicked')
     setOptimizationInProgress(false)
-    Optimizer.cancel(optimizationId)
+    Optimizer.cancel(window.store.getState().optimizationId)
   }
   window.optimizerCancelClicked = cancelClicked
 
@@ -227,11 +227,13 @@ export default function OptimizerForm() {
 
     DB.addFromForm(form)
     SaveState.save()
-    console.log('Form finished', form)
 
     let optimizationId = uuidv4()
-    setOptimizationId(optimizationId)
+    window.store.getState().setOptimizationId(optimizationId)
     form.optimizationId = optimizationId
+    form.statDisplay = window.store.getState().statDisplay
+
+    console.log('Form finished', form)
 
     setOptimizationInProgress(true)
     Optimizer.optimize(form)

--- a/src/components/OptimizerTab.jsx
+++ b/src/components/OptimizerTab.jsx
@@ -1,62 +1,25 @@
-import React, { useCallback, useMemo, useRef, useState } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 import { Flex } from 'antd'
-import { AgGridReact } from 'ag-grid-react'
 import 'ag-grid-community/styles/ag-grid.css'
 
 import OptimizerForm from 'components/OptimizerForm'
 import OptimizerBuildPreview from 'components/OptimizerBuildPreview'
-import { baseColumnDefs, combatColumnDefs, defaultColDef, gridOptions } from 'components/optimizerTab/constants'
 import Sidebar from 'components/optimizerTab/Sidebar'
-
-import { OptimizerTabController } from 'lib/optimizerTabController'
+import { OptimizerGrid } from 'components/optimizerTab/OptimizerGrid'
 
 export default function OptimizerTab() {
   console.log('======================================================================= RENDER OptimizerTab')
-  const optimizerGrid = useRef()
-  window.optimizerGrid = optimizerGrid
-
-  const [optimizerBuild, setOptimizerBuild] = useState()
-  window.setOptimizerBuild = setOptimizerBuild
-
-  const cellClickedListener = useCallback((event) => {
-    OptimizerTabController.cellClicked(event)
-  }, [])
-  const statDisplay = window.store((s) => s.statDisplay)
-  const columnDefs = useMemo(() => statDisplay == 'combat' ? combatColumnDefs : baseColumnDefs, [statDisplay])
-
-  const datasource = useMemo(() => {
-    return OptimizerTabController.getDataSource()
-  }, [])
-  gridOptions.datasource = datasource
 
   return (
-    <div>
-      <Flex style={{ marginBottom: 50 }}>
-        <Flex vertical gap={10}>
-          <OptimizerForm />
-
-          <Flex>
-            <div id="optimizerGridContainer" className="ag-theme-balham-dark" style={{ width: 1225, minHeight: 300, height: 600, resize: 'vertical', overflow: 'hidden' }}>
-              <AgGridReact
-                animateRows={false}
-                columnDefs={columnDefs}
-                defaultColDef={defaultColDef}
-                gridOptions={gridOptions}
-                headerHeight={24}
-                onCellClicked={cellClickedListener}
-                ref={optimizerGrid}
-                rowSelection="single"
-              />
-            </div>
-          </Flex>
-
-          <OptimizerBuildPreview build={optimizerBuild} />
-        </Flex>
-
-        <Sidebar />
+    <Flex>
+      <Flex vertical gap={10} style={{ marginBottom: 100 }}>
+        <OptimizerForm />
+        <OptimizerGrid />
+        <OptimizerBuildPreview />
       </Flex>
-    </div>
+      <Sidebar />
+    </Flex>
   )
 }
 OptimizerTab.propTypes = {

--- a/src/components/optimizerTab/OptimizerGrid.jsx
+++ b/src/components/optimizerTab/OptimizerGrid.jsx
@@ -1,0 +1,41 @@
+import { AgGridReact } from 'ag-grid-react'
+import { baseColumnDefs, combatColumnDefs, defaultColDef, gridOptions } from 'components/optimizerTab/constants.ts'
+import { OptimizerTabController } from 'lib/optimizerTabController.js'
+import React, { useMemo, useRef } from 'react'
+import { Flex } from 'antd'
+
+export function OptimizerGrid() {
+  console.log('======================================================================= RENDER OptimizerGrid')
+
+  const optimizerGrid = useRef()
+  window.optimizerGrid = optimizerGrid
+
+  const datasource = useMemo(() => {
+    return OptimizerTabController.getDataSource()
+  }, [])
+
+  const statDisplay = window.store((s) => s.statDisplay)
+  const columnDefs = useMemo(() => {
+    return statDisplay == 'combat' ? combatColumnDefs : baseColumnDefs
+  }, [statDisplay])
+
+  gridOptions.datasource = datasource
+
+  // TODO: I think these things need memos: https://www.ag-grid.com/react-data-grid/react-hooks/
+  return (
+    <Flex>
+      <div id="optimizerGridContainer" className="ag-theme-balham-dark" style={{ width: 1225, minHeight: 300, height: 600, resize: 'vertical', overflow: 'hidden' }}>
+        <AgGridReact
+          animateRows={false}
+          columnDefs={columnDefs}
+          defaultColDef={defaultColDef}
+          gridOptions={gridOptions}
+          headerHeight={24}
+          onCellClicked={OptimizerTabController.cellClicked}
+          ref={optimizerGrid}
+          rowSelection="single"
+        />
+      </div>
+    </Flex>
+  )
+}

--- a/src/components/optimizerTab/OptimizerOptions.tsx
+++ b/src/components/optimizerTab/OptimizerOptions.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import { Flex, Form, Radio, RadioChangeEvent, Select, Switch, Typography } from 'antd'
+import { Flex, Form, RadioChangeEvent, Select, Switch, Typography } from 'antd'
 import { CheckOutlined, CloseOutlined } from '@ant-design/icons'
 
 import { Hint } from '../../lib/hint'
@@ -105,23 +105,6 @@ const OptimizerOptions = ({ defaultGap = 0 as number, panelWidth = 0 as number }
           />
         </Form.Item>
       </Flex>
-
-      <Flex justify="space-between" align="center" style={{ marginTop: 15 }}>
-        <HeaderText>Stat display</HeaderText>
-        {/* <TooltipImage type={Hint.optimizerOptions()} /> */}
-      </Flex>
-
-      <Form.Item name="statDisplay">
-        <Radio.Group
-          onChange={onChangeStatDisplay}
-          optionType="button"
-          buttonStyle="solid"
-          style={{ width: '100%', display: 'flex' }}
-        >
-          <Radio style={{ display: 'flex', flex: 1, justifyContent: 'center', paddingInline: 0 }} value="base" defaultChecked>Base stats</Radio>
-          <Radio style={{ display: 'flex', flex: 1, justifyContent: 'center', paddingInline: 0 }} value="combat">Combat stats</Radio>
-        </Radio.Group>
-      </Form.Item>
 
       {/*
       <Button type="primary" onClick={showDrawer}>

--- a/src/components/optimizerTab/Sidebar.jsx
+++ b/src/components/optimizerTab/Sidebar.jsx
@@ -1,4 +1,4 @@
-import { Button, Divider, Flex, Progress, Typography } from 'antd'
+import { Button, Divider, Flex, Progress, Radio, Typography } from 'antd'
 import React from 'react'
 import FormCard from 'components/optimizerTab/FormCard'
 import { HeaderText } from '../HeaderText'
@@ -35,6 +35,9 @@ PermutationDisplay.propTypes = {
 let defaultGap = 5
 
 export default function Sidebar() {
+  const statDisplay = window.store((s) => s.statDisplay)
+  const setStatDisplay = window.store((s) => s.setStatDisplay)
+
   const permutationDetails = window.store((s) => s.permutationDetails)
   const permutations = window.store((s) => s.permutations)
   const permutationsSearched = window.store((s) => s.permutationsSearched)
@@ -45,7 +48,7 @@ export default function Sidebar() {
   return (
     <Flex vertical style={{ overflow: 'clip' }}>
       <Flex style={{ position: 'sticky', top: '50%', transform: 'translateY(-50%)', paddingLeft: 10 }}>
-        <FormCard height={525}>
+        <FormCard height={600}>
           <Flex vertical gap={10}>
             <Flex justify="space-between" align="center">
               <HeaderText>Permutations</HeaderText>
@@ -80,7 +83,6 @@ export default function Sidebar() {
             <Flex justify="space-between" align="center">
               <HeaderText>Controls</HeaderText>
             </Flex>
-
             <Flex gap={defaultGap} style={{ marginBottom: 2 }} vertical>
               <Flex gap={defaultGap}>
                 <Button type="primary" loading={optimizationInProgress} onClick={window.optimizerStartClicked} style={{ width: '205px' }}>
@@ -98,6 +100,24 @@ export default function Sidebar() {
               <Flex gap={defaultGap}>
               </Flex>
             </Flex>
+
+            <Flex justify="space-between" align="center" style={{ }}>
+              <HeaderText>Stat display</HeaderText>
+              <TooltipImage type={Hint.statDisplay()} />
+            </Flex>
+            <Radio.Group
+              onChange={(e) => {
+                const { target: { value } } = e
+                setStatDisplay(value)
+              }}
+              optionType="button"
+              buttonStyle="solid"
+              value={statDisplay}
+              style={{ width: '100%', display: 'flex' }}
+            >
+              <Radio style={{ display: 'flex', flex: 1, justifyContent: 'center', paddingInline: 0 }} value="base" defaultChecked>Base stats</Radio>
+              <Radio style={{ display: 'flex', flex: 1, justifyContent: 'center', paddingInline: 0 }} value="combat">Combat stats</Radio>
+            </Radio.Group>
 
             <Flex justify="space-between" align="center">
               <HeaderText>Results</HeaderText>

--- a/src/components/optimizerTab/Sidebar.jsx
+++ b/src/components/optimizerTab/Sidebar.jsx
@@ -6,6 +6,7 @@ import { TooltipImage } from '../TooltipImage'
 import { OptimizerTabController } from 'lib/optimizerTabController'
 import { Hint } from 'lib/hint'
 import PropTypes from 'prop-types'
+import { ThunderboltFilled } from '@ant-design/icons'
 
 const { Text } = Typography
 
@@ -85,8 +86,8 @@ export default function Sidebar() {
             </Flex>
             <Flex gap={defaultGap} style={{ marginBottom: 2 }} vertical>
               <Flex gap={defaultGap}>
-                <Button type="primary" loading={optimizationInProgress} onClick={window.optimizerStartClicked} style={{ width: '205px' }}>
-                  Start
+                <Button icon={<ThunderboltFilled />} type="primary" loading={optimizationInProgress} onClick={window.optimizerStartClicked} style={{ width: '205px' }}>
+                  Start optimizer
                 </Button>
               </Flex>
               <Flex gap={defaultGap}>

--- a/src/components/optimizerTab/TeammateCard.tsx
+++ b/src/components/optimizerTab/TeammateCard.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import FormCard from 'components/optimizerTab/FormCard.js'
-import { PlusCircleOutlined } from '@ant-design/icons'
+import { PlusCircleOutlined, SyncOutlined } from '@ant-design/icons'
 import { Button, Flex, Form, Image, Select, SelectProps, Typography } from 'antd'
 import { Utils } from 'lib/utils.js'
 import { Constants, eidolonOptions, Sets, superimpositionOptions } from 'lib/constants.ts'
@@ -141,7 +141,7 @@ const TeammateCard = (props: { index: number }) => {
   const characterOptions = useMemo(() => Utils.generateCharacterOptions(), [])
   const lightConeOptions = useMemo(() => Utils.generateLightConeOptions(), [])
 
-  useEffect(() => {
+  function updateTeammate() {
     if (!teammateCharacterId) {
       window.optimizerForm.setFieldValue([teammateProperty], getDefaultTeammateForm())
       return
@@ -178,7 +178,11 @@ const TeammateCard = (props: { index: number }) => {
     teammateValues.characterConditionals = Object.assign({}, characterConditionals.teammateDefaults(), teammateValues.characterConditionals)
 
     window.optimizerForm.setFieldValue([teammateProperty], teammateValues)
-  }, [teammateCharacterId, teammateEidolon, props.index])
+  }
+
+  useEffect(() => {
+    updateTeammate()
+  }, [teammateCharacterId, props.index])
 
   useEffect(() => {
     if (!teammateLightConeId) return
@@ -224,16 +228,22 @@ const TeammateCard = (props: { index: number }) => {
     <FormCard size="medium" height={cardHeight} style={{ overflow: 'auto' }}>
       <Flex vertical gap={5}>
         <Flex gap={5}>
-          <Form.Item name={[teammateProperty, `characterId`]}>
+          <Form.Item name={[teammateProperty, `characterId`]} style={{ flex: 1 }}>
             <Select
               showSearch
               filterOption={Utils.labelFilterOption}
-              style={{ width: 250 }}
               options={characterOptions}
               placeholder="Character"
               allowClear
             />
           </Form.Item>
+
+          <Button
+            icon={<SyncOutlined />}
+            style={{ width: 35 }}
+            disabled={disabled}
+            onClick={updateTeammate}
+          />
 
           <Form.Item name={[teammateProperty, `characterEidolon`]}>
             <Select

--- a/src/components/optimizerTab/constants.ts
+++ b/src/components/optimizerTab/constants.ts
@@ -70,6 +70,7 @@ export const gridOptions = {
   paginationPageSize: 500,
   paginationPageSizeSelector: [100, 500, 1000],
   cacheBlockSize: 500,
+  maxBlocksInCache: 1,
   suppressDragLeaveHidesColumns: true,
   suppressScrollOnNewData: true,
   suppressMultiSort: true,

--- a/src/lib/db.js
+++ b/src/lib/db.js
@@ -55,6 +55,7 @@ window.store = create((set) => ({
   scoringMetadataOverrides: {},
   statDisplay: 'base',
   optimizationInProgress: false,
+  optimizationId: undefined,
 
   permutationDetails: {
     Head: 0,
@@ -107,6 +108,7 @@ window.store = create((set) => ({
   setStatDisplay: (x) => set(() => ({ statDisplay: x })),
   setOptimizerMenuState: (x) => set(() => ({ optimizerMenuState: x })),
   setOptimizationInProgress: (x) => set(() => ({ optimizationInProgress: x })),
+  setOptimizationId: (x) => set(() => ({ optimizationId: x })),
 }))
 
 export const DB = {

--- a/src/lib/hint.jsx
+++ b/src/lib/hint.jsx
@@ -220,4 +220,17 @@ export const Hint = {
       ),
     }
   },
+
+  statDisplay: () => {
+    return {
+      title: 'Stat display',
+      content: (
+        <Flex vertical gap={10}>
+          <p>This allows for switching between viewing results as Base stats vs Combat stats. Stat filters will also be applied to the selected view.</p>
+          <p>Base stats - The stats as shown on the character's screen ingame, with no in-combat buffs applied.</p>
+          <p>Combat stats - The character's stats with all stat modifiers in combat included: ability buffs, character & light cone passives, teammates, conditional set effects, etc.</p>
+        </Flex>
+      ),
+    }
+  },
 }

--- a/src/lib/optimizerTabController.js
+++ b/src/lib/optimizerTabController.js
@@ -577,6 +577,7 @@ export const OptimizerTabController = {
 
   applyRowFilters: () => {
     let fieldValues = OptimizerTabController.getForm()
+    fieldValues.statDisplay = window.store.getState().statDisplay
     filterModel = fieldValues
     console.log('Apply filters to rows', fieldValues)
     OptimizerTabController.resetDataSource()


### PR DESCRIPTION
# Pull Request

## Description

A couple QOLs:

* Selecting a teammate will auto-load their eidolon/lc/s/sets now
* Added a sync button to re-load the teammate's data
* Fixed edit character modal not loading the right numbers
* Move stat display to the sidebar, small refactor of optimizer stuff to support this
* Cleaned up some more optimizer tab / grid / form rendering. Cut out a bunch of wasted rerenders of the form
* Added an icon to optimize button

## Related Issue

https://github.com/fribbels/hsr-optimizer/issues/107

https://github.com/fribbels/hsr-optimizer/issues/108

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots

![image](https://github.com/fribbels/hsr-optimizer/assets/7908525/0dc4392c-e086-4e4c-99da-e6e6594bfe76)

![image](https://github.com/fribbels/hsr-optimizer/assets/7908525/0383e013-3412-4467-80dc-66e07817fa58)

