### PR TITLE
doc: replace wrong pic in guide

### DIFF
--- a/src/components/GettingStartedTab.jsx
+++ b/src/components/GettingStartedTab.jsx
@@ -142,7 +142,7 @@ export default function GettingStartedTab() {
               Step 3: Apply filters
             </h2>
 
-            <img src={Assets.getGuideImage('relicsGrid')} style={screenshotStyle}></img>
+            <img src={Assets.getGuideImage('relicsFilters')} style={screenshotStyle}></img>
 
             <h4 style={titleStyle}>
               Main Stats


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* The picture in `Get-Started`/`Step 3: Apply filters` is placed incorrectly. See the Screenshots.

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [ ] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->
original step 3
![image](https://github.com/fribbels/hsr-optimizer/assets/5477995/e564c906-3c1c-47bb-af77-0e68a3a05198)

modified step 3
![image](https://github.com/fribbels/hsr-optimizer/assets/5477995/6be3e8d6-afda-4dd6-a99f-e0c00ce706a5)

