### PR TITLE
feat: hotfix seele set -> glamoth, nerf penalty multiplier

### DIFF
--- a/src/components/characterPreview/CharacterScoringSummary.tsx
+++ b/src/components/characterPreview/CharacterScoringSummary.tsx
@@ -102,7 +102,7 @@ export const CharacterScoringSummary = (props: { simScoringResult: SimulationSco
   function ScoringDetails() {
     return (
       <Flex vertical style={{ marginTop: 80, width: 1000 }}>
-        <h1 style={{ margin: 'auto' }}>DPS Score Calculation</h1>
+        <h1 style={{ margin: 'auto' }}>DPS Score Calculation (Beta)</h1>
         <Text style={{ fontSize: 18 }}>
           <h2>
             What is DPS Score?
@@ -223,7 +223,6 @@ export const CharacterScoringSummary = (props: { simScoringResult: SimulationSco
                 <li>F+ = 40%</li>
                 <li>F  = 35%</li>
               </ul>
-
             </Flex>
           </pre>
 
@@ -262,10 +261,10 @@ export const CharacterScoringSummary = (props: { simScoringResult: SimulationSco
             The only forced breakpoints currently are Effect Hit Rate minimums for DoT characters.
             Take Black Swan for example, the purpose of forcing the sim to use her 120% breakpoint is so it can't just ignore EHR
             to chase more maximum DoT damage. EHR is more than just DMG conversion as it also lets her land Arcana debuffs to reach her 7th Arcana stack
-            for DEF pen. The penalty is calculated with half the missing percentage.
+            for DEF pen. The penalty is calculated as a 1% deduction per missing roll from the breakpoint.
           </p>
           <p>
-            <code>dmg scale = min(1, (breakpoint - combat stat) / (breakpoint) * (1/2))</code>
+            <code>dmg scale = min(1, (breakpoint - combat stat) / (min stat value))</code>
           </p>
 
           <h4>How were the default simulation teams / sets chosen?</h4>

--- a/src/lib/characterScorer.ts
+++ b/src/lib/characterScorer.ts
@@ -577,7 +577,7 @@ export function calculatePenaltyMultiplier(simulationResult, breakpoints) {
   let newPenaltyMultiplier = 1
   for (const stat of Object.keys(breakpoints)) {
     // Penalize by half of the missing stat breakpoint percentage
-    newPenaltyMultiplier *= Math.min(1, 1 - (breakpoints[stat] - simulationResult.x[stat]) / (breakpoints[stat] * 2))
+    newPenaltyMultiplier *= Math.min(1, 1 - (breakpoints[stat] - simulationResult.x[stat]) / StatCalculator.getMaxedSubstatValue(stat, QUALITY))
   }
   simulationResult.penaltyMultiplier = newPenaltyMultiplier
   return newPenaltyMultiplier

--- a/src/lib/dataParser.js
+++ b/src/lib/dataParser.js
@@ -2140,7 +2140,7 @@ function getScoringMetadata() {
         },
         relicSet1: Sets.GeniusOfBrilliantStars,
         relicSet2: Sets.GeniusOfBrilliantStars,
-        ornamentSet: Sets.RutilantArena,
+        ornamentSet: Sets.FirmamentFrontlineGlamoth,
         teammates: [
           {
             characterId: '1006', // SW


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Penalty multiplier was too harsh for kafka, update it to 1% per missing roll
* Change seele default set to glamoth

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

