### PR TITLE
fix: set relic owner correctly on creation

### DIFF
--- a/src/components/RelicsTab.jsx
+++ b/src/components/RelicsTab.jsx
@@ -275,7 +275,15 @@ export default function RelicsTab() {
   }, [])
 
   function onAddOk(relic) {
+    // remove `equippedBy` as relic is not actually equipped yet
+    const equippedBy = relic.equippedBy
+    relic.equippedBy = undefined
     DB.setRelic(relic)
+    // prior removal is required because `equippedBy` will be swapped if the character already has
+    // a relic on the same part, resulting in the character "holding" two relics on the same part
+    DB.equipRelic(relic, equippedBy)
+    window.forceCharacterTabUpdate()
+
     setRelicRows(DB.getRelics())
     SaveState.save()
 

--- a/src/components/RelicsTab.jsx
+++ b/src/components/RelicsTab.jsx
@@ -275,15 +275,8 @@ export default function RelicsTab() {
   }, [])
 
   function onAddOk(relic) {
-    // remove `equippedBy` as relic is not actually equipped yet
-    const equippedBy = relic.equippedBy
-    relic.equippedBy = undefined
     DB.setRelic(relic)
-    // prior removal is required because `equippedBy` will be swapped if the character already has
-    // a relic on the same part, resulting in the character "holding" two relics on the same part
-    DB.equipRelic(relic, equippedBy)
     window.forceCharacterTabUpdate()
-
     setRelicRows(DB.getRelics())
     SaveState.save()
 

--- a/src/lib/relicModalController.ts
+++ b/src/lib/relicModalController.ts
@@ -9,12 +9,6 @@ export const RelicModalController = {
 
     const updatedRelic = { ...selectedRelic, ...relic }
 
-    if (updatedRelic.equippedBy) {
-      DB.equipRelic(updatedRelic, updatedRelic.equippedBy)
-    } else {
-      DB.unequipRelicById(updatedRelic.id)
-    }
-
     DB.setRelic(updatedRelic)
     window.setRelicRows(DB.getRelics())
     SaveState.save()


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Fixed assigning the owner of relic during creation, when relic is originally stored

However, I feel that this fix is rather suboptimal, no?
Would it not make more sense to move this kind of consistency work into `DB` itself?
On the other hand, refactoring `DB` (and also moving it to TS, see #44) seems like a lot of work for a (currently) small gain(?).
Although this is my naive view on these things ^^

Edit:

I have found two more issues (both being fixed):
#### 1. Changing the part of an equipped relic does not correctly assign the relic.
Reproduce:
- Add/import a character
- Add a relic to the character
- Go to the `Characters` screen (to visually see the issue)
- Edit the relic to be of a different part
- The relic should still be visually on the original part, but the score is shown on the new part (see first screenshot)

#### 2. Adding and assigning a relic does not correctly reassign an already equipped relic
Reproduce:
- Add/import a character
- Add a relic to the character
- Add another relic to the same character with the same part
- Relics page should show both (or even more) relics assigned to the character (see second screenshot)

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* Closes #184 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [ ] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->
![2024-04-05 15 59 57 fribbels github io 216ac1885fed](https://github.com/fribbels/hsr-optimizer/assets/64530741/aa7725bf-af92-43c3-80f6-106fc6d4ad0e)
![2024-04-05 16 09 16 fribbels github io 82d6d0237da4](https://github.com/fribbels/hsr-optimizer/assets/64530741/ad14dc79-82aa-455b-af1e-61707d3d3789)

