### PR TITLE
hotfix: allow non full builds for dps score, change contrast color, choose scoring type

### DIFF
--- a/src/components/CharacterPreview.jsx
+++ b/src/components/CharacterPreview.jsx
@@ -245,7 +245,7 @@ export function CharacterPreview(props) {
     const result = props.result
 
     const textStyle = {
-      fontSize: 16,
+      fontSize: 17,
       fontWeight: '600',
       textAlign: 'center',
       color: '#DD624D',

--- a/src/components/CharacterPreview.jsx
+++ b/src/components/CharacterPreview.jsx
@@ -486,38 +486,40 @@ export function CharacterPreview(props) {
               simScoringResult
               && (
                 <Flex vertical>
-                  <Flex
-                    vertical
-                    style={{
-                      position: 'relative',
-                      height: 0,
-                      top: newLcHeight - 35,
-                      // top: newLcHeight - 221, // top right
-                      paddingRight: 12,
-                    }}
-                    align="flex-end"
-                  >
-                    <Text
+                  {lightConeName && (
+                    <Flex
+                      vertical
                       style={{
-                        position: 'absolute',
-                        height: 30,
-                        backgroundColor: 'rgb(0 0 0 / 70%)',
-                        padding: '4px 12px',
-                        borderRadius: 8,
-                        fontSize: 14,
-                        maxWidth: parentW - 50,
-                        textOverflow: 'ellipsis',
-                        overflow: 'hidden',
-                        whiteSpace: 'nowrap',
-                        zIndex: 3,
-                        textShadow: '0px 0px 10px black',
-                        outline: outline,
-                        boxShadow: shadow,
+                        position: 'relative',
+                        height: 0,
+                        top: newLcHeight - 35,
+                        // top: newLcHeight - 221, // top right
+                        paddingRight: 12,
                       }}
+                      align="flex-end"
                     >
-                      {`S${lightConeSuperimposition} - ${lightConeName}`}
-                    </Text>
-                  </Flex>
+                      <Text
+                        style={{
+                          position: 'absolute',
+                          height: 30,
+                          backgroundColor: 'rgb(0 0 0 / 70%)',
+                          padding: '4px 12px',
+                          borderRadius: 8,
+                          fontSize: 14,
+                          maxWidth: parentW - 50,
+                          textOverflow: 'ellipsis',
+                          overflow: 'hidden',
+                          whiteSpace: 'nowrap',
+                          zIndex: 3,
+                          textShadow: '0px 0px 10px black',
+                          outline: outline,
+                          boxShadow: shadow,
+                        }}
+                      >
+                        {`S${lightConeSuperimposition} - ${lightConeName}`}
+                      </Text>
+                    </Flex>
+                  )}
                   <Flex
                     style={{
                       width: `${tempLcParentW}px`,

--- a/src/components/CharacterPreview.jsx
+++ b/src/components/CharacterPreview.jsx
@@ -242,17 +242,21 @@ export function CharacterPreview(props) {
   function ScoreHeader(props) {
     const result = props.result
 
+    const textStyle = {
+      fontSize: 16,
+      fontWeight: '600',
+      textAlign: 'center',
+      color: '#EC5353',
+      height: 26,
+      whiteSpace: 'pre-line',
+    }
+
     const textDisplay = (
-      <StatText style={{
-        fontSize: 17,
-        fontWeight: '600',
-        textAlign: 'center',
-        color: '#d53333',
-        height: 30,
-      }}
-      >
-        {`DPS score: ${Utils.truncate10ths(result.percent * 100).toFixed(1)}% (${getSimScoreGrade(result.percent)})`}
-      </StatText>
+      <Flex vertical>
+        <StatText style={textStyle}>
+          {`DPS Score: ${Utils.truncate10ths(Math.max(0, result.percent * 100)).toFixed(1)}% (${getSimScoreGrade(result.percent)})`}
+        </StatText>
+      </Flex>
     )
 
     return (
@@ -576,7 +580,7 @@ export function CharacterPreview(props) {
                   !simScoringResult
                   && (
                     <Flex vertical>
-                      <StatText style={{ fontSize: 17, fontWeight: 600, textAlign: 'center', color: '#e1a564' }}>
+                      <StatText style={{ fontSize: 17, marginBottom: 10, fontWeight: 600, textAlign: 'center', color: '#e1a564' }}>
                         {`Character score: ${scoringResults.totalScore.toFixed(0)} ${scoringResults.totalScore == 0 ? '' : '(' + scoringResults.totalRating + ')'}`}
                       </StatText>
                     </Flex>

--- a/src/components/CharacterPreview.jsx
+++ b/src/components/CharacterPreview.jsx
@@ -254,10 +254,7 @@ export function CharacterPreview(props) {
     }
 
     const textDisplay = (
-      <Flex vertical style={{ marginBottom: 4 }}>
-        <StatText style={textStyle}>
-          Combat Simulation
-        </StatText>
+      <Flex align="center" vertical style={{ marginBottom: 4 }}>
         <StatText style={textStyle}>
           {`DPS Score: ${Utils.truncate10ths(Math.max(0, result.percent * 100)).toFixed(1)}% (${getSimScoreGrade(result.percent)})`}
         </StatText>
@@ -588,7 +585,7 @@ export function CharacterPreview(props) {
                   && (
                     <Flex vertical>
                       <StatText style={{ fontSize: 17, marginBottom: 10, fontWeight: 600, textAlign: 'center', color: '#e1a564' }}>
-                        {`Character score: ${scoringResults.totalScore.toFixed(0)} ${scoringResults.totalScore == 0 ? '' : '(' + scoringResults.totalRating + ')'}`}
+                        {`Character Score: ${scoringResults.totalScore.toFixed(0)} ${scoringResults.totalScore == 0 ? '' : '(' + scoringResults.totalRating + ')'}`}
                       </StatText>
                     </Flex>
                   )

--- a/src/components/CharacterPreview.jsx
+++ b/src/components/CharacterPreview.jsx
@@ -249,12 +249,12 @@ export function CharacterPreview(props) {
       fontWeight: '600',
       textAlign: 'center',
       color: '#DD624D',
-      height: 26,
+      height: 23,
       whiteSpace: 'pre-line',
     }
 
     const textDisplay = (
-      <Flex vertical>
+      <Flex vertical style={{ marginBottom: 4 }}>
         <StatText style={textStyle}>
           Combat Simulation
         </StatText>
@@ -274,7 +274,7 @@ export function CharacterPreview(props) {
   function ScoreFooter(props) {
     const textDisplay = (
       <Flex vertical align="center">
-        <HeaderText style={{ fontSize: 16, marginBottom: 4 }}>
+        <HeaderText style={{ fontSize: 16, marginBottom: 2 }}>
           DPS score upgrades
         </HeaderText>
       </Flex>

--- a/src/components/CharacterPreview.jsx
+++ b/src/components/CharacterPreview.jsx
@@ -185,8 +185,12 @@ export function CharacterPreview(props) {
     finalStats = StatCalculator.calculate(character)
   }
 
-  let simScoringResult = scoringType == SIMULATION_SCORE && scoreCharacterSimulation(character, finalStats, displayRelics, teamSelection)
-  if (!simScoringResult?.sims) simScoringResult = null
+  let combatSimResult = scoreCharacterSimulation(character, finalStats, displayRelics, teamSelection)
+  let simScoringResult = scoringType == SIMULATION_SCORE && combatSimResult
+  if (!simScoringResult?.sims) {
+    combatSimResult = null
+    simScoringResult = null
+  }
 
   const scoredRelics = scoringResults.relics || []
 
@@ -759,8 +763,16 @@ export function CharacterPreview(props) {
             value={scoringType}
             block
             options={[
-              SIMULATION_SCORE,
-              CHARACTER_SCORE,
+              {
+                label: `${SIMULATION_SCORE}${combatSimResult == null ? ' (TBD)' : ''}`,
+                value: SIMULATION_SCORE,
+                disabled: false,
+              },
+              {
+                label: CHARACTER_SCORE,
+                value: CHARACTER_SCORE,
+                disabled: false,
+              },
             ]}
           />
         </Flex>

--- a/src/components/characterPreview/CharacterScoringSummary.tsx
+++ b/src/components/characterPreview/CharacterScoringSummary.tsx
@@ -507,6 +507,7 @@ export function CharacterCardScoringStatUpgrades(props: { result: SimulationScor
 
   const setUpgrade = result.setUpgrades[0]
   if (setUpgrade.percent! - basePercent > 0) {
+    rows.splice(4, 1)
     rows.push(
       <Flex gap={3} key={Utils.randomId()} justify="space-between" align="center" style={{ width: '100%', paddingLeft: 1 }}>
         <img src={Assets.getSetImage(setUpgrade.simulation.request.simRelicSet1)} style={{ width: iconSize, height: iconSize, marginRight: 3 }} />

--- a/src/components/characterPreview/CharacterStatSummary.tsx
+++ b/src/components/characterPreview/CharacterStatSummary.tsx
@@ -4,18 +4,18 @@ import { Constants } from 'lib/constants.ts'
 
 export const CharacterStatSummary = (props: { finalStats: any; elementalDmgValue: string; hideCv?: boolean }) => {
   return (
-    <Flex vertical style={{paddingLeft: 6, paddingRight: 8}} gap={3}>
-      <StatRow finalStats={props.finalStats} stat={Constants.Stats.HP}/>
-      <StatRow finalStats={props.finalStats} stat={Constants.Stats.ATK}/>
-      <StatRow finalStats={props.finalStats} stat={Constants.Stats.DEF}/>
-      <StatRow finalStats={props.finalStats} stat={Constants.Stats.SPD}/>
-      <StatRow finalStats={props.finalStats} stat={Constants.Stats.CR}/>
-      <StatRow finalStats={props.finalStats} stat={Constants.Stats.CD}/>
-      <StatRow finalStats={props.finalStats} stat={Constants.Stats.EHR}/>
-      <StatRow finalStats={props.finalStats} stat={Constants.Stats.RES}/>
-      <StatRow finalStats={props.finalStats} stat={Constants.Stats.BE}/>
-      <StatRow finalStats={props.finalStats} stat={props.elementalDmgValue}/>
-      {!props.hideCv && <StatRow finalStats={props.finalStats} stat="CV"/>}
+    <Flex vertical style={{ paddingLeft: 6, paddingRight: 8 }} gap={3}>
+      <StatRow finalStats={props.finalStats} stat={Constants.Stats.HP} />
+      <StatRow finalStats={props.finalStats} stat={Constants.Stats.ATK} />
+      <StatRow finalStats={props.finalStats} stat={Constants.Stats.DEF} />
+      <StatRow finalStats={props.finalStats} stat={Constants.Stats.SPD} />
+      <StatRow finalStats={props.finalStats} stat={Constants.Stats.CR} />
+      <StatRow finalStats={props.finalStats} stat={Constants.Stats.CD} />
+      <StatRow finalStats={props.finalStats} stat={Constants.Stats.EHR} />
+      <StatRow finalStats={props.finalStats} stat={Constants.Stats.RES} />
+      <StatRow finalStats={props.finalStats} stat={Constants.Stats.BE} />
+      <StatRow finalStats={props.finalStats} stat={props.elementalDmgValue} />
+      {!props.hideCv && <StatRow finalStats={props.finalStats} stat="CV" />}
     </Flex>
   )
 }

--- a/src/lib/characterScorer.ts
+++ b/src/lib/characterScorer.ts
@@ -38,6 +38,23 @@ export type SimulationScore = {
   metadata: any
 }
 
+function cloneRelicsFillEmptySlots(displayRelics: any) {
+  const cloned = Utils.clone(displayRelics)
+  const relicsByPart = {}
+  for (const part of Object.values(Parts)) {
+    relicsByPart[part] = cloned[part] || {
+      set: -1,
+      substats: [],
+      main: {
+        stat: 'NONE',
+        value: 0,
+      },
+    }
+  }
+
+  return relicsByPart
+}
+
 export function scoreCharacterSimulation(character: Character, finalStats: any, displayRelics: any, teamSelection: string) {
   // Since this is a compute heavy sim, and we don't currently control the reloads on the character tab well,
   // just cache the results for now
@@ -64,13 +81,14 @@ export function scoreCharacterSimulation(character: Character, finalStats: any, 
     defaultMetadata.teammates = customMetadata.teammates
   }
   const metadata = defaultMetadata
+  const relicsByPart = cloneRelicsFillEmptySlots(displayRelics)
 
   const cacheKey = Utils.objectHash({
     characterId,
     characterEidolon,
     lightCone,
     lightConeSuperimposition,
-    displayRelics,
+    relicsByPart,
     metadata,
   })
 
@@ -79,9 +97,9 @@ export function scoreCharacterSimulation(character: Character, finalStats: any, 
     return cachedSims[cacheKey]
   }
 
-  const has6Piece = Object.values(displayRelics).filter((x) => x).length == 6
+  const has6Piece = Object.values(relicsByPart).filter((x) => x).length == 6
 
-  if (!characterId || !originalForm || !metadata || !lightCone || !has6Piece) {
+  if (!characterId || !originalForm || !metadata || !lightCone) {
     console.log('Invalid character sim setup')
     return null
   }
@@ -121,14 +139,14 @@ export function scoreCharacterSimulation(character: Character, finalStats: any, 
   }
 
   // Simulate the original character
-  const { originalSimResult, originalSim } = simulateOriginalCharacter(displayRelics, simulationForm)
+  const { originalSimResult, originalSim } = simulateOriginalCharacter(relicsByPart, simulationForm)
   const originalFinalSpeed = originalSimResult.xSPD
   const originalBaseSpeed = originalSimResult.SPD
 
-  const { baselineSimResult } = simulateBaselineCharacter(displayRelics, simulationForm)
+  const { baselineSimResult } = simulateBaselineCharacter(relicsByPart, simulationForm)
 
   // Generate partials
-  const partialSimulationWrappers = generatePartialSimulations(metadata, displayRelics, originalBaseSpeed)
+  const partialSimulationWrappers = generatePartialSimulations(metadata, relicsByPart, originalBaseSpeed)
   // console.debug(partialSimulationWrappers)
 
   const bestPartialSims: Simulation[] = []

--- a/src/lib/characterScorer.ts
+++ b/src/lib/characterScorer.ts
@@ -99,7 +99,7 @@ export function scoreCharacterSimulation(character: Character, finalStats: any, 
 
   const has6Piece = Object.values(relicsByPart).filter((x) => x).length == 6
 
-  if (!characterId || !originalForm || !metadata || !lightCone) {
+  if (!characterId || !originalForm || !metadata) {
     console.log('Invalid character sim setup')
     return null
   }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -703,3 +703,6 @@ export const DamageKeys = ['BASIC', 'SKILL', 'ULT', 'FUA', 'DOT', 'BREAK']
 export const DEFAULT_TEAM = 'Default'
 export const CUSTOM_TEAM = 'Custom'
 export const RESET_TEAM = 'Reset'
+
+export const SIMULATION_SCORE = 'Combat Simulation Score'
+export const CHARACTER_SCORE = 'Character Score'

--- a/src/lib/constantsSession.ts
+++ b/src/lib/constantsSession.ts
@@ -1,4 +1,5 @@
 export enum SavedSessionKeys {
   optimizerCharacterId = 'optimizerCharacterId',
   relicScorerSidebarOpen = 'relicScorerSidebarOpen',
+  scoringType = 'scoringType',
 }

--- a/src/lib/db.js
+++ b/src/lib/db.js
@@ -2,7 +2,7 @@ import { create } from 'zustand'
 import objectHash from 'object-hash'
 import { OptimizerTabController } from 'lib/optimizerTabController'
 import { RelicAugmenter } from 'lib/relicAugmenter'
-import { Constants, CURRENT_OPTIMIZER_VERSION, DEFAULT_STAT_DISPLAY, RelicSetFilterOptions } from 'lib/constants.ts'
+import { Constants, CURRENT_OPTIMIZER_VERSION, DEFAULT_STAT_DISPLAY, RelicSetFilterOptions, SIMULATION_SCORE } from 'lib/constants.ts'
 import { SavedSessionKeys } from 'lib/constantsSession'
 import { getDefaultForm } from 'lib/defaultForm'
 import { Utils } from 'lib/utils'
@@ -132,48 +132,49 @@ window.store = create((set) => ({
   savedSession: {
     [SavedSessionKeys.optimizerCharacterId]: null,
     [SavedSessionKeys.relicScorerSidebarOpen]: true,
+    [SavedSessionKeys.scoringType]: SIMULATION_SCORE,
   },
 
   settings: DefaultSettingOptions,
 
-  setVersion: (x) => set(() => ({version: x})),
-  setActiveKey: (x) => set(() => ({activeKey: x})),
-  setCharacters: (x) => set(() => ({characters: x})),
-  setCharactersById: (x) => set(() => ({charactersById: x})),
-  setConditionalSetEffectsDrawerOpen: (x) => set(() => ({conditionalSetEffectsDrawerOpen: x})),
-  setCombatBuffsDrawerOpen: (x) => set(() => ({combatBuffsDrawerOpen: x})),
-  setSettingsDrawerOpen: (x) => set(() => ({settingsDrawerOpen: x})),
-  setOptimizerTabFocusCharacter: (characterId) => set(() => ({optimizerTabFocusCharacter: characterId})),
-  setCharacterTabFocusCharacter: (characterId) => set(() => ({characterTabFocusCharacter: characterId})),
-  setScoringAlgorithmFocusCharacter: (characterId) => set(() => ({scoringAlgorithmFocusCharacter: characterId})),
-  setPermutationDetails: (x) => set(() => ({permutationDetails: x})),
-  setPermutations: (x) => set(() => ({permutations: x})),
-  setPermutationsResults: (x) => set(() => ({permutationsResults: x})),
-  setPermutationsSearched: (x) => set(() => ({permutationsSearched: x})),
-  setRelicsById: (x) => set(() => ({relicsById: x})),
-  setRelicTabFilters: (x) => set(() => ({relicTabFilters: x})),
-  setScorerId: (x) => set(() => ({scorerId: x})),
-  setScoringMetadataOverrides: (x) => set(() => ({scoringMetadataOverrides: x})),
-  setStatDisplay: (x) => set(() => ({statDisplay: x})),
-  setStatSimulationDisplay: (x) => set(() => ({statSimulationDisplay: x})),
-  setStatSimulations: (x) => set(() => ({statSimulations: Utils.clone(x)})),
-  setSelectedStatSimulations: (x) => set(() => ({selectedStatSimulations: x})),
-  setOptimizerMenuState: (x) => set(() => ({optimizerMenuState: x})),
-  setOptimizationInProgress: (x) => set(() => ({optimizationInProgress: x})),
-  setOptimizationId: (x) => set(() => ({optimizationId: x})),
-  setTeammateCount: (x) => set(() => ({teammateCount: x})),
-  setOptimizerFormCharacterEidolon: (x) => set(() => ({optimizerFormCharacterEidolon: x})),
-  setOptimizerFormSelectedLightCone: (x) => set(() => ({optimizerFormSelectedLightCone: x})),
-  setOptimizerFormSelectedLightConeSuperimposition: (x) => set(() => ({optimizerFormSelectedLightConeSuperimposition: x})),
-  setZeroPermutationsModalOpen: (x) => set(() => ({zeroPermutationModalOpen: x})),
-  setExcludedRelicPotentialCharacters: (x) => set(() => ({excludedRelicPotentialCharacters: x})),
-  setMenuSidebarOpen: (x) => set(() => ({menuSidebarOpen: x})),
-  setSettings: (x) => set(() => ({settings: x})),
-  setSavedSession: (x) => set(() => ({savedSession: x})),
+  setVersion: (x) => set(() => ({ version: x })),
+  setActiveKey: (x) => set(() => ({ activeKey: x })),
+  setCharacters: (x) => set(() => ({ characters: x })),
+  setCharactersById: (x) => set(() => ({ charactersById: x })),
+  setConditionalSetEffectsDrawerOpen: (x) => set(() => ({ conditionalSetEffectsDrawerOpen: x })),
+  setCombatBuffsDrawerOpen: (x) => set(() => ({ combatBuffsDrawerOpen: x })),
+  setSettingsDrawerOpen: (x) => set(() => ({ settingsDrawerOpen: x })),
+  setOptimizerTabFocusCharacter: (characterId) => set(() => ({ optimizerTabFocusCharacter: characterId })),
+  setCharacterTabFocusCharacter: (characterId) => set(() => ({ characterTabFocusCharacter: characterId })),
+  setScoringAlgorithmFocusCharacter: (characterId) => set(() => ({ scoringAlgorithmFocusCharacter: characterId })),
+  setPermutationDetails: (x) => set(() => ({ permutationDetails: x })),
+  setPermutations: (x) => set(() => ({ permutations: x })),
+  setPermutationsResults: (x) => set(() => ({ permutationsResults: x })),
+  setPermutationsSearched: (x) => set(() => ({ permutationsSearched: x })),
+  setRelicsById: (x) => set(() => ({ relicsById: x })),
+  setRelicTabFilters: (x) => set(() => ({ relicTabFilters: x })),
+  setScorerId: (x) => set(() => ({ scorerId: x })),
+  setScoringMetadataOverrides: (x) => set(() => ({ scoringMetadataOverrides: x })),
+  setStatDisplay: (x) => set(() => ({ statDisplay: x })),
+  setStatSimulationDisplay: (x) => set(() => ({ statSimulationDisplay: x })),
+  setStatSimulations: (x) => set(() => ({ statSimulations: Utils.clone(x) })),
+  setSelectedStatSimulations: (x) => set(() => ({ selectedStatSimulations: x })),
+  setOptimizerMenuState: (x) => set(() => ({ optimizerMenuState: x })),
+  setOptimizationInProgress: (x) => set(() => ({ optimizationInProgress: x })),
+  setOptimizationId: (x) => set(() => ({ optimizationId: x })),
+  setTeammateCount: (x) => set(() => ({ teammateCount: x })),
+  setOptimizerFormCharacterEidolon: (x) => set(() => ({ optimizerFormCharacterEidolon: x })),
+  setOptimizerFormSelectedLightCone: (x) => set(() => ({ optimizerFormSelectedLightCone: x })),
+  setOptimizerFormSelectedLightConeSuperimposition: (x) => set(() => ({ optimizerFormSelectedLightConeSuperimposition: x })),
+  setZeroPermutationsModalOpen: (x) => set(() => ({ zeroPermutationModalOpen: x })),
+  setExcludedRelicPotentialCharacters: (x) => set(() => ({ excludedRelicPotentialCharacters: x })),
+  setMenuSidebarOpen: (x) => set(() => ({ menuSidebarOpen: x })),
+  setSettings: (x) => set(() => ({ settings: x })),
+  setSavedSession: (x) => set(() => ({ savedSession: x })),
   setSavedSessionKey: (key, x) => set((state) => ({
-    savedSession: {...state.savedSession, [key]: x},
+    savedSession: { ...state.savedSession, [key]: x },
   })),
-  setColorTheme: (x) => set(() => ({colorTheme: x})),
+  setColorTheme: (x) => set(() => ({ colorTheme: x })),
 }))
 
 export const DB = {
@@ -307,7 +308,7 @@ export const DB = {
     const dbLightCones = DB.getMetadata().lightCones
 
     // Remove invalid characters
-    x.characters = x.characters.filter(x => dbCharacters[x.id])
+    x.characters = x.characters.filter((x) => dbCharacters[x.id])
 
     for (const character of x.characters) {
       character.equipped = {}
@@ -315,7 +316,7 @@ export const DB = {
 
       // Previously sim requests didnt use the stats field
       if (character.form?.statSim?.simulations) {
-        character.form.statSim.simulations = character.form.statSim.simulations.filter(x => x.request?.stats)
+        character.form.statSim.simulations = character.form.statSim.simulations.filter((x) => x.request?.stats)
       }
 
       // Previously characters had customizable options, now we're defaulting to 80s
@@ -416,10 +417,10 @@ export const DB = {
       }
       DB.setCharacters(characters)
     } else {
-      const defaultForm = getDefaultForm({id: form.characterId})
+      const defaultForm = getDefaultForm({ id: form.characterId })
       found = {
         id: form.characterId,
-        form: {...defaultForm, ...form},
+        form: { ...defaultForm, ...form },
         equipped: {},
       }
       DB.addCharacter(found)
@@ -432,7 +433,7 @@ export const DB = {
      * Since the grid resets the rows, we have to re-select the grid node and inform the character tab
      */
     if (window.characterGrid?.current?.api) {
-      window.characterGrid.current.api.updateGridOptions({rowData: characters})
+      window.characterGrid.current.api.updateGridOptions({ rowData: characters })
       window.characterGrid.current.api.forEachNode((node) => node.data.id == found.id ? node.setSelected(true) : 0)
       window.store.getState().setCharacterTabFocusCharacter(found.id)
     }
@@ -445,7 +446,7 @@ export const DB = {
   saveCharacterPortrait: (characterId, portrait) => {
     let character = DB.getCharacterById(characterId)
     if (!character) {
-      DB.addFromForm({characterId: characterId})
+      DB.addFromForm({ characterId: characterId })
       character = DB.getCharacterById(characterId)
       console.log('Character did not previously exist, adding', character)
     }
@@ -476,7 +477,7 @@ export const DB = {
     if (build) {
       const errorMessage = `Build name [${name}] already exists`
       console.warn(errorMessage)
-      return {error: errorMessage}
+      return { error: errorMessage }
     } else {
       if (!character.builds) character.builds = []
       character.builds.push({
@@ -600,7 +601,7 @@ export const DB = {
     console.log('Equipping relics to character', relicIds, characterId)
 
     for (const relicId of relicIds) {
-      DB.equipRelic({id: relicId}, characterId, forceSwap)
+      DB.equipRelic({ id: relicId }, characterId, forceSwap)
     }
   },
 
@@ -738,7 +739,7 @@ export const DB = {
 
     // only valid when on relics tab
     if (window.relicsGrid?.current?.api) {
-      window.relicsGrid.current.api.updateGridOptions({rowData: replacementRelics})
+      window.relicsGrid.current.api.updateGridOptions({ rowData: replacementRelics })
     }
 
     // only valid when on character tab
@@ -790,15 +791,15 @@ export const DB = {
 
           // Different substats mean different relics - break
           if (!newSubstat) {
-            exit = true;
+            exit = true
             break
           }
           if (matchSubstat.stat != newSubstat.stat) {
-            exit = true;
+            exit = true
             break
           }
           if (compareSameTypeSubstat(matchSubstat, newSubstat) == -1) {
-            exit = true;
+            exit = true
             break
           }
 

--- a/src/lib/optimizer/optimizerUtils.js
+++ b/src/lib/optimizer/optimizerUtils.js
@@ -13,13 +13,14 @@ export function emptyRelic() {
     mainStat: Constants.Stats.HP,
     mainValue: 0,
   }
-  for (let stat of Object.values(Constants.Stats)) {
+  for (const stat of Object.values(Constants.Stats)) {
     augmentedStats[stat] = 0
   }
   return {
     set: -1,
     augmentedStats: augmentedStats,
     substats: [],
+
   }
 }
 

--- a/src/lib/statCalculator.js
+++ b/src/lib/statCalculator.js
@@ -36,6 +36,9 @@ export const StatCalculator = {
     return Utils.precisionRound(SubStatValues[stat][5].high)
   },
   getMaxedStatValue: (stat) => {
+    if (stat === 'NONE') { // Fake stat for relic scoring
+      return 0
+    }
     const scaling = Utils.isFlat(stat) ? 1 : 100
     return Utils.precisionRound(maxedMainStats[stat][3] / scaling)
   },


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Previously non full builds defaulted to character score, force it to dps score
* Adding option to select previous scoring type

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* #376 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

<img width="881" alt="image" src="https://github.com/fribbels/hsr-optimizer/assets/7908525/9e8e10b7-43ef-4e5e-a93f-7bdaa3bf0232">
