### PR TITLE
feat: sticky sidebar, hover stats to show 1000th decimals, fix pela e2 default off

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -59,13 +59,18 @@ const App = () => {
         <Sider
           width={170}
           style={{
-            overflow: 'auto',
-            // height: '100vh',
-            position: 'sticky',
-            top: 0,
+            background: '#243356',
           }}
         >
-          <MenuDrawer />
+          <div
+            style={{
+              position: 'sticky',
+              top: 0,
+              backgroundColor: '#243356',
+            }}
+          >
+            <MenuDrawer />
+          </div>
         </Sider>
         <Layout
           style={{

--- a/src/components/MenuDrawer.jsx
+++ b/src/components/MenuDrawer.jsx
@@ -86,9 +86,6 @@ const MenuDrawer = () => {
       onClick={onClick}
       // inlineIndent={15}
       style={{
-        height: '100%',
-        overflow: 'auto',
-
       }}
       defaultSelectedKeys={['1']}
       defaultOpenKeys={['subOptimizer', 'subTools', 'subLinks']}

--- a/src/components/characterPreview/StatRow.tsx
+++ b/src/components/characterPreview/StatRow.tsx
@@ -11,16 +11,23 @@ import StatText from 'components/characterPreview/StatText'
 const StatRow = (props: { stat: string; finalStats: any }): JSX.Element => {
   const { stat, finalStats } = props
   const readableStat = stat.replace('DMG Boost', 'DMG')
-  let value = finalStats[stat]
+  const value = finalStats[stat]
+
+  let valueDisplay
+  let value1000thsPrecision
 
   if (stat == 'CV') {
-    value = Utils.truncate10ths(value).toFixed(1)
+    valueDisplay = Utils.truncate10ths(value).toFixed(1)
+    value1000thsPrecision = Utils.truncate1000ths(value).toFixed(3)
   } else if (stat == Constants.Stats.SPD) {
-    value = Utils.truncate10ths(value).toFixed(1)
+    valueDisplay = Utils.truncate10ths(value).toFixed(1)
+    value1000thsPrecision = Utils.truncate1000ths(value).toFixed(3)
   } else if (Utils.isFlat(stat)) {
-    value = Math.floor(value)
+    valueDisplay = Math.floor(value)
+    value1000thsPrecision = Utils.truncate1000ths(value).toFixed(3)
   } else {
-    value = Utils.truncate10ths(value * 100).toFixed(1)
+    valueDisplay = Utils.truncate10ths(value * 100).toFixed(1)
+    value1000thsPrecision = Utils.truncate1000ths(value * 100).toFixed(3)
   }
 
   if (!finalStats) {
@@ -28,11 +35,11 @@ const StatRow = (props: { stat: string; finalStats: any }): JSX.Element => {
     return (<div></div>)
   }
   return (
-    <Flex justify="space-between" align="center">
+    <Flex justify="space-between" align="center" title={value1000thsPrecision}>
       <img src={Assets.getStatIcon(stat)} style={{ width: iconSize, height: iconSize, marginRight: 3 }} />
       <StatText>{readableStat}</StatText>
       <Divider style={{ margin: 'auto 10px', flexGrow: 1, width: 'unset', minWidth: 'unset' }} dashed />
-      <StatText>{`${value}${Utils.isFlat(stat) || stat == 'CV' ? '' : '%'}`}</StatText>
+      <StatText>{`${valueDisplay}${Utils.isFlat(stat) || stat == 'CV' ? '' : '%'}`}</StatText>
     </Flex>
   )
 }

--- a/src/lib/conditionals/character/Pela.ts
+++ b/src/lib/conditionals/character/Pela.ts
@@ -68,7 +68,7 @@ export default (e: Eidolon): CharacterConditional => {
     defaults: () => ({
       teamEhrBuff: true,
       enemyDebuffed: true,
-      skillRemovedBuff: true,
+      skillRemovedBuff: false,
       ultDefPenDebuff: true,
       e4SkillResShred: true,
     }),

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -156,6 +156,16 @@ export const Utils = {
     return Math.floor(x * 10) / 10
   },
 
+  // truncate100ths(16.1999999312682) == 16.99
+  truncate100ths: (x) => {
+    return Math.floor(x * 100) / 100
+  },
+
+  // truncate100ths(16.1999999312682) == 16.999
+  truncate1000ths: (x) => {
+    return Math.floor(x * 1000) / 1000
+  },
+
   // truncate10000ths(16.1999999312682) == 16.9999
   truncate10000ths: (x) => {
     return Math.floor(x * 10000) / 10000


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* QOLs
  * Pela E2 should be off by default
  * Show decimals to 1000ths on character tab
  * Make menu sidebar sticky

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* N/A

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

![image](https://github.com/fribbels/hsr-optimizer/assets/7908525/61dc229e-db75-4246-b4d4-bf0627768b4b)

![image](https://github.com/fribbels/hsr-optimizer/assets/7908525/ae77eee1-6531-4e70-82ae-314c6871ffca)

