### PR TITLE
Updated default max energy stacks for Today is Another Peaceful Day lightcone

### DIFF
--- a/src/components/OptimizerForm.jsx
+++ b/src/components/OptimizerForm.jsx
@@ -93,8 +93,13 @@ export default function OptimizerForm() {
     Object.assign(defaults, lightConeForm)
     console.log('useMemo lcFn.defaults()', defaults, lcFn.defaults(), lightConeForm)
     console.log(lcFn.defaults.valueOf())
-    optimizerForm.setFieldValue('lightConeConditionals', lcFn.defaults())
-  }, [lightCone, lightConeSuperimposition])
+
+    if (lightCone === '21034') { // Today Is Another Peaceful Day
+      defaults.maxEnergyStacks = Math.min(160, DB.getMetadata().characters[optimizerTabFocusCharacter].max_sp)
+    }
+
+    optimizerForm.setFieldValue('lightConeConditionals', defaults)
+  }, [optimizerTabFocusCharacter, lightCone, lightConeSuperimposition])
 
   const initialCharacter = useMemo(() => {
     console.log('@initialCharacter')


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Updated default max energy stacks for Today is Another Peaceful Day lightcone depending on the selected character.

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* Closes #11 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

![hsr-11](https://github.com/fribbels/hsr-optimizer/assets/37397745/f250c841-22e4-436f-b195-971677380b9a)

