### PR TITLE
Toggle sidebar visibility and minor visual improvements

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
-import React from 'react'
-import { ConfigProvider, Flex, Layout, message, theme, Typography } from 'antd'
+import React, { useState } from 'react'
+import { CloseOutlined, MenuOutlined } from '@ant-design/icons'
+import { Button, ConfigProvider, Flex, Layout, message, theme, Typography } from 'antd'
 import MenuDrawer from 'components/MenuDrawer'
 import Tabs from 'components/Tabs'
 import { Assets } from 'lib/assets'
@@ -8,6 +9,7 @@ const { Header, Sider, Content } = Layout
 
 const App = () => {
   const [messageApi, messageContextHolder] = message.useMessage()
+  const [collapsed, setCollapsed] = useState(false)
   window.messageApi = messageApi
 
   return (
@@ -61,6 +63,10 @@ const App = () => {
           style={{
             background: '#243356',
           }}
+          collapsible
+          collapsedWidth={0}
+          collapsed={collapsed}
+          trigger={null}
         >
           <div
             style={{
@@ -88,17 +94,29 @@ const App = () => {
             }}
           >
             <Flex align="center" justify="space-between" style={{ width: '100%' }}>
-              <a href="/hsr-optimizer">
-                <Flex align="center">
-                  <img src={Assets.getLogo()} style={{ width: 30, height: 30, marginRight: 25 }}></img>
-                  <Typography
-                    style={{ fontWeight: 600, fontSize: 22 }}
-                    color="inherit"
-                  >
-                    Fribbels Honkai Star Rail Optimizer
-                  </Typography>
-                </Flex>
-              </a>
+              <Flex>
+                <Button
+                  type="text"
+                  icon={collapsed ? <MenuOutlined /> : <CloseOutlined />}
+                  onClick={() => setCollapsed(!collapsed)}
+                  style={{
+                    fontSize: '16px',
+                    position: 'relative',
+                    left: '-20px',
+                  }}
+                />
+                <a href="/hsr-optimizer">
+                  <Flex align="center">
+                    <img src={Assets.getLogo()} style={{ width: 30, height: 30, marginRight: 25 }}></img>
+                    <Typography
+                      style={{ fontWeight: 600, fontSize: 22 }}
+                      color="inherit"
+                    >
+                      Fribbels Honkai Star Rail Optimizer
+                    </Typography>
+                  </Flex>
+                </a>
+              </Flex>
               <Flex>
                 <a href="https://github.com/fribbels/hsr-optimizer" target="_blank" rel="noreferrer">
                   <Flex>

--- a/src/components/MenuDrawer.jsx
+++ b/src/components/MenuDrawer.jsx
@@ -1,5 +1,16 @@
 import React from 'react'
-import { MenuOutlined, StarFilled, UnorderedListOutlined } from '@ant-design/icons'
+import {
+  BarChartOutlined,
+  BarsOutlined,
+  BookOutlined,
+  LineChartOutlined,
+  RadarChartOutlined,
+  StarFilled,
+  ToolOutlined,
+  UnorderedListOutlined,
+  UploadOutlined,
+  UserOutlined,
+} from '@ant-design/icons'
 import { Flex, Menu, Typography } from 'antd'
 import { DiscordIcon } from 'icons/DiscordIcon'
 import { GithubIcon } from 'icons/GithubIcon'
@@ -16,20 +27,60 @@ function getItem(label, key, icon, children, type) {
   }
 }
 const items = [
-  getItem('Menu', 'subOptimizer', <MenuOutlined />, [
-    getItem('Optimizer', AppPages.OPTIMIZER),
-    getItem('Characters', AppPages.CHARACTERS),
-    getItem('Relics', AppPages.RELICS),
-    getItem('Import / Save', AppPages.IMPORT),
-    getItem('Getting started', AppPages.GETTING_STARTED),
+  getItem('Menu', 'subOptimizer', <LineChartOutlined />, [
+    getItem(
+      (
+        <Flex>
+          <BarChartOutlined style={{ marginRight: 5, width: 16 }} />
+          {' '}
+          Optimizer
+        </Flex>
+      ),
+      AppPages.OPTIMIZER),
+    getItem(
+      (
+        <Flex>
+          <UserOutlined style={{ marginRight: 5, width: 16 }} />
+          {' '}
+          Characters
+        </Flex>
+      ),
+      AppPages.CHARACTERS),
+    getItem(
+      (
+        <Flex>
+          <RadarChartOutlined style={{ marginRight: 5, width: 16 }} />
+          {' '}
+          Relics
+        </Flex>
+      ),
+      AppPages.RELICS),
+    getItem(
+      (
+        <Flex>
+          <UploadOutlined style={{ marginRight: 5, width: 16 }} />
+          {' '}
+          Import / Save
+        </Flex>
+      ),
+      AppPages.IMPORT),
+    getItem(
+      (
+        <Flex>
+          <BookOutlined style={{ marginRight: 5, width: 16 }} />
+          {' '}
+          Get Started
+        </Flex>
+      ),
+      AppPages.GETTING_STARTED),
   ]),
-  getItem('Tools', 'subTools', <MenuOutlined />, [
+  getItem('Tools', 'subTools', <ToolOutlined />, [
     getItem(
       (
         <Flex>
           <StarFilled style={{ marginRight: 5, width: 16 }} />
           {' '}
-          Relic scorer
+          Relic Scorer
         </Flex>
       ),
       AppPages.RELIC_SCORER),
@@ -43,7 +94,7 @@ const items = [
       ),
       AppPages.CHANGELOG),
   ]),
-  getItem('Links', 'subLinks', <MenuOutlined />, [
+  getItem('Links', 'subLinks', <BarsOutlined />, [
     getItem(
       <Typography.Link href="https://discord.gg/rDmB4Un7qg" target="_blank" rel="noopener noreferrer">
         <DiscordIcon style={{ marginRight: 5 }} />

--- a/tests/RelicModal/3-edit-from-relics-tab.spec.ts
+++ b/tests/RelicModal/3-edit-from-relics-tab.spec.ts
@@ -3,13 +3,13 @@ import { expect, test } from '@playwright/test'
 test('Open RelicModal in edit mode from the CharacterPreview tab', async ({ page }) => {
   // navigate to Relics tab
   await page.goto('/#scorer')
-  await page.getByRole('menuitem', { name: 'Getting started' }).click()
+  await page.getByRole('menuitem', { name: 'Get Started' }).click()
   await page.getByRole('button', { name: 'Try it out!' }).click()
   await page.getByRole('button', { name: 'Yes' }).click()
   await expect(page.locator('body')).toContainText('Successfully loaded data')
 
   // got relics tab
-  await page.getByRole('menuitem', { name: 'Relics' }).locator('span').click()
+  await page.getByRole('menuitem', { name: 'Relics' }).click()
   await page.getByRole('row', { name: 'Hunter of Glacial Forest Head 15 HP 705 11.0 10.3 3.4 5.1 32.4' }).click()
   await page.getByText('+15HP705CRIT Rate11.0%CRIT').click()
 

--- a/tests/RelicsTab/add-new-relic.spec.ts
+++ b/tests/RelicsTab/add-new-relic.spec.ts
@@ -2,13 +2,13 @@ import { expect, test } from '@playwright/test'
 
 test('Add new relic from RelicsTab', async ({ page }) => {
   await page.goto('/#scorer')
-  await page.getByRole('menuitem', { name: 'Getting started' }).click()
+  await page.getByRole('menuitem', { name: 'Get Started' }).click()
   await page.getByRole('button', { name: 'Try it out!' }).click()
   await page.getByRole('button', { name: 'Yes' }).click()
   await expect(page.locator('body')).toContainText('Successfully loaded data')
 
   // nav to RelicsTab
-  await page.getByRole('menuitem', { name: 'Relics' }).locator('span').click()
+  await page.getByRole('menuitem', { name: 'Relics' }).click()
   await expect(page.getByRole('main')).toContainText('Add New Relic')
   await page.getByRole('button', { name: 'Add New Relic' }).click()
 

--- a/tests/RelicsTab/delete-relic.spec.ts
+++ b/tests/RelicsTab/delete-relic.spec.ts
@@ -2,13 +2,13 @@ import { expect, test } from '@playwright/test'
 
 test('Delete relic from RelicsTab', async ({ page }) => {
   await page.goto('/#scorer')
-  await page.getByRole('menuitem', { name: 'Getting started' }).click()
+  await page.getByRole('menuitem', { name: 'Get Started' }).click()
   await page.getByRole('button', { name: 'Try it out!' }).click()
   await page.getByRole('button', { name: 'Yes' }).click()
   await expect(page.locator('body')).toContainText('Successfully loaded data')
 
   // nav to RelicsTab
-  await page.getByRole('menuitem', { name: 'Relics' }).locator('span').click()
+  await page.getByRole('menuitem', { name: 'Relics' }).click()
   await page.getByRole('row', { name: 'Hunter of Glacial Forest Head 15 HP 705 11.0 10.3 3.4 5.1 32.4' }).click()
   await page.getByRole('button', { name: 'Delete Relic' }).click()
   await page.getByRole('button', { name: 'Yes' }).click()

--- a/tests/TabRender/tab-render.ts
+++ b/tests/TabRender/tab-render.ts
@@ -28,12 +28,12 @@ test('Tab render happy-path', async ({ page }) => {
   await expect(page.locator('#rc-tabs-0-tab-4')).toContainText('Clear optimizer data')
 
   // Getting Started
-  await page.getByRole('menuitem', { name: 'Getting started' }).click()
+  await page.getByRole('menuitem', { name: 'Get Started' }).click()
   await page.getByRole('heading', { name: 'Try it out!' }).click()
   await expect(page.getByRole('main')).toContainText('Importing')
 
   // RelicScorer
-  await page.getByRole('menuitem', { name: 'Relic scorer' }).click()
+  await page.getByRole('menuitem', { name: 'Relic Scorer' }).click()
   await expect(page.getByRole('main')).toContainText('Account ID:')
 
   // Coming soon

--- a/tests/global.setup.ts
+++ b/tests/global.setup.ts
@@ -4,7 +4,7 @@ import { STORAGE_STATE } from '../playwright.config'
 setup('HSR Optimizer loading test data', async ({ page }) => {
   await page.goto('http://localhost:3000/hsr-optimizer#scorer')
   await expect(page.getByRole('banner')).toContainText('Fribbels Honkai Star Rail Optimizer')
-  await page.getByRole('menuitem', { name: 'Getting started' }).click()
+  await page.getByRole('menuitem', { name: 'Get Started' }).click()
   await page.getByRole('button', { name: 'Try it out!' }).click()
   await page.getByRole('button', { name: 'Yes' }).click()
   await expect(page.locator('body')).toContainText('Successfully loaded data')


### PR DESCRIPTION
# Pull Request


## Description
- Adds ability to toggle left sidebar open and closed to save screen space
- Adds new icons for the top submenu
- Change subheadings to PascalCase

## Related Issue
Adds #274.

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
Menu, set to be opened on default, with new icons:
<img width="218" alt="image" src="https://github.com/fribbels/hsr-optimizer/assets/8635193/d99582d0-38c3-4f2f-86c8-11e435c031dd">

Closed menu:
<img width="274" alt="image" src="https://github.com/fribbels/hsr-optimizer/assets/8635193/0e2c1406-59f7-4673-91c1-eeff6002d9e0">
