### PR TITLE
feat: stat simulator QOLs, optimizer width adjustments, fix sparkle skill default

### DIFF
--- a/src/components/ChangelogTab.tsx
+++ b/src/components/ChangelogTab.tsx
@@ -33,6 +33,7 @@ export default function ChangelogTab(): React.JSX.Element {
             style={{
               border: `2px solid ${token.colorBgContainer}`,
               margin: 5,
+              maxWidth: 1200,
             }}
           />,
         )

--- a/src/components/MenuDrawer.jsx
+++ b/src/components/MenuDrawer.jsx
@@ -33,7 +33,7 @@ const MenuDrawer = () => {
   const setActiveKey = window.store((s) => s.setActiveKey)
 
   const items = useMemo(() => [
-    getItem('Menu', 'subOptimizer', <LineChartOutlined />, [
+    getItem('Optimization', 'subOptimizer', <LineChartOutlined />, [
       getItem(
         (
           <Flex>

--- a/src/components/optimizerTab/FilterContainer.tsx
+++ b/src/components/optimizerTab/FilterContainer.tsx
@@ -13,7 +13,7 @@ export default function FilterContainer(props: { children: ReactElement | ReactE
         background: 'rgb(29 42 81 / 73%)',
         boxShadow: '0 4px 30px rgba(0, 0, 0, 0.1)',
         backdropFilter: 'blur(5px)',
-        border: '1px solid rgba(255, 255, 255, 0.10)',
+        outline: '1px solid rgba(255, 255, 255, 0.10)',
         WebkitBackdropFilter: 'blur(5px)',
       }}
     >

--- a/src/components/optimizerTab/FormCard.tsx
+++ b/src/components/optimizerTab/FormCard.tsx
@@ -1,16 +1,15 @@
 import { Flex, theme } from 'antd'
 import { CSSProperties, ReactElement } from 'react'
+import { defaultPadding, panelWidth } from "components/optimizerTab/optimizerTabConstants";
 
 const { useToken } = theme
 const shadow = 'rgba(0, 0, 0, 0.25) 0px 0.0625em 0.0625em, rgba(0, 0, 0, 0.25) 0px 0.125em 0.5em, rgba(255, 255, 255, 0.15) 0px 0px 0px 1px inset'
 
-const panelWidth = 203
 const defaultGap = 5
-const defaultPadding = 12
 
 const smallWidth = panelWidth
-const mediumWidth = 365
-const largeWidth = 1175
+const mediumWidth = 373
+const largeWidth = 1183
 
 const dimsBySize = {
   'small': smallWidth,

--- a/src/components/optimizerTab/FormRow.tsx
+++ b/src/components/optimizerTab/FormRow.tsx
@@ -5,7 +5,7 @@ export const OptimizerMenuIds = {
   characterOptions: 'Character options',
   relicAndStatFilters: 'Relic & stat filters',
   teammates: 'Teammates',
-  characterStatsSimulation: 'Character stats simulation',
+  characterStatsSimulation: 'Character custom stats simulation',
 }
 
 export function FormRow(props: { id: string; label?: string; children: ReactElement | ReactElement[] }) {

--- a/src/components/optimizerTab/OptimizerForm.jsx
+++ b/src/components/optimizerTab/OptimizerForm.jsx
@@ -23,7 +23,7 @@ import { CombatBuffsFilters } from 'components/optimizerTab/optimizerForm/Combat
 import { OptimizerTabCharacterPanel } from 'components/optimizerTab/optimizerForm/OptimizerTabCharacterPanel'
 import { LightConeConditionals } from 'lib/lightConeConditionals'
 import FilterContainer from 'components/optimizerTab/FilterContainer.tsx'
-import { DamageCalculatorDisplay } from './optimizerForm/DamageCalculatorDisplay'
+import { StatSimulationDisplay } from 'components/optimizerTab/optimizerForm/StatSimulationDisplay'
 
 export default function OptimizerForm() {
   console.log('======================================================================= RENDER OptimizerForm')
@@ -195,7 +195,7 @@ export default function OptimizerForm() {
           {/* Row 4 */}
 
           <FormRow id={OptimizerMenuIds.characterStatsSimulation}>
-            <DamageCalculatorDisplay />
+            <StatSimulationDisplay />
           </FormRow>
         </FilterContainer>
       </Form>

--- a/src/components/optimizerTab/Sidebar.jsx
+++ b/src/components/optimizerTab/Sidebar.jsx
@@ -109,15 +109,15 @@ export default function Sidebar() {
             </Flex>
             <Flex gap={defaultGap} style={{ marginBottom: 2 }} vertical>
               <Flex gap={defaultGap}>
-                <Button icon={<ThunderboltFilled />} type="primary" loading={optimizationInProgress} onClick={window.optimizerStartClicked} style={{ width: '205px' }}>
+                <Button icon={<ThunderboltFilled />} type="primary" loading={optimizationInProgress} onClick={window.optimizerStartClicked} style={{ flex: 1 }}>
                   Start optimizer
                 </Button>
               </Flex>
               <Flex gap={defaultGap}>
-                <Button onClick={cancelClicked} style={{ width: '100px' }}>
+                <Button onClick={cancelClicked} style={{ flex: 1 }}>
                   Cancel
                 </Button>
-                <Button onClick={resetClicked} style={{ width: '100px' }}>
+                <Button onClick={resetClicked} style={{ flex: 1 }}>
                   Reset
                 </Button>
               </Flex>

--- a/src/components/optimizerTab/conditionals/FormSlider.tsx
+++ b/src/components/optimizerTab/conditionals/FormSlider.tsx
@@ -7,7 +7,7 @@ const justify = 'flex-start'
 const align = 'center'
 const inputWidth = 62
 const numberWidth = 55
-const sliderWidth = 145
+const sliderWidth = 170
 
 const Text = styled(Typography)`
   white-space: pre-line;

--- a/src/components/optimizerTab/optimizerForm/CharacterSelectorDisplay.tsx
+++ b/src/components/optimizerTab/optimizerForm/CharacterSelectorDisplay.tsx
@@ -89,7 +89,7 @@ export default function CharacterSelectorDisplay(_props: CharacterSelectorDispla
         <Form.Item name="characterId">
           <CharacterSelect
             value=""
-            selectStyle={{ width: 150 }}
+            selectStyle={{ width: 156 }}
             onChange={setOptimizerTabFocusCharacter}
           />
         </Form.Item>
@@ -114,7 +114,7 @@ export default function CharacterSelectorDisplay(_props: CharacterSelectorDispla
           <Form.Item name="lightCone">
             <LightConeSelect
               value=""
-              selectStyle={{ width: 150 }}
+              selectStyle={{ width: 156 }}
               characterId={optimizerTabFocusCharacter}
               onChange={setOptimizerFormSelectedLightCone}
             />

--- a/src/components/optimizerTab/optimizerForm/FormStatRollSlider.jsx
+++ b/src/components/optimizerTab/optimizerForm/FormStatRollSlider.jsx
@@ -4,7 +4,7 @@ import styled from 'styled-components'
 import { Utils } from 'lib/utils'
 import PropTypes from 'prop-types'
 
-let sliderWidth = 130
+let sliderWidth = 140
 const Text = styled(Typography)`
   white-space: pre-line;
 `

--- a/src/components/optimizerTab/optimizerForm/OrnamentSetTagRenderer.tsx
+++ b/src/components/optimizerTab/optimizerForm/OrnamentSetTagRenderer.tsx
@@ -1,0 +1,31 @@
+import { Flex, Tag } from "antd";
+import { Assets } from "lib/assets";
+import { Constants } from "lib/constants";
+import PropTypes from "prop-types";
+import React from "react";
+
+// NOTE: Be careful hot-reloading with this file, can cause DB to wipe. Unsure why yet
+export function OrnamentSetTagRenderer(props) {
+  const { value, closable, onClose } = props
+  const onPreventMouseDown = (event) => {
+    event.preventDefault()
+    event.stopPropagation()
+  }
+  return (
+    <Tag
+      onMouseDown={onPreventMouseDown}
+      closable={closable}
+      onClose={onClose}
+      style={{ display: 'flex', flexDirection: 'row', paddingInline: '1px', marginInlineEnd: '4px', height: 21, alignItems: 'center', overflow: 'hidden' }}
+    >
+      <Flex>
+        <img title={value} src={Assets.getSetImage(value, Constants.Parts.PlanarSphere)} style={{ width: 24, height: 24 }}></img>
+      </Flex>
+    </Tag>
+  )
+}
+OrnamentSetTagRenderer.propTypes = {
+  value: PropTypes.string,
+  closable: PropTypes.bool,
+  onClose: PropTypes.func,
+}

--- a/src/components/optimizerTab/optimizerForm/RecommendedPresetsButton.tsx
+++ b/src/components/optimizerTab/optimizerForm/RecommendedPresetsButton.tsx
@@ -125,6 +125,7 @@ const RecommendedPresetsButton = () => {
   const optimizerTabFocusCharacter = window.store((s) => s.optimizerTabFocusCharacter)
 
   const items = useMemo(function() {
+    if (!optimizerTabFocusCharacter) return []
     const character = DB.getMetadata().characters[optimizerTabFocusCharacter]
     if (!character) return []
 

--- a/src/components/optimizerTab/optimizerForm/RelicMainSetFilters.tsx
+++ b/src/components/optimizerTab/optimizerForm/RelicMainSetFilters.tsx
@@ -1,16 +1,17 @@
-import { Button, Cascader, Flex, Form, Select, Tag } from 'antd'
+import { Button, Cascader, Flex, Form, Select } from 'antd'
 import { HeaderText } from 'components/HeaderText.jsx'
 import { TooltipImage } from 'components/TooltipImage.jsx'
 import { Hint } from 'lib/hint.jsx'
 import { optimizerTabDefaultGap, panelWidth } from 'components/optimizerTab/optimizerTabConstants.ts'
-import { Constants, Parts, RelicSetFilterOptions } from 'lib/constants.ts'
+import { Constants, Parts } from 'lib/constants.ts'
 import GenerateSetsOptions from 'components/optimizerTab/optimizerForm/SetsOptions.tsx'
 import GenerateOrnamentsOptions from 'components/optimizerTab/optimizerForm/OrnamentsOptions.tsx'
 import { SettingOutlined } from '@ant-design/icons'
 import { Assets } from 'lib/assets.js'
-import PropTypes from 'prop-types'
 
 import React from 'react'
+import { RelicSetTagRenderer } from "components/optimizerTab/optimizerForm/RelicSetTagRenderer";
+import { OrnamentSetTagRenderer } from "components/optimizerTab/optimizerForm/OrnamentSetTagRenderer";
 
 const { SHOW_CHILD } = Cascader
 
@@ -160,96 +161,4 @@ export default function RelicMainSetFilters(_props: RelicMainSetFiltersProps) {
       </Button>
     </Flex>
   )
-}
-
-function RelicSetTagRenderer(props) {
-  const { value, closable, onClose } = props
-  /*
-   * The value comes in as:
-   * "2 PieceBand of Sizzling Thunder__RC_CASCADER_SPLIT__Guard of Wuthering Snow"
-   */
-  /*
-   *['4 Piece', 'Passerby of Wandering Cloud']
-   *['2 + 2 Piece', 'Knight of Purity Palace', 'Hunter of Glacial Forest']
-   *['2 + Any', 'Knight of Purity Palace']
-   */
-
-  const pieces = value.split('__RC_CASCADER_SPLIT__')
-  let inner
-
-  if (pieces[0] == RelicSetFilterOptions.relic4Piece) {
-    inner
-      = (
-        <React.Fragment>
-          <img title={pieces[1]} src={Assets.getSetImage(pieces[1], Constants.Parts.Head)} style={{ width: 26, height: 26 }}></img>
-          <img title={pieces[1]} src={Assets.getSetImage(pieces[1], Constants.Parts.Head)} style={{ width: 26, height: 26 }}></img>
-        </React.Fragment>
-      )
-  }
-
-  if (pieces[0] == RelicSetFilterOptions.relic2Plus2Piece) {
-    inner
-      = (
-        <React.Fragment>
-          <img title={pieces[1]} src={Assets.getSetImage(pieces[1], Constants.Parts.Head)} style={{ width: 26, height: 26 }}></img>
-          <img title={pieces[2]} src={Assets.getSetImage(pieces[2], Constants.Parts.Head)} style={{ width: 26, height: 26 }}></img>
-        </React.Fragment>
-      )
-  }
-
-  if (pieces[0] == RelicSetFilterOptions.relic2PlusAny) {
-    inner
-      = (
-        <React.Fragment>
-          <img title={pieces[1]} src={Assets.getSetImage(pieces[1], Constants.Parts.Head)} style={{ width: 26, height: 26 }}></img>
-        </React.Fragment>
-      )
-  }
-
-  const onPreventMouseDown = (event) => {
-    event.preventDefault()
-    event.stopPropagation()
-  }
-  return (
-    <Tag
-      onMouseDown={onPreventMouseDown}
-      closable={closable}
-      onClose={onClose}
-      style={{ display: 'flex', flexDirection: 'row', paddingInline: '1px', marginInlineEnd: '4px', height: 22, alignItems: 'center', overflow: 'hidden' }}
-    >
-      <Flex>
-        {inner}
-      </Flex>
-    </Tag>
-  )
-}
-RelicSetTagRenderer.propTypes = {
-  value: PropTypes.string,
-  closable: PropTypes.bool,
-  onClose: PropTypes.func,
-}
-
-export function OrnamentSetTagRenderer(props) {
-  const { value, closable, onClose } = props
-  const onPreventMouseDown = (event) => {
-    event.preventDefault()
-    event.stopPropagation()
-  }
-  return (
-    <Tag
-      onMouseDown={onPreventMouseDown}
-      closable={closable}
-      onClose={onClose}
-      style={{ display: 'flex', flexDirection: 'row', paddingInline: '1px', marginInlineEnd: '4px', height: 21, alignItems: 'center', overflow: 'hidden' }}
-    >
-      <Flex>
-        <img title={value} src={Assets.getSetImage(value, Constants.Parts.PlanarSphere)} style={{ width: 24, height: 24 }}></img>
-      </Flex>
-    </Tag>
-  )
-}
-OrnamentSetTagRenderer.propTypes = {
-  value: PropTypes.string,
-  closable: PropTypes.bool,
-  onClose: PropTypes.func,
 }

--- a/src/components/optimizerTab/optimizerForm/RelicMainSetFilters.tsx
+++ b/src/components/optimizerTab/optimizerForm/RelicMainSetFilters.tsx
@@ -115,7 +115,7 @@ export default function RelicMainSetFilters(_props: RelicMainSetFiltersProps) {
       </Flex>
 
       <Flex vertical gap={optimizerTabDefaultGap}>
-        <Flex justify="space-between" align="center">
+        <Flex justify="space-between" align="center" style={{marginTop: 12}}>
           <HeaderText>Sets</HeaderText>
           <TooltipImage type={Hint.sets()} />
         </Flex>
@@ -253,41 +253,3 @@ OrnamentSetTagRenderer.propTypes = {
   closable: PropTypes.bool,
   onClose: PropTypes.func,
 }
-
-export const BodyStatOptions = [
-  {value: Constants.Stats.HP_P, short: "HP%", label: 'HP%'},
-  {value: Constants.Stats.ATK_P, short: "ATK%", label: 'ATK%'},
-  {value: Constants.Stats.DEF_P, short: "DEF%", label: 'DEF%'},
-  {value: Constants.Stats.CR, short: "Crit Rate", label: 'CRIT Rate'},
-  {value: Constants.Stats.CD, short: "Crit DMG", label: 'CRIT DMG'},
-  {value: Constants.Stats.EHR, short: "EHR", label: 'Effect HIT Rate'},
-  {value: Constants.Stats.OHB, short: "Healing", label: 'Outgoing Healing Boost'},
-]
-
-export const FeetStatOptions = [
-  {value: Constants.Stats.HP_P, short: "HP%", label: 'HP%'},
-  {value: Constants.Stats.ATK_P, short: "ATK%", label: 'ATK%'},
-  {value: Constants.Stats.DEF_P, short: "DEF%", label: 'DEF%'},
-  {value: Constants.Stats.SPD, short: "SPD", label: 'Speed'},
-]
-
-export const LinkRopeStatOptions = [
-  {value: Constants.Stats.HP_P, short: "HP%", label: 'HP%'},
-  {value: Constants.Stats.ATK_P, short: "ATK%", label: 'ATK%'},
-  {value: Constants.Stats.DEF_P, short: "DEF%", label: 'DEF%'},
-  {value: Constants.Stats.BE, short: "Break", label: 'Break Effect'},
-  {value: Constants.Stats.ERR, short: "Energy", label: 'Energy Regeneration Rate'},
-]
-
-export const PlanarSphereStatOptions = [
-  {value: Constants.Stats.HP_P, short: "HP%", label: 'HP%'},
-  {value: Constants.Stats.ATK_P, short: "ATK%", label: 'ATK%'},
-  {value: Constants.Stats.DEF_P, short: "DEF%", label: 'DEF%'},
-  {value: Constants.Stats.Physical_DMG, short: "Physical", label: 'Physical DMG'},
-  {value: Constants.Stats.Fire_DMG, short: "Fire", label: 'Fire DMG'},
-  {value: Constants.Stats.Ice_DMG, short: "Ice", label: 'Ice DMG'},
-  {value: Constants.Stats.Lightning_DMG, short: "Lightning", label: 'Lightning DMG'},
-  {value: Constants.Stats.Wind_DMG, short: "Wind", label: 'Wind DMG'},
-  {value: Constants.Stats.Quantum_DMG, short: "Quantum", label: 'Quantum DMG'},
-  {value: Constants.Stats.Imaginary_DMG, short: "Imaginary", label: 'Imaginary DMG'},
-]

--- a/src/components/optimizerTab/optimizerForm/RelicSetTagRenderer.tsx
+++ b/src/components/optimizerTab/optimizerForm/RelicSetTagRenderer.tsx
@@ -1,0 +1,73 @@
+import { Constants, RelicSetFilterOptions } from "lib/constants";
+import React from "react";
+import { Assets } from "lib/assets";
+import { Flex, Tag } from "antd";
+import PropTypes from "prop-types";
+
+// NOTE: Be careful hot-reloading with this file, can cause DB to wipe. Unsure why yet
+export function RelicSetTagRenderer(props) {
+  const { value, closable, onClose } = props
+  /*
+   * The value comes in as:
+   * "2 PieceBand of Sizzling Thunder__RC_CASCADER_SPLIT__Guard of Wuthering Snow"
+   */
+  /*
+   *['4 Piece', 'Passerby of Wandering Cloud']
+   *['2 + 2 Piece', 'Knight of Purity Palace', 'Hunter of Glacial Forest']
+   *['2 + Any', 'Knight of Purity Palace']
+   */
+
+  const pieces = value.split('__RC_CASCADER_SPLIT__')
+  let inner
+
+  if (pieces[0] == RelicSetFilterOptions.relic4Piece) {
+    inner
+      = (
+      <React.Fragment>
+        <img title={pieces[1]} src={Assets.getSetImage(pieces[1], Constants.Parts.Head)} style={{ width: 26, height: 26 }}></img>
+        <img title={pieces[1]} src={Assets.getSetImage(pieces[1], Constants.Parts.Head)} style={{ width: 26, height: 26 }}></img>
+      </React.Fragment>
+    )
+  }
+
+  if (pieces[0] == RelicSetFilterOptions.relic2Plus2Piece) {
+    inner
+      = (
+      <React.Fragment>
+        <img title={pieces[1]} src={Assets.getSetImage(pieces[1], Constants.Parts.Head)} style={{ width: 26, height: 26 }}></img>
+        <img title={pieces[2]} src={Assets.getSetImage(pieces[2], Constants.Parts.Head)} style={{ width: 26, height: 26 }}></img>
+      </React.Fragment>
+    )
+  }
+
+  if (pieces[0] == RelicSetFilterOptions.relic2PlusAny) {
+    inner
+      = (
+      <React.Fragment>
+        <img title={pieces[1]} src={Assets.getSetImage(pieces[1], Constants.Parts.Head)} style={{ width: 26, height: 26 }}></img>
+      </React.Fragment>
+    )
+  }
+
+  const onPreventMouseDown = (event) => {
+    event.preventDefault()
+    event.stopPropagation()
+  }
+  return (
+    <Tag
+      onMouseDown={onPreventMouseDown}
+      closable={closable}
+      onClose={onClose}
+      style={{ display: 'flex', flexDirection: 'row', paddingInline: '1px', marginInlineEnd: '4px', height: 22, alignItems: 'center', overflow: 'hidden' }}
+    >
+      <Flex>
+        {inner}
+      </Flex>
+    </Tag>
+  )
+}
+RelicSetTagRenderer.propTypes = {
+  value: PropTypes.string,
+  closable: PropTypes.bool,
+  onClose: PropTypes.func,
+}

--- a/src/components/optimizerTab/optimizerForm/SimulatedBuildsGrid.tsx
+++ b/src/components/optimizerTab/optimizerForm/SimulatedBuildsGrid.tsx
@@ -1,6 +1,6 @@
-import { Flex, Table, TableColumnsType } from 'antd'
+import { Empty, Flex, Table, TableColumnsType } from 'antd'
 import { CloseOutlined } from "@ant-design/icons";
-import { STAT_SIMULATION_GRID_WIDTH } from "components/optimizerTab/optimizerForm/DamageCalculatorDisplay";
+import { STAT_SIMULATION_GRID_WIDTH } from "components/optimizerTab/optimizerForm/StatSimulationDisplay";
 import { deleteStatSimulationBuild, renderDefaultSimulationName } from "lib/statSimulationController.tsx";
 import { IRowNode } from "ag-grid-community";
 import { useEffect } from "react";
@@ -15,7 +15,7 @@ interface DataType {
 
 const columns: TableColumnsType<DataType> = [
   {
-    title: (<Flex style={{marginLeft: 5}}>Simulation identifier</Flex>),
+    title: (<Flex style={{marginLeft: 5}}>Simulation details</Flex>),
     dataIndex: 'name',
     fixed: 'left',
     width: '560',
@@ -84,6 +84,7 @@ export function SimulatedBuildsGrid() {
 
   return (
     <Table
+      locale={{emptyText: <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No simulations selected" />}}
       rowSelection={{
         selectedRowKeys: selectedStatSimulations,
         type: 'radio',

--- a/src/components/optimizerTab/optimizerForm/StatSimulationDisplay.tsx
+++ b/src/components/optimizerTab/optimizerForm/StatSimulationDisplay.tsx
@@ -14,10 +14,10 @@ import {
 } from "lib/statSimulationController.tsx";
 import { BodyStatOptions, FeetStatOptions, LinkRopeStatOptions, Parts, PlanarSphereStatOptions } from "lib/constants";
 import { Assets } from "lib/assets";
-import { OrnamentSetTagRenderer, } from "components/optimizerTab/optimizerForm/RelicMainSetFilters";
 import GenerateOrnamentsOptions from "components/optimizerTab/optimizerForm/OrnamentsOptions";
 import { GenerateBasicSetsOptions } from "components/optimizerTab/optimizerForm/SetsOptions";
 import { Utils } from "lib/utils";
+import { OrnamentSetTagRenderer } from "components/optimizerTab/optimizerForm/OrnamentSetTagRenderer";
 
 const { Text } = Typography
 

--- a/src/components/optimizerTab/optimizerForm/StatSimulationDisplay.tsx
+++ b/src/components/optimizerTab/optimizerForm/StatSimulationDisplay.tsx
@@ -12,15 +12,9 @@ import {
   saveStatSimulationBuildFromForm,
   startOptimizerStatSimulation
 } from "lib/statSimulationController.tsx";
-import { Parts } from "lib/constants";
+import { BodyStatOptions, FeetStatOptions, LinkRopeStatOptions, Parts, PlanarSphereStatOptions } from "lib/constants";
 import { Assets } from "lib/assets";
-import {
-  BodyStatOptions,
-  FeetStatOptions,
-  LinkRopeStatOptions,
-  OrnamentSetTagRenderer,
-  PlanarSphereStatOptions
-} from "components/optimizerTab/optimizerForm/RelicMainSetFilters";
+import { OrnamentSetTagRenderer, } from "components/optimizerTab/optimizerForm/RelicMainSetFilters";
 import GenerateOrnamentsOptions from "components/optimizerTab/optimizerForm/OrnamentsOptions";
 import { GenerateBasicSetsOptions } from "components/optimizerTab/optimizerForm/SetsOptions";
 import { Utils } from "lib/utils";

--- a/src/components/optimizerTab/optimizerForm/StatSimulationDisplay.tsx
+++ b/src/components/optimizerTab/optimizerForm/StatSimulationDisplay.tsx
@@ -39,7 +39,7 @@ export const STAT_SIMULATION_GRID_WIDTH = 680
 export const STAT_SIMULATION_OPTIONS_WIDTH = 215
 export const STAT_SIMULATION_STATS_WIDTH = 180
 
-export function DamageCalculatorDisplay() {
+export function StatSimulationDisplay() {
   const statSimulationDisplay = window.store((s) => s.statSimulationDisplay)
   const setStatSimulationDisplay = window.store((s) => s.setStatSimulationDisplay)
   const setConditionalSetEffectsDrawerOpen = window.store((s) => s.setConditionalSetEffectsDrawerOpen)
@@ -62,9 +62,9 @@ export function DamageCalculatorDisplay() {
             value={statSimulationDisplay}
             style={{ width: `${STAT_SIMULATION_GRID_WIDTH}px`, display: 'flex' }}
           >
-            <Radio style={{ display: 'flex', flex: 0.5, justifyContent: 'center', paddingInline: 0 }} value={StatSimTypes.Disabled}>Off</Radio>
-            <Radio style={{ display: 'flex', flex: 1, justifyContent: 'center', paddingInline: 0 }} value={StatSimTypes.SubstatRolls}>Simulate substat rolls</Radio>
-            <Radio style={{ display: 'flex', flex: 1, justifyContent: 'center', paddingInline: 0 }} value={StatSimTypes.SubstatTotals}>Simulate substat totals</Radio>
+            <Radio style={{ display: 'flex', flex: 0.3, justifyContent: 'center', paddingInline: 0 }} value={StatSimTypes.Disabled}>Off</Radio>
+            <Radio style={{ display: 'flex', flex: 1, justifyContent: 'center', paddingInline: 0 }} value={StatSimTypes.SubstatRolls}>Simulate custom substat rolls</Radio>
+            <Radio style={{ display: 'flex', flex: 1, justifyContent: 'center', paddingInline: 0 }} value={StatSimTypes.SubstatTotals}>Simulate custom substat totals</Radio>
             {/*<Radio style={{ display: 'flex', flex: 1, justifyContent: 'center', paddingInline: 0 }} value={StatSimTypes.CharacterStats} disabled>Character stats</Radio>*/}
           </Radio.Group>
 
@@ -89,9 +89,14 @@ export function DamageCalculatorDisplay() {
           </Flex>
         </Flex>
 
-        <Flex vertical justify='space-around' style={{display: isHidden() ? 'none' : 'flex'}} >
+        <Flex vertical justify='space-around'>
           <Flex vertical gap={10} >
-            <Button type="primary" style={{width: 35, height: 100, padding: 0}} onClick={saveStatSimulationBuildFromForm}>
+            <Button
+              type="primary"
+              style={{width: 35, height: 100, padding: 0}}
+              onClick={saveStatSimulationBuildFromForm}
+              disabled={isHidden()}
+            >
               <DoubleLeftOutlined />
             </Button>
             <Popconfirm
@@ -102,7 +107,11 @@ export function DamageCalculatorDisplay() {
               okText="Yes"
               cancelText="Cancel"
             >
-              <Button type="dashed" style={{width: 35, height: 35, padding: 0}}>
+              <Button
+                type="dashed"
+                style={{width: 35, height: 35, padding: 0}}
+                disabled={isHidden()}
+              >
                 <DeleteOutlined />
               </Button>
             </Popconfirm>
@@ -140,28 +149,6 @@ function SimulationInputs() {
           <Input placeholder='This is a fake hidden input to save simulations into the form' style={{display: 'none'}}/>
         </Form.Item>
 
-        {/*<Flex gap={5} style={{display: statSimulationDisplay == StatSimTypes.CharacterStats ? 'flex' : 'none'}}>*/}
-        {/*  <Flex vertical gap={5} style={{ width: STAT_SIMULATION_OPTIONS_WIDTH }}>*/}
-        {/*    <HeaderText>Character stat options</HeaderText>*/}
-        {/*    <Form.Item name={formName(StatSimTypes.CharacterStats, 'name')}>*/}
-        {/*      <Input placeholder='Build name (Optional)' />*/}
-        {/*    </Form.Item>*/}
-
-        {/*    <SetsSection simType={StatSimTypes.CharacterStats} />*/}
-
-        {/*    <HeaderText>Options</HeaderText>*/}
-        {/*    <Button*/}
-        {/*      onClick={() => setConditionalSetEffectsDrawerOpen(true)}*/}
-        {/*      icon={<SettingOutlined />}*/}
-        {/*    >*/}
-        {/*      Conditional set effects*/}
-        {/*    </Button>*/}
-        {/*  </Flex>*/}
-
-        {/*  <VerticalDivider />*/}
-
-        {/*  <CharacterStatsSection />*/}
-        {/*</Flex>*/}
         <Flex gap={5} style={{display: statSimulationDisplay == StatSimTypes.SubstatTotals ? 'flex' : 'none'}}>
           <Flex vertical gap={5} style={{ width: STAT_SIMULATION_OPTIONS_WIDTH }}>
             <SetsSection simType={StatSimTypes.SubstatTotals} />
@@ -170,24 +157,24 @@ function SimulationInputs() {
             <HeaderText>Options</HeaderText>
 
             <Form.Item name={formName(StatSimTypes.SubstatTotals, 'name')}>
-              <Input placeholder='Simulation name (Optional)' />
+              <Input placeholder='Simulation name (Optional)' autoComplete="off" />
             </Form.Item>
           </Flex>
 
           <VerticalDivider />
 
-          <SubstatsSection simType={StatSimTypes.SubstatTotals} title='Substat totals'/>
+          <SubstatsSection simType={StatSimTypes.SubstatTotals} title='Substat value totals'/>
         </Flex>
+
         <Flex gap={5} style={{display: statSimulationDisplay == StatSimTypes.SubstatRolls ? 'flex' : 'none'}}>
           <Flex vertical gap={5} style={{ width: STAT_SIMULATION_OPTIONS_WIDTH }}>
             <SetsSection simType={StatSimTypes.SubstatRolls} />
             <MainStatsSection simType={StatSimTypes.SubstatRolls} />
 
             <HeaderText>Options</HeaderText>
-            {/*<Select placeholder='Roll quality' />*/}
 
             <Form.Item name={formName(StatSimTypes.SubstatRolls, 'name')}>
-              <Input placeholder='Simulation name (Optional)' />
+              <Input placeholder='Simulation name (Optional)' autoComplete="off" />
             </Form.Item>
           </Flex>
 
@@ -195,8 +182,10 @@ function SimulationInputs() {
 
           <SubstatsSection simType={StatSimTypes.SubstatRolls} title='Substat max rolls' total={substatRollsTotal}/>
         </Flex>
-        <Flex style={{display: statSimulationDisplay == StatSimTypes.Disabled ? 'flex' : 'none'}}>
-          <></>
+
+        <Flex gap={5} style={{display: statSimulationDisplay == StatSimTypes.Disabled ? 'flex' : 'none'}}>
+          <div style={{width: STAT_SIMULATION_OPTIONS_WIDTH}}/>
+          <VerticalDivider />
         </Flex>
       </>
     )

--- a/src/components/optimizerTab/optimizerForm/SubstatWeightFilters.tsx
+++ b/src/components/optimizerTab/optimizerForm/SubstatWeightFilters.tsx
@@ -20,7 +20,7 @@ export const SubstatWeightFilters = () => {
         <TooltipImage type={Hint.substatWeightFilter()} />
       </Flex>
 
-      <Flex vertical gap={0}>
+      <Flex vertical gap={1}>
         <FormStatRollSlider text="HP" name={Constants.Stats.HP_P} />
         <FormStatRollSlider text="ATK" name={Constants.Stats.ATK_P} />
         <FormStatRollSlider text="DEF" name={Constants.Stats.DEF_P} />

--- a/src/components/optimizerTab/optimizerForm/TeammateCard.tsx
+++ b/src/components/optimizerTab/optimizerForm/TeammateCard.tsx
@@ -233,7 +233,7 @@ const TeammateCard = (props: { index: number }) => {
         </Flex>
 
         <Flex>
-          <Flex vertical style={{ minWidth: 250, marginLeft: 5 }}>
+          <Flex vertical style={{ minWidth: 258, marginLeft: 5 }}>
             <CharacterConditionalDisplay
               id={teammateCharacterId}
               eidolon={teammateEidolon}
@@ -247,7 +247,6 @@ const TeammateCard = (props: { index: number }) => {
                 width={rightPanelWidth}
                 height={rightPanelWidth}
                 src={Assets.getCharacterAvatarById(teammateCharacterId)}
-                // style={{ transform: `translate(${(innerW - parentW) / 2 / innerW * -100}%, ${(innerH - parentH) / 2 / innerH * -100}%)` }}
               />
             </div>
 
@@ -287,7 +286,7 @@ const TeammateCard = (props: { index: number }) => {
           <Form.Item name={[teammateProperty, `lightCone`]}>
             <LightConeSelect
               value=""
-              selectStyle={{ width: 250 }}
+              selectStyle={{ width: 258 }}
               characterId={teammateCharacterId}
             />
           </Form.Item>

--- a/src/components/optimizerTab/optimizerForm/TeammateCard.tsx
+++ b/src/components/optimizerTab/optimizerForm/TeammateCard.tsx
@@ -303,7 +303,7 @@ const TeammateCard = (props: { index: number }) => {
         </Flex>
 
         <Flex>
-          <Flex vertical style={{ minWidth: 250, marginLeft: 5 }}>
+          <Flex vertical style={{ minWidth: 258, marginLeft: 5 }}>
             <LightConeConditionalDisplay
               id={teammateLightConeId}
               superImposition={teammateSuperimposition}

--- a/src/components/optimizerTab/optimizerTabConstants.ts
+++ b/src/components/optimizerTab/optimizerTabConstants.ts
@@ -7,7 +7,8 @@ export const DIGITS_4 = 52
 export const DIGITS_5 = 60
 
 export const optimizerTabDefaultGap = 5
-export const panelWidth = 203
+export const panelWidth = 211
+export const defaultPadding = 11
 
 export const baseColumnDefs = [
   { field: 'relicSetIndex', cellRenderer: Renderer.relicSet, width: 67, headerName: 'Set' },

--- a/src/lib/conditionals/character/Sparkle.ts
+++ b/src/lib/conditionals/character/Sparkle.ts
@@ -85,7 +85,7 @@ export default (e: Eidolon): CharacterConditional => {
   ]
 
   const defaults = {
-    skillCdBuff: true,
+    skillCdBuff: false,
     cipherBuff: true,
     talentStacks: 3,
     quantumAllies: 3,

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -481,39 +481,39 @@ export const DEFAULT_STAT_DISPLAY = 'combat'
 export const MAX_RESULTS = 2_000_000
 
 export const BodyStatOptions = [
-  {value: Constants.Stats.HP_P, short: "HP%", label: 'HP%'},
-  {value: Constants.Stats.ATK_P, short: "ATK%", label: 'ATK%'},
-  {value: Constants.Stats.DEF_P, short: "DEF%", label: 'DEF%'},
-  {value: Constants.Stats.CR, short: "Crit Rate", label: 'CRIT Rate'},
-  {value: Constants.Stats.CD, short: "Crit DMG", label: 'CRIT DMG'},
-  {value: Constants.Stats.EHR, short: "EHR", label: 'Effect HIT Rate'},
-  {value: Constants.Stats.OHB, short: "Healing", label: 'Outgoing Healing Boost'},
+  {value: Stats.HP_P, short: "HP%", label: 'HP%'},
+  {value: Stats.ATK_P, short: "ATK%", label: 'ATK%'},
+  {value: Stats.DEF_P, short: "DEF%", label: 'DEF%'},
+  {value: Stats.CR, short: "Crit Rate", label: 'CRIT Rate'},
+  {value: Stats.CD, short: "Crit DMG", label: 'CRIT DMG'},
+  {value: Stats.EHR, short: "EHR", label: 'Effect HIT Rate'},
+  {value: Stats.OHB, short: "Healing", label: 'Outgoing Healing Boost'},
 ]
 
 export const FeetStatOptions = [
-  {value: Constants.Stats.HP_P, short: "HP%", label: 'HP%'},
-  {value: Constants.Stats.ATK_P, short: "ATK%", label: 'ATK%'},
-  {value: Constants.Stats.DEF_P, short: "DEF%", label: 'DEF%'},
-  {value: Constants.Stats.SPD, short: "SPD", label: 'Speed'},
+  {value: Stats.HP_P, short: "HP%", label: 'HP%'},
+  {value: Stats.ATK_P, short: "ATK%", label: 'ATK%'},
+  {value: Stats.DEF_P, short: "DEF%", label: 'DEF%'},
+  {value: Stats.SPD, short: "SPD", label: 'Speed'},
 ]
 
 export const LinkRopeStatOptions = [
-  {value: Constants.Stats.HP_P, short: "HP%", label: 'HP%'},
-  {value: Constants.Stats.ATK_P, short: "ATK%", label: 'ATK%'},
-  {value: Constants.Stats.DEF_P, short: "DEF%", label: 'DEF%'},
-  {value: Constants.Stats.BE, short: "Break", label: 'Break Effect'},
-  {value: Constants.Stats.ERR, short: "Energy", label: 'Energy Regeneration Rate'},
+  {value: Stats.HP_P, short: "HP%", label: 'HP%'},
+  {value: Stats.ATK_P, short: "ATK%", label: 'ATK%'},
+  {value: Stats.DEF_P, short: "DEF%", label: 'DEF%'},
+  {value: Stats.BE, short: "Break", label: 'Break Effect'},
+  {value: Stats.ERR, short: "Energy", label: 'Energy Regeneration Rate'},
 ]
 
 export const PlanarSphereStatOptions = [
-  {value: Constants.Stats.HP_P, short: "HP%", label: 'HP%'},
-  {value: Constants.Stats.ATK_P, short: "ATK%", label: 'ATK%'},
-  {value: Constants.Stats.DEF_P, short: "DEF%", label: 'DEF%'},
-  {value: Constants.Stats.Physical_DMG, short: "Physical", label: 'Physical DMG'},
-  {value: Constants.Stats.Fire_DMG, short: "Fire", label: 'Fire DMG'},
-  {value: Constants.Stats.Ice_DMG, short: "Ice", label: 'Ice DMG'},
-  {value: Constants.Stats.Lightning_DMG, short: "Lightning", label: 'Lightning DMG'},
-  {value: Constants.Stats.Wind_DMG, short: "Wind", label: 'Wind DMG'},
-  {value: Constants.Stats.Quantum_DMG, short: "Quantum", label: 'Quantum DMG'},
-  {value: Constants.Stats.Imaginary_DMG, short: "Imaginary", label: 'Imaginary DMG'},
+  {value: Stats.HP_P, short: "HP%", label: 'HP%'},
+  {value: Stats.ATK_P, short: "ATK%", label: 'ATK%'},
+  {value: Stats.DEF_P, short: "DEF%", label: 'DEF%'},
+  {value: Stats.Physical_DMG, short: "Physical", label: 'Physical DMG'},
+  {value: Stats.Fire_DMG, short: "Fire", label: 'Fire DMG'},
+  {value: Stats.Ice_DMG, short: "Ice", label: 'Ice DMG'},
+  {value: Stats.Lightning_DMG, short: "Lightning", label: 'Lightning DMG'},
+  {value: Stats.Wind_DMG, short: "Wind", label: 'Wind DMG'},
+  {value: Stats.Quantum_DMG, short: "Quantum", label: 'Quantum DMG'},
+  {value: Stats.Imaginary_DMG, short: "Imaginary", label: 'Imaginary DMG'},
 ]

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -479,3 +479,41 @@ export const RelicSetFilterOptions = {
 
 export const DEFAULT_STAT_DISPLAY = 'combat'
 export const MAX_RESULTS = 2_000_000
+
+export const BodyStatOptions = [
+  {value: Constants.Stats.HP_P, short: "HP%", label: 'HP%'},
+  {value: Constants.Stats.ATK_P, short: "ATK%", label: 'ATK%'},
+  {value: Constants.Stats.DEF_P, short: "DEF%", label: 'DEF%'},
+  {value: Constants.Stats.CR, short: "Crit Rate", label: 'CRIT Rate'},
+  {value: Constants.Stats.CD, short: "Crit DMG", label: 'CRIT DMG'},
+  {value: Constants.Stats.EHR, short: "EHR", label: 'Effect HIT Rate'},
+  {value: Constants.Stats.OHB, short: "Healing", label: 'Outgoing Healing Boost'},
+]
+
+export const FeetStatOptions = [
+  {value: Constants.Stats.HP_P, short: "HP%", label: 'HP%'},
+  {value: Constants.Stats.ATK_P, short: "ATK%", label: 'ATK%'},
+  {value: Constants.Stats.DEF_P, short: "DEF%", label: 'DEF%'},
+  {value: Constants.Stats.SPD, short: "SPD", label: 'Speed'},
+]
+
+export const LinkRopeStatOptions = [
+  {value: Constants.Stats.HP_P, short: "HP%", label: 'HP%'},
+  {value: Constants.Stats.ATK_P, short: "ATK%", label: 'ATK%'},
+  {value: Constants.Stats.DEF_P, short: "DEF%", label: 'DEF%'},
+  {value: Constants.Stats.BE, short: "Break", label: 'Break Effect'},
+  {value: Constants.Stats.ERR, short: "Energy", label: 'Energy Regeneration Rate'},
+]
+
+export const PlanarSphereStatOptions = [
+  {value: Constants.Stats.HP_P, short: "HP%", label: 'HP%'},
+  {value: Constants.Stats.ATK_P, short: "ATK%", label: 'ATK%'},
+  {value: Constants.Stats.DEF_P, short: "DEF%", label: 'DEF%'},
+  {value: Constants.Stats.Physical_DMG, short: "Physical", label: 'Physical DMG'},
+  {value: Constants.Stats.Fire_DMG, short: "Fire", label: 'Fire DMG'},
+  {value: Constants.Stats.Ice_DMG, short: "Ice", label: 'Ice DMG'},
+  {value: Constants.Stats.Lightning_DMG, short: "Lightning", label: 'Lightning DMG'},
+  {value: Constants.Stats.Wind_DMG, short: "Wind", label: 'Wind DMG'},
+  {value: Constants.Stats.Quantum_DMG, short: "Quantum", label: 'Quantum DMG'},
+  {value: Constants.Stats.Imaginary_DMG, short: "Imaginary", label: 'Imaginary DMG'},
+]

--- a/src/lib/db.js
+++ b/src/lib/db.js
@@ -10,7 +10,7 @@ import { SaveState } from 'lib/saveState'
 import { Message } from 'lib/message'
 import { OptimizerMenuIds } from 'components/optimizerTab/FormRow.tsx'
 import { Themes } from 'lib/theme'
-import { StatSimTypes } from 'components/optimizerTab/optimizerForm/DamageCalculatorDisplay'
+import { StatSimTypes } from 'components/optimizerTab/optimizerForm/StatSimulationDisplay'
 
 const state = {
   relics: [],

--- a/src/lib/db.js
+++ b/src/lib/db.js
@@ -169,8 +169,6 @@ window.store = create((set) => ({
 }))
 
 export const DB = {
-  getGlobals: () => state.globals,
-
   getMetadata: () => state.metadata,
   setMetadata: (x) => state.metadata = x,
 

--- a/src/lib/defaultForm.js
+++ b/src/lib/defaultForm.js
@@ -1,6 +1,6 @@
 import { Constants, DEFAULT_STAT_DISPLAY } from './constants.ts'
 import DB from 'lib/db'
-import { StatSimTypes } from 'components/optimizerTab/optimizerForm/DamageCalculatorDisplay'
+import { StatSimTypes } from 'components/optimizerTab/optimizerForm/StatSimulationDisplay'
 
 export function getDefaultForm(initialCharacter) {
   const metadata = DB.getMetadata().characters[initialCharacter]

--- a/src/lib/hint.jsx
+++ b/src/lib/hint.jsx
@@ -31,7 +31,7 @@ export const Hint = {
       title: 'Stat filters',
       content: (
         <Flex vertical gap={10}>
-          <p>Min / Max filters for character stats, inclusive. The optimizer will only show results within these ranges </p>
+          <p>Min (left) / Max (right) filters for character stats, inclusive. The optimizer will only show results within these ranges </p>
           <p>Stat abbreviations are ATK / HP / DEF / SPD / Crit Rate / Crit Damage / Effect Hit Rate / Effect RES / Break Effect</p>
           <p>NOTE: Ingame speed decimals are truncated so you may see speed values ingame higher than shown here. This is because the OCR importer can't detect the hidden decimals.</p>
         </Flex>

--- a/src/lib/optimizer/optimizer.js
+++ b/src/lib/optimizer/optimizer.js
@@ -16,6 +16,20 @@ import { setSortColumn } from 'components/optimizerTab/optimizerForm/Recommended
 
 let CANCEL = false
 
+export function calculateCurrentlyEquippedRow(request) {
+  let relics = Utils.clone(DB.getRelics())
+  RelicFilters.calculateWeightScore(request, relics)
+  relics = relics.filter((x) => x.equippedBy == request.characterId)
+  relics = RelicFilters.applyMaxedMainStatsFilter(request, relics)
+  relics = RelicFilters.splitRelicsByPart(relics)
+  RelicFilters.condenseRelicSubstatsForOptimizer(relics)
+  Object.keys(relics).map((key) => relics[key] = relics[key][0])
+
+  const c = calculateBuild(request, relics)
+  renameFields(c)
+  OptimizerTabController.setTopRow(c)
+}
+
 export const Optimizer = {
   cancel: (id) => {
     CANCEL = true
@@ -106,20 +120,7 @@ export const Optimizer = {
     const params = generateParams(request)
 
     // Create a special optimization request for the top row, ignoring filters and with a custom callback
-    function handleTopRow() {
-      let relics = Utils.clone(DB.getRelics())
-      RelicFilters.calculateWeightScore(request, relics)
-      relics = relics.filter((x) => x.equippedBy == request.characterId)
-      relics = RelicFilters.applyMaxedMainStatsFilter(request, relics)
-      relics = RelicFilters.splitRelicsByPart(relics)
-      RelicFilters.condenseRelicSubstatsForOptimizer(relics)
-      Object.keys(relics).map((key) => relics[key] = relics[key][0])
-
-      const c = calculateBuild(request, relics)
-      renameFields(c)
-      OptimizerTabController.setTopRow(c)
-    }
-    handleTopRow()
+    calculateCurrentlyEquippedRow(request)
 
     let searched = 0
     let resultsShown = false

--- a/src/lib/statSimulationController.tsx
+++ b/src/lib/statSimulationController.tsx
@@ -1,4 +1,4 @@
-import { StatSimTypes } from 'components/optimizerTab/optimizerForm/DamageCalculatorDisplay'
+import { StatSimTypes } from 'components/optimizerTab/optimizerForm/StatSimulationDisplay'
 import { Utils } from 'lib/utils'
 import { Constants, Parts, SetsRelicsNames, Stats, StatsToShort, SubStats } from 'lib/constants'
 import { emptyRelic } from 'lib/optimizer/optimizerUtils'
@@ -152,6 +152,21 @@ function SimMainsDisplay(props: { sim: any }) {
   )
 }
 
+const substatToPriority = {
+  [Stats.ATK_P]: 0,
+  [Stats.CR]: 1,
+  [Stats.CD]: 2,
+  [Stats.SPD]: 3,
+  [Stats.BE]: 4,
+  [Stats.ATK]: 5,
+  [Stats.HP_P]: 6,
+  [Stats.DEF_P]: 7,
+  [Stats.HP]: 8,
+  [Stats.DEF]: 9,
+  [Stats.EHR]: 10,
+  [Stats.RES]: 11,
+}
+
 function SimSubstatsDisplay(props: { sim: any }) {
   const renderArray: Stat[] = []
   const substats = inputToSubstats(props.sim)
@@ -165,6 +180,8 @@ function SimSubstatsDisplay(props: { sim: any }) {
     }
   }
 
+  renderArray.sort((a, b) => substatToPriority[a.stat] - substatToPriority[b.stat])
+
   function renderStat(x) {
     return props.sim.simType == StatSimTypes.SubstatRolls
       ? `${StatsToShort[x.stat]} x${x.value}`
@@ -177,7 +194,11 @@ function SimSubstatsDisplay(props: { sim: any }) {
         renderArray.map((x) => {
           return (
             <Flex key={x.stat}>
-              <Tag>{renderStat(x)} </Tag>
+              <Tag
+                style={{ paddingInline: '5px', marginInlineEnd: '5px' }}
+              >
+                {renderStat(x)}
+              </Tag>
             </Flex>
           )
         })

--- a/src/lib/statSimulationController.tsx
+++ b/src/lib/statSimulationController.tsx
@@ -7,7 +7,7 @@ import { Stat } from 'types/Relic'
 import { RelicFilters } from 'lib/relicFilters'
 import { calculateBuild } from 'lib/optimizer/calculateBuild'
 import { OptimizerTabController } from 'lib/optimizerTabController'
-import { renameFields } from 'lib/optimizer/optimizer'
+import { calculateCurrentlyEquippedRow, renameFields } from 'lib/optimizer/optimizer'
 import { Assets } from 'lib/assets'
 import { Flex, Tag } from 'antd'
 import { Message } from 'lib/message'
@@ -339,6 +339,8 @@ export function startOptimizerStatSimulation() {
   const simulationResults = runSimulations(form, existingSimulations)
 
   OptimizerTabController.setRows(simulationResults)
+
+  calculateCurrentlyEquippedRow(form)
   window.optimizerGrid.current.api.updateGridOptions({ datasource: OptimizerTabController.getDataSource() })
 
   const sortOption = SortOption[form.resultSort]


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Changed sparkle skill on self to default to false
* Calculate the pinned top row when simulations are run
* Sort the autogenerated stats summary for simulator by damage stats first
* Fixed some messed up widths on the optimizer page
* Set a max width on the changelog images
* Fix form container border taking up 2 extra px
* Renamed menu header Menu -> Optimization 
* Rename simulation filter row to Character custom stats simulation

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

