### PR TITLE
fix: content width bleeding into the sidebar

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -64,10 +64,12 @@ const App = () => {
               padding: 10,
               margin: 0,
               minHeight: 280,
-              minWidth: 1300,
               marginLeft: 'auto',
               marginRight: 'auto',
               overflow: 'initial',
+              display: 'flex',
+              justifyContent: 'space-around',
+              width: '100%',
             }}
           >
             <Tabs />

--- a/src/components/Tabs.jsx
+++ b/src/components/Tabs.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
-import { Flex, Typography } from 'antd'
+import { Typography } from 'antd'
 
 import OptimizerTab from 'components/optimizerTab/OptimizerTab'
 import RelicsTab from 'components/RelicsTab'
@@ -46,7 +46,7 @@ const Tabs = () => {
   }, [activeKey])
 
   return (
-    <Flex justify="space-around">
+    <>
       <TabRenderer activeKey={activeKey} tabKey={AppPages.OPTIMIZER} content={optimizerTab} />
       <TabRenderer activeKey={activeKey} tabKey={AppPages.CHARACTERS} content={characterTab} />
       <TabRenderer activeKey={activeKey} tabKey={AppPages.RELICS} content={relicsTab} />
@@ -58,7 +58,7 @@ const Tabs = () => {
       <ErrorBoundary fallbackRender={defaultErrorRender}>
         <ScoringModal />
       </ErrorBoundary>
-    </Flex>
+    </>
   )
 }
 


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Fixing a bug where the content width bleeds into the sidebar on firefox/opera

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

Before:

![image](https://github.com/fribbels/hsr-optimizer/assets/7908525/85f19e96-30e5-408c-b80d-20f304fa72ce)


After: 

![image](https://github.com/fribbels/hsr-optimizer/assets/7908525/0986324b-c676-4138-a32c-a4ff980ca38c)
