### PR TITLE
Fix/infinity% optimality

### DIFF
--- a/src/lib/relicScorer.ts
+++ b/src/lib/relicScorer.ts
@@ -336,6 +336,14 @@ export class RelicScorer {
     // We max it a 0 to avoid negative percents
     if(maxWeight == 0){// Catch the edge case of only 1 weighted substat -> gets used as mainstat
       const scoringMetadata = this.getRelicScoreMeta(id)
+      if(!(scoringMetadata.sortedSubstats[0][1] > 0)){
+        return{
+          bestPct: 0,
+      averagePct: 0,
+      worstPct: 0,
+      meta: score.meta,
+        }
+      }
       const substats = [
         {
           stat: scoringMetadata.sortedSubstats[0][0],
@@ -663,6 +671,7 @@ function isSpecial(scoringMetadata){
   if(substats[2][1] > 0 || substats[1][1] == 0){
     return{
       isSpecial: special,
+
       stat1: stat1,
       stat2: stat2
     }

--- a/src/lib/relicScorer.ts
+++ b/src/lib/relicScorer.ts
@@ -303,7 +303,7 @@ export class RelicScorer {
     const subs = generateSubStats(5, substats[0][0], SubStatValues[substats[0][0]][5]["high"] * 6, substats[1][0], SubStatValues[substats[1][0]][5]["high"]
                                   , substats[2][0], SubStatValues[substats[2][0]][5]["high"], substats[3][0], SubStatValues[substats[3][0]][5]["high"], )
     const fake = fakeRelic(5, 15, part, mainStat, subs)
-    let ideal = parseFloat(this.score(fake, id).score)
+    let ideal = parseFloat(this.score(fake, id).longscore)
     ideal -= mainStatFreeRoll(part, mainStat, scoringMetadata)
     maxWeight = Utils.precisionRound(ideal)
 
@@ -350,7 +350,7 @@ export class RelicScorer {
       ]
       const fake = fakeRelic(5, 15, relic.part, relic.main.stat, substats)
       const ideal = this.score(fake, id)
-      maxWeight = parseFloat(ideal.score)
+      maxWeight = parseFloat(ideal.longscore)
       maxWeight -= mainStatFreeRoll(relic.part, relic.main.stat, scoringMetadata)
     }
     return {
@@ -369,7 +369,7 @@ export class RelicScorer {
     const scoringMetadata = this.getRelicScoreMeta(id)
 
     const scoringResult = this.score(relic, id)
-    const currentWeight = parseFloat(scoringResult.score) + scoringResult.mainStatScore - 64.8
+    const currentWeight = parseFloat(scoringResult.longscore) + scoringResult.mainStatScore - 64.8
 
     const substats: [StatsValues, number][] = relic.substats.map((x) => [x.stat, scoringMetadata.stats[x.stat]])
     const substatNames = relic.substats.map((x) => x.stat)
@@ -437,6 +437,7 @@ export class RelicScorer {
     mainStatScore: number
     part?: number
     meta?: object
+    longscore: string
   } {
     // console.log('score', relic, characterId)
 
@@ -445,6 +446,7 @@ export class RelicScorer {
         score: '0',
         rating: 'N/A',
         mainStatScore: 0,
+        longscore: '0',
       }
     }
 
@@ -459,6 +461,7 @@ export class RelicScorer {
           score: '0',
           rating: 'N/A',
           mainStatScore: 0,
+          longscore: '0',
         }
       }
     }
@@ -511,11 +514,12 @@ export class RelicScorer {
     }
 
     return {
-      score: sum.toFixed(5),//.toFixed(1), using 1 led to issues with detecting what should be a 0 score relic
+      score: sum.toFixed(1),
       rating: rating,
       mainStatScore: mainStatScore,
       part: relic.part,
       meta: scoringMetadata,
+      longscore: sum.toFixed(5)
     }
   }
 }


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Added an extra return to score()
* Added fakeRelic and generateSubStats
* Changed scoreRelicPct and scoreOptimalRelic to use fakeRelic and generateSubStats alongside score() to get more accurate scores
* Fixed scoreOptimalRelic to replace infinity% with a more natural behaviour
* TODO: scoreRelic currently undervalues future speed rolls, leading to counter-intuitive behaviour of potential

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* Closes #255 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.
- [x] I have ensured the code passes the test suite

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->
