### PR TITLE
fix: relic substat ordering

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -71,18 +71,18 @@ export const MainStatsValues = {
 }
 
 export const SubStats = [
-  Stats.ATK_P,
-  Stats.ATK,
-  Stats.BE,
-  Stats.CD,
-  Stats.CR,
-  Stats.DEF_P,
-  Stats.DEF,
-  Stats.EHR,
   Stats.HP_P,
+  Stats.ATK_P,
+  Stats.DEF_P,
   Stats.HP,
-  Stats.RES,
+  Stats.ATK,
+  Stats.DEF,
   Stats.SPD,
+  Stats.CR,
+  Stats.CD,
+  Stats.EHR,
+  Stats.BE,
+  Stats.RES,
 ]
 export type SubStats = typeof SubStats[number]
 


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
Implemented the changes specified by Issue #181. Relic substat ordering in the filter menu change. This PR is under src/lib/constants.ts

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->


## Checklist
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
![image](https://github.com/fribbels/hsr-optimizer/assets/143555536/b14d3727-cc8b-411c-bafd-d299860eb8d6)



