### PR TITLE
fix: update node version to 18.19.0; remove extra 0

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -1,6 +1,6 @@
 # Getting started
 #### Install NodeJS & NPM
-Currently, the best balance between legacy dependencies and future direction is `node v18.19.00` - if this changes, it will be reflected in the `.node-version` file in the root directory.
+Currently, the best balance between legacy dependencies and future direction is `node v18.19.0` - if this changes, it will be reflected in the `.node-version` file in the root directory.
 We suggest using a Node version manager such as [NVM](https://github.com/nvm-sh/nvm) or [FNM](https://github.com/Schniz/fnm) to quickly switch between this project and any other node/js project you are working in.
 
 #### Install project dependencies


### PR DESCRIPTION
There is not typically two 0's in the node version here, and nvm-windows (maybe nvm too) complains during install.

# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Fix node version format in GETTING_STARTED.md guide. This is the typical version number format.
* Also, the previous string with extra 0 is not supported in nvm-windows (maybe nvm too).

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* N/A

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->
