### PR TITLE
feat: import optimizer builds as simulation

### DIFF
--- a/src/components/optimizerTab/optimizerForm/SimulatedBuildsGrid.tsx
+++ b/src/components/optimizerTab/optimizerForm/SimulatedBuildsGrid.tsx
@@ -38,7 +38,7 @@ const columns: TableColumnsType<DataType> = [
         </a>
       )
     },
-    width: 26,
+    width: 24,
     fixed: 'right',
   },
 ];
@@ -104,7 +104,8 @@ export function SimulatedBuildsGrid() {
         width: STAT_SIMULATION_GRID_WIDTH,
         borderRadius: 8,
         height: '100%',
-        backgroundColor: '#0000001a'
+        backgroundColor: '#0000001a',
+        border: '1px solid #ffffff1a'
       }}
       scroll={{
         y: 265,

--- a/src/lib/optimizerTabController.js
+++ b/src/lib/optimizerTabController.js
@@ -204,7 +204,7 @@ export const OptimizerTabController = {
     }
   },
 
-  calculateRelicsFromId: (id) => {
+  calculateRelicsFromId: (id, returnRelics = false) => {
     const lSize = consts.lSize
     const pSize = consts.pSize
     const fSize = consts.fSize
@@ -227,6 +227,17 @@ export const OptimizerTabController = {
     relics.Feet[f].optimizerCharacterId = characterId
     relics.PlanarSphere[p].optimizerCharacterId = characterId
     relics.LinkRope[l].optimizerCharacterId = characterId
+
+    if (returnRelics) {
+      return {
+        Head: relics.Head[h],
+        Hands: relics.Hands[g],
+        Body: relics.Body[b],
+        Feet: relics.Feet[f],
+        PlanarSphere: relics.PlanarSphere[p],
+        LinkRope: relics.LinkRope[l],
+      }
+    }
 
     return {
       Head: relics.Head[h].id,

--- a/src/lib/relicFilters.js
+++ b/src/lib/relicFilters.js
@@ -270,7 +270,6 @@ export const RelicFilters = {
         relic.condensedStats.push([relic.augmentedStats.mainStat, relic.augmentedStats.mainValue])
 
         delete relic.augmentedStats
-        delete relic.main
         delete relic.weights
       }
     }

--- a/src/lib/statSimulationController.tsx
+++ b/src/lib/statSimulationController.tsx
@@ -1,6 +1,6 @@
 import { StatSimTypes } from "components/optimizerTab/optimizerForm/DamageCalculatorDisplay";
 import { Utils } from "lib/utils";
-import { Constants, Parts, Stats, StatsToShort, SubStats } from "lib/constants";
+import { Constants, Parts, SetsRelicsNames, Stats, StatsToShort, SubStats } from "lib/constants";
 import { emptyRelic } from "lib/optimizer/optimizerUtils";
 import { StatCalculator } from "lib/statCalculator";
 import { Stat } from "types/Relic";
@@ -16,7 +16,7 @@ import { SortOption } from "lib/optimizer/sortOptions";
 import { SaveState } from "lib/saveState";
 import DB from "lib/db";
 
-export function saveStatSimulationBuild() {
+export function saveStatSimulationBuildFromForm() {
   const form = window.optimizerForm.getFieldsValue()
   console.log('Save statSim', form.statSim)
 
@@ -35,6 +35,10 @@ export function saveStatSimulationBuild() {
     return
   }
 
+  saveStatSimulationRequest(simRequest, simType)
+}
+
+export function saveStatSimulationRequest(simRequest, simType) {
   const existingSimulations = window.store.getState().statSimulations || []
   const key = Utils.randomId()
   const name = simRequest.name || undefined
@@ -82,11 +86,10 @@ function hashSim(sim) {
 }
 
 function validateRequest(request) {
-  console.debug('validateRequest', request)
-  if (!request.simRelicSet1 || !request.simRelicSet2 || !request.simOrnamentSet) {
-    Message.error('Missing simulation sets')
-    return false
-  }
+  // if (!request.simRelicSet1 || !request.simRelicSet2 || !request.simOrnamentSet) {
+  //   Message.error('Missing simulation sets')
+  //   return false
+  // }
 
   if (!request.simBody || !request.simFeet || !request.simLinkRope || !request.simPlanarSphere) {
     Message.error('Missing simulation main stats')
@@ -123,14 +126,17 @@ export function renderDefaultSimulationName(sim) {
 function SimSetsDisplay(props: { sim: any }) {
   const request = props.sim.request
   const imgSize = 22
+  const relicImage1 = Assets.getSetImage(request.simRelicSet1)
+  const relicImage2 = Assets.getSetImage(request.simRelicSet2)
+  const ornamentImage = request.simOrnamentSet ? Assets.getSetImage(request.simOrnamentSet) : Assets.getBlank()
   return (
     <Flex gap={5}>
-      <Flex>
-        <img style={{width: imgSize}} src={Assets.getSetImage(request.simRelicSet1)}/>
-        <img style={{width: imgSize}} src={Assets.getSetImage(request.simRelicSet2)}/>
+      <Flex style={{width: imgSize * 2 + 5}} justify="center">
+        <img style={{width: request.simRelicSet1 ? imgSize : 0}} src={relicImage1}/>
+        <img style={{width: request.simRelicSet2 ? imgSize : 0}} src={relicImage2}/>
       </Flex>
 
-      <img style={{width: imgSize}} src={Assets.getSetImage(request.simOrnamentSet)}/>
+      <img style={{width: imgSize}} src={ornamentImage}/>
     </Flex>
   )
 }
@@ -142,8 +148,8 @@ function SimMainsDisplay(props: { sim: any }) {
     <Flex>
       <img style={{width: imgSize}} src={Assets.getStatIcon(request.simBody, true)}/>
       <img style={{width: imgSize}} src={Assets.getStatIcon(request.simFeet, true)}/>
-      <img style={{width: imgSize}} src={Assets.getStatIcon(request.simLinkRope, true)}/>
       <img style={{width: imgSize}} src={Assets.getStatIcon(request.simPlanarSphere, true)}/>
+      <img style={{width: imgSize}} src={Assets.getStatIcon(request.simLinkRope, true)}/>
     </Flex>
   )
 }
@@ -234,14 +240,16 @@ export function runSimulations(form, simulations) {
     planarSphere.augmentedStats.mainStat = request.simPlanarSphere
     planarSphere.augmentedStats.mainValue = StatCalculator.getMaxedStatValue(request.simPlanarSphere)
 
-    const relicSet1 = request.simRelicSet1 || -1
-    const relicSet2 = request.simRelicSet2 || -1
+    // Generate relic sets
+    // Since the optimizer uses index based relic set identification, it can't handle an empty set
+    // We have to fake rainbow sets by forcing a 2+1+1 or a 1+1+1+1 combination
+    const unusedRelicSets = SetsRelicsNames.filter(x => x != request.simRelicSet1 && x != request.simRelicSet2)
     const ornamentSet = request.simOrnamentSet || -1
 
-    head.set = relicSet1
-    hands.set = relicSet1
-    body.set = relicSet2
-    feet.set = relicSet2
+    head.set = request.simRelicSet1 || unusedRelicSets[0]
+    hands.set = request.simRelicSet1 || unusedRelicSets[1]
+    body.set = request.simRelicSet2 || unusedRelicSets[2]
+    feet.set = request.simRelicSet2 || unusedRelicSets[3]
     linkRope.set = ornamentSet
     planarSphere.set = ornamentSet
 
@@ -353,6 +361,84 @@ export function importOptimizerBuild() {
     return
   }
 
+  if (selectedRow.statSim) {
+    Message.warning('The selected optimizer build is already a simulation')
+    return
+  }
 
-  console.log(selectedRow)
+  // Generate relics from optimizer row
+  const relicsByPart = OptimizerTabController.calculateRelicsFromId(selectedRow.id, true)
+  const relics = Object.values(relicsByPart)
+  const accumulatedSubstatRolls = {}
+  SubStats.map(x => accumulatedSubstatRolls[x] = 0)
+
+  // Sum up substat rolls
+  for (const relic of relics) {
+    for (const substat of relic.substats) {
+      accumulatedSubstatRolls[substat.stat] += substat.value / StatCalculator.getMaxedSubstatValue(substat.stat)
+    }
+  }
+
+  // Round them to 5 precision
+  SubStats.map(x => accumulatedSubstatRolls[x] = Utils.precisionRound(accumulatedSubstatRolls[x], 5))
+
+  console.log(relicsByPart)
+  console.log(accumulatedSubstatRolls)
+
+  // Calculate relic sets
+  const relicSetNames: string[] = []
+  const relicSetIndex = selectedRow.relicSetIndex
+  const numSetsR = Object.values(Constants.SetsRelics).length
+  const s1 = relicSetIndex % numSetsR
+  const s2 = ((relicSetIndex - s1) / numSetsR) % numSetsR
+  const s3 = ((relicSetIndex - s2 * numSetsR - s1) / (numSetsR * numSetsR)) % numSetsR
+  const s4 = ((relicSetIndex - s3 * numSetsR * numSetsR - s2 * numSetsR - s1) / (numSetsR * numSetsR * numSetsR)) % numSetsR
+  const relicSets = [s1, s2, s3, s4]
+  while (relicSets.length > 0) {
+    const value = relicSets[0]
+    if (relicSets.lastIndexOf(value)) {
+      const setName = Object.entries(Constants.RelicSetToIndex).find((x) => x[1] == value)![0]
+      relicSetNames.push(setName)
+
+      const otherIndex = relicSets.lastIndexOf(value)
+      relicSets.splice(otherIndex, 1)
+    }
+    relicSets.splice(0, 1)
+  }
+
+  // Calculate ornament sets
+  let ornamentSetName: string | undefined
+  const ornamentSetIndex = selectedRow.ornamentSetIndex
+  const ornamentSetCount = Object.values(Constants.SetsOrnaments).length
+  const os1 = ornamentSetIndex % ornamentSetCount
+  const os2 = ((ornamentSetIndex - os1) / ornamentSetCount) % ornamentSetCount
+  if (os1 == os2) {
+    ornamentSetName = Object.entries(Constants.OrnamentSetToIndex).find((x) => x[1] == os1)![0]
+  }
+
+  // Generate the fake request and submit it
+  const request = {
+    name: '',
+    simRelicSet1: relicSetNames[0],
+    simRelicSet2: relicSetNames[1],
+    simOrnamentSet: ornamentSetName,
+    simBody: relicsByPart[Parts.Body].main.stat,
+    simFeet: relicsByPart[Parts.Feet].main.stat,
+    simPlanarSphere: relicsByPart[Parts.PlanarSphere].main.stat,
+    simLinkRope: relicsByPart[Parts.LinkRope].main.stat,
+    simHp: accumulatedSubstatRolls[Stats.HP] || null,
+    simAtk: accumulatedSubstatRolls[Stats.ATK] || null,
+    simDef: accumulatedSubstatRolls[Stats.DEF] || null,
+    simHpP: accumulatedSubstatRolls[Stats.HP_P] || null,
+    simAtkP: accumulatedSubstatRolls[Stats.ATK_P] || null,
+    simDefP: accumulatedSubstatRolls[Stats.DEF_P] || null,
+    simCr: accumulatedSubstatRolls[Stats.CR] || null,
+    simCd: accumulatedSubstatRolls[Stats.CD] || null,
+    simSpd: accumulatedSubstatRolls[Stats.SPD] || null,
+    simEhr: accumulatedSubstatRolls[Stats.EHR] || null,
+    simRes: accumulatedSubstatRolls[Stats.RES] || null,
+    simBe: accumulatedSubstatRolls[Stats.BE] || null,
+  }
+
+  saveStatSimulationRequest(request, StatSimTypes.SubstatRolls)
 }

--- a/src/lib/statSimulationController.tsx
+++ b/src/lib/statSimulationController.tsx
@@ -86,11 +86,6 @@ function hashSim(sim) {
 }
 
 function validateRequest(request) {
-  // if (!request.simRelicSet1 || !request.simRelicSet2 || !request.simOrnamentSet) {
-  //   Message.error('Missing simulation sets')
-  //   return false
-  // }
-
   if (!request.simBody || !request.simFeet || !request.simLinkRope || !request.simPlanarSphere) {
     Message.error('Missing simulation main stats')
     return false
@@ -381,9 +376,6 @@ export function importOptimizerBuild() {
 
   // Round them to 5 precision
   SubStats.map(x => accumulatedSubstatRolls[x] = Utils.precisionRound(accumulatedSubstatRolls[x], 5))
-
-  console.log(relicsByPart)
-  console.log(accumulatedSubstatRolls)
 
   // Calculate relic sets
   const relicSetNames: string[] = []

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -157,22 +157,22 @@ export const Utils = {
     return byId
   },
 
-  // truncate10ths(16.1999999312682) == 16.9
+  // truncate10ths(16.1999999312682) == 16.1
   truncate10ths: (x) => {
     return Math.floor(x * 10) / 10
   },
 
-  // truncate100ths(16.1999999312682) == 16.99
+  // truncate100ths(16.1999999312682) == 16.19
   truncate100ths: (x) => {
     return Math.floor(x * 100) / 100
   },
 
-  // truncate100ths(16.1999999312682) == 16.999
+  // truncate100ths(16.1999999312682) == 16.199
   truncate1000ths: (x) => {
     return Math.floor(x * 1000) / 1000
   },
 
-  // truncate10000ths(16.1999999312682) == 16.9999
+  // truncate10000ths(16.1999999312682) == 16.1999
   truncate10000ths: (x) => {
     return Math.floor(x * 10000) / 10000
   },


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Adding simulated builds import from optimizer
* This imports a selected build a Substat Rolls simulation, filling in the equivalent rolls and main stats and set
* Moved conditional set effects to the grid footer instead of having it in options
* Enabled partial relic sets

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* N/A

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

![image](https://github.com/fribbels/hsr-optimizer/assets/7908525/7d26faf7-f542-480c-994a-55c842388402)
