### PR TITLE
hotfix: add crit vulnerability calc to aventurine/topaz lc/ratio lc, black swan e1 res pen elements

### DIFF
--- a/src/lib/conditionals/character/Aventurine.ts
+++ b/src/lib/conditionals/character/Aventurine.ts
@@ -43,7 +43,7 @@ const Aventurine = (e: Eidolon): CharacterConditional => {
       name: 'enemyUnnervedDebuff',
       text: 'Enemy Unnerved',
       title: 'Roulette Shark',
-      content: `When an ally hits an Unnerved enemy target, the CRIT DMG dealt increases by ${precisionRound(ultCdScaling * 100)}%.`,
+      content: `When an ally hits an Unnerved enemy target, the CRIT DMG dealt increases by ${precisionRound(ultCritVulnerability * 100)}%.`,
     },
     {
       formItem: 'slider',

--- a/src/lib/conditionals/character/Aventurine.ts
+++ b/src/lib/conditionals/character/Aventurine.ts
@@ -11,7 +11,7 @@ const Aventurine = (e: Eidolon): CharacterConditional => {
 
   const basicScaling = basic(e, 1.00, 1.10)
   const ultScaling = ult(e, 2.70, 2.916)
-  const ultCdScaling = ult(e, 0.15, 0.162)
+  const ultCritVulnerability = ult(e, 0.15, 0.162)
 
   const talentDmgScaling = talent(e, 0.25, 0.275)
   const talentResScaling = talent(e, 0.50, 0.55)
@@ -128,10 +128,10 @@ const Aventurine = (e: Eidolon): CharacterConditional => {
     precomputeMutualEffects: (x: ComputedStatsObject, request: Form) => {
       const m = request.characterConditionals
 
-      x[Stats.CD] += (m.enemyUnnervedDebuff) ? ultCdScaling : 0
       x[Stats.CD] += (e >= 1 && m.fortifiedWagerBuff) ? 0.20 : 0
       x[Stats.RES] += (m.fortifiedWagerBuff) ? talentResScaling : 0
       x.RES_PEN += (e >= 2 && m.e2ResShred) ? 0.12 : 0
+      x.CRIT_VULNERABILITY += (m.enemyUnnervedDebuff) ? ultCritVulnerability : 0
     },
     calculateBaseMultis: (c: PrecomputedCharacterConditional, request: Form) => {
       const r = request.characterConditionals

--- a/src/lib/conditionals/character/BlackSwan.ts
+++ b/src/lib/conditionals/character/BlackSwan.ts
@@ -103,7 +103,10 @@ When there are 3 or more Arcana stacks, deals Wind DoT to adjacent targets. When
       // TODO: Technically this isnt a DoT vulnerability but rather vulnerability to damage on the enemy's turn which includes ults/etc.
       x.DOT_VULNERABILITY += (m.epiphanyDebuff) ? epiphanyDmgTakenBoost : 0
       x.DEF_SHRED += (m.defDecreaseDebuff) ? defShredValue : 0
-      x.RES_PEN += (e >= 1 && m.e1ResReduction) ? 0.25 : 0
+      x.WIND_RES_PEN += (e >= 1 && m.e1ResReduction) ? 0.25 : 0
+      x.FIRE_RES_PEN += (e >= 1 && m.e1ResReduction) ? 0.25 : 0
+      x.PHYSICAL_RES_PEN += (e >= 1 && m.e1ResReduction) ? 0.25 : 0
+      x.LIGHTNING_RES_PEN += (e >= 1 && m.e1ResReduction) ? 0.25 : 0
     },
     calculateBaseMultis: (c: PrecomputedCharacterConditional, request: Form) => {
       const r = request.characterConditionals

--- a/src/lib/conditionals/conditionalConstants.ts
+++ b/src/lib/conditionals/conditionalConstants.ts
@@ -54,6 +54,7 @@ export const baseComputedStatsObject = {
   FUA_VULNERABILITY: 0,
   DOT_VULNERABILITY: 0,
   BREAK_VULNERABILITY: 0,
+  CRIT_VULNERABILITY: 0,
 
   // TODO: Consolidate wording as DEF_SHRED
   DEF_SHRED: 0,

--- a/src/lib/conditionals/lightcone/5star/BaptismOfPureThought.ts
+++ b/src/lib/conditionals/lightcone/5star/BaptismOfPureThought.ts
@@ -39,7 +39,7 @@ const BaptismOfPureThought = (s: SuperImpositionLevel): LightConeConditional => 
     formItem: 'slider',
     id: 'debuffCdStacks',
     name: 'debuffCdStacks',
-    text: 'Debuff cd stacks',
+    text: 'Debuff crit vulnerability stacks',
     title: lcRank.skill,
     content: getContentFromLCRanks(s, lcRank),
     min: 0,

--- a/src/lib/conditionals/lightcone/5star/BaptismOfPureThought.ts
+++ b/src/lib/conditionals/lightcone/5star/BaptismOfPureThought.ts
@@ -1,11 +1,9 @@
-import { Stats } from 'lib/constants'
-
 import { SuperImpositionLevel } from 'types/LightCone'
-import { PrecomputedCharacterConditional } from 'types/CharacterConditional'
 import { Form } from 'types/Form'
-import { ConditionalLightConeMap, LightConeConditional } from 'types/LightConeConditionals'
+import { LightConeConditional } from 'types/LightConeConditionals'
 import getContentFromLCRanks from '../getContentFromLCRank'
 import { ContentItem } from 'types/Conditionals'
+import { ComputedStatsObject } from 'lib/conditionals/conditionalConstants.ts'
 
 const lcRank = {
   id: '23020',
@@ -32,7 +30,7 @@ const lcRank2 = {
 }
 
 const BaptismOfPureThought = (s: SuperImpositionLevel): LightConeConditional => {
-  const sValuesCd = [0.08, 0.09, 0.10, 0.11, 0.12]
+  const sValuesCritVulnerability = [0.08, 0.09, 0.10, 0.11, 0.12]
   const sValuesDmg = [0.36, 0.42, 0.48, 0.54, 0.60]
   const sValuesFuaPen = [0.24, 0.28, 0.32, 0.36, 0.40]
 
@@ -63,10 +61,10 @@ const BaptismOfPureThought = (s: SuperImpositionLevel): LightConeConditional => 
       debuffCdStacks: 3,
       postUltBuff: true,
     }),
-    precomputeEffects: (x: PrecomputedCharacterConditional, request: Form) => {
+    precomputeEffects: (x: ComputedStatsObject, request: Form) => {
       const r = request.lightConeConditionals
 
-      x[Stats.CD] += r.debuffCdStacks * sValuesCd[s]
+      x.CRIT_VULNERABILITY += r.debuffCdStacks * sValuesCritVulnerability[s]
       x.ELEMENTAL_DMG += r.postUltBuff ? sValuesDmg[s] : 0
       x.FUA_DEF_PEN += r.postUltBuff ? sValuesFuaPen[s] : 0
     },

--- a/src/lib/conditionals/lightcone/5star/WorrisomeBlissful.ts
+++ b/src/lib/conditionals/lightcone/5star/WorrisomeBlissful.ts
@@ -4,12 +4,11 @@ import { Form } from 'types/Form'
 import getContentFromLCRanks from '../getContentFromLCRank'
 import { SuperImpositionLevel } from 'types/LightCone'
 import { LightConeConditional, LightConeRawRank } from 'types/LightConeConditionals'
-import { Stats } from 'lib/constants'
 import { ComputedStatsObject } from 'lib/conditionals/conditionalConstants.ts'
 
 export default (s: SuperImpositionLevel): LightConeConditional => {
   const sValuesFuaDmg = [0.30, 0.35, 0.40, 0.45, 0.50]
-  const sValuesCd = [0.12, 0.14, 0.16, 0.18, 0.20]
+  const sValuesCritVulnerability = [0.12, 0.14, 0.16, 0.18, 0.20]
   const lcRank: LightConeRawRank = {
     id: '23016',
     skill: 'One At A Time',
@@ -38,7 +37,7 @@ export default (s: SuperImpositionLevel): LightConeConditional => {
     id: 'targetTameStacks',
     name: 'targetTameStacks',
     formItem: 'slider',
-    text: 'Target Tame stacks (WIP)',
+    text: 'Target Tame stacks',
     title: lcRank.skill,
     content: getContentFromLCRanks(s, lcRank2),
     min: 0,
@@ -60,7 +59,7 @@ export default (s: SuperImpositionLevel): LightConeConditional => {
     precomputeMutualEffects: (x: ComputedStatsObject, request: Form) => {
       const m = request.lightConeConditionals
 
-      x[Stats.CD] += m.targetTameStacks * sValuesCd[s]
+      x.CRIT_VULNERABILITY += m.targetTameStacks * sValuesCritVulnerability[s]
     },
     calculatePassives: (/* c, request */) => { },
     calculateBaseMultis: (/* c, request */) => { },

--- a/src/lib/optimizer/calculateDamage.js
+++ b/src/lib/optimizer/calculateDamage.js
@@ -31,6 +31,13 @@ export function calculateDamage(c, request, params) {
 
   const ULT_CD = x.ULT_CD_OVERRIDE || (x[Stats.CD] + x.ULT_CD_BOOST) // Robin overrides ULT CD
 
+  const breakVulnerability = 1 + x.DMG_TAKEN_MULTI + x.BREAK_VULNERABILITY
+  const basicVulnerability = 1 + x.DMG_TAKEN_MULTI + x.BASIC_VULNERABILITY
+  const skillVulnerability = 1 + x.DMG_TAKEN_MULTI + x.SKILL_VULNERABILITY
+  const ultVulnerability = 1 + x.DMG_TAKEN_MULTI + x.ULT_VULNERABILITY
+  const fuaVulnerability = 1 + x.DMG_TAKEN_MULTI + x.FUA_VULNERABILITY
+  const dotVulnerability = 1 + x.DMG_TAKEN_MULTI + x.DOT_VULNERABILITY
+
   // BREAK
   const maxToughness = request.enemyMaxToughness
 
@@ -40,7 +47,7 @@ export function calculateDamage(c, request, params) {
     * params.ELEMENTAL_BREAK_SCALING
     * calculateDefMultiplier(cLevel, eLevel, defReduction, defIgnore, x.BREAK_DEF_PEN)
     * (0.5 + maxToughness / 120)
-    * (1 + x.DMG_TAKEN_MULTI + x.BREAK_VULNERABILITY)
+    * breakVulnerability
     * (1 - baseResistance)
     * (1 + x[Stats.BE])
 
@@ -49,8 +56,7 @@ export function calculateDamage(c, request, params) {
     * universalMulti
     * (dmgBoostMultiplier + x.BASIC_BOOST)
     * calculateDefMultiplier(cLevel, eLevel, defReduction, defIgnore, x.BASIC_DEF_PEN)
-    * (Math.min(1, x[Stats.CR] + x.BASIC_CR_BOOST) * (1 + x[Stats.CD] + x.BASIC_CD_BOOST) + (1 - Math.min(1, x[Stats.CR] + x.BASIC_CR_BOOST)))
-    * (1 + x.DMG_TAKEN_MULTI + x.BASIC_VULNERABILITY)
+    * ((basicVulnerability + x.CRIT_VULNERABILITY) * Math.min(1, x[Stats.CR] + x.BASIC_CR_BOOST) * (1 + x[Stats.CD] + x.BASIC_CD_BOOST) + basicVulnerability * (1 - Math.min(1, x[Stats.CR] + x.BASIC_CR_BOOST)))
     * (1 - (baseResistance - x.BASIC_RES_PEN))
     * (1 + x.BASIC_ORIGINAL_DMG_BOOST)
     + x.BASIC_BREAK_DMG_MODIFIER * x.BREAK_DMG
@@ -59,8 +65,7 @@ export function calculateDamage(c, request, params) {
     *= universalMulti
     * (dmgBoostMultiplier + x.SKILL_BOOST)
     * calculateDefMultiplier(cLevel, eLevel, defReduction, defIgnore, x.SKILL_DEF_PEN)
-    * (Math.min(1, x[Stats.CR] + x.SKILL_CR_BOOST) * (1 + x[Stats.CD] + x.SKILL_CD_BOOST) + (1 - Math.min(1, x[Stats.CR] + x.SKILL_CR_BOOST)))
-    * (1 + x.DMG_TAKEN_MULTI + x.SKILL_VULNERABILITY)
+    * ((skillVulnerability + x.CRIT_VULNERABILITY) * Math.min(1, x[Stats.CR] + x.SKILL_CR_BOOST) * (1 + x[Stats.CD] + x.SKILL_CD_BOOST) + skillVulnerability * (1 - Math.min(1, x[Stats.CR] + x.SKILL_CR_BOOST)))
     * (1 - (baseResistance - x.SKILL_RES_PEN))
     * (1 + x.SKILL_ORIGINAL_DMG_BOOST)
 
@@ -68,8 +73,7 @@ export function calculateDamage(c, request, params) {
     *= universalMulti
     * (dmgBoostMultiplier + x.ULT_BOOST)
     * calculateDefMultiplier(cLevel, eLevel, defReduction, defIgnore, x.ULT_DEF_PEN)
-    * (Math.min(1, x[Stats.CR] + x.ULT_CR_BOOST) * (1 + ULT_CD) + (1 - Math.min(1, x[Stats.CR] + x.ULT_CR_BOOST)))
-    * (1 + x.DMG_TAKEN_MULTI + x.ULT_VULNERABILITY)
+    * ((ultVulnerability + x.CRIT_VULNERABILITY) * Math.min(1, x[Stats.CR] + x.ULT_CR_BOOST) * (1 + ULT_CD) + ultVulnerability * (1 - Math.min(1, x[Stats.CR] + x.ULT_CR_BOOST)))
     * (1 - (baseResistance - x.ULT_RES_PEN))
     * (1 + x.ULT_ORIGINAL_DMG_BOOST)
 
@@ -77,15 +81,14 @@ export function calculateDamage(c, request, params) {
     *= universalMulti
     * (dmgBoostMultiplier + x.FUA_BOOST)
     * calculateDefMultiplier(cLevel, eLevel, defReduction, defIgnore, x.FUA_DEF_PEN)
-    * (Math.min(1, x[Stats.CR] + x.FUA_CR_BOOST) * (1 + x[Stats.CD] + x.FUA_CD_BOOST) + (1 - Math.min(1, x[Stats.CR] + x.FUA_CR_BOOST)))
-    * (1 + x.DMG_TAKEN_MULTI + x.FUA_VULNERABILITY)
+    * ((fuaVulnerability + x.CRIT_VULNERABILITY) * Math.min(1, x[Stats.CR] + x.FUA_CR_BOOST) * (1 + x[Stats.CD] + x.FUA_CD_BOOST) + fuaVulnerability * (1 - Math.min(1, x[Stats.CR] + x.FUA_CR_BOOST)))
     * (1 - (baseResistance - x.FUA_RES_PEN))
 
   x.DOT_DMG
     *= universalMulti
     * (dmgBoostMultiplier + x.DOT_BOOST)
     * calculateDefMultiplier(cLevel, eLevel, defReduction, defIgnore, x.DOT_DEF_PEN)
-    * (1 + x.DMG_TAKEN_MULTI + x.DOT_VULNERABILITY)
+    * dotVulnerability
     * (1 - (baseResistance - x.DOT_RES_PEN))
 }
 


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Crit vulnerability implementation in damage formula
* Updated Aventurine ult / Ratio LC / Topaz LC
* Updated black swan e1 to be dot type res pen instead of all type

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* N/A

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

