### PR TITLE
feat: make permutations sidebar and main menu sidebar responsive

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -38,6 +38,8 @@ const App = () => {
           colorTextBase: colorTheme.colorTextBase,
           colorPrimary: colorTheme.colorPrimary,
           colorPrimaryBorderHover: colorTheme.colorPrimary,
+          screenXL: 1530,
+          screenXLMin: 1530,
         },
         components: {
           // OptimizerForm.js
@@ -54,6 +56,7 @@ const App = () => {
           // MenuDrawer.js
           Menu: {
             margin: 2,
+            itemPaddingInline: 0,
           },
 
           Table: {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,8 +6,8 @@ import { LayoutSider } from 'components/LayoutSider.tsx'
 import { SettingsDrawer } from 'components/SettingsDrawer'
 import { checkForUpdatesNotification } from 'lib/notifications'
 
-const {useToken, getDesignToken} = theme
-const {Content} = Layout
+const { useToken, getDesignToken } = theme
+const { Content } = Layout
 
 const App = () => {
   const [messageApi, messageContextHolder] = message.useMessage()
@@ -22,7 +22,6 @@ const App = () => {
       token: colorTheme,
     }))
   }, [colorTheme])
-
 
   useEffect(() => {
     checkForUpdatesNotification(DB.getState().version)
@@ -40,6 +39,8 @@ const App = () => {
           colorPrimaryBorderHover: colorTheme.colorPrimary,
           screenXL: 1530,
           screenXLMin: 1530,
+          screenXXL: 1660,
+          screenXXLMin: 1660,
         },
         components: {
           // OptimizerForm.js
@@ -88,7 +89,7 @@ const App = () => {
             defaultColor: '#ffffff',
           },
           Notification: {
-            width: 450
+            width: 450,
           },
         },
         algorithm: theme.darkAlgorithm,
@@ -97,9 +98,9 @@ const App = () => {
       {messageContextHolder}
       {notificationContextHolder}
       <Layout style={{minHeight: '100%'}}>
-        <LayoutHeader/>
+        <LayoutHeader />
         <Layout hasSider>
-          <LayoutSider/>
+          <LayoutSider />
           <Content
             style={{
               padding: 10,
@@ -113,9 +114,9 @@ const App = () => {
               width: '100%',
             }}
           >
-            <Tabs/>
+            <Tabs />
           </Content>
-          <SettingsDrawer/>
+          <SettingsDrawer />
         </Layout>
       </Layout>
     </ConfigProvider>

--- a/src/components/LayoutHeader.tsx
+++ b/src/components/LayoutHeader.tsx
@@ -31,7 +31,7 @@ export function LayoutHeader() {
             icon={menuSidebarOpen ? <CloseOutlined /> : <MenuOutlined />}
             onClick={() => setMenuSidebarOpen(!menuSidebarOpen)}
             style={{
-              fontSize: '15.5px',
+              fontSize: '16px',
               position: 'relative',
               left: '-20px',
             }}

--- a/src/components/LayoutSider.tsx
+++ b/src/components/LayoutSider.tsx
@@ -16,7 +16,7 @@ export function LayoutSider() {
         background: token.colorBgContainer,
       }}
       collapsible
-      collapsedWidth={0}
+      collapsedWidth={48}
       collapsed={!menuSidebarOpen}
       trigger={null}
     >

--- a/src/components/MenuDrawer.jsx
+++ b/src/components/MenuDrawer.jsx
@@ -156,9 +156,7 @@ const MenuDrawer = () => {
   return (
     <Menu
       onClick={onClick}
-      // inlineIndent={15}
-      style={{
-      }}
+      inlineIndent={12}
       defaultSelectedKeys={['1']}
       defaultOpenKeys={['subOptimizer', 'subTools', 'subLinks']}
       selectedKeys={activeKey}

--- a/src/components/SettingsDrawer.tsx
+++ b/src/components/SettingsDrawer.tsx
@@ -1,11 +1,16 @@
 import { Drawer, Flex, Form, Select, Typography } from 'antd'
 import React, { useEffect } from 'react'
-import { SaveState } from "lib/saveState";
-import { Utils } from "lib/utils";
+import { SaveState } from 'lib/saveState'
+import { Utils } from 'lib/utils'
+import styled from 'styled-components'
 
 const { Text } = Typography
 
 const defaultGap = 5
+
+const SelectOptionWordWrap = styled.span`
+  white-space: wrap !important;
+  word-break: break-word !important;`
 
 export const SettingOptions = {
   RelicEquippingBehavior: {
@@ -13,10 +18,17 @@ export const SettingOptions = {
     Swap: 'Swap',
     Replace: 'Replace',
   },
+  PermutationsSidebarBehavior: {
+    name: 'PermutationsSidebarBehavior',
+    NoShow: 'Do Not Show',
+    ShowXL: 'Show XL',
+    ShowXXL: 'Show XXL',
+  },
 }
 
 export const DefaultSettingOptions = {
-  [SettingOptions.RelicEquippingBehavior.name]: SettingOptions.RelicEquippingBehavior.Replace
+  [SettingOptions.RelicEquippingBehavior.name]: SettingOptions.RelicEquippingBehavior.Replace,
+  [SettingOptions.PermutationsSidebarBehavior.name]: SettingOptions.PermutationsSidebarBehavior.ShowXL,
 }
 
 export const SettingsDrawer = () => {
@@ -27,6 +39,32 @@ export const SettingsDrawer = () => {
 
   const settings = window.store((s) => s.settings)
   const setSettings = window.store((s) => s.setSettings)
+
+  const optionsRelicEquippingBehavior = [
+    {
+      value: SettingOptions.RelicEquippingBehavior.Swap,
+      label: <span>Swap relics with previous owner</span>,
+    },
+    {
+      value: SettingOptions.RelicEquippingBehavior.Replace,
+      label: <span>Replace relics without swapping</span>,
+    },
+  ]
+
+  const optionsPermutationsSidebarBehavior = [
+    {
+      value: SettingOptions.PermutationsSidebarBehavior.NoShow,
+      label: <span>No, always keep the sidebar on the right</span>,
+    },
+    {
+      value: SettingOptions.PermutationsSidebarBehavior.ShowXL,
+      label: <span>Show on bottom only at the smallest possible screen size</span>,
+    },
+    {
+      value: SettingOptions.PermutationsSidebarBehavior.ShowXXL,
+      label: <span>Show on bottom for best-looking layout</span>,
+    },
+  ]
 
   useEffect(() => {
     const initialSettings = Utils.clone(DefaultSettingOptions)
@@ -55,15 +93,22 @@ export const SettingsDrawer = () => {
         forceRender
       >
         <Flex vertical gap={defaultGap}>
-          <Flex justify="space-between" align='center'>
+          <Flex justify="space-between" align="center">
             <Text>
               Equipping relics from another character
             </Text>
             <Form.Item name={SettingOptions.RelicEquippingBehavior.name}>
-              <Select style={{width: 300}}>
-                <Select.Option value={SettingOptions.RelicEquippingBehavior.Swap}>Swap relics with previous owner</Select.Option>
-                <Select.Option value={SettingOptions.RelicEquippingBehavior.Replace}>Replace relics without swapping</Select.Option>
-              </Select>
+              <Select style={{ width: 300 }} options={optionsRelicEquippingBehavior} />
+            </Form.Item>
+          </Flex>
+          <Flex justify="space-between" align="center">
+            <Text>Move Optimizer sidebar to the bottom on smaller screens</Text>
+            <Form.Item name={SettingOptions.PermutationsSidebarBehavior.name}>
+              <Select
+                style={{ width: 300 }}
+                options={optionsPermutationsSidebarBehavior}
+                optionRender={(option) => <SelectOptionWordWrap>{option.label}</SelectOptionWordWrap>}
+              />
             </Form.Item>
           </Flex>
         </Flex>

--- a/src/components/optimizerTab/Sidebar.jsx
+++ b/src/components/optimizerTab/Sidebar.jsx
@@ -1,4 +1,4 @@
-import { Button, Divider, Flex, Progress, Radio, theme, Typography } from 'antd'
+import { Button, Divider, Flex, Grid, Progress, Radio, theme, Typography } from 'antd'
 import React from 'react'
 import FormCard from 'components/optimizerTab/FormCard'
 import { HeaderText } from '../HeaderText'
@@ -8,8 +8,10 @@ import { Hint } from 'lib/hint'
 import PropTypes from 'prop-types'
 import { ThunderboltFilled } from '@ant-design/icons'
 import { Optimizer } from 'lib/optimizer/optimizer'
+import { defaultPadding } from 'components/optimizerTab/optimizerTabConstants';
 
 const { useToken } = theme
+const { useBreakpoint } = Grid
 
 const { Text } = Typography
 
@@ -39,6 +41,14 @@ PermutationDisplay.propTypes = {
 const defaultGap = 5
 
 export default function Sidebar() {
+  const { lg, xl } = useBreakpoint()
+
+  return (!lg || xl
+    ? <SidebarContent />
+    : <MobileSidebarContent />)
+}
+
+function SidebarContent() {
   const { token } = useToken()
 
   const statDisplay = window.store((s) => s.statDisplay)
@@ -125,7 +135,7 @@ export default function Sidebar() {
               </Flex>
             </Flex>
 
-            <Flex justify="space-between" align="center" style={{ }}>
+            <Flex justify="space-between" align="center">
               <HeaderText>Stat and filter view</HeaderText>
               <TooltipImage type={Hint.statDisplay()} />
             </Flex>
@@ -157,6 +167,131 @@ export default function Sidebar() {
             </Flex>
           </Flex>
         </FormCard>
+      </Flex>
+    </Flex>
+  )
+}
+
+function MobileSidebarContent() {
+  const { token } = useToken()
+  const shadow = 'rgba(0, 0, 0, 0.25) 0px 0.0625em 0.0625em, rgba(0, 0, 0, 0.25) 0px 0.125em 0.5em, rgba(255, 255, 255, 0.15) 0px 0px 0px 1px inset'
+
+  const statDisplay = window.store((s) => s.statDisplay)
+  const setStatDisplay = window.store((s) => s.setStatDisplay)
+
+  const permutations = window.store((s) => s.permutations)
+  const permutationsSearched = window.store((s) => s.permutationsSearched)
+  const permutationsResults = window.store((s) => s.permutationsResults)
+
+  const optimizationInProgress = window.store((s) => s.optimizationInProgress)
+  const setOptimizationInProgress = window.store((s) => s.setOptimizationInProgress)
+
+  function cancelClicked() {
+    console.log('Cancel clicked')
+    setOptimizationInProgress(false)
+    Optimizer.cancel(window.store.getState().optimizationId)
+  }
+  window.optimizerCancelClicked = cancelClicked
+
+  function resetClicked() {
+    console.log('Reset clicked')
+    OptimizerTabController.resetFilters()
+  }
+
+  function filterClicked() {
+    console.log('Filter clicked')
+    OptimizerTabController.applyRowFilters()
+  }
+
+  return (
+    <Flex
+      height={150}
+      justify="center"
+      style={{
+        overflow: 'clip',
+        position: 'fixed',
+        width: '100%',
+        bottom: 0,
+        left: 0,
+        backgroundColor: token.colorBgContainer,
+        boxShadow: shadow,
+        borderRadius: 5,
+        padding: defaultPadding,
+      }}
+    >
+      <Flex gap={20} justify="space-evenly">
+        <Flex vertical gap={defaultGap} align="center" justify="space-between" style={{ minWidth: 211 }}>
+          <Flex vertical gap={defaultGap}>
+            <Flex vertical>
+              <HeaderText>Progress</HeaderText>
+              <Progress
+                strokeColor={token.colorPrimary}
+                steps={17}
+                size={[8, 5]}
+                percent={Math.floor(Number(permutationsSearched) / Number(permutations) * 100)}
+              />
+            </Flex>
+            <Flex vertical>
+              <PermutationDisplay left="Searched" right={permutationsSearched} />
+              <PermutationDisplay left="Results" right={permutationsResults} />
+            </Flex>
+          </Flex>
+        </Flex>
+        <Flex vertical gap={defaultGap} style={{ minWidth: 211 }}>
+          <Flex justify="space-between" align="center">
+            <HeaderText>Stat and filter view</HeaderText>
+            <TooltipImage type={Hint.statDisplay()} />
+          </Flex>
+          <Radio.Group
+            onChange={(e) => {
+              const { target: { value } } = e
+              setStatDisplay(value)
+            }}
+            optionType="button"
+            buttonStyle="solid"
+            value={statDisplay}
+            style={{ width: '100%', display: 'flex' }}
+          >
+            <Radio style={{ display: 'flex', flex: 1, justifyContent: 'center', paddingInline: 0 }} value="base" defaultChecked>Base stats</Radio>
+            <Radio style={{ display: 'flex', flex: 1, justifyContent: 'center', paddingInline: 0 }} value="combat">Combat stats</Radio>
+          </Radio.Group>
+        </Flex>
+        <Flex vertical gap={defaultGap} style={{ minWidth: 211 }}>
+          <Flex justify="space-between" align="center">
+            <HeaderText>Controls</HeaderText>
+          </Flex>
+          <Flex vertical gap={defaultGap} style={{ marginBottom: 2 }}>
+            <Flex gap={defaultGap}>
+              <Button icon={<ThunderboltFilled />} type="primary" loading={optimizationInProgress} onClick={window.optimizerStartClicked} style={{ flex: 1 }}>
+                Start optimizer
+              </Button>
+            </Flex>
+            <Flex gap={defaultGap}>
+              <Button onClick={cancelClicked} style={{ flex: 1 }}>
+                Cancel
+              </Button>
+              <Button onClick={resetClicked} style={{ flex: 1 }}>
+                Reset
+              </Button>
+            </Flex>
+            <Flex gap={defaultGap}>
+            </Flex>
+          </Flex>
+        </Flex>
+        <Flex vertical gap={defaultGap} style={{ minWidth: 211 }}>
+          <Flex justify="space-between" align="center">
+            <HeaderText>Results</HeaderText>
+            <TooltipImage type={Hint.actions()} />
+          </Flex>
+          <Flex gap={defaultGap} justify="space-around">
+            <Button onClick={filterClicked} style={{ width: '100px' }}>
+              Filter
+            </Button>
+            <Button onClick={OptimizerTabController.equipClicked} style={{ width: '100px' }}>
+              Equip
+            </Button>
+          </Flex>
+        </Flex>
       </Flex>
     </Flex>
   )

--- a/src/components/optimizerTab/Sidebar.jsx
+++ b/src/components/optimizerTab/Sidebar.jsx
@@ -213,7 +213,7 @@ function MobileSidebarContent() {
         width: '100%',
         bottom: 0,
         left: 0,
-        backgroundColor: token.colorBgContainer,
+        backgroundColor: 'rgb(29 42 71)',
         boxShadow: shadow,
         borderRadius: 5,
         padding: defaultPadding,

--- a/src/style/style.css
+++ b/src/style/style.css
@@ -297,10 +297,6 @@ a {
     padding-left: 10px !important;
 }
 
-.ant-menu-item-only-child {
-    padding-left: 34px !important;
-}
-
 .ant-tag-checkable {
     margin-inline-end: 0px;
     border-radius: 0px;

--- a/src/style/style.css
+++ b/src/style/style.css
@@ -297,6 +297,10 @@ a {
     padding-left: 10px !important;
 }
 
+/* .ant-menu-item-only-child {
+    padding-left: 34px !important;
+} */
+
 .ant-tag-checkable {
     margin-inline-end: 0px;
     border-radius: 0px;


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
* permutations sidebar now changes into a fixed footer when screens are 992px < [screen resolution] < 1530px
* add new screen breakpoint at 1530px
* reduce the left padding on `LayoutSider` menu items: this may need a discussion. Basically, antd applies a single CSS class with extra left padding when there is only "one" item within a subitem menu, preventing any use of it being overridden even with `inlineIndent` prop. Due to the structure of our current menu items, antd views every single submenu option as "one" item and forces extra padding on it. Aside from removing the CSS class scoped exclusively for this purpose, the alternative would be fake-inserting extra phantom tags to wrap around each menu item instead of the `<Flex>menu item contents like the icon + label</Flex>` that is currently set up right now.

## Related Issue
* 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [ ] I have reviewed the code changes.

## Screenshots
Permanent fixed footer in action + reduced padding on menu items in main menu sidebar
<img width="1437" alt="image" src="https://github.com/fribbels/hsr-optimizer/assets/8635193/6f4267db-78c4-4d00-aab9-c8a65aa7a682">

Permutations sidebar/footer UI added to settings menu
<img width="1436" alt="image" src="https://github.com/fribbels/hsr-optimizer/assets/8635193/6207db16-f0b4-488b-932a-af0174eb2cfd">