### PR TITLE
feature: enable mobile/safari scorer image download

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "btoa": "^1.2.1",
         "fast-sort": "^3.4.0",
         "html-to-image": "^1.11.11",
+        "modern-screenshot": "^4.4.38",
         "object-hash": "^3.0.0",
         "path": "^0.12.7",
         "plotly.js": "^2.29.1",
@@ -8446,6 +8447,11 @@
         "pkg-types": "^1.0.3",
         "ufo": "^1.3.2"
       }
+    },
+    "node_modules/modern-screenshot": {
+      "version": "4.4.38",
+      "resolved": "https://registry.npmjs.org/modern-screenshot/-/modern-screenshot-4.4.38.tgz",
+      "integrity": "sha512-WeC3BuaJYjKvtXPSvSZRV5uvoJ4A1yrdb4mu1w5eLWkrONwD2mxYecRIJx3scf6/IwNl4zRh1SBrMibeJHMrYQ=="
     },
     "node_modules/mouse-change": {
       "version": "1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "antd": "^5.15.1",
         "btoa": "^1.2.1",
         "fast-sort": "^3.4.0",
-        "html-to-image": "^1.11.11",
         "modern-screenshot": "^4.4.38",
         "object-hash": "^3.0.0",
         "path": "^0.12.7",
@@ -7190,11 +7189,6 @@
       "engines": {
         "node": ">=18"
       }
-    },
-    "node_modules/html-to-image": {
-      "version": "1.11.11",
-      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.11.tgz",
-      "integrity": "sha512-9gux8QhvjRO/erSnDPv28noDZcPZmYE7e1vFsBLKLlRlKDSqNJYebj6Qz1TGd5lsRV+X+xYyjCKjuZdABinWjA=="
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "antd": "^5.15.1",
     "btoa": "^1.2.1",
     "fast-sort": "^3.4.0",
-    "html-to-image": "^1.11.11",
+    "modern-screenshot": "^4.4.38",
     "object-hash": "^3.0.0",
     "path": "^0.12.7",
     "plotly.js": "^2.29.1",

--- a/src/lib/db.js
+++ b/src/lib/db.js
@@ -560,6 +560,19 @@ export const DB = {
       }
     }
 
+    // Clean up characters who have relics equipped by someone else, or characters that dont exist ingame yet
+    for (let character of DB.getCharacters()) {
+      for (let part of Object.keys(character.equipped)) {
+        const relicId = character.equipped[part]
+        if (relicId) {
+          const relic = DB.getRelicById(relicId)
+          if (relic.equippedBy != character.id) {
+            character.equipped[part] = undefined
+          }
+        }
+      }
+    }
+
     DB.setRelics(replacementRelics)
     DB.setCharacters(characters)
 

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,4 +1,4 @@
-import { toBlob as htmlToBlob } from 'html-to-image'
+import { domToBlob as htmlToBlob } from 'modern-screenshot'
 import DB from './db'
 import { Constants } from './constants.ts'
 import { Message } from './message'
@@ -101,7 +101,10 @@ export const Utils = {
 
   // Util to capture a div and screenshot it to clipboard/file
   screenshotElementById: async (elementId, action, characterName) => {
-    return htmlToBlob(document.getElementById(elementId), { pixelRatio: 1.5 }).then(async (blob) => {
+    return htmlToBlob(document.getElementById(elementId), {
+      scale: 1.5,
+      drawImageInterval: 0,
+    }).then(async (blob) => {
       /*
        * Save to clipboard
        * This is not supported in firefox, possibly other browsers too


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Changed the img generation library
* Downloads now show images correctly on safari on desktop and mobile
* Fixed bug with character imports not clearing out unreleased characters

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* https://github.com/fribbels/hsr-optimizer/issues/208

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

