### PR TITLE
fix: ensure mainstat is always assigned

### DIFF
--- a/src/lib/relicScorer.ts
+++ b/src/lib/relicScorer.ts
@@ -234,6 +234,7 @@ export class RelicScorer {
       // First candidate, i.e. has the highest weight
       const mainStatIndex = scoreEntries.findIndex(([name, _weight]) => PartsMainStats[part].includes(name))
       const mainStatWeight = scoreEntries[mainStatIndex][1]
+      mainStat = scoreEntries[mainStatIndex][0]
       // Worst case, will be overriden on first loop iteration by true values
       let isIdeal = false
       let isSubstat = true


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* If the user selects 0 valid mainstats and there are no possible substats of equal weight to the highest weight possible non-substat mainstat, the mainstat would not be assigned
* Changed scoreOptimalRelic to assign an initial mainstat to prevent aforementioned issue

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

