### PR TITLE
feat: add enemy def values to enemy level selector

### DIFF
--- a/src/components/OptimizerForm.jsx
+++ b/src/components/OptimizerForm.jsx
@@ -475,6 +475,8 @@ export default function OptimizerForm() {
                       filterOption={Utils.labelFilterOption}
                       style={{ width: (panelWidth - defaultGap) / 2 }}
                       options={enemyLevelOptions}
+                      optionLabelProp="number"
+                      popupMatchSelectWidth={160}
                     />
                   </Form.Item>
                   <Form.Item size="default" name="enemyCount">

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -254,11 +254,12 @@ export const levelOptions = (() => {
 })()
 
 export const enemyLevelOptions = (() => {
-  const levelStats: { value: number; label: string }[] = []
+  const levelStats: { value: number; label: string; number: string }[] = []
   for (let i = 95; i >= 1; i--) {
     levelStats.push({
       value: i,
-      label: `Lv. ${i}`,
+      label: `Lv. ${i} - ${200 + 10 * i} DEF`,
+      number: `Lv. ${i}`,
     })
   }
 


### PR DESCRIPTION
# Pull Request

## Description
Adds enemy DEF values to the Enemy Level selector, while keeping the simplified enemy levels only when the dropdown is not displayed.

## Related Issue
Adds #182. 

## Checklist
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<img width="198" alt="image" src="https://github.com/fribbels/hsr-optimizer/assets/8635193/e9d08740-1735-4ca9-8f35-52c35d07a58d">
