### PR TITLE
hotfix: 2.3 wording, remove jade skill dmg, fix grid styling, robin ult boosts

### DIFF
--- a/src/components/ChangelogTab.tsx
+++ b/src/components/ChangelogTab.tsx
@@ -115,7 +115,7 @@ function getChangelogContent() {
         'rollSim.webp',
         'The substat totals view simulates the sum of the substat values',
         leaks('totalsSim.webp'),
-        leaks(`Jade and Firefly have been added, with damage calculations and to the Relic Scorer experiment options`),
+        leaks(`Jade and Firefly have been added with damage calculations, and to the Relic Scorer experiment options`),
         leaks('jade.webp'),
         'Custom character portraits can now be saved from the Relic Scorer',
         leaks('scorer.webp'),

--- a/src/components/optimizerTab/optimizerForm/SimulatedBuildsGrid.tsx
+++ b/src/components/optimizerTab/optimizerForm/SimulatedBuildsGrid.tsx
@@ -34,12 +34,12 @@ const columns: TableColumnsType<DataType> = [
       return (
         <a onClick={() => {
           deleteStatSimulationBuild(record)
-        }}>
+        }} style={{ display: 'flex', justifyContent: 'center' }}>
           <CloseOutlined/>
         </a>
       )
     },
-    width: 24,
+    width: 36,
     fixed: 'right',
   },
 ]
@@ -111,7 +111,7 @@ export function SimulatedBuildsGrid() {
         border: '1px solid rgba(255, 255, 255, 0.15)'
       }}
       scroll={{
-        y: 265,
+        y: 300,
       }}
     />
   )

--- a/src/components/optimizerTab/optimizerForm/SimulatedBuildsGrid.tsx
+++ b/src/components/optimizerTab/optimizerForm/SimulatedBuildsGrid.tsx
@@ -1,9 +1,9 @@
 import { Empty, Flex, Table, TableColumnsType } from 'antd'
-import { CloseOutlined } from "@ant-design/icons";
-import { STAT_SIMULATION_GRID_WIDTH } from "components/optimizerTab/optimizerForm/StatSimulationDisplay";
-import { deleteStatSimulationBuild, renderDefaultSimulationName } from "lib/statSimulationController.tsx";
-import { IRowNode } from "ag-grid-community";
-import { useEffect } from "react";
+import { CloseOutlined } from '@ant-design/icons'
+import { STAT_SIMULATION_GRID_WIDTH } from 'components/optimizerTab/optimizerForm/StatSimulationDisplay'
+import { deleteStatSimulationBuild, renderDefaultSimulationName } from 'lib/statSimulationController.tsx'
+import { IRowNode } from 'ag-grid-community'
+import { useEffect } from 'react'
 
 interface DataType {
   key: React.Key
@@ -15,7 +15,7 @@ interface DataType {
 
 const columns: TableColumnsType<DataType> = [
   {
-    title: (<Flex style={{marginLeft: 5}}>Simulation details</Flex>),
+    title: (<Flex style={{ marginLeft: 5 }}>Simulation details</Flex>),
     dataIndex: 'name',
     fixed: 'left',
     width: '560',
@@ -42,7 +42,7 @@ const columns: TableColumnsType<DataType> = [
     width: 24,
     fixed: 'right',
   },
-];
+]
 
 export function SimulatedBuildsGrid() {
   const statSimulations = window.store((s) => s.statSimulations)
@@ -85,12 +85,13 @@ export function SimulatedBuildsGrid() {
 
   return (
     <Table
-      locale={{emptyText: <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No custom simulations selected" />}}
+      showHeader={false}
+      locale={{ emptyText: <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No custom simulations selected"/> }}
       rowSelection={{
         selectedRowKeys: selectedStatSimulations,
         type: 'radio',
         columnWidth: 0,
-        renderCell: () => "", // Render nothing for the selection column
+        renderCell: () => '', // Render nothing for the selection column
       }}
       columns={columns}
       dataSource={statSimulations}
@@ -100,18 +101,18 @@ export function SimulatedBuildsGrid() {
         }
       })}
       pagination={false}
-      size='small'
+      size="small"
       style={{
         flex: 1,
         width: STAT_SIMULATION_GRID_WIDTH,
-        borderRadius: 8,
+        // borderRadius: 8,
         height: '100%',
         backgroundColor: '#0000001a',
-        border: '1px solid #ffffff1a'
+        border: '1px solid rgba(255, 255, 255, 0.15)'
       }}
       scroll={{
         y: 265,
       }}
     />
-  );
+  )
 }

--- a/src/components/optimizerTab/optimizerForm/StatSimulationDisplay.tsx
+++ b/src/components/optimizerTab/optimizerForm/StatSimulationDisplay.tsx
@@ -1,27 +1,27 @@
 import FormCard from '../FormCard'
 import { Button, Flex, Form, Input, InputNumber, Popconfirm, Radio, Select, Typography } from 'antd'
 import { VerticalDivider } from '../../Dividers'
-import { SimulatedBuildsGrid } from "components/optimizerTab/optimizerForm/SimulatedBuildsGrid";
-import { HeaderText } from "components/HeaderText";
-import { DeleteOutlined, DoubleLeftOutlined, DownOutlined, SettingOutlined, UpOutlined } from "@ant-design/icons";
-import { useMemo } from "react";
+import { SimulatedBuildsGrid } from 'components/optimizerTab/optimizerForm/SimulatedBuildsGrid'
+import { HeaderText } from 'components/HeaderText'
+import { DeleteOutlined, DoubleLeftOutlined, DownOutlined, SettingOutlined, UpOutlined } from '@ant-design/icons'
+import { useMemo } from 'react'
 import {
   deleteAllStatSimulationBuilds,
   importOptimizerBuild,
   saveStatSimulationBuildFromForm,
   startOptimizerStatSimulation
-} from "lib/statSimulationController.tsx";
-import { BodyStatOptions, FeetStatOptions, LinkRopeStatOptions, Parts, PlanarSphereStatOptions } from "lib/constants";
-import { Assets } from "lib/assets";
-import GenerateOrnamentsOptions from "components/optimizerTab/optimizerForm/OrnamentsOptions";
-import { GenerateBasicSetsOptions } from "components/optimizerTab/optimizerForm/SetsOptions";
-import { Utils } from "lib/utils";
-import { OrnamentSetTagRenderer } from "components/optimizerTab/optimizerForm/OrnamentSetTagRenderer";
+} from 'lib/statSimulationController.tsx'
+import { BodyStatOptions, FeetStatOptions, LinkRopeStatOptions, Parts, PlanarSphereStatOptions } from 'lib/constants'
+import { Assets } from 'lib/assets'
+import GenerateOrnamentsOptions from 'components/optimizerTab/optimizerForm/OrnamentsOptions'
+import { GenerateBasicSetsOptions } from 'components/optimizerTab/optimizerForm/SetsOptions'
+import { Utils } from 'lib/utils'
+import { OrnamentSetTagRenderer } from 'components/optimizerTab/optimizerForm/OrnamentSetTagRenderer'
 
 const { Text } = Typography
 
 export enum StatSimTypes {
-  Disabled = "disabled",
+  Disabled = 'disabled',
   CharacterStats = 'characterStats',
   SubstatTotals = 'substatTotals',
   SubstatRolls = 'substatRolls',
@@ -42,9 +42,9 @@ export function StatSimulationDisplay() {
   }
 
   return (
-    <FormCard style={{ overflow: 'hidden' }} size='large' height={STAT_SIMULATION_ROW_HEIGHT}>
-      <Flex gap={15} style={{height: '100%'}}>
-        <Flex vertical gap={15} align='center'>
+    <FormCard style={{ overflow: 'hidden' }} size="large" height={STAT_SIMULATION_ROW_HEIGHT}>
+      <Flex gap={15} style={{ height: '100%' }}>
+        <Flex vertical gap={15} align="center">
           <Radio.Group
             onChange={(e) => {
               const { target: { value } } = e
@@ -55,42 +55,45 @@ export function StatSimulationDisplay() {
             value={statSimulationDisplay}
             style={{ width: `${STAT_SIMULATION_GRID_WIDTH}px`, display: 'flex' }}
           >
-            <Radio style={{ display: 'flex', flex: 0.3, justifyContent: 'center', paddingInline: 0 }} value={StatSimTypes.Disabled}>Off</Radio>
-            <Radio style={{ display: 'flex', flex: 1, justifyContent: 'center', paddingInline: 0 }} value={StatSimTypes.SubstatRolls}>Simulate custom substat rolls</Radio>
-            <Radio style={{ display: 'flex', flex: 1, justifyContent: 'center', paddingInline: 0 }} value={StatSimTypes.SubstatTotals}>Simulate custom substat totals</Radio>
+            <Radio style={{ display: 'flex', flex: 0.3, justifyContent: 'center', paddingInline: 0 }}
+                   value={StatSimTypes.Disabled}>Off</Radio>
+            <Radio style={{ display: 'flex', flex: 1, justifyContent: 'center', paddingInline: 0 }}
+                   value={StatSimTypes.SubstatRolls}>Simulate custom substat rolls</Radio>
+            <Radio style={{ display: 'flex', flex: 1, justifyContent: 'center', paddingInline: 0 }}
+                   value={StatSimTypes.SubstatTotals}>Simulate custom substat totals</Radio>
             {/*<Radio style={{ display: 'flex', flex: 1, justifyContent: 'center', paddingInline: 0 }} value={StatSimTypes.CharacterStats} disabled>Character stats</Radio>*/}
           </Radio.Group>
 
-          <Flex style={{minHeight: 302}}>
-            <SimulatedBuildsGrid />
+          <Flex style={{ minHeight: 302 }}>
+            <SimulatedBuildsGrid/>
           </Flex>
 
           <Flex gap={10}>
-            <Button style={{width: 200, display: isHidden() ? 'none' : 'block'}} onClick={startOptimizerStatSimulation} icon={<DownOutlined/>}>
+            <Button style={{ width: 200 }} disabled={isHidden()} onClick={startOptimizerStatSimulation}
+                    icon={<DownOutlined/>}>
               Simulate builds
             </Button>
-            <Button style={{width: 200, display: isHidden() ? 'none' : 'block'}} onClick={importOptimizerBuild} icon={<UpOutlined/>}>
+            <Button style={{ width: 200 }} disabled={isHidden()} onClick={importOptimizerBuild} icon={<UpOutlined/>}>
               Import optimizer build
             </Button>
-            <Button
-              style={{width: 200, display: isHidden() ? 'none' : 'block'}}
-              onClick={() => setConditionalSetEffectsDrawerOpen(true)}
-              icon={<SettingOutlined />}
+            <Button style={{ width: 200 }} disabled={isHidden()}
+                    onClick={() => setConditionalSetEffectsDrawerOpen(true)}
+                    icon={<SettingOutlined/>}
             >
               Conditional set effects
             </Button>
           </Flex>
         </Flex>
 
-        <Flex vertical justify='space-around'>
-          <Flex vertical gap={10} >
+        <Flex vertical justify="space-around">
+          <Flex vertical gap={10}>
             <Button
               type="primary"
-              style={{width: 35, height: 100, padding: 0}}
+              style={{ width: 35, height: 100, padding: 0 }}
               onClick={saveStatSimulationBuildFromForm}
               disabled={isHidden()}
             >
-              <DoubleLeftOutlined />
+              <DoubleLeftOutlined/>
             </Button>
             <Popconfirm
               title="Erase stat simulations"
@@ -102,16 +105,16 @@ export function StatSimulationDisplay() {
             >
               <Button
                 type="dashed"
-                style={{width: 35, height: 35, padding: 0}}
+                style={{ width: 35, height: 35, padding: 0 }}
                 disabled={isHidden()}
               >
-                <DeleteOutlined />
+                <DeleteOutlined/>
               </Button>
             </Popconfirm>
           </Flex>
         </Flex>
 
-        <SimulationInputs />
+        <SimulationInputs/>
       </Flex>
     </FormCard>
   )
@@ -139,53 +142,54 @@ function SimulationInputs() {
     return (
       <>
         <Form.Item name={formName('simulations')}>
-          <Input placeholder='This is a fake hidden input to save simulations into the form' style={{display: 'none'}}/>
+          <Input placeholder="This is a fake hidden input to save simulations into the form"
+                 style={{ display: 'none' }}/>
         </Form.Item>
 
-        <Flex gap={5} style={{display: statSimulationDisplay == StatSimTypes.SubstatTotals ? 'flex' : 'none'}}>
+        <Flex gap={5} style={{ display: statSimulationDisplay == StatSimTypes.SubstatTotals ? 'flex' : 'none' }}>
           <Flex vertical gap={5} style={{ width: STAT_SIMULATION_OPTIONS_WIDTH }}>
-            <SetsSection simType={StatSimTypes.SubstatTotals} />
+            <SetsSection simType={StatSimTypes.SubstatTotals}/>
             <MainStatsSection simType={StatSimTypes.SubstatTotals}/>
 
             <HeaderText>Options</HeaderText>
 
             <Form.Item name={formName(StatSimTypes.SubstatTotals, 'name')}>
-              <Input placeholder='Simulation name (Optional)' autoComplete="off" />
+              <Input placeholder="Simulation name (Optional)" autoComplete="off"/>
             </Form.Item>
           </Flex>
 
-          <VerticalDivider />
+          <VerticalDivider/>
 
-          <SubstatsSection simType={StatSimTypes.SubstatTotals} title='Substat value totals'/>
+          <SubstatsSection simType={StatSimTypes.SubstatTotals} title="Substat value totals"/>
         </Flex>
 
-        <Flex gap={5} style={{display: statSimulationDisplay == StatSimTypes.SubstatRolls ? 'flex' : 'none'}}>
+        <Flex gap={5} style={{ display: statSimulationDisplay == StatSimTypes.SubstatRolls ? 'flex' : 'none' }}>
           <Flex vertical gap={5} style={{ width: STAT_SIMULATION_OPTIONS_WIDTH }}>
-            <SetsSection simType={StatSimTypes.SubstatRolls} />
-            <MainStatsSection simType={StatSimTypes.SubstatRolls} />
+            <SetsSection simType={StatSimTypes.SubstatRolls}/>
+            <MainStatsSection simType={StatSimTypes.SubstatRolls}/>
 
             <HeaderText>Options</HeaderText>
 
             <Form.Item name={formName(StatSimTypes.SubstatRolls, 'name')}>
-              <Input placeholder='Simulation name (Optional)' autoComplete="off" />
+              <Input placeholder="Simulation name (Optional)" autoComplete="off"/>
             </Form.Item>
           </Flex>
 
-          <VerticalDivider />
+          <VerticalDivider/>
 
-          <SubstatsSection simType={StatSimTypes.SubstatRolls} title='Substat max rolls' total={substatRollsTotal}/>
+          <SubstatsSection simType={StatSimTypes.SubstatRolls} title="Substat max rolls" total={substatRollsTotal}/>
         </Flex>
 
-        <Flex gap={5} style={{display: statSimulationDisplay == StatSimTypes.Disabled ? 'flex' : 'none'}}>
-          <div style={{width: STAT_SIMULATION_OPTIONS_WIDTH}}/>
-          <VerticalDivider />
+        <Flex gap={5} style={{ display: statSimulationDisplay == StatSimTypes.Disabled ? 'flex' : 'none' }}>
+          <div style={{ width: STAT_SIMULATION_OPTIONS_WIDTH }}/>
+          <VerticalDivider/>
         </Flex>
       </>
     )
   }, [statSimulationDisplay, substatRollsTotal])
 
   return (
-    <Flex style={{minHeight: 300}}>
+    <Flex style={{ minHeight: 300 }}>
       {renderedOptions}
     </Flex>
   )
@@ -195,7 +199,7 @@ function SetsSection(props: { simType: string }) {
   return (
     <>
       <HeaderText>Sets</HeaderText>
-      <Form.Item name={formName(props.simType, 'simRelicSet1')} style={{maxHeight: 32}}>
+      <Form.Item name={formName(props.simType, 'simRelicSet1')} style={{ maxHeight: 32 }}>
         <Select
           dropdownStyle={{
             width: 250,
@@ -210,7 +214,7 @@ function SetsSection(props: { simType: string }) {
         >
         </Select>
       </Form.Item>
-      <Form.Item name={formName(props.simType, 'simRelicSet2')} style={{maxHeight: 32}}>
+      <Form.Item name={formName(props.simType, 'simRelicSet2')} style={{ maxHeight: 32 }}>
         <Select
           dropdownStyle={{
             width: 250,
@@ -226,7 +230,7 @@ function SetsSection(props: { simType: string }) {
         </Select>
       </Form.Item>
 
-      <Form.Item name={formName(props.simType, 'simOrnamentSet')} style={{maxHeight: 32}}>
+      <Form.Item name={formName(props.simType, 'simOrnamentSet')} style={{ maxHeight: 32 }}>
         <Select
           dropdownStyle={{
             width: 250,
@@ -250,13 +254,15 @@ function MainStatsSection(props: { simType: string }) {
     <>
       <HeaderText>Main stats</HeaderText>
       <Flex vertical gap={5}>
-        <Flex gap={5} style={{width: STAT_SIMULATION_OPTIONS_WIDTH}}>
-          <MainStatSelector placeholder='Body' part={Parts.Body} options={BodyStatOptions} simType={props.simType}/>
-          <MainStatSelector placeholder='Feet' part={Parts.Feet} options={FeetStatOptions} simType={props.simType}/>
+        <Flex gap={5} style={{ width: STAT_SIMULATION_OPTIONS_WIDTH }}>
+          <MainStatSelector placeholder="Body" part={Parts.Body} options={BodyStatOptions} simType={props.simType}/>
+          <MainStatSelector placeholder="Feet" part={Parts.Feet} options={FeetStatOptions} simType={props.simType}/>
         </Flex>
-        <Flex gap={5} style={{width: STAT_SIMULATION_OPTIONS_WIDTH}}>
-          <MainStatSelector placeholder='Sphere' part={Parts.PlanarSphere} options={PlanarSphereStatOptions} simType={props.simType}/>
-          <MainStatSelector placeholder='Rope' part={Parts.LinkRope} options={LinkRopeStatOptions} simType={props.simType}/>
+        <Flex gap={5} style={{ width: STAT_SIMULATION_OPTIONS_WIDTH }}>
+          <MainStatSelector placeholder="Sphere" part={Parts.PlanarSphere} options={PlanarSphereStatOptions}
+                            simType={props.simType}/>
+          <MainStatSelector placeholder="Rope" part={Parts.LinkRope} options={LinkRopeStatOptions}
+                            simType={props.simType}/>
         </Flex>
       </Flex>
     </>
@@ -265,14 +271,14 @@ function MainStatsSection(props: { simType: string }) {
 
 function MainStatSelector(props: { simType: string, placeholder: string, part: string, options: any[] }) {
   return (
-    <Form.Item name={formName(props.simType, 'sim' + props.part)} style={{flex: 1}}>
+    <Form.Item name={formName(props.simType, 'sim' + props.part)} style={{ flex: 1 }}>
       <Select
         placeholder={props.placeholder}
-        style={{flex: 1}}
+        style={{ flex: 1 }}
         allowClear
         optionLabelProp="short"
         maxTagCount="responsive"
-        suffixIcon={<img style={{ width: 16 }} src={Assets.getPart(props.part)} />}
+        suffixIcon={<img style={{ width: 16 }} src={Assets.getPart(props.part)}/>}
         options={props.options}
         listHeight={750}
         popupMatchSelectWidth={200}
@@ -287,18 +293,18 @@ function CharacterStatsSection() {
     <>
       <Flex vertical gap={5}>
         <HeaderText>Character display stats</HeaderText>
-        <StatInput simType={StatSimTypes.CharacterStats} name="Hp" label="HP" />
-        <StatInput simType={StatSimTypes.CharacterStats} name="Atk" label="ATK" />
-        <StatInput simType={StatSimTypes.CharacterStats} name="Def" label="DEF" />
-        <StatInput simType={StatSimTypes.CharacterStats} name="Cr" label="Crit Rate %" />
-        <StatInput simType={StatSimTypes.CharacterStats} name="Cd" label="Crit DMG %" />
-        <StatInput simType={StatSimTypes.CharacterStats} name="Spd" label="SPD" />
-        <StatInput simType={StatSimTypes.CharacterStats} name="Ehr" label="Effect Hit Rate" />
-        <StatInput simType={StatSimTypes.CharacterStats} name="Res" label="Effect RES" />
-        <StatInput simType={StatSimTypes.CharacterStats} name="Be" label="Break Effect" />
-        <StatInput simType={StatSimTypes.CharacterStats} name="Ohb" label="Healing Boost" />
-        <StatInput simType={StatSimTypes.CharacterStats} name="Err" label="Energy Regen" />
-        <StatInput simType={StatSimTypes.CharacterStats} name="Elem" label="Elemental DMG %" />
+        <StatInput simType={StatSimTypes.CharacterStats} name="Hp" label="HP"/>
+        <StatInput simType={StatSimTypes.CharacterStats} name="Atk" label="ATK"/>
+        <StatInput simType={StatSimTypes.CharacterStats} name="Def" label="DEF"/>
+        <StatInput simType={StatSimTypes.CharacterStats} name="Cr" label="Crit Rate %"/>
+        <StatInput simType={StatSimTypes.CharacterStats} name="Cd" label="Crit DMG %"/>
+        <StatInput simType={StatSimTypes.CharacterStats} name="Spd" label="SPD"/>
+        <StatInput simType={StatSimTypes.CharacterStats} name="Ehr" label="Effect Hit Rate"/>
+        <StatInput simType={StatSimTypes.CharacterStats} name="Res" label="Effect RES"/>
+        <StatInput simType={StatSimTypes.CharacterStats} name="Be" label="Break Effect"/>
+        <StatInput simType={StatSimTypes.CharacterStats} name="Ohb" label="Healing Boost"/>
+        <StatInput simType={StatSimTypes.CharacterStats} name="Err" label="Energy Regen"/>
+        <StatInput simType={StatSimTypes.CharacterStats} name="Elem" label="Elemental DMG %"/>
       </Flex>
     </>
   )
@@ -310,20 +316,20 @@ function SubstatsSection(props: { simType: string, title: string, total?: number
       <Flex vertical>
         <HeaderText>{props.title}</HeaderText>
         <Flex vertical gap={5}>
-          <StatInput simType={props.simType} name="AtkP" label="ATK %" />
-          <StatInput simType={props.simType} name="Atk" label="ATK" />
-          <StatInput simType={props.simType} name="Cr" label="Crit Rate %" />
-          <StatInput simType={props.simType} name="Cd" label="Crit DMG %" />
-          <StatInput simType={props.simType} name="Spd" label="SPD" />
-          <StatInput simType={props.simType} name="Be" label="Break Effect" />
-          <StatInput simType={props.simType} name="HpP" label="HP %" />
-          <StatInput simType={props.simType} name="Hp" label="HP" />
-          <StatInput simType={props.simType} name="DefP" label="DEF %" />
-          <StatInput simType={props.simType} name="Def" label="DEF" />
-          <StatInput simType={props.simType} name="Ehr" label="Effect Hit Rate" />
-          <StatInput simType={props.simType} name="Res" label="Effect RES" />
+          <StatInput simType={props.simType} name="AtkP" label="ATK %"/>
+          <StatInput simType={props.simType} name="Atk" label="ATK"/>
+          <StatInput simType={props.simType} name="Cr" label="Crit Rate %"/>
+          <StatInput simType={props.simType} name="Cd" label="Crit DMG %"/>
+          <StatInput simType={props.simType} name="Spd" label="SPD"/>
+          <StatInput simType={props.simType} name="Be" label="Break Effect"/>
+          <StatInput simType={props.simType} name="HpP" label="HP %"/>
+          <StatInput simType={props.simType} name="Hp" label="HP"/>
+          <StatInput simType={props.simType} name="DefP" label="DEF %"/>
+          <StatInput simType={props.simType} name="Def" label="DEF"/>
+          <StatInput simType={props.simType} name="Ehr" label="Effect Hit Rate"/>
+          <StatInput simType={props.simType} name="Res" label="Effect RES"/>
           {(props.simType == StatSimTypes.SubstatRolls) && (
-            <Flex justify="space-between" style={{width: STAT_SIMULATION_STATS_WIDTH}}>
+            <Flex justify="space-between" style={{ width: STAT_SIMULATION_STATS_WIDTH }}>
               <Text>
                 Total rolls
               </Text>
@@ -336,7 +342,7 @@ function SubstatsSection(props: { simType: string, title: string, total?: number
                 formatter={(value) => `${value} / 54`}
                 max={54}
                 status={props.total! > 54 ? 'error' : undefined}
-                style={{width: 70}}
+                style={{ width: 70 }}
               />
             </Flex>
           )}
@@ -346,14 +352,14 @@ function SubstatsSection(props: { simType: string, title: string, total?: number
   )
 }
 
-function StatInput(props: {label: string, name: string, simType: string, disabled?: boolean, value?: number}) {
+function StatInput(props: { label: string, name: string, simType: string, disabled?: boolean, value?: number }) {
   return (
-    <Flex justify="space-between" style={{width: STAT_SIMULATION_STATS_WIDTH}}>
+    <Flex justify="space-between" style={{ width: STAT_SIMULATION_STATS_WIDTH }}>
       <Text>
         {props.label}
       </Text>
       <Form.Item name={formName(props.simType, 'sim' + props.name)}>
-        <InputNumber size="small" controls={false} disabled={props.disabled} value={props.value} style={{width: 70}}/>
+        <InputNumber size="small" controls={false} disabled={props.disabled} value={props.value} style={{ width: 70 }}/>
       </Form.Item>
     </Flex>
   )

--- a/src/lib/characterConverter.ts
+++ b/src/lib/characterConverter.ts
@@ -86,12 +86,12 @@ export const CharacterConverter = {
 
 // Some special relics have a weird id -> set/part/main mapping
 const tidOverrides = {
-  55001: {set: '101', part: '3', main: '436'},
-  55002: {set: '102', part: '4', main: '441'},
-  55003: {set: '103', part: '3', main: '434'},
-  55004: {set: '104', part: '3', main: '433'},
-  55005: {set: '105', part: '4', main: '443'},
-  55006: {set: '106', part: '3', main: '434'},
+  55001: { set: '101', part: '3', main: '436' },
+  55002: { set: '101', part: '4', main: '441' },
+  55003: { set: '102', part: '3', main: '434' },
+  55004: { set: '103', part: '3', main: '433' },
+  55005: { set: '103', part: '4', main: '443' },
+  55006: { set: '105', part: '3', main: '434' },
 }
 
 function convertRelic(preRelic) {

--- a/src/lib/conditionals/character/Jade.ts
+++ b/src/lib/conditionals/character/Jade.ts
@@ -144,7 +144,7 @@ export default (e: Eidolon): CharacterConditional => {
       const x: ComputedStatsObject = c.x
 
       x.BASIC_DMG += x.BASIC_SCALING * x[Stats.ATK]
-      x.SKILL_DMG += x.SKILL_SCALING * x[Stats.ATK]
+      // x.SKILL_DMG += x.SKILL_SCALING * x[Stats.ATK] // Removing since its not on her action
       x.ULT_DMG += x.ULT_SCALING * x[Stats.ATK]
       x.FUA_DMG += x.FUA_SCALING * x[Stats.ATK]
     },

--- a/src/lib/conditionals/character/Robin.ts
+++ b/src/lib/conditionals/character/Robin.ts
@@ -135,7 +135,7 @@ export default (e: Eidolon): CharacterConditional => {
 
       x.BASIC_SCALING += basicScaling
       x.ULT_SCALING += (r.concertoActive) ? ultScaling : 0
-      x.ULT_BOOSTS_OVERRIDE = 0 // Her ult doesn't apply dmg boosts since its additional dmg
+      x.ULT_BOOSTS_MULTI = 0 // Her ult doesn't apply dmg boosts since its additional dmg
 
       x.BASIC_TOUGHNESS_DMG += 30
 

--- a/src/lib/conditionals/character/Robin.ts
+++ b/src/lib/conditionals/character/Robin.ts
@@ -135,6 +135,7 @@ export default (e: Eidolon): CharacterConditional => {
 
       x.BASIC_SCALING += basicScaling
       x.ULT_SCALING += (r.concertoActive) ? ultScaling : 0
+      x.ULT_BOOSTS_OVERRIDE = 0 // Her ult doesn't apply dmg boosts since its additional dmg
 
       x.BASIC_TOUGHNESS_DMG += 30
 

--- a/src/lib/conditionals/conditionalConstants.ts
+++ b/src/lib/conditionals/conditionalConstants.ts
@@ -40,7 +40,7 @@ export const baseComputedStatsObject = {
 
   // Robin
   ULT_CD_OVERRIDE: 0,
-  ULT_BOOSTS_OVERRIDE: 1,
+  ULT_BOOSTS_MULTI: 1,
 
   BASIC_BOOST: 0,
   SKILL_BOOST: 0,

--- a/src/lib/conditionals/conditionalConstants.ts
+++ b/src/lib/conditionals/conditionalConstants.ts
@@ -40,6 +40,7 @@ export const baseComputedStatsObject = {
 
   // Robin
   ULT_CD_OVERRIDE: 0,
+  ULT_BOOSTS_OVERRIDE: 1,
 
   BASIC_BOOST: 0,
   SKILL_BOOST: 0,

--- a/src/lib/conditionals/lightcone/5star/YetHopeIsPriceless.ts
+++ b/src/lib/conditionals/lightcone/5star/YetHopeIsPriceless.ts
@@ -27,8 +27,8 @@ export default (s: SuperImpositionLevel): LightConeConditional => {
       id: 'ultFuaDefShred',
       name: 'ultFuaDefShred',
       formItem: 'switch',
-      text: 'FUA DEF shred',
-      title: 'FUA DEF shred',
+      text: 'Ult / FUA DEF shred',
+      title: 'Ult / FUA DEF shred',
       content: betaUpdate,
     },
   ]
@@ -46,7 +46,8 @@ export default (s: SuperImpositionLevel): LightConeConditional => {
       x.ULT_DEF_PEN += (r.ultFuaDefShred) ? sValuesUltFuaDefShred[s] : 0
       x.FUA_DEF_PEN += (r.ultFuaDefShred) ? sValuesUltFuaDefShred[s] : 0
     },
-    calculatePassives: (/* c, request */) => { },
+    calculatePassives: (/* c, request */) => {
+    },
     calculateBaseMultis: (c: PrecomputedCharacterConditional, request: Form) => {
       const r = request.lightConeConditionals
       const x: ComputedStatsObject = c.x

--- a/src/lib/optimizer/calculateDamage.js
+++ b/src/lib/optimizer/calculateDamage.js
@@ -85,10 +85,10 @@ export function calculateDamage(c, request, params) {
 
   x.ULT_DMG = x.ULT_DMG
     * universalMulti
-    * (dmgBoostMultiplier + x.ULT_BOOST)
-    * calculateDefMultiplier(cLevel, eLevel, defReduction, defIgnore, x.ULT_DEF_PEN)
+    * (dmgBoostMultiplier + x.ULT_BOOST * x.ULT_BOOSTS_OVERRIDE)
+    * calculateDefMultiplier(cLevel, eLevel, defReduction, defIgnore, x.ULT_DEF_PEN * x.ULT_BOOSTS_OVERRIDE)
     * ((ultVulnerability + x.CRIT_VULNERABILITY) * Math.min(1, x[Stats.CR] + x.ULT_CR_BOOST) * (1 + ULT_CD) + ultVulnerability * (1 - Math.min(1, x[Stats.CR] + x.ULT_CR_BOOST)))
-    * (1 - (baseResistance - x.ULT_RES_PEN))
+    * (1 - (baseResistance - x.ULT_RES_PEN * x.ULT_BOOSTS_OVERRIDE))
     * (1 + x.ULT_ORIGINAL_DMG_BOOST)
     + (x.SUPER_BREAK_DMG * x.ULT_TOUGHNESS_DMG)
 

--- a/src/lib/optimizer/calculateDamage.js
+++ b/src/lib/optimizer/calculateDamage.js
@@ -36,7 +36,7 @@ export function calculateDamage(c, request, params) {
   const breakVulnerability = 1 + x.DMG_TAKEN_MULTI + x.BREAK_VULNERABILITY
   const basicVulnerability = 1 + x.DMG_TAKEN_MULTI + x.BASIC_VULNERABILITY
   const skillVulnerability = 1 + x.DMG_TAKEN_MULTI + x.SKILL_VULNERABILITY
-  const ultVulnerability = 1 + x.DMG_TAKEN_MULTI + x.ULT_VULNERABILITY
+  const ultVulnerability = 1 + x.DMG_TAKEN_MULTI + x.ULT_VULNERABILITY * x.ULT_BOOSTS_MULTI
   const fuaVulnerability = 1 + x.DMG_TAKEN_MULTI + x.FUA_VULNERABILITY
   const dotVulnerability = 1 + x.DMG_TAKEN_MULTI + x.DOT_VULNERABILITY
 
@@ -85,10 +85,10 @@ export function calculateDamage(c, request, params) {
 
   x.ULT_DMG = x.ULT_DMG
     * universalMulti
-    * (dmgBoostMultiplier + x.ULT_BOOST * x.ULT_BOOSTS_OVERRIDE)
-    * calculateDefMultiplier(cLevel, eLevel, defReduction, defIgnore, x.ULT_DEF_PEN * x.ULT_BOOSTS_OVERRIDE)
+    * (dmgBoostMultiplier + x.ULT_BOOST * x.ULT_BOOSTS_MULTI)
+    * calculateDefMultiplier(cLevel, eLevel, defReduction, defIgnore, x.ULT_DEF_PEN * x.ULT_BOOSTS_MULTI)
     * ((ultVulnerability + x.CRIT_VULNERABILITY) * Math.min(1, x[Stats.CR] + x.ULT_CR_BOOST) * (1 + ULT_CD) + ultVulnerability * (1 - Math.min(1, x[Stats.CR] + x.ULT_CR_BOOST)))
-    * (1 - (baseResistance - x.ULT_RES_PEN * x.ULT_BOOSTS_OVERRIDE))
+    * (1 - (baseResistance - x.ULT_RES_PEN * x.ULT_BOOSTS_MULTI))
     * (1 + x.ULT_ORIGINAL_DMG_BOOST)
     + (x.SUPER_BREAK_DMG * x.ULT_TOUGHNESS_DMG)
 

--- a/src/style/style.css
+++ b/src/style/style.css
@@ -363,7 +363,7 @@ a {
   border-bottom: none !important;
 }
 .ant-empty-description {
-  height: 140px !important;
+  height: 175px !important;
 }
 .ant-collapse-arrow {
   font-size: 16px !important;


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Turn off dmg boosts (salsotto) for robin ult dmg
* Fix wording on Yet Hope is Priceless
* Remove Jade skill dmg 
* Remove grid header which was disappearing randomly
* Changelog wording


## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

