### PR TITLE
Bugfix: Ashblazing FUA bonus calculation

### DIFF
--- a/src/lib/conditionals/utils.ts
+++ b/src/lib/conditionals/utils.ts
@@ -13,8 +13,8 @@ export const calculateAshblazingSet = (c, request, hitMulti): {
 } => {
   const enabled = p4(c.sets.TheAshblazingGrandDuke)
   const valueTheAshblazingGrandDuke = request.setConditionals[Constants.Sets.TheAshblazingGrandDuke][1]
-  const ashblazingAtk = 0.06 * valueTheAshblazingGrandDuke * enabled * c.baseAtk * enabled
-  const ashblazingMulti = hitMulti * enabled * c.baseAtk
+  const ashblazingAtk = 0.06 * valueTheAshblazingGrandDuke * enabled * request.baseAtk * enabled
+  const ashblazingMulti = hitMulti * enabled * request.baseAtk
 
   return {
     ashblazingMulti,


### PR DESCRIPTION
# Pull Request

## Description
Fix calculation of ashblazingAtk and ashblazingMulti via getting the baseAtk from request instead of c.


## Type of Changes

### Fixed
- Fixed getting baseAtk from request instead of c.

## Checklist
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots

Before fix:
![image](https://github.com/fribbels/hsr-optimizer/assets/12674637/8e421749-291f-4c88-91b7-facaf8ec3a01)

After fix:
![image](https://github.com/fribbels/hsr-optimizer/assets/12674637/33f43e6b-3be6-487c-848b-4d75ed2d91e8)
