### PR TITLE
fix: show correct mainstat options after reopening relic modal

### DIFF
--- a/src/components/RelicModal.jsx
+++ b/src/components/RelicModal.jsx
@@ -115,6 +115,7 @@ export default function RelicModal(props) {
     }
     setMainStatOptions(mainStatOptions || [])
     relicForm.setFieldValue('mainStatType', props.selectedRelic?.main?.stat)
+    onValuesChange(defaultValues)
   }, [props.selectedRelic?.part, props.selectedRelic?.main?.stat, relicForm])
 
   useEffect(() => {


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

#### Fixed a minor (and kinda unimportant :P) issue where the main stat options displayed when adding or editing a relic could be from a different part. 
**How to reproduce:**
- Add a new relic *or* edit a relic
- Choose a part with main stat options (i.e. `Body`, `Feet`, `PlanarSphere`, `LinkRope`)
- Close the editing window / modal
- Reopen the window
- Enjoy creating a `Head` relic with `Elemental Damage` main stat

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* None

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [ ] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->
![1_](https://github.com/fribbels/hsr-optimizer/assets/64530741/682234d8-d9b4-4cae-ada6-f5061105c3ba)
![2_](https://github.com/fribbels/hsr-optimizer/assets/64530741/fc1bf600-5fd4-414d-b611-b311606dc345)
![3_](https://github.com/fribbels/hsr-optimizer/assets/64530741/f181ec7a-81df-4269-b30d-b40c73381796)

