### PR TITLE
Add optionFilterProp to use label prop in character exclude options

### DIFF
--- a/src/components/optimizerTab/optimizerForm/OptimizerOptionsDisplay.tsx
+++ b/src/components/optimizerTab/optimizerForm/OptimizerOptionsDisplay.tsx
@@ -123,6 +123,7 @@ const OptimizerOptionsDisplay = (): JSX.Element => {
                 placeholder="Exclude"
                 autoClearSearchValue
                 options={characterExcludeOptions}
+                optionFilterProp='label'
               />
             </Form.Item>
           </Flex>


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Added `optionFilterProp='label'` in character exclude select search to use the label for the character instead of the value.

## Related Issue

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
Live beta now:

![image](https://github.com/fribbels/hsr-optimizer/assets/12674637/b9729fd6-2f05-47b8-aa20-0b29c7bb751f)

because it was only filtering by the id value:
![image](https://github.com/fribbels/hsr-optimizer/assets/12674637/a76d4be7-292b-42ca-838f-c79d11f6b6fb)


After this fix it changes to be the character name:
![image](https://github.com/fribbels/hsr-optimizer/assets/12674637/639f3455-9471-4ec1-be26-9f245ba0e462)



