### PR TITLE
feat: adding a speed scaling component to the damage sim

### DIFF
--- a/src/lib/characterScorer.ts
+++ b/src/lib/characterScorer.ts
@@ -75,7 +75,8 @@ export function scoreCharacterSimulation(character: Character, finalStats: any, 
       + result.DOT * formula.DOT
       + result.BREAK * formula.BREAK
 
-    result.SIM_SCORE = score
+    const spdScaling = (1 + result.xSPD / baselineSimResult.xSPD)
+    result.SIM_SCORE = score * spdScaling
   }
 
   // Simulate the original character
@@ -300,7 +301,7 @@ function calculateMaxSubstatRollCounts(partialSimulationWrapper, metadata) {
   maxCounts[Stats.ATK] -= 6
   maxCounts[Stats.HP] -= 6
 
-  maxCounts[Stats.SPD] = partialSimulationWrapper.speedRollsDeduction
+  // maxCounts[Stats.SPD] = partialSimulationWrapper.speedRollsDeduction
 
   for (const stat of SubStats) {
     maxCounts[stat] = Math.max(0, maxCounts[stat])

--- a/src/lib/dataParser.js
+++ b/src/lib/dataParser.js
@@ -1483,8 +1483,8 @@ function getScoringMetadata() {
           Stats.ATK_P,
           Stats.ATK,
           Stats.EHR,
-          Stats.CR,
           Stats.SPD,
+          Stats.CR,
         ],
         formula: {
           BASIC: 0,


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Uncapping the sim SPD substats
* Adding a SPD scaling component by multiplying the score by (1 + spd / baseline spd)

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

