### PR TITLE
feat(#243): add 1000th decimal display for certain speeds

### DIFF
--- a/src/components/characterPreview/StatRow.tsx
+++ b/src/components/characterPreview/StatRow.tsx
@@ -8,6 +8,22 @@ import { Utils } from 'lib/utils'
 
 import StatText from 'components/characterPreview/StatText'
 
+const checkSpeedInBreakpoint = (speedValue: number) : boolean => {
+  const breakpointPresets = [
+    [111.1, 111.2],
+    [114.2, 114.3],
+    [133.3, 133.4],
+    [142.8, 142.9],
+    [155.5, 155.6],
+    [171.4, 171.5],
+    [177.7, 177.8]
+  ]
+
+  return breakpointPresets.some(([min, max]) => {
+    return speedValue >= min && speedValue < max;
+  });
+}
+
 const StatRow = (props: { stat: string; finalStats: any }): JSX.Element => {
   const { stat, finalStats } = props
   const readableStat = stat.replace('DMG Boost', 'DMG')
@@ -20,7 +36,8 @@ const StatRow = (props: { stat: string; finalStats: any }): JSX.Element => {
     valueDisplay = Utils.truncate10ths(value).toFixed(1)
     value1000thsPrecision = Utils.truncate1000ths(value).toFixed(3)
   } else if (stat == Constants.Stats.SPD) {
-    valueDisplay = Utils.truncate10ths(value).toFixed(1)
+    const is1000thSpeed = checkSpeedInBreakpoint(value)
+    valueDisplay = is1000thSpeed ? Utils.truncate1000ths(value).toFixed(3) : valueDisplay = Utils.truncate10ths(value).toFixed(1)
     value1000thsPrecision = Utils.truncate1000ths(value).toFixed(3)
   } else if (Utils.isFlat(stat)) {
     valueDisplay = Math.floor(value)


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Added a function to detect whether the current speed value in the stat row is within the list of speed breakpoints.
* Changed the stat display behaviour to show the speed value in 1000th decimal place if it is within any of the speed breakpoints.

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* Closes #243 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [ ] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->
![image](https://github.com/fribbels/hsr-optimizer/assets/16659408/cda73856-83fa-4ce8-93b2-745206da4935)


