### PR TITLE
hotfix: unique relic ids, reliquary version

### DIFF
--- a/src/lib/characterConverter.ts
+++ b/src/lib/characterConverter.ts
@@ -84,6 +84,16 @@ export const CharacterConverter = {
   },
 }
 
+// Some special relics have a weird id -> set/part mapping
+const tidOverrides = {
+  55001: {set: '101', part: '3'},
+  55002: {set: '102', part: '4'},
+  55003: {set: '103', part: '3'},
+  55004: {set: '104', part: '3'},
+  55005: {set: '105', part: '4'},
+  55006: {set: '106', part: '3'},
+}
+
 function convertRelic(preRelic) {
   try {
     const metadata = DB.getMetadata().relics
@@ -91,10 +101,16 @@ function convertRelic(preRelic) {
 
     const enhance = preRelic.level || 0
 
-    const setId = tid.substring(1, 4)
+    let setId = tid.substring(1, 4)
+    if (tidOverrides[tid]) {
+      setId = tidOverrides[tid].set
+    }
     const setName = metadata.relicSets[setId].name
 
-    const partId = tid.substring(4, 5)
+    let partId = tid.substring(4, 5)
+    if (tidOverrides[tid]) {
+      partId = tidOverrides[tid].part
+    }
     const partName = partConversion[partId]
 
     const gradeId = tid.substring(0, 1)

--- a/src/lib/importer/importConfig.js
+++ b/src/lib/importer/importConfig.js
@@ -19,7 +19,7 @@ export const ReliquaryArchiverConfig = {
   releases: 'https://github.com/IceDynamix/reliquary-archiver/releases/latest',
   defaultFileName: 'archiver_output.json',
   sourceString: 'reliquary_archiver',
-  latestBuildVersion: 'v0.1.4',
+  latestBuildVersion: 'v0.1.5',
   latestOutputVersion: 3,
   speedVerified: true,
 }


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->


* Overriding special relic IDs that have unique set/part mappings. These were generally purples so low impact
* Upgrade reliquary to 0.1.5

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

![image](https://github.com/fribbels/hsr-optimizer/assets/7908525/2339a856-5744-4ed2-914c-c190827bb81f)
