### PR TITLE
hotfix: bug in post-calculateBaseMultis set effects not activating

### DIFF
--- a/src/components/characterPreview/CharacterScoringSummary.tsx
+++ b/src/components/characterPreview/CharacterScoringSummary.tsx
@@ -350,8 +350,8 @@ export const CharacterScoringSummary = (props: { simScoringResult: SimulationSco
             <ScoringNumber label="BASIC: " number={result.metadata.formula.BASIC} precision={0} />
             <ScoringNumber label="SKILL: " number={result.metadata.formula.SKILL} precision={0} />
             <ScoringNumber label="ULT:   " number={result.metadata.formula.ULT} precision={0} />
-            <ScoringNumber label="DOT:   " number={result.metadata.formula.DOT} precision={0} />
             <ScoringNumber label="FUA:   " number={result.metadata.formula.FUA} precision={0} />
+            <ScoringNumber label="DOT:   " number={result.metadata.formula.DOT} precision={0} />
             <ScoringNumber label="BREAK: " number={result.metadata.formula.BREAK} precision={0} />
           </Flex>
         </Flex>

--- a/src/lib/conditionals/character/Aventurine.ts
+++ b/src/lib/conditionals/character/Aventurine.ts
@@ -137,6 +137,12 @@ const Aventurine = (e: Eidolon): CharacterConditional => {
       x.RES_PEN += (e >= 2 && m.e2ResShred) ? 0.12 : 0
       x.CRIT_VULNERABILITY += (m.enemyUnnervedDebuff) ? ultCritVulnerability : 0
     },
+    calculatePassives: (c: PrecomputedCharacterConditional, request: Form) => {
+      const r = request.characterConditionals
+      const x = c.x
+
+      x[Stats.CR] += (r.defToCrBoost && x[Stats.DEF] > 1600) ? Math.min(0.48, 0.02 * Math.floor((x[Stats.DEF] - 1600) / 100)) : 0
+    },
     calculateBaseMultis: (c: PrecomputedCharacterConditional, request: Form) => {
       const r = request.characterConditionals
       const x = c.x
@@ -144,8 +150,6 @@ const Aventurine = (e: Eidolon): CharacterConditional => {
       x.BASIC_DMG += x.BASIC_SCALING * x[Stats.DEF]
       x.ULT_DMG += x.ULT_SCALING * x[Stats.DEF]
       x.FUA_DMG += x.FUA_SCALING * x[Stats.DEF]
-
-      x[Stats.CR] += (r.defToCrBoost && x[Stats.DEF] > 1600) ? Math.min(0.48, 0.02 * Math.floor((x[Stats.DEF] - 1600) / 100)) : 0
     },
   }
 }

--- a/src/lib/optimizer/calculateBuild.js
+++ b/src/lib/optimizer/calculateBuild.js
@@ -2,7 +2,7 @@ import { generateParams } from 'lib/optimizer/calculateParams'
 import { calculateConditionals } from 'lib/optimizer/calculateConditionals'
 import { calculateTeammates } from 'lib/optimizer/calculateTeammates'
 import { OrnamentSetCount, OrnamentSetToIndex, RelicSetCount, RelicSetToIndex } from 'lib/constants'
-import { baseCharacterStats, calculateBaseStats, calculateComputedStats, calculateElementalStats, calculatePostBaseSetEffects, calculateRelicStats, calculateSetCounts } from 'lib/optimizer/calculateStats'
+import { baseCharacterStats, calculateBaseStats, calculateComputedStats, calculateElementalStats, calculateRelicStats, calculateSetCounts } from 'lib/optimizer/calculateStats'
 import { calculateBaseMultis, calculateDamage } from 'lib/optimizer/calculateDamage'
 import { emptyRelic } from 'lib/optimizer/optimizerUtils'
 import { Constants } from 'lib/constants.ts'
@@ -57,7 +57,6 @@ export function calculateBuild(request, relics) {
   calculateElementalStats(c, request, params)
   calculateComputedStats(c, request, params)
   calculateBaseMultis(c, request, params)
-  calculatePostBaseSetEffects(c, request, params)
   calculateDamage(c, request, params)
 
   return c

--- a/src/lib/optimizer/calculateBuild.js
+++ b/src/lib/optimizer/calculateBuild.js
@@ -2,7 +2,7 @@ import { generateParams } from 'lib/optimizer/calculateParams'
 import { calculateConditionals } from 'lib/optimizer/calculateConditionals'
 import { calculateTeammates } from 'lib/optimizer/calculateTeammates'
 import { OrnamentSetCount, OrnamentSetToIndex, RelicSetCount, RelicSetToIndex } from 'lib/constants'
-import { baseCharacterStats, calculateBaseStats, calculateComputedStats, calculateElementalStats, calculateRelicStats, calculateSetCounts } from 'lib/optimizer/calculateStats'
+import { baseCharacterStats, calculateBaseStats, calculateComputedStats, calculateElementalStats, calculatePostBaseSetEffects, calculateRelicStats, calculateSetCounts } from 'lib/optimizer/calculateStats'
 import { calculateBaseMultis, calculateDamage } from 'lib/optimizer/calculateDamage'
 import { emptyRelic } from 'lib/optimizer/optimizerUtils'
 import { Constants } from 'lib/constants.ts'
@@ -57,6 +57,7 @@ export function calculateBuild(request, relics) {
   calculateElementalStats(c, request, params)
   calculateComputedStats(c, request, params)
   calculateBaseMultis(c, request, params)
+  calculatePostBaseSetEffects(c, request, params)
   calculateDamage(c, request, params)
 
   return c

--- a/src/lib/optimizer/calculateDamage.js
+++ b/src/lib/optimizer/calculateDamage.js
@@ -9,6 +9,12 @@ export function calculateBaseMultis(c, request, params) {
   if (characterConditionals.calculateBaseMultis) characterConditionals.calculateBaseMultis(c, request, params)
 }
 
+export function calculatePassiveStatConversions(c, request, params) {
+  const characterConditionals = params.characterConditionals
+
+  if (characterConditionals.calculatePassives) characterConditionals.calculatePassives(c, request, params)
+}
+
 export function calculateDamage(c, request, params) {
   const x = c.x
   const sets = c.sets

--- a/src/lib/optimizer/calculateStats.js
+++ b/src/lib/optimizer/calculateStats.js
@@ -196,6 +196,19 @@ export function calculateComputedStats(c, request, params) {
 
   x[Stats.HP] += x[Stats.HP_P] * request.baseHp
 
+  x[Stats.BE]
+    += 0.20 * (x[Stats.SPD] >= 145 ? 1 : 0) * p2(sets.TaliaKingdomOfBanditry)
+    + 0.30 * params.enabledWatchmakerMasterOfDreamMachinations * p4(sets.WatchmakerMasterOfDreamMachinations)
+    + 0.40 * params.enabledForgeOfTheKalpagniLantern * p2(sets.ForgeOfTheKalpagniLantern)
+
+  return x
+}
+
+// This is for set effects that happen after calculateBaseMultis
+export function calculatePostBaseSetEffects(c, request, params) {
+  const sets = c.sets
+  const x = c.x
+
   x[Stats.CD]
     += 0.25 * params.enabledHunterOfGlacialForest * p4(sets.HunterOfGlacialForest)
     + 0.10 * (params.valueWastelanderOfBanditryDesert == 2 ? 1 : 0) * p4(sets.WastelanderOfBanditryDesert)
@@ -210,11 +223,6 @@ export function calculateComputedStats(c, request, params) {
     + 0.60 * params.enabledCelestialDifferentiator * (x[Stats.CD] >= 1.20 ? 1 : 0) * p2(sets.CelestialDifferentiator)
     + 0.04 * (params.valuePioneerDiverOfDeadWaters > 2 ? 1 : 0) * p4(sets.PioneerDiverOfDeadWaters)
     + 0.12 * (params.enabledIzumoGenseiAndTakamaDivineRealm) * p2(sets.IzumoGenseiAndTakamaDivineRealm)
-
-  x[Stats.BE]
-    += 0.20 * (x[Stats.SPD] >= 145 ? 1 : 0) * p2(sets.TaliaKingdomOfBanditry)
-    + 0.30 * params.enabledWatchmakerMasterOfDreamMachinations * p4(sets.WatchmakerMasterOfDreamMachinations)
-    + 0.40 * params.enabledForgeOfTheKalpagniLantern * p2(sets.ForgeOfTheKalpagniLantern)
 
   x.BASIC_BOOST
     += 0.10 * p4(sets.MusketeerOfWildWheat)
@@ -255,8 +263,6 @@ export function calculateComputedStats(c, request, params) {
 
   x.ULT_BOOST
     += 0.30 * params.enabledTheWindSoaringValorous * p4(sets.TheWindSoaringValorous)
-
-  return x
 }
 
 export function calculateRelicStats(c, head, hands, body, feet, planarSphere, linkRope) {

--- a/src/lib/optimizer/calculateStats.js
+++ b/src/lib/optimizer/calculateStats.js
@@ -1,5 +1,6 @@
 import { Stats } from 'lib/constants.ts'
 import { p2, p4 } from 'lib/optimizer/optimizerUtils'
+import { calculatePassiveStatConversions } from 'lib/optimizer/calculateDamage.js'
 
 const statValues = Object.values(Stats)
 
@@ -196,18 +197,7 @@ export function calculateComputedStats(c, request, params) {
 
   x[Stats.HP] += x[Stats.HP_P] * request.baseHp
 
-  x[Stats.BE]
-    += 0.20 * (x[Stats.SPD] >= 145 ? 1 : 0) * p2(sets.TaliaKingdomOfBanditry)
-    + 0.30 * params.enabledWatchmakerMasterOfDreamMachinations * p4(sets.WatchmakerMasterOfDreamMachinations)
-    + 0.40 * params.enabledForgeOfTheKalpagniLantern * p2(sets.ForgeOfTheKalpagniLantern)
-
-  return x
-}
-
-// This is for set effects that happen after calculateBaseMultis
-export function calculatePostBaseSetEffects(c, request, params) {
-  const sets = c.sets
-  const x = c.x
+  calculatePassiveStatConversions(c, request, params)
 
   x[Stats.CD]
     += 0.25 * params.enabledHunterOfGlacialForest * p4(sets.HunterOfGlacialForest)
@@ -223,6 +213,11 @@ export function calculatePostBaseSetEffects(c, request, params) {
     + 0.60 * params.enabledCelestialDifferentiator * (x[Stats.CD] >= 1.20 ? 1 : 0) * p2(sets.CelestialDifferentiator)
     + 0.04 * (params.valuePioneerDiverOfDeadWaters > 2 ? 1 : 0) * p4(sets.PioneerDiverOfDeadWaters)
     + 0.12 * (params.enabledIzumoGenseiAndTakamaDivineRealm) * p2(sets.IzumoGenseiAndTakamaDivineRealm)
+
+  x[Stats.BE]
+    += 0.20 * (x[Stats.SPD] >= 145 ? 1 : 0) * p2(sets.TaliaKingdomOfBanditry)
+    + 0.30 * params.enabledWatchmakerMasterOfDreamMachinations * p4(sets.WatchmakerMasterOfDreamMachinations)
+    + 0.40 * params.enabledForgeOfTheKalpagniLantern * p2(sets.ForgeOfTheKalpagniLantern)
 
   x.BASIC_BOOST
     += 0.10 * p4(sets.MusketeerOfWildWheat)
@@ -263,6 +258,8 @@ export function calculatePostBaseSetEffects(c, request, params) {
 
   x.ULT_BOOST
     += 0.30 * params.enabledTheWindSoaringValorous * p4(sets.TheWindSoaringValorous)
+
+  return x
 }
 
 export function calculateRelicStats(c, head, hands, body, feet, planarSphere, linkRope) {

--- a/src/lib/worker/optimizerWorker.js
+++ b/src/lib/worker/optimizerWorker.js
@@ -1,6 +1,6 @@
 import { OrnamentSetToIndex, RelicSetToIndex, SetsOrnaments, SetsRelics, Stats } from '../constants.ts'
 import { BufferPacker } from '../bufferPacker.js'
-import { baseCharacterStats, calculateBaseStats, calculateComputedStats, calculateElementalStats, calculatePostBaseSetEffects, calculateRelicStats, calculateSetCounts } from 'lib/optimizer/calculateStats'
+import { baseCharacterStats, calculateBaseStats, calculateComputedStats, calculateElementalStats, calculateRelicStats, calculateSetCounts } from 'lib/optimizer/calculateStats'
 import { calculateBaseMultis, calculateDamage } from 'lib/optimizer/calculateDamage'
 import { calculateTeammates } from 'lib/optimizer/calculateTeammates'
 import { calculateConditionals } from 'lib/optimizer/calculateConditionals'
@@ -114,7 +114,6 @@ self.onmessage = function(e) {
 
     calculateComputedStats(c, request, params)
     calculateBaseMultis(c, request, params)
-    calculatePostBaseSetEffects(c, request, params)
     calculateDamage(c, request, params)
 
     if (failsCombatFilter(x)) {

--- a/src/lib/worker/optimizerWorker.js
+++ b/src/lib/worker/optimizerWorker.js
@@ -1,13 +1,6 @@
 import { OrnamentSetToIndex, RelicSetToIndex, SetsOrnaments, SetsRelics, Stats } from '../constants.ts'
 import { BufferPacker } from '../bufferPacker.js'
-import {
-  baseCharacterStats,
-  calculateBaseStats,
-  calculateComputedStats,
-  calculateElementalStats,
-  calculateRelicStats,
-  calculateSetCounts
-} from 'lib/optimizer/calculateStats'
+import { baseCharacterStats, calculateBaseStats, calculateComputedStats, calculateElementalStats, calculatePostBaseSetEffects, calculateRelicStats, calculateSetCounts } from 'lib/optimizer/calculateStats'
 import { calculateBaseMultis, calculateDamage } from 'lib/optimizer/calculateDamage'
 import { calculateTeammates } from 'lib/optimizer/calculateTeammates'
 import { calculateConditionals } from 'lib/optimizer/calculateConditionals'
@@ -16,7 +9,7 @@ import { SortOption } from 'lib/optimizer/sortOptions'
 const relicSetCount = Object.values(SetsRelics).length
 const ornamentSetCount = Object.values(SetsOrnaments).length
 
-self.onmessage = function (e) {
+self.onmessage = function(e) {
   // console.log('Message received from main script', e.data)
   // console.log("Request received from main script", JSON.stringify(e.data.request.characterConditionals, null, 4));
 
@@ -42,7 +35,7 @@ self.onmessage = function (e) {
   const baseDisplay = !combatDisplay
   let passCount = 0
 
-  const {failsBasicFilter, failsCombatFilter} = generateResultMinFilter(request, combatDisplay)
+  const { failsBasicFilter, failsCombatFilter } = generateResultMinFilter(request, combatDisplay)
 
   calculateConditionals(request, params)
   calculateTeammates(request, params)
@@ -85,8 +78,8 @@ self.onmessage = function (e) {
       continue
     }
 
-    const c = {...baseCharacterStats}
-    const x = {...params.precomputedX}
+    const c = { ...baseCharacterStats }
+    const x = { ...params.precomputedX }
 
     c.relicSetIndex = relicSetIndex
     c.ornamentSetIndex = ornamentSetIndex
@@ -121,6 +114,7 @@ self.onmessage = function (e) {
 
     calculateComputedStats(c, request, params)
     calculateBaseMultis(c, request, params)
+    calculatePostBaseSetEffects(c, request, params)
     calculateDamage(c, request, params)
 
     if (failsCombatFilter(x)) {

--- a/src/types/Conditionals.d.ts
+++ b/src/types/Conditionals.d.ts
@@ -20,7 +20,8 @@ export interface Conditional {
    * ComputedStatsObject arg is mutated by ref
    */
   calculateBaseMultis: (c: ComputedStatsObject, request: Form) => void
-  calculatePassives?: () => void
+  // Stat conversions
+  calculatePassives?: (c: ComputedStatsObject, request: Form) => void
 }
 
 export type ContentComponentMap = {


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Fixing a bug where Crit sets were applying before calculateBaseMultis. This meant that in some scenarios, salsotto for example would not activate for aventurine unless his base CR was > 50%. 
* Now we calculate in this order, where crit passives and boost passives from sets are calculated in calculatePostBaseSetEffects, which gain the benefit of being after calculateBaseMultis so that aventurine's trace can apply first.

```
    calculateComputedStats(c, request, params)
    calculateBaseMultis(c, request, params)
    calculatePostBaseSetEffects(c, request, params)
    calculateDamage(c, request, params)
```

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

