### PR TITLE
fix: inherit speed verified status from reliquary importer

### DIFF
--- a/src/lib/db.js
+++ b/src/lib/db.js
@@ -511,8 +511,10 @@ export const DB = {
       let stableRelicId
       if (found) {
         if (newRelic.verified) {
-          // Inherit the new verified status
+          // Inherit the new verified speed stats
           found.verified = true
+          found.substats = newRelic.substats
+          found.augmentedStats = newRelic.augmentedStats
         }
 
         if (newRelic.equippedBy && newCharacters) {

--- a/src/lib/db.js
+++ b/src/lib/db.js
@@ -510,6 +510,11 @@ export const DB = {
       let found = oldRelicHashes[hash]
       let stableRelicId
       if (found) {
+        if (newRelic.verified) {
+          // Inherit the new verified status
+          found.verified = true
+        }
+
         if (newRelic.equippedBy && newCharacters) {
           // Update the owner of the existing relic with the newly imported owner
           found.equippedBy = newRelic.equippedBy

--- a/src/lib/importer/importConfig.js
+++ b/src/lib/importer/importConfig.js
@@ -9,6 +9,7 @@ export const KelzScannerConfig = {
   sourceString: 'HSR-Scanner',
   latestBuildVersion: 'v0.6.2',
   latestOutputVersion: 3,
+  speedVerified: false,
 }
 
 export const ReliquaryArchiverConfig = {
@@ -20,6 +21,7 @@ export const ReliquaryArchiverConfig = {
   sourceString: 'reliquary_archiver',
   latestBuildVersion: 'v0.1.1',
   latestOutputVersion: 3,
+  speedVerified: true,
 }
 
 export const KelzScannerParser = new KelzFormatParser(KelzScannerConfig)

--- a/src/lib/importer/kelzFormatParser.jsx
+++ b/src/lib/importer/kelzFormatParser.jsx
@@ -60,7 +60,7 @@ export class KelzFormatParser { // TODO abstract class
 
     if (json.relics) {
       parsed.relics = json.relics
-        .map((r) => readRelic(r))
+        .map((r) => readRelic(r, parsed.metadata.trailblazer, this.config))
         .map((r) => RelicAugmenter.augment(r))
         .filter((r) => {
           if (!r) {
@@ -113,7 +113,7 @@ function readCharacter(character, lightCones, trailblazer) {
   }
 }
 
-function readRelic(relic, trailblazer) {
+function readRelic(relic, trailblazer, config) {
   let partMatches = stringSimilarity.findBestMatch(relic.slot, Object.values(Parts))
   let part = partMatches.bestMatch.target
 
@@ -143,6 +143,7 @@ function readRelic(relic, trailblazer) {
     main,
     substats,
     equippedBy,
+    verified: config.speedVerified,
   }
 }
 


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Because the reliquary archiver has accurate decimals, we have to specify that in the kelz format parser
* Unverified -> verified imports should now update correctly for reliquary import

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

