### PR TITLE
fix: main stat free roll was incorrect for cases where the optimal main wasnt at 1 weight

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -98,8 +98,8 @@ const App = () => {
             }}
           >
             <Tabs />
-            <SettingsDrawer />
           </Content>
+          <SettingsDrawer />
         </Layout>
       </Layout>
     </ConfigProvider>

--- a/src/components/optimizerTab/conditionals/FormSlider.tsx
+++ b/src/components/optimizerTab/conditionals/FormSlider.tsx
@@ -5,7 +5,7 @@ import WithPopover from 'components/common/WithPopover.tsx'
 
 const justify = 'flex-start'
 const align = 'center'
-const inputWidth = 55
+const inputWidth = 57
 const numberWidth = 50
 const sliderWidth = 155
 
@@ -61,8 +61,7 @@ export const FormSlider: ComponentType<FormSliderProps> = (props) => {
                 width: numberWidth,
               }}
               parser={(value) => value == null || value == '' ? 0 : precisionRound(parseFloat(value) / multiplier)}
-              formatter={(value) => `${precisionRound((value ?? 0) * multiplier)}`}
-              addonAfter={symbol}
+              formatter={(value) => `${precisionRound((value ?? 0) * multiplier)}${symbol}`}
               onChange={setInputValue}
               disabled={props.disabled}
             />

--- a/src/lib/relicScorer.ts
+++ b/src/lib/relicScorer.ts
@@ -52,9 +52,12 @@ const mainStatFreeRolls = {
   },
 }
 
-function mainStatFreeRoll(part, mainStat, multipliers) {
+function mainStatFreeRoll(part, mainStat, scoringMetadata) {
+  const stats = scoringMetadata.stats
+  const parts = scoringMetadata.parts
   if (part == Constants.Parts.Body || part == Constants.Parts.Feet || part == Constants.Parts.PlanarSphere || part == Constants.Parts.LinkRope) {
-    return mainStatFreeRolls[part][mainStat] * minRollValue * multipliers[mainStat]
+    const multiplier = parts[part].includes(mainStat) ? 1 : stats[mainStat]
+    return mainStatFreeRolls[part][mainStat] * minRollValue * multiplier
   }
   return 0
 }
@@ -323,7 +326,7 @@ export class RelicScorer {
     if (Utils.hasMainStat(relic.part)) {
       // undo mainstat free roll as it's not relevant for potential
       const scoringMetadata = this.getRelicScoreMeta(id)
-      const freeRoll = mainStatFreeRoll(relic.part, relic.main.stat, scoringMetadata.stats)
+      const freeRoll = mainStatFreeRoll(relic.part, relic.main.stat, scoringMetadata)
       score.best -= freeRoll
       score.average -= freeRoll
       score.worst -= freeRoll
@@ -474,7 +477,7 @@ export class RelicScorer {
       sum += substat.value * (multipliers[substat.stat] || 0) * scaling[substat.stat]
     }
 
-    sum += mainStatFreeRoll(relic.part, relic.main.stat, multipliers)
+    sum += mainStatFreeRoll(relic.part, relic.main.stat, scoringMetadata)
 
     let rating = 'F'
     for (let i = 0; i < ratings.length; i++) {

--- a/tests/CharacterPreview/switch-relics-with-character.spec.ts
+++ b/tests/CharacterPreview/switch-relics-with-character.spec.ts
@@ -30,7 +30,7 @@ test('Switch relics between characters in Characters tab', async ({ page }) => {
   // Orb
   await expect(page.locator('.ant-card').filter({ hasText: /^\+15Lightning DMG38\.8%ATK59ATK %8\.2%DEF %5\.4%Effect HIT6\.9%Score14\.1 \(D\+\)$/ })).toHaveCount(1)
   // Rope
-  await expect(page.locator('.ant-card').filter({ hasText: /^\+15ATK %43\.2%HP38ATK63SPD5Effect HIT8\.2%Score22\.3 \(B\)$/ })).toHaveCount(1)
+  await expect(page.locator('.ant-card').filter({ hasText: /^\+15ATK %43\.2%HP38ATK63SPD5Effect HIT8\.2%Score23\.7 \(B\+\)$/ })).toHaveCount(1)
 
   // Verify Kafka now has Jingliu's relics
   await page.locator('#characterGrid').getByText('Kafka').click()


### PR DESCRIPTION

# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Fixed a bug that applied to sparkle/bronya's spheres main stat free roll mainly
* Fixed the margin issues from last commit
* Fixed some spacing issues for form input

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

