### PR TITLE
hotfix: S0 light cone imports from scanner

### DIFF
--- a/src/components/optimizerTab/TeammateCard.tsx
+++ b/src/components/optimizerTab/TeammateCard.tsx
@@ -161,7 +161,7 @@ const TeammateCard = (props: { index: number }) => {
     if (teammateCharacter) {
       // Fill out fields based on the teammate's form
       teammateValues.lightCone = teammateCharacter.form.lightCone
-      teammateValues.lightConeSuperimposition = teammateCharacter.form.lightConeSuperimposition
+      teammateValues.lightConeSuperimposition = teammateCharacter.form.lightConeSuperimposition || 1
       teammateValues.characterEidolon = teammateCharacter.form.characterEidolon
 
       const activeTeammateSets = calculateTeammateSets(teammateCharacter)

--- a/src/lib/ocrParserKelz3.js
+++ b/src/lib/ocrParserKelz3.js
@@ -167,11 +167,11 @@ function readCharacter(character, lightCone) {
 
   // Set information
   newCharacter.characterId = characterId
-  newCharacter.characterLevel = character.level
-  newCharacter.characterEidolon = character.eidolon
+  newCharacter.characterLevel = character.level || 80
+  newCharacter.characterEidolon = character.eidolon || 0
   newCharacter.lightCone = lightConeId
-  newCharacter.lightConeLevel = lightCone?.level || 0
-  newCharacter.lightConeSuperimposition = lightCone?.superimposition || 0
+  newCharacter.lightConeLevel = lightCone?.level || 80
+  newCharacter.lightConeSuperimposition = lightCone?.superimposition || 1
 
   return newCharacter
 }


### PR DESCRIPTION
# Pull Request

## Description

* 2.0 broke the kelz scanner for S levels and equipped
* Hotfix the S0 light cone imports, default to S1 and level 80s

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.
