### PR TITLE
hotfix: relic tab crash

### DIFF
--- a/src/lib/relicScorer.ts
+++ b/src/lib/relicScorer.ts
@@ -208,7 +208,14 @@ export class RelicScorer {
     const scoringMetadata = this.getRelicScoreMeta(id)
     let maxWeight = 0
 
+    const optimalMainStats = scoringMetadata.parts[part] || []
     const scoreEntries = Object.entries(scoringMetadata.stats)
+      .map((entry: [string, number]) => {
+        if (optimalMainStats.includes(entry[0])) {
+          return [entry[0], 1]
+        }
+        return [entry[0], entry[1]]
+      })
       .sort((a: [string, number], b: [string, number]) => b[1] - a[1])
 
     // Find the mainstat for this relic
@@ -224,7 +231,6 @@ export class RelicScorer {
       // which causes unintuitive optimal relic creation effects (i.e. it's best to choose the
       // lowest weighted one so the higher weighted one ends up as a substat and be scored
       // normally)
-      const optimalMainStats = scoringMetadata.parts[part]
       // First candidate, i.e. has the highest weight
       const mainStatIndex = scoreEntries.findIndex(([name, _weight]) => PartsMainStats[part].includes(name))
       const mainStatWeight = scoreEntries[mainStatIndex][1]
@@ -265,6 +271,7 @@ export class RelicScorer {
     const subs = generateSubStats(5
       , { stat: substats[0][0], value: SubStatValues[substats[0][0]][5].high * 6 }, { stat: substats[1][0], value: SubStatValues[substats[1][0]][5].high }
       , { stat: substats[2][0], value: SubStatValues[substats[2][0]][5].high }, { stat: substats[3][0], value: SubStatValues[substats[3][0]][5].high })
+
     const fake = fakeRelic(5, 15, part, mainStat, subs)
     let ideal = parseFloat(this.score(fake, id).longscore)
     ideal -= mainStatFreeRoll(part, mainStat, scoringMetadata)


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Fixing an issue with relic scoring where 0 weight main stats not matching optimal main stats would break the page

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

