### PR TITLE
Changing relic scorer buttons

### DIFF
--- a/src/components/RelicScorerTab.jsx
+++ b/src/components/RelicScorerTab.jsx
@@ -258,15 +258,15 @@ function CharacterPreviewSelection(props) {
   return (
     <Flex vertical align="center" gap={5} style={{ marginBottom: 100, width: 1022 }}>
       <Flex gap={10} style={{ display: (props.availableCharacters.length > 0) ? 'flex' : 'none' }}>
-        <Button icon={<ExperimentOutlined />} onClick={simulateClicked} style={{ width: 280 }}>
-          Simulate relics on another character
+        <Button icon={<ImportOutlined />} onClick={importClicked} style={{ width: 240 }}>
+          Import all relics into optimizer
         </Button>
         <Button onClick={clipboardClicked} style={{ width: 200 }} icon={<CameraOutlined />} loading={screenshotLoading}>
           Copy screenshot
         </Button>
         <Button style={{ width: 40 }} icon={<DownloadOutlined />} onClick={downloadClicked} loading={downloadLoading} />
-        <Button icon={<ImportOutlined />} onClick={importClicked} style={{ width: 230 }}>
-          Import relics into optimizer
+        <Button icon={<ExperimentOutlined />} onClick={simulateClicked} style={{ width: 280 }}>
+          Simulate relics on another character
         </Button>
       </Flex>
 


### PR DESCRIPTION
# Pull Request

## Description
Changing relic scorer buttons order to reflect the old ordering.

## Type of Changes

### Added
- Added `all` to the `import all relics into optimizer` button.

### Changed
- Inverted the `Import all relics into optimizer` and new `Simulate relics on another character` buttons in relic scorer tab.

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots

Live:
![image](https://github.com/fribbels/hsr-optimizer/assets/12674637/722948bf-1579-4724-b771-bd5c870e995e)

Beta (changed the button orders):
![image](https://github.com/fribbels/hsr-optimizer/assets/12674637/149f5977-aec7-4faf-8b81-dd0ef0d093b4)

After this change:
![image](https://github.com/fribbels/hsr-optimizer/assets/12674637/a590bab9-a46e-4947-a645-804aae3cdcd1)

## Additional Notes
Maybe on a near future when we add more buttons to this menu, we could do the `More Options` menu just like the character options tab to avoid too much buttons on a single view.

![image](https://github.com/fribbels/hsr-optimizer/assets/12674637/4b84ec86-3d3d-44d6-8176-2d7a9c1a5cad)
