### PR TITLE
Chore: Reordering Rotation Formula

### DIFF
--- a/src/components/characterPreview/CharacterScoringSummary.tsx
+++ b/src/components/characterPreview/CharacterScoringSummary.tsx
@@ -350,8 +350,8 @@ export const CharacterScoringSummary = (props: { simScoringResult: SimulationSco
             <ScoringNumber label="BASIC: " number={result.metadata.formula.BASIC} precision={0} />
             <ScoringNumber label="SKILL: " number={result.metadata.formula.SKILL} precision={0} />
             <ScoringNumber label="ULT:   " number={result.metadata.formula.ULT} precision={0} />
-            <ScoringNumber label="DOT:   " number={result.metadata.formula.DOT} precision={0} />
             <ScoringNumber label="FUA:   " number={result.metadata.formula.FUA} precision={0} />
+            <ScoringNumber label="DOT:   " number={result.metadata.formula.DOT} precision={0} />
             <ScoringNumber label="BREAK: " number={result.metadata.formula.BREAK} precision={0} />
           </Flex>
         </Flex>


### PR DESCRIPTION
Reorders the rotation formula for character tab to be consistent with optimizer rotation formula order.

## Description
* Just inverting the FUA with DOT markers to be equal to the character formula tab.

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots

###Before

Character Tab:
![image](https://github.com/fribbels/hsr-optimizer/assets/12674637/5c4a1044-dfde-4821-9dbb-ebf8e678267f)
Optimizer Tab:
![image](https://github.com/fribbels/hsr-optimizer/assets/12674637/e35202d6-d674-4b14-a028-3c5f2a0949a1)

### After

Character Tab:
![image](https://github.com/fribbels/hsr-optimizer/assets/12674637/0c0bad33-e16c-4f8a-88f8-24059f04bad4)
Optimizer Tab:
![image](https://github.com/fribbels/hsr-optimizer/assets/12674637/aecc13e6-de49-4212-9485-06fda105c277)