### PR TITLE
hotfix: set equivalency and set effects upgrade display

### DIFF
--- a/src/components/CharacterPreview.jsx
+++ b/src/components/CharacterPreview.jsx
@@ -265,8 +265,8 @@ export function CharacterPreview(props) {
   function ScoreFooter(props) {
     const textDisplay = (
       <Flex vertical align="center">
-        <HeaderText style={{ fontSize: 16, marginBottom: 5 }}>
-          Substat score upgrades
+        <HeaderText style={{ fontSize: 16, marginBottom: 4 }}>
+          DPS score upgrades
         </HeaderText>
       </Flex>
     )
@@ -308,7 +308,7 @@ export function CharacterPreview(props) {
     )
 
     return (
-      <Flex vertical style={{}} gap={5}>
+      <Flex vertical style={{}} gap={2}>
         <CharacterModal
           onOk={onCharacterModalOk}
           open={isCharacterModalOpen}
@@ -548,24 +548,24 @@ export function CharacterPreview(props) {
                 justify="space-between"
               >
                 <Flex vertical gap={0}>
-                  <Flex justify="space-between" style={{ height: 50 }}>
+                  <Flex justify="space-between" style={{ height: 40 }}>
                     <Image
                       preview={false}
-                      width={50}
+                      width={40}
                       src={Assets.getElement(characterElement)}
                     />
                     <Rarity rarity={characterMetadata.rarity} />
                     <Image
                       preview={false}
-                      width={50}
+                      width={40}
                       src={Assets.getPathFromClass(characterPath)}
                     />
                   </Flex>
                   <Flex vertical>
-                    <StatText style={{ fontSize: 24, fontWeight: 400, textAlign: 'center' }}>
+                    <StatText style={{ fontSize: 24, lineHeight: '30px', fontWeight: 400, textAlign: 'center' }}>
                       {characterName}
                     </StatText>
-                    <StatText style={{ fontSize: 18, fontWeight: 400, textAlign: 'center' }}>
+                    <StatText style={{ fontSize: 16, fontWeight: 400, textAlign: 'center' }}>
                       {`Lv${characterLevel} E${characterEidolon}`}
                     </StatText>
                   </Flex>
@@ -584,11 +584,14 @@ export function CharacterPreview(props) {
                 }
                 {
                   simScoringResult
+                  && <ScoreHeader result={simScoringResult} />
+                }
+                {
+                  simScoringResult
                   && (
                     <Flex
                       vertical
                     >
-                      <ScoreHeader result={simScoringResult} />
                       <Card
                         style={{
                           backgroundColor: token.colorBgLayout,

--- a/src/components/characterPreview/CharacterScoringSummary.tsx
+++ b/src/components/characterPreview/CharacterScoringSummary.tsx
@@ -176,6 +176,14 @@ export const CharacterScoringSummary = (props: { simScoringResult: SimulationSco
           </p>
 
           <h4>
+            Relic / ornament sets
+          </h4>
+          <p>
+            Each character has a defined BiS set, and a few other equivalent sets that can be considered similar in performance. If the original character's
+            sets matches any of the acceptable sets, the character will be scored against a benchmark generated matching that set, otherwise the original character will be scored against the BiS.
+          </p>
+
+          <h4>
             Stat breakpoint penalty
           </h4>
           <p>
@@ -271,6 +279,18 @@ export const CharacterScoringSummary = (props: { simScoringResult: SimulationSco
           <p>
             The defaults come from a combination of usage statistics and community guidance. Best in slot sets and teammates will change
             with new game updates, so the default parameters may also change. Please visit the Discord server for suggestions and feedback on the scoring design.
+          </p>
+
+          <h4>Why is a character scoring low?</h4>
+          <p>
+            The `DPS score upgrades` section will give a quick overview of the sets and stats that could be improved. For a more detailed explanation,
+            the full simulation is detailed below the character card, including the benchmark character's stat distribution, basic stats, combat stats, and main stats.
+            Comparing the original character's stats to the benchmark character's stats is helpful to show the difference in builds and see where to improve.
+          </p>
+
+          <p>
+            An often underestimated component of the build is completed BiS set effects. Set effects can play a large part in optimizing a character's potential damage output
+            and rainbow or broken sets will often score worse than full sets.
           </p>
         </Text>
       </Flex>
@@ -488,7 +508,7 @@ export function CharacterCardScoringStatUpgrades(props: { result: SimulationScor
   const setUpgrade = result.setUpgrades[0]
   if (setUpgrade.percent! - basePercent > 0) {
     rows.push(
-      <Flex gap={3} key={Utils.randomId()} justify="space-between" align="center" style={{ width: '100%', paddingLeft: 2 }}>
+      <Flex gap={3} key={Utils.randomId()} justify="space-between" align="center" style={{ width: '100%', paddingLeft: 1 }}>
         <img src={Assets.getSetImage(setUpgrade.simulation.request.simRelicSet1)} style={{ width: iconSize, height: iconSize, marginRight: 3 }} />
         <img src={Assets.getSetImage(setUpgrade.simulation.request.simRelicSet2)} style={{ width: iconSize, height: iconSize, marginRight: 10 }} />
         <img src={Assets.getSetImage(setUpgrade.simulation.request.simOrnamentSet)} style={{ width: iconSize, height: iconSize, marginRight: 3 }} />

--- a/src/components/characterPreview/CharacterScoringSummary.tsx
+++ b/src/components/characterPreview/CharacterScoringSummary.tsx
@@ -484,6 +484,22 @@ export function CharacterCardScoringStatUpgrades(props: { result: SimulationScor
       </Flex>,
     )
   }
+
+  const setUpgrade = result.setUpgrades[0]
+  if (setUpgrade.percent! - basePercent > 0) {
+    rows.push(
+      <Flex gap={3} key={Utils.randomId()} justify="space-between" align="center" style={{ width: '100%', paddingLeft: 2 }}>
+        <img src={Assets.getSetImage(setUpgrade.simulation.request.simRelicSet1)} style={{ width: iconSize, height: iconSize, marginRight: 3 }} />
+        <img src={Assets.getSetImage(setUpgrade.simulation.request.simRelicSet2)} style={{ width: iconSize, height: iconSize, marginRight: 10 }} />
+        <img src={Assets.getSetImage(setUpgrade.simulation.request.simOrnamentSet)} style={{ width: iconSize, height: iconSize, marginRight: 3 }} />
+        <Divider style={{ margin: 'auto 10px', flexGrow: 1, width: 'unset', minWidth: 'unset' }} dashed />
+        <StatText>{`+ ${((setUpgrade.percent! - basePercent) * 100).toFixed(2)}%`}</StatText>
+      </Flex>,
+    )
+  }
+
+  console.debug(setUpgrade)
+
   //  =>  ${(statUpgrade.percent! * 100).toFixed(2)}%
   return (
     <Flex vertical gap={3} align="center" style={{ paddingLeft: 6, paddingRight: 8, marginBottom: 5 }}>

--- a/src/components/characterPreview/CharacterScoringSummary.tsx
+++ b/src/components/characterPreview/CharacterScoringSummary.tsx
@@ -301,11 +301,11 @@ export const CharacterScoringSummary = (props: { simScoringResult: SimulationSco
           </pre>
           <Flex vertical gap={defaultGap}>
             <Flex>
-              <ScoringSet set={result.metadata.relicSet1} />
-              <ScoringSet set={result.metadata.relicSet2} />
+              <ScoringSet set={result.maxSim.request.simRelicSet1} />
+              <ScoringSet set={result.maxSim.request.simRelicSet2} />
             </Flex>
 
-            <ScoringSet set={result.metadata.ornamentSet} />
+            <ScoringSet set={result.maxSim.request.simOrnamentSet} />
           </Flex>
         </Flex>
 

--- a/src/lib/dataParser.js
+++ b/src/lib/dataParser.js
@@ -13,6 +13,29 @@ import { SortOption } from 'lib/optimizer/sortOptions'
 
 export const UnreleasedSets = {}
 
+const RELICS_2P_BREAK_EFFECT_SPEED = [
+  Sets.MessengerTraversingHackerspace,
+  Sets.ThiefOfShootingMeteor,
+  Sets.WatchmakerMasterOfDreamMachinations,
+  Sets.IronCavalryAgainstScourge,
+]
+
+const SPREAD_RELICS_2P_GENERAL_CONDITIONALS = [
+  [Sets.GeniusOfBrilliantStars, Sets.GeniusOfBrilliantStars],
+  [Sets.PioneerDiverOfDeadWaters, Sets.PioneerDiverOfDeadWaters],
+]
+
+const SPREAD_ORNAMENTS_2P_FUA = [
+  Sets.DuranDynastyOfRunningWolves,
+  Sets.SigoniaTheUnclaimedDesolation,
+  Sets.InertSalsotto,
+]
+
+const SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS = [
+  Sets.FirmamentFrontlineGlamoth,
+  Sets.SigoniaTheUnclaimedDesolation,
+]
+
 export const DataParser = {
   parse: (officialOnly) => {
     if (officialOnly) {
@@ -1366,11 +1389,11 @@ function getScoringMetadata() {
         },
         relicSets: [
           [Sets.PioneerDiverOfDeadWaters, Sets.PioneerDiverOfDeadWaters],
-          [Sets.GeniusOfBrilliantStars, Sets.GeniusOfBrilliantStars],
+          ...SPREAD_RELICS_2P_GENERAL_CONDITIONALS,
         ],
         ornamentSets: [
           Sets.RutilantArena,
-          Sets.FirmamentFrontlineGlamoth,
+          ...SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
         ],
         teammates: [
           {
@@ -1475,11 +1498,13 @@ function getScoringMetadata() {
         },
         relicSets: [
           [Sets.TheAshblazingGrandDuke, Sets.TheAshblazingGrandDuke],
+          ...SPREAD_RELICS_2P_GENERAL_CONDITIONALS,
         ],
         ornamentSets: [
           Sets.InertSalsotto,
-          Sets.FirmamentFrontlineGlamoth,
           Sets.RutilantArena,
+          ...SPREAD_ORNAMENTS_2P_FUA,
+          ...SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
         ],
         teammates: [
           {
@@ -1589,10 +1614,11 @@ function getScoringMetadata() {
         },
         relicSets: [
           [Sets.PioneerDiverOfDeadWaters, Sets.PioneerDiverOfDeadWaters],
+          ...SPREAD_RELICS_2P_GENERAL_CONDITIONALS,
         ],
         ornamentSets: [
           Sets.RutilantArena,
-          Sets.FirmamentFrontlineGlamoth,
+          ...SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
         ],
         teammates: [
           {
@@ -1854,11 +1880,11 @@ function getScoringMetadata() {
         },
         relicSets: [
           [Sets.BandOfSizzlingThunder, Sets.BandOfSizzlingThunder],
-          [Sets.GeniusOfBrilliantStars, Sets.GeniusOfBrilliantStars],
+          ...SPREAD_RELICS_2P_GENERAL_CONDITIONALS,
         ],
         ornamentSets: [
           Sets.RutilantArena,
-          Sets.FirmamentFrontlineGlamoth,
+          ...SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
         ],
         teammates: [
           {
@@ -2011,10 +2037,12 @@ function getScoringMetadata() {
         relicSets: [
           [Sets.TheAshblazingGrandDuke, Sets.TheAshblazingGrandDuke],
           [Sets.HunterOfGlacialForest, Sets.HunterOfGlacialForest],
+          ...SPREAD_RELICS_2P_GENERAL_CONDITIONALS,
         ],
         ornamentSets: [
           Sets.InertSalsotto,
-          Sets.FirmamentFrontlineGlamoth,
+          ...SPREAD_ORNAMENTS_2P_FUA,
+          ...SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
         ],
         teammates: [
           {
@@ -2167,10 +2195,12 @@ function getScoringMetadata() {
         },
         relicSets: [
           [SetsRelics.GeniusOfBrilliantStars, SetsRelics.GeniusOfBrilliantStars],
+          ...SPREAD_RELICS_2P_GENERAL_CONDITIONALS,
         ],
         ornamentSets: [
           Sets.FirmamentFrontlineGlamoth,
           Sets.RutilantArena,
+          ...SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
         ],
         teammates: [
           {
@@ -2273,12 +2303,12 @@ function getScoringMetadata() {
         },
         relicSets: [
           [Sets.BandOfSizzlingThunder, Sets.BandOfSizzlingThunder],
-          [Sets.GeniusOfBrilliantStars, Sets.GeniusOfBrilliantStars],
-          [Sets.PioneerDiverOfDeadWaters, Sets.PioneerDiverOfDeadWaters],
+          ...SPREAD_RELICS_2P_GENERAL_CONDITIONALS,
         ],
         ornamentSets: [
           Sets.FirmamentFrontlineGlamoth,
           Sets.RutilantArena,
+          ...SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
         ],
         teammates: [
           {
@@ -2515,10 +2545,12 @@ function getScoringMetadata() {
         },
         relicSets: [
           [Sets.ChampionOfStreetwiseBoxing, Sets.ChampionOfStreetwiseBoxing],
+          ...SPREAD_RELICS_2P_GENERAL_CONDITIONALS,
         ],
         ornamentSets: [
           Sets.InertSalsotto,
-          Sets.FirmamentFrontlineGlamoth,
+          ...SPREAD_ORNAMENTS_2P_FUA,
+          ...SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
         ],
         teammates: [
           {
@@ -2733,10 +2765,11 @@ function getScoringMetadata() {
         },
         relicSets: [
           [Sets.PioneerDiverOfDeadWaters, Sets.PioneerDiverOfDeadWaters],
+          ...SPREAD_RELICS_2P_GENERAL_CONDITIONALS,
         ],
         ornamentSets: [
           Sets.RutilantArena,
-          Sets.FirmamentFrontlineGlamoth,
+          ...SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
         ],
         teammates: [
           {
@@ -2887,8 +2920,8 @@ function getScoringMetadata() {
         },
         relicSets: [
           [Sets.PrisonerInDeepConfinement, Sets.PrisonerInDeepConfinement],
-          [Sets.GeniusOfBrilliantStars, Sets.GeniusOfBrilliantStars],
-          [Sets.ThiefOfShootingMeteor, Sets.WatchmakerMasterOfDreamMachinations, Sets.IronCavalryAgainstScourge],
+          ...SPREAD_RELICS_2P_GENERAL_CONDITIONALS,
+          RELICS_2P_BREAK_EFFECT_SPEED,
         ],
         ornamentSets: [
           Sets.TaliaKingdomOfBanditry,
@@ -2997,11 +3030,12 @@ function getScoringMetadata() {
         },
         relicSets: [
           [Sets.TheAshblazingGrandDuke, Sets.TheAshblazingGrandDuke],
-          [Sets.PioneerDiverOfDeadWaters, Sets.PioneerDiverOfDeadWaters],
+          ...SPREAD_RELICS_2P_GENERAL_CONDITIONALS,
         ],
         ornamentSets: [
           Sets.InertSalsotto,
-          Sets.FirmamentFrontlineGlamoth,
+          ...SPREAD_ORNAMENTS_2P_FUA,
+          ...SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
         ],
         teammates: [
           {
@@ -3104,10 +3138,12 @@ function getScoringMetadata() {
         },
         relicSets: [
           [Sets.GeniusOfBrilliantStars, Sets.GeniusOfBrilliantStars],
+          ...SPREAD_RELICS_2P_GENERAL_CONDITIONALS,
         ],
         ornamentSets: [
           Sets.RutilantArena,
-          Sets.FirmamentFrontlineGlamoth,
+          ...SPREAD_ORNAMENTS_2P_FUA,
+          ...SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
         ],
         teammates: [
           {
@@ -3305,10 +3341,12 @@ function getScoringMetadata() {
         },
         relicSets: [
           [Sets.TheAshblazingGrandDuke, Sets.TheAshblazingGrandDuke],
+          ...SPREAD_RELICS_2P_GENERAL_CONDITIONALS,
         ],
         ornamentSets: [
           Sets.InertSalsotto,
-          Sets.FirmamentFrontlineGlamoth,
+          ...SPREAD_ORNAMENTS_2P_FUA,
+          ...SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
           Sets.RutilantArena,
         ],
         teammates: [
@@ -3417,7 +3455,7 @@ function getScoringMetadata() {
         ornamentSets: [
           Sets.RutilantArena,
           Sets.InertSalsotto,
-          Sets.FirmamentFrontlineGlamoth,
+          ...SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
         ],
         teammates: [
           {
@@ -3523,9 +3561,11 @@ function getScoringMetadata() {
         relicSets: [
           [Sets.ChampionOfStreetwiseBoxing, Sets.ChampionOfStreetwiseBoxing],
           [Sets.IronCavalryAgainstScourge, Sets.IronCavalryAgainstScourge],
+          ...SPREAD_RELICS_2P_GENERAL_CONDITIONALS,
         ],
         ornamentSets: [
           Sets.FirmamentFrontlineGlamoth,
+          ...SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
           Sets.RutilantArena,
         ],
         teammates: [
@@ -3720,13 +3760,13 @@ function getScoringMetadata() {
           BREAK: 0,
         },
         relicSets: [
-          [Sets.HunterOfGlacialForest, Sets.HunterOfGlacialForest],
           [Sets.PioneerDiverOfDeadWaters, Sets.PioneerDiverOfDeadWaters],
-          [Sets.GeniusOfBrilliantStars, Sets.GeniusOfBrilliantStars],
+          [Sets.HunterOfGlacialForest, Sets.HunterOfGlacialForest],
+          ...SPREAD_RELICS_2P_GENERAL_CONDITIONALS,
         ],
         ornamentSets: [
           Sets.RutilantArena,
-          Sets.FirmamentFrontlineGlamoth,
+          ...SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
         ],
         teammates: [
           {
@@ -3917,10 +3957,11 @@ function getScoringMetadata() {
         },
         relicSets: [
           [Sets.HunterOfGlacialForest, Sets.HunterOfGlacialForest],
-          [Sets.GeniusOfBrilliantStars, Sets.GeniusOfBrilliantStars],
+          ...SPREAD_RELICS_2P_GENERAL_CONDITIONALS,
         ],
         ornamentSets: [
           Sets.RutilantArena,
+          ...SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
         ],
         teammates: [
           {
@@ -4025,12 +4066,12 @@ function getScoringMetadata() {
         },
         relicSets: [
           [Sets.MusketeerOfWildWheat, Sets.MusketeerOfWildWheat],
-          [Sets.MusketeerOfWildWheat, Sets.MusketeerOfWildWheat],
           [Sets.WastelanderOfBanditryDesert, Sets.WastelanderOfBanditryDesert],
+          ...SPREAD_RELICS_2P_GENERAL_CONDITIONALS,
         ],
         ornamentSets: [
           Sets.RutilantArena,
-          Sets.FirmamentFrontlineGlamoth,
+          ...SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
         ],
         teammates: [
           {
@@ -4137,11 +4178,13 @@ function getScoringMetadata() {
         },
         relicSets: [
           [Sets.GeniusOfBrilliantStars, Sets.GeniusOfBrilliantStars],
+          ...SPREAD_RELICS_2P_GENERAL_CONDITIONALS,
         ],
         ornamentSets: [
           Sets.TaliaKingdomOfBanditry,
           Sets.InertSalsotto,
-          Sets.FirmamentFrontlineGlamoth,
+          ...SPREAD_ORNAMENTS_2P_FUA,
+          ...SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
         ],
         teammates: [
           {
@@ -4374,11 +4417,11 @@ function getScoringMetadata() {
         },
         relicSets: [
           [Sets.ChampionOfStreetwiseBoxing, Sets.ChampionOfStreetwiseBoxing],
-          [Sets.GeniusOfBrilliantStars, Sets.GeniusOfBrilliantStars],
+          ...SPREAD_RELICS_2P_GENERAL_CONDITIONALS,
         ],
         ornamentSets: [
           Sets.InertSalsotto,
-          Sets.FirmamentFrontlineGlamoth,
+          ...SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
           Sets.RutilantArena,
         ],
         teammates: [
@@ -4533,9 +4576,12 @@ function getScoringMetadata() {
           [Sets.PioneerDiverOfDeadWaters, Sets.PioneerDiverOfDeadWaters],
           [Sets.KnightOfPurityPalace, Sets.KnightOfPurityPalace],
           [Sets.TheAshblazingGrandDuke, Sets.KnightOfPurityPalace, Sets.PioneerDiverOfDeadWaters],
+          ...SPREAD_RELICS_2P_GENERAL_CONDITIONALS,
         ],
         ornamentSets: [
           Sets.InertSalsotto,
+          ...SPREAD_ORNAMENTS_2P_FUA,
+          ...SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
           Sets.BrokenKeel,
           Sets.PenaconyLandOfTheDreams,
           Sets.FleetOfTheAgeless,
@@ -4645,10 +4691,12 @@ function getScoringMetadata() {
         },
         relicSets: [
           [Sets.PioneerDiverOfDeadWaters, Sets.PioneerDiverOfDeadWaters],
+          ...SPREAD_RELICS_2P_GENERAL_CONDITIONALS,
         ],
         ornamentSets: [
           Sets.InertSalsotto,
-          Sets.FirmamentFrontlineGlamoth,
+          ...SPREAD_ORNAMENTS_2P_FUA,
+          ...SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
         ],
         teammates: [
           {
@@ -4914,9 +4962,11 @@ function getScoringMetadata() {
         },
         relicSets: [
           [Sets.PioneerDiverOfDeadWaters, Sets.PioneerDiverOfDeadWaters],
+          ...SPREAD_RELICS_2P_GENERAL_CONDITIONALS,
         ],
         ornamentSets: [
           Sets.IzumoGenseiAndTakamaDivineRealm,
+          ...SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
         ],
         teammates: [
           {
@@ -5065,7 +5115,9 @@ function getScoringMetadata() {
           BREAK: 1,
         },
         relicSets: [
+          RELICS_2P_BREAK_EFFECT_SPEED,
           [Sets.IronCavalryAgainstScourge, Sets.IronCavalryAgainstScourge],
+          ...SPREAD_RELICS_2P_GENERAL_CONDITIONALS,
         ],
         ornamentSets: [
           Sets.TaliaKingdomOfBanditry,
@@ -5173,11 +5225,12 @@ function getScoringMetadata() {
         relicSets: [
           [Sets.PioneerDiverOfDeadWaters, Sets.PioneerDiverOfDeadWaters],
           [Sets.HunterOfGlacialForest, Sets.HunterOfGlacialForest],
+          ...SPREAD_RELICS_2P_GENERAL_CONDITIONALS,
         ],
         ornamentSets: [
           Sets.InertSalsotto,
           Sets.RutilantArena,
-          Sets.FirmamentFrontlineGlamoth,
+          ...SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
         ],
         teammates: [
           {
@@ -5280,12 +5333,13 @@ function getScoringMetadata() {
         },
         relicSets: [
           [Sets.GeniusOfBrilliantStars, Sets.GeniusOfBrilliantStars],
+          ...SPREAD_RELICS_2P_GENERAL_CONDITIONALS,
         ],
         ornamentSets: [
-          Sets.RutilantArena,
           Sets.InertSalsotto,
-          Sets.FirmamentFrontlineGlamoth,
-          Sets.DuranDynastyOfRunningWolves,
+          ...SPREAD_ORNAMENTS_2P_FUA,
+          ...SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
+          Sets.RutilantArena,
         ],
         teammates: [
           {
@@ -5389,9 +5443,9 @@ function getScoringMetadata() {
           BREAK: 1,
         },
         relicSets: [
-          [Sets.ThiefOfShootingMeteor, Sets.WatchmakerMasterOfDreamMachinations, Sets.IronCavalryAgainstScourge],
+          RELICS_2P_BREAK_EFFECT_SPEED,
           [Sets.IronCavalryAgainstScourge, Sets.IronCavalryAgainstScourge],
-          [Sets.GeniusOfBrilliantStars, Sets.GeniusOfBrilliantStars],
+          ...SPREAD_RELICS_2P_GENERAL_CONDITIONALS,
         ],
         ornamentSets: [
           Sets.TaliaKingdomOfBanditry,
@@ -5499,11 +5553,11 @@ function getScoringMetadata() {
         },
         relicSets: [
           [Sets.ChampionOfStreetwiseBoxing, Sets.ChampionOfStreetwiseBoxing],
-          [Sets.GeniusOfBrilliantStars, Sets.GeniusOfBrilliantStars],
+          ...SPREAD_RELICS_2P_GENERAL_CONDITIONALS,
         ],
         ornamentSets: [
           Sets.RutilantArena,
-          Sets.FirmamentFrontlineGlamoth,
+          ...SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
         ],
         teammates: [
           {
@@ -5608,11 +5662,11 @@ function getScoringMetadata() {
         },
         relicSets: [
           [Sets.ChampionOfStreetwiseBoxing, Sets.ChampionOfStreetwiseBoxing],
-          [Sets.GeniusOfBrilliantStars, Sets.GeniusOfBrilliantStars],
+          ...SPREAD_RELICS_2P_GENERAL_CONDITIONALS,
         ],
         ornamentSets: [
           Sets.RutilantArena,
-          Sets.FirmamentFrontlineGlamoth,
+          ...SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
         ],
         teammates: [
           {

--- a/src/lib/dataParser.js
+++ b/src/lib/dataParser.js
@@ -6,7 +6,7 @@ import lightConeRanks from 'data/en/light_cone_ranks.json'
 import relicMainAffixes from 'data/relic_main_affixes.json'
 import relicSubAffixes from 'data/relic_sub_affixes.json'
 import relicSets from 'data/relic_sets.json'
-import { Parts, Sets, Stats } from 'lib/constants.ts'
+import { Parts, Sets, SetsRelics, Stats } from 'lib/constants.ts'
 import DB from 'lib/db'
 import { PresetEffects } from 'components/optimizerTab/optimizerForm/RecommendedPresetsButton.tsx'
 import { SortOption } from 'lib/optimizer/sortOptions'
@@ -1364,9 +1364,14 @@ function getScoringMetadata() {
           DOT: 0,
           BREAK: 0,
         },
-        relicSet1: Sets.PioneerDiverOfDeadWaters,
-        relicSet2: Sets.PioneerDiverOfDeadWaters,
-        ornamentSet: Sets.RutilantArena,
+        relicSets: [
+          [Sets.PioneerDiverOfDeadWaters, Sets.PioneerDiverOfDeadWaters],
+          [Sets.GeniusOfBrilliantStars, Sets.GeniusOfBrilliantStars],
+        ],
+        ornamentSets: [
+          Sets.RutilantArena,
+          Sets.FirmamentFrontlineGlamoth,
+        ],
         teammates: [
           {
             characterId: '1101', // Bronya
@@ -1468,9 +1473,14 @@ function getScoringMetadata() {
           DOT: 0,
           BREAK: 0,
         },
-        relicSet1: Sets.TheAshblazingGrandDuke,
-        relicSet2: Sets.TheAshblazingGrandDuke,
-        ornamentSet: Sets.InertSalsotto,
+        relicSets: [
+          [Sets.TheAshblazingGrandDuke, Sets.TheAshblazingGrandDuke],
+        ],
+        ornamentSets: [
+          Sets.InertSalsotto,
+          Sets.FirmamentFrontlineGlamoth,
+          Sets.RutilantArena,
+        ],
         teammates: [
           {
             characterId: '1112', // Topaz
@@ -1577,9 +1587,13 @@ function getScoringMetadata() {
           DOT: 0,
           BREAK: 0,
         },
-        relicSet1: Sets.PioneerDiverOfDeadWaters,
-        relicSet2: Sets.PioneerDiverOfDeadWaters,
-        ornamentSet: Sets.RutilantArena,
+        relicSets: [
+          [Sets.PioneerDiverOfDeadWaters, Sets.PioneerDiverOfDeadWaters],
+        ],
+        ornamentSets: [
+          Sets.RutilantArena,
+          Sets.FirmamentFrontlineGlamoth,
+        ],
         teammates: [
           {
             characterId: '1308', // Acheron
@@ -1683,9 +1697,12 @@ function getScoringMetadata() {
           DOT: 6,
           BREAK: 0,
         },
-        relicSet1: Sets.PrisonerInDeepConfinement,
-        relicSet2: Sets.PrisonerInDeepConfinement,
-        ornamentSet: Sets.FirmamentFrontlineGlamoth,
+        relicSets: [
+          [Sets.PrisonerInDeepConfinement, Sets.PrisonerInDeepConfinement],
+        ],
+        ornamentSets: [
+          Sets.FirmamentFrontlineGlamoth,
+        ],
         teammates: [
           {
             characterId: '1307', // Swan
@@ -1835,9 +1852,14 @@ function getScoringMetadata() {
           DOT: 0,
           BREAK: 0,
         },
-        relicSet1: Sets.BandOfSizzlingThunder,
-        relicSet2: Sets.BandOfSizzlingThunder,
-        ornamentSet: Sets.RutilantArena,
+        relicSets: [
+          [Sets.BandOfSizzlingThunder, Sets.BandOfSizzlingThunder],
+          [Sets.GeniusOfBrilliantStars, Sets.GeniusOfBrilliantStars],
+        ],
+        ornamentSets: [
+          Sets.RutilantArena,
+          Sets.FirmamentFrontlineGlamoth,
+        ],
         teammates: [
           {
             characterId: '1101', // Bronya
@@ -1986,9 +2008,14 @@ function getScoringMetadata() {
           DOT: 0,
           BREAK: 0,
         },
-        relicSet1: Sets.TheAshblazingGrandDuke,
-        relicSet2: Sets.TheAshblazingGrandDuke,
-        ornamentSet: Sets.InertSalsotto,
+        relicSets: [
+          [Sets.TheAshblazingGrandDuke, Sets.TheAshblazingGrandDuke],
+          [Sets.HunterOfGlacialForest, Sets.HunterOfGlacialForest],
+        ],
+        ornamentSets: [
+          Sets.InertSalsotto,
+          Sets.FirmamentFrontlineGlamoth,
+        ],
         teammates: [
           {
             characterId: '1003', // Himeko
@@ -2138,9 +2165,13 @@ function getScoringMetadata() {
           DOT: 0,
           BREAK: 0,
         },
-        relicSet1: Sets.GeniusOfBrilliantStars,
-        relicSet2: Sets.GeniusOfBrilliantStars,
-        ornamentSet: Sets.FirmamentFrontlineGlamoth,
+        relicSets: [
+          [SetsRelics.GeniusOfBrilliantStars, SetsRelics.GeniusOfBrilliantStars],
+        ],
+        ornamentSets: [
+          Sets.FirmamentFrontlineGlamoth,
+          Sets.RutilantArena,
+        ],
         teammates: [
           {
             characterId: '1006', // SW
@@ -2240,9 +2271,15 @@ function getScoringMetadata() {
           DOT: 0,
           BREAK: 0,
         },
-        relicSet1: Sets.BandOfSizzlingThunder,
-        relicSet2: Sets.BandOfSizzlingThunder,
-        ornamentSet: Sets.FirmamentFrontlineGlamoth,
+        relicSets: [
+          [Sets.BandOfSizzlingThunder, Sets.BandOfSizzlingThunder],
+          [Sets.GeniusOfBrilliantStars, Sets.GeniusOfBrilliantStars],
+          [Sets.PioneerDiverOfDeadWaters, Sets.PioneerDiverOfDeadWaters],
+        ],
+        ornamentSets: [
+          Sets.FirmamentFrontlineGlamoth,
+          Sets.RutilantArena,
+        ],
         teammates: [
           {
             characterId: '1005', // Kafka
@@ -2476,9 +2513,13 @@ function getScoringMetadata() {
           DOT: 0,
           BREAK: 0,
         },
-        relicSet1: Sets.ChampionOfStreetwiseBoxing,
-        relicSet2: Sets.ChampionOfStreetwiseBoxing,
-        ornamentSet: Sets.InertSalsotto,
+        relicSets: [
+          [Sets.ChampionOfStreetwiseBoxing, Sets.ChampionOfStreetwiseBoxing],
+        ],
+        ornamentSets: [
+          Sets.InertSalsotto,
+          Sets.FirmamentFrontlineGlamoth,
+        ],
         teammates: [
           {
             characterId: '1112', // Topaz
@@ -2583,9 +2624,12 @@ function getScoringMetadata() {
           DOT: 30,
           BREAK: 0,
         },
-        relicSet1: Sets.PrisonerInDeepConfinement,
-        relicSet2: Sets.PrisonerInDeepConfinement,
-        ornamentSet: Sets.FirmamentFrontlineGlamoth,
+        relicSets: [
+          [Sets.PrisonerInDeepConfinement, Sets.PrisonerInDeepConfinement],
+        ],
+        ornamentSets: [
+          Sets.FirmamentFrontlineGlamoth,
+        ],
         teammates: [
           {
             characterId: '1005', // Kafka
@@ -2687,9 +2731,13 @@ function getScoringMetadata() {
           DOT: 0,
           BREAK: 0,
         },
-        relicSet1: Sets.PioneerDiverOfDeadWaters,
-        relicSet2: Sets.PioneerDiverOfDeadWaters,
-        ornamentSet: Sets.RutilantArena,
+        relicSets: [
+          [Sets.PioneerDiverOfDeadWaters, Sets.PioneerDiverOfDeadWaters],
+        ],
+        ornamentSets: [
+          Sets.RutilantArena,
+          Sets.FirmamentFrontlineGlamoth,
+        ],
         teammates: [
           {
             characterId: '1101', // Bronya
@@ -2837,9 +2885,15 @@ function getScoringMetadata() {
           DOT: 2,
           BREAK: 1,
         },
-        relicSet1: Sets.PrisonerInDeepConfinement,
-        relicSet2: Sets.PrisonerInDeepConfinement,
-        ornamentSet: Sets.TaliaKingdomOfBanditry,
+        relicSets: [
+          [Sets.PrisonerInDeepConfinement, Sets.PrisonerInDeepConfinement],
+          [Sets.GeniusOfBrilliantStars, Sets.GeniusOfBrilliantStars],
+          [Sets.ThiefOfShootingMeteor, Sets.WatchmakerMasterOfDreamMachinations, Sets.IronCavalryAgainstScourge],
+        ],
+        ornamentSets: [
+          Sets.TaliaKingdomOfBanditry,
+          Sets.FirmamentFrontlineGlamoth,
+        ],
         teammates: [
           {
             characterId: '1005', // Kafka
@@ -2941,9 +2995,14 @@ function getScoringMetadata() {
           DOT: 0,
           BREAK: 0,
         },
-        relicSet1: Sets.TheAshblazingGrandDuke,
-        relicSet2: Sets.TheAshblazingGrandDuke,
-        ornamentSet: Sets.InertSalsotto,
+        relicSets: [
+          [Sets.TheAshblazingGrandDuke, Sets.TheAshblazingGrandDuke],
+          [Sets.PioneerDiverOfDeadWaters, Sets.PioneerDiverOfDeadWaters],
+        ],
+        ornamentSets: [
+          Sets.InertSalsotto,
+          Sets.FirmamentFrontlineGlamoth,
+        ],
         teammates: [
           {
             characterId: '1305', // Ratio
@@ -3043,9 +3102,13 @@ function getScoringMetadata() {
           DOT: 0,
           BREAK: 0,
         },
-        relicSet1: Sets.GeniusOfBrilliantStars,
-        relicSet2: Sets.GeniusOfBrilliantStars,
-        ornamentSet: Sets.RutilantArena,
+        relicSets: [
+          [Sets.GeniusOfBrilliantStars, Sets.GeniusOfBrilliantStars],
+        ],
+        ornamentSets: [
+          Sets.RutilantArena,
+          Sets.FirmamentFrontlineGlamoth,
+        ],
         teammates: [
           {
             characterId: '1006', // SW
@@ -3240,9 +3303,14 @@ function getScoringMetadata() {
           DOT: 0,
           BREAK: 0,
         },
-        relicSet1: Sets.TheAshblazingGrandDuke,
-        relicSet2: Sets.TheAshblazingGrandDuke,
-        ornamentSet: Sets.InertSalsotto,
+        relicSets: [
+          [Sets.TheAshblazingGrandDuke, Sets.TheAshblazingGrandDuke],
+        ],
+        ornamentSets: [
+          Sets.InertSalsotto,
+          Sets.FirmamentFrontlineGlamoth,
+          Sets.RutilantArena,
+        ],
         teammates: [
           {
             characterId: '1306', // Sparkle
@@ -3343,9 +3411,14 @@ function getScoringMetadata() {
           DOT: 0,
           BREAK: 0,
         },
-        relicSet1: Sets.LongevousDisciple,
-        relicSet2: Sets.LongevousDisciple,
-        ornamentSet: Sets.RutilantArena,
+        relicSets: [
+          [Sets.LongevousDisciple, Sets.LongevousDisciple],
+        ],
+        ornamentSets: [
+          Sets.RutilantArena,
+          Sets.InertSalsotto,
+          Sets.FirmamentFrontlineGlamoth,
+        ],
         teammates: [
           {
             characterId: '1212', // Jingliu
@@ -3447,9 +3520,14 @@ function getScoringMetadata() {
           DOT: 0,
           BREAK: 1,
         },
-        relicSet1: Sets.IronCavalryAgainstScourge,
-        relicSet2: Sets.IronCavalryAgainstScourge,
-        ornamentSet: Sets.FirmamentFrontlineGlamoth,
+        relicSets: [
+          [Sets.ChampionOfStreetwiseBoxing, Sets.ChampionOfStreetwiseBoxing],
+          [Sets.IronCavalryAgainstScourge, Sets.IronCavalryAgainstScourge],
+        ],
+        ornamentSets: [
+          Sets.FirmamentFrontlineGlamoth,
+          Sets.RutilantArena,
+        ],
         teammates: [
           {
             characterId: '8006', // Stelle
@@ -3641,9 +3719,15 @@ function getScoringMetadata() {
           DOT: 0,
           BREAK: 0,
         },
-        relicSet1: Sets.HunterOfGlacialForest,
-        relicSet2: Sets.HunterOfGlacialForest,
-        ornamentSet: Sets.RutilantArena,
+        relicSets: [
+          [Sets.HunterOfGlacialForest, Sets.HunterOfGlacialForest],
+          [Sets.PioneerDiverOfDeadWaters, Sets.PioneerDiverOfDeadWaters],
+          [Sets.GeniusOfBrilliantStars, Sets.GeniusOfBrilliantStars],
+        ],
+        ornamentSets: [
+          Sets.RutilantArena,
+          Sets.FirmamentFrontlineGlamoth,
+        ],
         teammates: [
           {
             characterId: '1303', // Ruan Mei
@@ -3831,17 +3915,12 @@ function getScoringMetadata() {
           DOT: 0,
           BREAK: 0,
         },
-        relicSet1: Sets.HunterOfGlacialForest,
-        relicSet2: Sets.HunterOfGlacialForest,
-        ornamentSet: Sets.RutilantArena,
-        equivalentRelicSets: [
-          [
-            Sets.GeniusOfBrilliantStars,
-            Sets.GeniusOfBrilliantStars,
-          ],
+        relicSets: [
+          [Sets.HunterOfGlacialForest, Sets.HunterOfGlacialForest],
+          [Sets.GeniusOfBrilliantStars, Sets.GeniusOfBrilliantStars],
         ],
-        equivalentOrnamentSets: [
-          Sets.GeniusOfBrilliantStars,
+        ornamentSets: [
+          Sets.RutilantArena,
         ],
         teammates: [
           {
@@ -3944,9 +4023,15 @@ function getScoringMetadata() {
           DOT: 0,
           BREAK: 0,
         },
-        relicSet1: Sets.MusketeerOfWildWheat,
-        relicSet2: Sets.MusketeerOfWildWheat,
-        ornamentSet: Sets.RutilantArena,
+        relicSets: [
+          [Sets.MusketeerOfWildWheat, Sets.MusketeerOfWildWheat],
+          [Sets.MusketeerOfWildWheat, Sets.MusketeerOfWildWheat],
+          [Sets.WastelanderOfBanditryDesert, Sets.WastelanderOfBanditryDesert],
+        ],
+        ornamentSets: [
+          Sets.RutilantArena,
+          Sets.FirmamentFrontlineGlamoth,
+        ],
         teammates: [
           {
             characterId: '1306', // Sparkle
@@ -4050,9 +4135,14 @@ function getScoringMetadata() {
           DOT: 0,
           BREAK: 1,
         },
-        relicSet1: Sets.GeniusOfBrilliantStars,
-        relicSet2: Sets.GeniusOfBrilliantStars,
-        ornamentSet: Sets.InertSalsotto,
+        relicSets: [
+          [Sets.GeniusOfBrilliantStars, Sets.GeniusOfBrilliantStars],
+        ],
+        ornamentSets: [
+          Sets.TaliaKingdomOfBanditry,
+          Sets.InertSalsotto,
+          Sets.FirmamentFrontlineGlamoth,
+        ],
         teammates: [
           {
             characterId: '8006', // Stelle
@@ -4282,9 +4372,15 @@ function getScoringMetadata() {
           DOT: 0,
           BREAK: 0,
         },
-        relicSet1: Sets.ChampionOfStreetwiseBoxing,
-        relicSet2: Sets.ChampionOfStreetwiseBoxing,
-        ornamentSet: Sets.InertSalsotto,
+        relicSets: [
+          [Sets.ChampionOfStreetwiseBoxing, Sets.ChampionOfStreetwiseBoxing],
+          [Sets.GeniusOfBrilliantStars, Sets.GeniusOfBrilliantStars],
+        ],
+        ornamentSets: [
+          Sets.InertSalsotto,
+          Sets.FirmamentFrontlineGlamoth,
+          Sets.RutilantArena,
+        ],
         teammates: [
           {
             characterId: '1303', // Ruan Mei
@@ -4433,9 +4529,17 @@ function getScoringMetadata() {
           DOT: 0,
           BREAK: 0,
         },
-        relicSet1: Sets.PioneerDiverOfDeadWaters,
-        relicSet2: Sets.PioneerDiverOfDeadWaters,
-        ornamentSet: Sets.InertSalsotto,
+        relicSets: [
+          [Sets.PioneerDiverOfDeadWaters, Sets.PioneerDiverOfDeadWaters],
+          [Sets.KnightOfPurityPalace, Sets.KnightOfPurityPalace],
+          [Sets.TheAshblazingGrandDuke, Sets.KnightOfPurityPalace, Sets.PioneerDiverOfDeadWaters],
+        ],
+        ornamentSets: [
+          Sets.InertSalsotto,
+          Sets.BrokenKeel,
+          Sets.PenaconyLandOfTheDreams,
+          Sets.FleetOfTheAgeless,
+        ],
         teammates: [
           {
             characterId: '1112', // Topaz
@@ -4539,9 +4643,13 @@ function getScoringMetadata() {
           DOT: 0,
           BREAK: 0,
         },
-        relicSet1: Sets.PioneerDiverOfDeadWaters,
-        relicSet2: Sets.PioneerDiverOfDeadWaters,
-        ornamentSet: Sets.InertSalsotto,
+        relicSets: [
+          [Sets.PioneerDiverOfDeadWaters, Sets.PioneerDiverOfDeadWaters],
+        ],
+        ornamentSets: [
+          Sets.InertSalsotto,
+          Sets.FirmamentFrontlineGlamoth,
+        ],
         teammates: [
           {
             characterId: '1112', // Topaz
@@ -4696,9 +4804,13 @@ function getScoringMetadata() {
           DOT: 8,
           BREAK: 0,
         },
-        relicSet1: Sets.PrisonerInDeepConfinement,
-        relicSet2: Sets.PrisonerInDeepConfinement,
-        ornamentSet: Sets.FirmamentFrontlineGlamoth,
+        relicSets: [
+          [Sets.PrisonerInDeepConfinement, Sets.PrisonerInDeepConfinement],
+        ],
+        ornamentSets: [
+          Sets.FirmamentFrontlineGlamoth,
+          Sets.PanCosmicCommercialEnterprise,
+        ],
         teammates: [
           {
             characterId: '1005', // Kafka
@@ -4800,9 +4912,12 @@ function getScoringMetadata() {
           DOT: 0,
           BREAK: 0,
         },
-        relicSet1: Sets.PioneerDiverOfDeadWaters,
-        relicSet2: Sets.PioneerDiverOfDeadWaters,
-        ornamentSet: Sets.IzumoGenseiAndTakamaDivineRealm,
+        relicSets: [
+          [Sets.PioneerDiverOfDeadWaters, Sets.PioneerDiverOfDeadWaters],
+        ],
+        ornamentSets: [
+          Sets.IzumoGenseiAndTakamaDivineRealm,
+        ],
         teammates: [
           {
             characterId: '1106', // Pela
@@ -4949,9 +5064,13 @@ function getScoringMetadata() {
           DOT: 0,
           BREAK: 1,
         },
-        relicSet1: Sets.IronCavalryAgainstScourge,
-        relicSet2: Sets.IronCavalryAgainstScourge,
-        ornamentSet: Sets.ForgeOfTheKalpagniLantern,
+        relicSets: [
+          [Sets.IronCavalryAgainstScourge, Sets.IronCavalryAgainstScourge],
+        ],
+        ornamentSets: [
+          Sets.TaliaKingdomOfBanditry,
+          Sets.ForgeOfTheKalpagniLantern,
+        ],
         teammates: [
           {
             characterId: '8006', // Stelle
@@ -5051,9 +5170,15 @@ function getScoringMetadata() {
           DOT: 0,
           BREAK: 0,
         },
-        relicSet1: Sets.HunterOfGlacialForest,
-        relicSet2: Sets.HunterOfGlacialForest,
-        ornamentSet: Sets.InertSalsotto,
+        relicSets: [
+          [Sets.PioneerDiverOfDeadWaters, Sets.PioneerDiverOfDeadWaters],
+          [Sets.HunterOfGlacialForest, Sets.HunterOfGlacialForest],
+        ],
+        ornamentSets: [
+          Sets.InertSalsotto,
+          Sets.RutilantArena,
+          Sets.FirmamentFrontlineGlamoth,
+        ],
         teammates: [
           {
             characterId: '1303', // Ruan Mei
@@ -5153,9 +5278,15 @@ function getScoringMetadata() {
           DOT: 0,
           BREAK: 0,
         },
-        relicSet1: Sets.GeniusOfBrilliantStars,
-        relicSet2: Sets.GeniusOfBrilliantStars,
-        ornamentSet: Sets.DuranDynastyOfRunningWolves,
+        relicSets: [
+          [Sets.GeniusOfBrilliantStars, Sets.GeniusOfBrilliantStars],
+        ],
+        ornamentSets: [
+          Sets.RutilantArena,
+          Sets.InertSalsotto,
+          Sets.FirmamentFrontlineGlamoth,
+          Sets.DuranDynastyOfRunningWolves,
+        ],
         teammates: [
           {
             characterId: '1112', // Topaz
@@ -5257,9 +5388,14 @@ function getScoringMetadata() {
           DOT: 0,
           BREAK: 1,
         },
-        relicSet1: Sets.IronCavalryAgainstScourge,
-        relicSet2: Sets.IronCavalryAgainstScourge,
-        ornamentSet: Sets.TaliaKingdomOfBanditry,
+        relicSets: [
+          [Sets.ThiefOfShootingMeteor, Sets.WatchmakerMasterOfDreamMachinations, Sets.IronCavalryAgainstScourge],
+          [Sets.IronCavalryAgainstScourge, Sets.IronCavalryAgainstScourge],
+          [Sets.GeniusOfBrilliantStars, Sets.GeniusOfBrilliantStars],
+        ],
+        ornamentSets: [
+          Sets.TaliaKingdomOfBanditry,
+        ],
         teammates: [
           {
             characterId: '8006', // Stelle
@@ -5361,9 +5497,14 @@ function getScoringMetadata() {
           DOT: 0,
           BREAK: 1,
         },
-        relicSet1: Sets.ChampionOfStreetwiseBoxing,
-        relicSet2: Sets.ChampionOfStreetwiseBoxing,
-        ornamentSet: Sets.RutilantArena,
+        relicSets: [
+          [Sets.ChampionOfStreetwiseBoxing, Sets.ChampionOfStreetwiseBoxing],
+          [Sets.GeniusOfBrilliantStars, Sets.GeniusOfBrilliantStars],
+        ],
+        ornamentSets: [
+          Sets.RutilantArena,
+          Sets.FirmamentFrontlineGlamoth,
+        ],
         teammates: [
           {
             characterId: '1101', // Bronya
@@ -5465,9 +5606,14 @@ function getScoringMetadata() {
           DOT: 0,
           BREAK: 1,
         },
-        relicSet1: Sets.ChampionOfStreetwiseBoxing,
-        relicSet2: Sets.ChampionOfStreetwiseBoxing,
-        ornamentSet: Sets.RutilantArena,
+        relicSets: [
+          [Sets.ChampionOfStreetwiseBoxing, Sets.ChampionOfStreetwiseBoxing],
+          [Sets.GeniusOfBrilliantStars, Sets.GeniusOfBrilliantStars],
+        ],
+        ornamentSets: [
+          Sets.RutilantArena,
+          Sets.FirmamentFrontlineGlamoth,
+        ],
         teammates: [
           {
             characterId: '1101', // Bronya


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Made sim set effects more lenient with similar sets
* Added BIS set score upgrade to the card
* Methodology docs update

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

<img width="313" alt="image" src="https://github.com/fribbels/hsr-optimizer/assets/7908525/83551d67-35a3-4442-8e0d-3230fba6be37">
