### PR TITLE
fix: ui adjustments for small screens/firefox, boothill text adjustments, dont autostart sim on import

### DIFF
--- a/src/components/CharacterTab.jsx
+++ b/src/components/CharacterTab.jsx
@@ -29,7 +29,6 @@ import SwitchRelicsModal from './SwitchRelicsModal'
 import { getGridTheme } from 'lib/theme'
 
 const { useToken } = theme
-
 const { Text } = Typography
 
 function cellImageRenderer(params) {
@@ -65,12 +64,22 @@ function cellNameRenderer(params) {
   const equippedNumber = data.equipped ? Object.values(data.equipped).filter((x) => x != undefined).length : 0
   // console.log('CellRenderer', equippedNumber, data, characterMetadata)
   let color = '#81d47e'
-  if (equippedNumber < 6) color = '#eaaf84'
+  if (equippedNumber < 6) color = 'rgb(229, 135, 66)'
   if (equippedNumber < 1) color = '#d72f2f'
 
   return (
     <Flex align="center" justify="flex-start" style={{ height: '100%', width: '100%' }}>
-      <Text style={{ margin: 'auto', padding: '0px 5px', textAlign: 'center', overflow: 'hidden', whiteSpace: 'break-spaces', textWrap: 'wrap', fontSize: 14, width: '100%', lineHeight: '18px' }}>
+      <Text style={{
+        margin: 'auto',
+        padding: '0px 5px',
+        textAlign: 'center',
+        overflow: 'hidden',
+        whiteSpace: 'break-spaces',
+        textWrap: 'wrap',
+        fontSize: 14,
+        width: '100%',
+        lineHeight: '18px'
+      }}>
         {characterName}
       </Text>
       <Flex style={{ display: 'block', width: 3, height: '100%', backgroundColor: color, zIndex: 2 }}>
@@ -342,7 +351,7 @@ export default function CharacterTab() {
 
   async function sortByScoreClicked() {
     if (!await confirm(<>
-      Are you sure you want to sort all characters? <br />
+      Are you sure you want to sort all characters? <br/>
       You will lose any custom rankings you have set.
     </>)) {
       return
@@ -383,7 +392,10 @@ export default function CharacterTab() {
 
   function confirmSaveBuild(name) {
     const score = RelicScorer.scoreCharacter(selectedCharacter)
-    const res = DB.saveCharacterBuild(name, selectedCharacter.id, { score: score.totalScore.toFixed(0), rating: score.totalRating })
+    const res = DB.saveCharacterBuild(name, selectedCharacter.id, {
+      score: score.totalScore.toFixed(0),
+      rating: score.totalRating
+    })
     if (res) {
       Message.error(res.error)
       return
@@ -447,7 +459,7 @@ export default function CharacterTab() {
   async function confirm(content) {
     return confirmationModal.confirm({
       title: 'Confirm',
-      icon: <ExclamationCircleOutlined />,
+      icon: <ExclamationCircleOutlined/>,
       content: content,
       okText: 'Confirm',
       cancelText: 'Cancel',
@@ -469,9 +481,9 @@ export default function CharacterTab() {
         <Flex vertical gap={8} style={{ marginRight: 8 }}>
           <div
             id="characterGrid" className="ag-theme-balham-dark" style={{
-              ...{ display: 'block', width: 230, height: parentH - 85 },
-              ...getGridTheme(token),
-            }}
+            ...{ display: 'block', width: 230, height: parentH - 85 },
+            ...getGridTheme(token),
+          }}
           >
             <AgGridReact
               ref={characterGrid}
@@ -500,28 +512,34 @@ export default function CharacterTab() {
                 menu={actionsMenuProps}
                 trigger={['hover']}
               >
-                <Button style={{ width: '100%' }} icon={<UserOutlined />}>
+                <Button style={{ width: '100%' }} icon={<UserOutlined/>}>
                   Character actions
-                  <DownOutlined />
+                  <DownOutlined/>
                 </Button>
               </Dropdown>
             </Flex>
             <Flex gap={8}>
-              <Button style={{ flex: 'auto' }} icon={<CameraOutlined />} onClick={clipboardClicked} type="primary" loading={screenshotLoading}>
+              <Button style={{ flex: 'auto' }} icon={<CameraOutlined/>} onClick={clipboardClicked} type="primary"
+                      loading={screenshotLoading}>
                 Copy screenshot
               </Button>
-              <Button style={{ width: 40 }} type="primary" icon={<DownloadOutlined />} onClick={downloadClicked} loading={downloadLoading} />
+              <Button style={{ width: 40 }} type="primary" icon={<DownloadOutlined/>} onClick={downloadClicked}
+                      loading={downloadLoading}/>
             </Flex>
           </Flex>
         </Flex>
-        <CharacterPreview id="characterTabPreview" character={selectedCharacter} />
+        <CharacterPreview id="characterTabPreview" character={selectedCharacter}/>
 
         {/* <CharacterTabDebugPanel selectedCharacter={selectedCharacter} /> */}
       </Flex>
-      <CharacterModal onOk={onCharacterModalOk} open={isCharacterModalOpen} setOpen={setCharacterModalOpen} initialCharacter={characterModalInitialCharacter} />
-      <SwitchRelicsModal onOk={onSwitchRelicsModalOk} open={isSwitchRelicsModalOpen} setOpen={setSwitchRelicsModalOpen} currentCharacter={selectedCharacter} />
-      <NameBuild open={isSaveBuildModalOpen} setOpen={setIsSaveBuildModalOpen} onOk={confirmSaveBuild} />
-      <BuildsModal open={isBuildsModalOpen} setOpen={setIsBuildsModalOpen} selectedCharacter={selectedCharacter} imgRenderer={cellImageRenderer} />
+      <CharacterModal onOk={onCharacterModalOk} open={isCharacterModalOpen} setOpen={setCharacterModalOpen}
+                      initialCharacter={characterModalInitialCharacter}/>
+      <SwitchRelicsModal onOk={onSwitchRelicsModalOk} open={isSwitchRelicsModalOpen}
+                         setOpen={setSwitchRelicsModalOpen}
+                         currentCharacter={selectedCharacter}/>
+      <NameBuild open={isSaveBuildModalOpen} setOpen={setIsSaveBuildModalOpen} onOk={confirmSaveBuild}/>
+      <BuildsModal open={isBuildsModalOpen} setOpen={setIsBuildsModalOpen} selectedCharacter={selectedCharacter}
+                   imgRenderer={cellImageRenderer}/>
       {contextHolder}
     </Flex>
   )

--- a/src/components/optimizerTab/FormCard.tsx
+++ b/src/components/optimizerTab/FormCard.tsx
@@ -6,7 +6,7 @@ const shadow = 'rgba(0, 0, 0, 0.25) 0px 0.0625em 0.0625em, rgba(0, 0, 0, 0.25) 0
 
 const panelWidth = 203
 const defaultGap = 5
-const defaultPadding = 15
+const defaultPadding = 12
 
 const smallWidth = panelWidth
 const mediumWidth = 365
@@ -18,7 +18,13 @@ const dimsBySize = {
   'large': largeWidth,
 }
 
-export default function FormCard(props: { size?: string; children?: ReactElement | ReactElement[]; height?: number; style?: CSSProperties; justify?: string }) {
+export default function FormCard(props: {
+  size?: string;
+  children?: ReactElement | ReactElement[];
+  height?: number;
+  style?: CSSProperties;
+  justify?: string
+}) {
   const { token } = useToken()
 
   const size = props.size || 'small'

--- a/src/components/optimizerTab/conditionals/LightConeConditionalDisplay.tsx
+++ b/src/components/optimizerTab/conditionals/LightConeConditionalDisplay.tsx
@@ -26,9 +26,9 @@ export const LightConeConditionalDisplay = memo((props: LightConeConditionalDisp
       <Flex vertical gap={5}>
         <Flex justify="space-between" align="center">
           <HeaderText>Light cone passives</HeaderText>
-          <TooltipImage type={Hint.lightConePassives()} />
+          <TooltipImage type={Hint.lightConePassives()}/>
         </Flex>
-        {(teammateIndex == null) && <Typography.Text italic>Select Light cone to view passives</Typography.Text>}
+        {(teammateIndex == null) && <Typography.Text italic></Typography.Text>}
       </Flex>
     )
   }
@@ -44,9 +44,9 @@ export const LightConeConditionalDisplay = memo((props: LightConeConditionalDisp
     <Flex vertical gap={5}>
       <Flex justify="space-between" align="center">
         <HeaderText>Light cone passives</HeaderText>
-        <TooltipImage type={Hint.lightConePassives()} />
+        <TooltipImage type={Hint.lightConePassives()}/>
       </Flex>
-      <DisplayFormControl content={content} teammateIndex={teammateIndex} />
+      <DisplayFormControl content={content} teammateIndex={teammateIndex}/>
     </Flex>
   )
 })

--- a/src/components/optimizerTab/optimizerForm/EnemyOptionsDisplay.tsx
+++ b/src/components/optimizerTab/optimizerForm/EnemyOptionsDisplay.tsx
@@ -3,20 +3,24 @@ import { HeaderText } from 'components/HeaderText.jsx'
 import { TooltipImage } from 'components/TooltipImage.jsx'
 import { Hint } from 'lib/hint.jsx'
 import { Utils } from 'lib/utils.js'
-import { enemyCountOptions, enemyLevelOptions, enemyMaxToughnessOptions, enemyResistanceOptions } from 'lib/constants.ts'
+import {
+  enemyCountOptions,
+  enemyLevelOptions,
+  enemyMaxToughnessOptions,
+  enemyResistanceOptions
+} from 'lib/constants.ts'
 import { optimizerTabDefaultGap, panelWidth } from 'components/optimizerTab/optimizerTabConstants.ts'
 import { CheckOutlined, CloseOutlined } from '@ant-design/icons'
 
 const { Text } = Typography
 
-type EnemyOptionsDisplayProps = {
-}
+type EnemyOptionsDisplayProps = {}
 export default function EnemyOptionsDisplay(_props: EnemyOptionsDisplayProps) {
   return (
     <Flex vertical gap={5} style={{ marginBottom: 5 }}>
       <Flex justify="space-between" align="center">
         <HeaderText style={{}}>Enemy options</HeaderText>
-        <TooltipImage type={Hint.enemyOptions()} />
+        <TooltipImage type={Hint.enemyOptions()}/>
       </Flex>
 
       <Flex gap={optimizerTabDefaultGap} justify="space-between">
@@ -68,10 +72,10 @@ export default function EnemyOptionsDisplay(_props: EnemyOptionsDisplayProps) {
       <Flex align="center">
         <Form.Item name="enemyElementalWeak" valuePropName="checked">
           <Switch
-            checkedChildren={<CheckOutlined />}
-            unCheckedChildren={<CloseOutlined />}
+            checkedChildren={<CheckOutlined/>}
+            unCheckedChildren={<CloseOutlined/>}
             defaultChecked
-            style={{ width: 45, marginRight: 10 }}
+            style={{ width: 45, marginRight: 5 }}
           />
         </Form.Item>
         <Text>Elemental weakness</Text>
@@ -80,9 +84,9 @@ export default function EnemyOptionsDisplay(_props: EnemyOptionsDisplayProps) {
       <Flex align="center">
         <Form.Item name="enemyWeaknessBroken" valuePropName="checked">
           <Switch
-            checkedChildren={<CheckOutlined />}
-            unCheckedChildren={<CloseOutlined />}
-            style={{ width: 45, marginRight: 10 }}
+            checkedChildren={<CheckOutlined/>}
+            unCheckedChildren={<CloseOutlined/>}
+            style={{ width: 45, marginRight: 5 }}
           />
         </Form.Item>
         <Text>Weakness broken</Text>

--- a/src/components/optimizerTab/optimizerForm/OptimizerOptionsDisplay.tsx
+++ b/src/components/optimizerTab/optimizerForm/OptimizerOptionsDisplay.tsx
@@ -36,16 +36,16 @@ const OptimizerOptionsDisplay = (): JSX.Element => {
       <Flex vertical gap={optimizerTabDefaultGap}>
         <Flex justify="space-between" align="center">
           <HeaderText>Optimizer options</HeaderText>
-          <TooltipImage type={Hint.optimizerOptions()} />
+          <TooltipImage type={Hint.optimizerOptions()}/>
         </Flex>
 
         <Flex align="center">
           <Form.Item name="predictMaxedMainStat" valuePropName="checked">
             <Switch
-              checkedChildren={<CheckOutlined />}
-              unCheckedChildren={<CloseOutlined />}
+              checkedChildren={<CheckOutlined/>}
+              unCheckedChildren={<CloseOutlined/>}
               defaultChecked
-              style={{ width: 45, marginRight: 10 }}
+              style={{ width: 45, marginRight: 5 }}
             />
           </Form.Item>
           <Text>Maxed main stat</Text>
@@ -54,22 +54,22 @@ const OptimizerOptionsDisplay = (): JSX.Element => {
         <Flex align="center">
           <Form.Item name="includeEquippedRelics" valuePropName="checked">
             <Switch
-              checkedChildren={<CheckOutlined />}
-              unCheckedChildren={<CloseOutlined />}
+              checkedChildren={<CheckOutlined/>}
+              unCheckedChildren={<CloseOutlined/>}
               defaultChecked
-              style={{ width: 45, marginRight: 10 }}
+              style={{ width: 45, marginRight: 5 }}
             />
           </Form.Item>
-          <Text>Include equipped relics</Text>
+          <Text>Allow equipped relics</Text>
         </Flex>
 
         <Flex align="center">
           <Form.Item name="rankFilter" valuePropName="checked">
             <Switch
-              checkedChildren={<CheckOutlined />}
-              unCheckedChildren={<CloseOutlined />}
+              checkedChildren={<CheckOutlined/>}
+              unCheckedChildren={<CloseOutlined/>}
               defaultChecked
-              style={{ width: 45, marginRight: 10 }}
+              style={{ width: 45, marginRight: 5 }}
             />
           </Form.Item>
           <Text>Character priority filter</Text>
@@ -78,10 +78,10 @@ const OptimizerOptionsDisplay = (): JSX.Element => {
         <Flex align="center">
           <Form.Item name="keepCurrentRelics" valuePropName="checked">
             <Switch
-              checkedChildren={<CheckOutlined />}
-              unCheckedChildren={<CloseOutlined />}
+              checkedChildren={<CheckOutlined/>}
+              unCheckedChildren={<CloseOutlined/>}
               defaultChecked
-              style={{ width: 45, marginRight: 10 }}
+              style={{ width: 45, marginRight: 5 }}
             />
           </Form.Item>
           <Text>Keep current relics</Text>

--- a/src/lib/conditionals/character/Boothill.ts
+++ b/src/lib/conditionals/character/Boothill.ts
@@ -56,8 +56,8 @@ export default (e: Eidolon): CharacterConditional => {
       formItem: 'switch',
       id: 'talentBreakDmgScaling',
       name: 'talentBreakDmgScaling',
-      text: 'Talent break DMG (forces weakness break)',
-      title: 'Talent break DMG',
+      text: 'Talent Break DMG (force weakness break)',
+      title: 'Talent Break DMG',
       content: betaUpdate,
     },
     {
@@ -82,8 +82,8 @@ export default (e: Eidolon): CharacterConditional => {
       formItem: 'switch',
       id: 'e4TargetStandoffVulnerability',
       name: 'e4TargetStandoffVulnerability',
-      text: 'E4 Standoff vulnerability',
-      title: 'E4 Standoff vulnerability',
+      text: 'E4 Skill vulnerability',
+      title: 'E4 Skill vulnerability',
       content: betaUpdate,
       disabled: e < 4,
     },
@@ -98,8 +98,7 @@ export default (e: Eidolon): CharacterConditional => {
     },
   ]
 
-  const teammateContent: ContentItem[] = [
-  ]
+  const teammateContent: ContentItem[] = []
 
   const defaults = {
     standoffActive: true,
@@ -116,8 +115,7 @@ export default (e: Eidolon): CharacterConditional => {
     content: () => content,
     teammateContent: () => teammateContent,
     defaults: () => (defaults),
-    teammateDefaults: () => ({
-    }),
+    teammateDefaults: () => ({}),
     precomputeEffects: (request: Form) => {
       const r = request.characterConditionals
       const x = Object.assign({}, baseComputedStatsObject)

--- a/src/lib/statSimulationController.tsx
+++ b/src/lib/statSimulationController.tsx
@@ -1,20 +1,20 @@
-import { StatSimTypes } from "components/optimizerTab/optimizerForm/DamageCalculatorDisplay";
-import { Utils } from "lib/utils";
-import { Constants, Parts, SetsRelicsNames, Stats, StatsToShort, SubStats } from "lib/constants";
-import { emptyRelic } from "lib/optimizer/optimizerUtils";
-import { StatCalculator } from "lib/statCalculator";
-import { Stat } from "types/Relic";
-import { RelicFilters } from "lib/relicFilters";
-import { calculateBuild } from "lib/optimizer/calculateBuild";
-import { OptimizerTabController } from "lib/optimizerTabController";
-import { renameFields } from "lib/optimizer/optimizer";
-import { Assets } from "lib/assets";
-import { Flex, Tag } from "antd";
-import { Message } from "lib/message";
-import { setSortColumn } from "components/optimizerTab/optimizerForm/RecommendedPresetsButton";
-import { SortOption } from "lib/optimizer/sortOptions";
-import { SaveState } from "lib/saveState";
-import DB from "lib/db";
+import { StatSimTypes } from 'components/optimizerTab/optimizerForm/DamageCalculatorDisplay'
+import { Utils } from 'lib/utils'
+import { Constants, Parts, SetsRelicsNames, Stats, StatsToShort, SubStats } from 'lib/constants'
+import { emptyRelic } from 'lib/optimizer/optimizerUtils'
+import { StatCalculator } from 'lib/statCalculator'
+import { Stat } from 'types/Relic'
+import { RelicFilters } from 'lib/relicFilters'
+import { calculateBuild } from 'lib/optimizer/calculateBuild'
+import { OptimizerTabController } from 'lib/optimizerTabController'
+import { renameFields } from 'lib/optimizer/optimizer'
+import { Assets } from 'lib/assets'
+import { Flex, Tag } from 'antd'
+import { Message } from 'lib/message'
+import { setSortColumn } from 'components/optimizerTab/optimizerForm/RecommendedPresetsButton'
+import { SortOption } from 'lib/optimizer/sortOptions'
+import { SaveState } from 'lib/saveState'
+import DB from 'lib/db'
 
 export function saveStatSimulationBuildFromForm() {
   const form = window.optimizerForm.getFieldsValue()
@@ -35,10 +35,10 @@ export function saveStatSimulationBuildFromForm() {
     return
   }
 
-  saveStatSimulationRequest(simRequest, simType)
+  saveStatSimulationRequest(simRequest, simType, true)
 }
 
-export function saveStatSimulationRequest(simRequest, simType) {
+export function saveStatSimulationRequest(simRequest, simType, startSim = false) {
   const existingSimulations = window.store.getState().statSimulations || []
   const key = Utils.randomId()
   const name = simRequest.name || undefined
@@ -66,7 +66,10 @@ export function saveStatSimulationRequest(simRequest, simType) {
   const cloned = Utils.clone(existingSimulations)
   window.store.getState().setStatSimulations(cloned)
   setFormStatSimulations(cloned)
-  startOptimizerStatSimulation()
+
+  if (startSim) {
+    startOptimizerStatSimulation()
+  }
 
   autosave()
 }
@@ -126,12 +129,12 @@ function SimSetsDisplay(props: { sim: any }) {
   const ornamentImage = request.simOrnamentSet ? Assets.getSetImage(request.simOrnamentSet) : Assets.getBlank()
   return (
     <Flex gap={5}>
-      <Flex style={{width: imgSize * 2 + 5}} justify="center">
-        <img style={{width: request.simRelicSet1 ? imgSize : 0}} src={relicImage1}/>
-        <img style={{width: request.simRelicSet2 ? imgSize : 0}} src={relicImage2}/>
+      <Flex style={{ width: imgSize * 2 + 5 }} justify="center">
+        <img style={{ width: request.simRelicSet1 ? imgSize : 0 }} src={relicImage1}/>
+        <img style={{ width: request.simRelicSet2 ? imgSize : 0 }} src={relicImage2}/>
       </Flex>
 
-      <img style={{width: imgSize}} src={ornamentImage}/>
+      <img style={{ width: imgSize }} src={ornamentImage}/>
     </Flex>
   )
 }
@@ -141,10 +144,10 @@ function SimMainsDisplay(props: { sim: any }) {
   const imgSize = 22
   return (
     <Flex>
-      <img style={{width: imgSize}} src={Assets.getStatIcon(request.simBody, true)}/>
-      <img style={{width: imgSize}} src={Assets.getStatIcon(request.simFeet, true)}/>
-      <img style={{width: imgSize}} src={Assets.getStatIcon(request.simPlanarSphere, true)}/>
-      <img style={{width: imgSize}} src={Assets.getStatIcon(request.simLinkRope, true)}/>
+      <img style={{ width: imgSize }} src={Assets.getStatIcon(request.simBody, true)}/>
+      <img style={{ width: imgSize }} src={Assets.getStatIcon(request.simFeet, true)}/>
+      <img style={{ width: imgSize }} src={Assets.getStatIcon(request.simPlanarSphere, true)}/>
+      <img style={{ width: imgSize }} src={Assets.getStatIcon(request.simLinkRope, true)}/>
     </Flex>
   )
 }
@@ -374,8 +377,8 @@ export function importOptimizerBuild() {
     }
   }
 
-  // Round them to 5 precision
-  SubStats.map(x => accumulatedSubstatRolls[x] = Utils.precisionRound(accumulatedSubstatRolls[x], 5))
+  // Round them to 4 precision
+  SubStats.map(x => accumulatedSubstatRolls[x] = Utils.precisionRound(accumulatedSubstatRolls[x], 4))
 
   // Calculate relic sets
   const relicSetNames: string[] = []
@@ -432,5 +435,5 @@ export function importOptimizerBuild() {
     simBe: accumulatedSubstatRolls[Stats.BE] || null,
   }
 
-  saveStatSimulationRequest(request, StatSimTypes.SubstatRolls)
+  saveStatSimulationRequest(request, StatSimTypes.SubstatRolls, false)
 }


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Fixed some ui element overflows on small screens/firefox
* Fixed boothill's text causing overflows
* Remove autostart on simulation for imports
* Round sim rolls to 4 precision instead of 5

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

Before

<img width="848" alt="image" src="https://github.com/fribbels/hsr-optimizer/assets/7908525/614e3732-a047-4551-ab1a-0909dc02b03e">


After

<img width="947" alt="image" src="https://github.com/fribbels/hsr-optimizer/assets/7908525/aa4c2796-e970-414f-a373-b411d2d902af">
