### PR TITLE
Weight mainstat free roll

### DIFF
--- a/src/lib/relicScorer.ts
+++ b/src/lib/relicScorer.ts
@@ -182,7 +182,7 @@ export const RelicScorer = {
     }
 
     if (relic.part == Constants.Parts.Body || relic.part == Constants.Parts.Feet || relic.part == Constants.Parts.PlanarSphere || relic.part == Constants.Parts.LinkRope) {
-      sum += mainStatFreeRolls[relic.part][relic.main.stat] * minRollValue
+      sum += mainStatFreeRolls[relic.part][relic.main.stat] * minRollValue * multipliers[relic.main.stat]
     }
 
     let rating = 'F'

--- a/src/lib/relicScorer.ts
+++ b/src/lib/relicScorer.ts
@@ -174,11 +174,7 @@ export const RelicScorer = {
 
     let sum = 0
     for (const substat of relic.substats) {
-      substat.scoreMeta = {
-        multiplier: (multipliers[substat.stat] || 0),
-        score: substat.value * (multipliers[substat.stat] || 0) * scaling[substat.stat],
-      }
-      sum += substat.scoreMeta.score
+      sum += substat.value * (multipliers[substat.stat] || 0) * scaling[substat.stat]
     }
 
     if (relic.part == Constants.Parts.Body || relic.part == Constants.Parts.Feet || relic.part == Constants.Parts.PlanarSphere || relic.part == Constants.Parts.LinkRope) {

--- a/src/types/Relic.d.ts
+++ b/src/types/Relic.d.ts
@@ -30,9 +30,5 @@ export type Relic = {
   substats: [{
     stat: SubStats
     value: number
-    scoreMeta: {
-      multiplier: number
-      score: number
-    }
   }]
 }


### PR DESCRIPTION
# Pull Request

## Description
Previously the free roll given to mainstats were unweighted, which gives false weight to useless mainstats. E.g. a relic with healing boost on argenti would have a nonzero total weight. 

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->
https://discord.com/channels/800607517074784256/1177491834369474570/1208161718014967890

## Type of Changes

### Added
<!-- Please describe the additions made in this pull request. -->

### Changed
<!-- Please describe the changes made in this pull request. -->
 - added weighting to the mainstat free roll
 - removed a useless field from relics to try and make them more read-only and less mutable

### Fixed
<!-- Please describe the fixes made in this pull request. -->

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->
Fake relics, filtered for Argenti (all stats on the body are 0 value on argenti)

Before:
![image](https://github.com/fribbels/hsr-optimizer/assets/1050652/7ceddfe5-b957-4ad8-a6b1-2263647a461a)

After:
![image](https://github.com/fribbels/hsr-optimizer/assets/1050652/b4bf18c1-5bfe-4f3a-97f6-930618a94b16)


## Additional Notes
<!-- Add any additional notes or context about the pull request here. -->
