### PR TITLE
fix: routing fragments, preset speed decimals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,8 @@ jobs:
       - name: Find and Replace router path
         uses: jacobtomlinson/gha-find-replace@v3
         with:
-          find: "const BASE_PATH = '/hsr-optimizer'"
-          replace: "const BASE_PATH = '/dreary-quibbles'"
+          find: "const BASE_PATH = '/hsr-optimizer/'"
+          replace: "const BASE_PATH = '/dreary-quibbles/'"
           include: "src/lib/db.js"
       - name: Find and Replace API endpoint
         uses: jacobtomlinson/gha-find-replace@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,8 @@ jobs:
       - name: Find and Replace router path
         uses: jacobtomlinson/gha-find-replace@v3
         with:
-          find: "const BASE_PATH = '/hsr-optimizer/'"
-          replace: "const BASE_PATH = '/dreary-quibbles/'"
+          find: "const BASE_PATH = '/hsr-optimizer'"
+          replace: "const BASE_PATH = '/dreary-quibbles'"
           include: "src/lib/db.js"
       - name: Find and Replace API endpoint
         uses: jacobtomlinson/gha-find-replace@v3

--- a/src/components/optimizerTab/optimizerForm/OptimizerTabCharacterPanel.tsx
+++ b/src/components/optimizerTab/optimizerForm/OptimizerTabCharacterPanel.tsx
@@ -1,4 +1,3 @@
-import { Image } from 'antd'
 import { Assets } from 'lib/assets.js'
 
 const parentW = 233
@@ -10,9 +9,8 @@ export const OptimizerTabCharacterPanel = () => {
   const optimizerTabFocusCharacter = window.store((s) => s.optimizerTabFocusCharacter)
 
   return (
-    <div style={{ width: `${parentW}px`, height: `${parentH}px`, borderRadius: '10px' }}>
-      <Image
-        preview={false}
+    <div style={{ width: `${parentW}px`, height: `${parentH}px`, borderRadius: '10px', position: 'relative' }}>
+      <img
         width={innerW}
         src={Assets.getCharacterPreviewById(optimizerTabFocusCharacter)}
         style={{ transform: `translate(${(innerW - parentW) / 2 / innerW * -100}%, ${(innerH - parentH) / 2 / innerH * -100}%)` }}
@@ -20,3 +18,9 @@ export const OptimizerTabCharacterPanel = () => {
     </div>
   )
 }
+// TODO: I don't really like the way the light cone icon looks on top of the character portrait
+// <img
+//   width={100}
+//   src={Assets.getLightConeIconById(optimizerFormSelectedLightCone)}
+//   style={{ position: 'absolute', top: 235, left: 120 }}
+// />

--- a/src/components/optimizerTab/optimizerForm/RecommendedPresetsButton.tsx
+++ b/src/components/optimizerTab/optimizerForm/RecommendedPresetsButton.tsx
@@ -29,13 +29,13 @@ const SpdValues = {
   },
   SPD111: {
     key: 'SPD111',
-    label: '111.11 SPD - 5 actions in first four cycles',
-    value: 111.11,
+    label: '111.12 SPD - 5 actions in first four cycles',
+    value: 111.12,
   },
   SPD114: {
     key: 'SPD114',
-    label: '114.28 SPD - 4 actions in first three cycles',
-    value: 114.28,
+    label: '114.29 SPD - 4 actions in first three cycles',
+    value: 114.29,
   },
   SPD120: {
     key: 'SPD120',
@@ -44,18 +44,18 @@ const SpdValues = {
   },
   SPD133: {
     key: 'SPD133',
-    label: (<b>133.33 SPD - 2 actions in first cycle, 6 actions in first four cycles</b>),
-    value: 133.33,
+    label: (<b>133.34 SPD - 2 actions in first cycle, 6 actions in first four cycles</b>),
+    value: 133.34,
   },
   SPD142: {
     key: 'SPD142',
-    label: '142.85 SPD - 5 actions in first three cycles',
-    value: 142.85,
+    label: '142.86 SPD - 5 actions in first three cycles',
+    value: 142.86,
   },
   SPD155: {
     key: 'SPD155',
-    label: '155.55 SPD - 7 actions in first four cycles',
-    value: 155.55,
+    label: '155.56 SPD - 7 actions in first four cycles',
+    value: 155.56,
   },
   SPD160: {
     key: 'SPD160',
@@ -64,13 +64,13 @@ const SpdValues = {
   },
   SPD171: {
     key: 'SPD171',
-    label: '171.42 SPD - 6 actions in first three cycles',
-    value: 171.42,
+    label: '171.43 SPD - 6 actions in first three cycles',
+    value: 171.43,
   },
   SPD177: {
     key: 'SPD177',
-    label: '177.77 SPD - 8 actions in first four cycles',
-    value: 177.77,
+    label: '177.78 SPD - 8 actions in first four cycles',
+    value: 177.78,
   },
   SPD200: {
     key: 'SPD200',

--- a/src/lib/db.js
+++ b/src/lib/db.js
@@ -61,7 +61,7 @@ window.store = create((set) => ({
   characterTabFocusCharacter: undefined,
   scoringAlgorithmFocusCharacter: undefined,
 
-  activeKey: RouteToPage[window.location.pathname] ? RouteToPage[window.location.pathname + window.location.hash] : AppPages.OPTIMIZER,
+  activeKey: RouteToPage[Utils.stripTrailingSlashes(window.location.pathname)] ? RouteToPage[Utils.stripTrailingSlashes(window.location.pathname) + window.location.hash] : AppPages.OPTIMIZER,
   characters: [],
   charactersById: {},
   characterTabBlur: false,

--- a/src/lib/db.js
+++ b/src/lib/db.js
@@ -18,8 +18,8 @@ const state = {
   scorerId: undefined,
 }
 
-// This string is replaced by /dreary-quibbles/ by github actions, don't change
-const BASE_PATH = '/hsr-optimizer/'
+// This string is replaced by /dreary-quibbles by github actions, don't change
+const BASE_PATH = '/hsr-optimizer'
 
 export const AppPages = {
   OPTIMIZER: 'OPTIMIZER',

--- a/src/lib/db.js
+++ b/src/lib/db.js
@@ -18,8 +18,8 @@ const state = {
   scorerId: undefined,
 }
 
-// This string is replaced by /dreary-quibbles by github actions, don't change
-const BASE_PATH = '/hsr-optimizer'
+// This string is replaced by /dreary-quibbles/ by github actions, don't change
+const BASE_PATH = '/hsr-optimizer/'
 
 export const AppPages = {
   OPTIMIZER: 'OPTIMIZER',

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -231,4 +231,9 @@ export const Utils = {
   getCharacterNameById: (id) => {
     return DB.getMetadata().characters[id]?.displayName
   },
+
+  // hsr-optimizer// => hsr-optimizer
+  stripTrailingSlashes: (str) => {
+    return str.replace(/\/+$/, '')
+  },
 }


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Fragment routing has been broken, so hsr-optimizer#scorer redirects back to the homepage. Attempt to fix
* Round up to 100th on speed decimal for preset breakpoint min spd filters

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

