### PR TITLE
feat: scorer simulate character sidebar

### DIFF
--- a/src/lib/dataParser.js
+++ b/src/lib/dataParser.js
@@ -951,7 +951,7 @@ function getOverrideImageCenter() {
     },
     1308: { // Acheron
       x: 1000,
-      y: 1000,
+      y: 960,
     },
     1312: { // Misha
       x: 1050,

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -55,7 +55,7 @@ export const Utils = {
           await navigator.clipboard.write(data)
           Message.success('Copied screenshot to clipboard')
         } catch (e) {
-          Message.error('Unable to save screenshot to clipboard, try downloading the screenshot instead')
+          Message.error('Unable to save screenshot to clipboard, try the download button to the right')
         }
       }
 


### PR DESCRIPTION
# Pull Request

## Description
<!-- Please provide a brief description of the changes made in this pull request. -->

* Adding a scoring character selector sidebar dropdown with unreleased characters
* Clicking it simulates their E0S1, otherwise there's a + for customizing
* Removed the simulate button in favor of the sidebar

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

![image](https://github.com/fribbels/hsr-optimizer/assets/7908525/76d938b6-8116-49dd-8f72-469e0a134f8c)

![image](https://github.com/fribbels/hsr-optimizer/assets/7908525/f0709b99-8faf-40ef-bbaf-85b9ae90a9f0)


