### PR TITLE
feat: scoring update, simulate perfect sphere, fix cruising lc sim, min rolls filter

### DIFF
--- a/src/components/CharacterPreview.jsx
+++ b/src/components/CharacterPreview.jsx
@@ -226,7 +226,7 @@ export function CharacterPreview(props) {
 
   const tempParentH = simScoringResult ? parentH - newLcHeight - newLcMargin : parentH
 
-  // Reuse the same modal for both edit/add and scroll to the selected character
+  // Teammate character modal OK
   function onCharacterModalOk(form) {
     if (!form.characterId) {
       return Message.error('No selected character')
@@ -240,7 +240,7 @@ export function CharacterPreview(props) {
 
     simulation.teammates[selectedTeammateIndex] = form
 
-    DB.updateCharacterScoreOverrides(characterId, scoringMetadata)
+    DB.updateSimulationScoreOverrides(characterId, scoringMetadata)
 
     setTeamSelection(CUSTOM_TEAM)
   }

--- a/src/components/characterPreview/CharacterScoringSummary.tsx
+++ b/src/components/characterPreview/CharacterScoringSummary.tsx
@@ -370,10 +370,10 @@ export const CharacterScoringSummary = (props: { simScoringResult: SimulationSco
             Sim main stats
           </pre>
           <Flex vertical gap={defaultGap}>
-            <ScoringStat stat={StatsToReadable[result.maximumSim.request.simBody]} part={Parts.Body} />
-            <ScoringStat stat={StatsToReadable[result.maximumSim.request.simFeet]} part={Parts.Feet} />
-            <ScoringStat stat={StatsToReadable[result.maximumSim.request.simPlanarSphere]} part={Parts.PlanarSphere} />
-            <ScoringStat stat={StatsToReadable[result.maximumSim.request.simLinkRope]} part={Parts.LinkRope} />
+            <ScoringStat stat={StatsToReadable[result.benchmarkSim.request.simBody]} part={Parts.Body} />
+            <ScoringStat stat={StatsToReadable[result.benchmarkSim.request.simFeet]} part={Parts.Feet} />
+            <ScoringStat stat={StatsToReadable[result.benchmarkSim.request.simPlanarSphere]} part={Parts.PlanarSphere} />
+            <ScoringStat stat={StatsToReadable[result.benchmarkSim.request.simLinkRope]} part={Parts.LinkRope} />
           </Flex>
         </Flex>
 

--- a/src/components/characterPreview/CharacterScoringSummary.tsx
+++ b/src/components/characterPreview/CharacterScoringSummary.tsx
@@ -206,13 +206,13 @@ export const CharacterScoringSummary = (props: { simScoringResult: SimulationSco
 
           <pre style={{ width: 500 }}>
             <Flex>
-              <ul style={{ width: 250 }}>
-                <li>WTF+ = 135%</li>
-                <li>WTF  = 126%</li>
-                <li>SSS+ = 118%</li>
-                <li>SSS  = 111%</li>
-                <li>SS+  = 105%</li>
-                <li>SS   = 100%</li>
+              <ul style={{ width: 300 }}>
+                <li>WTF+ = 135% ↑ 9%</li>
+                <li>WTF  = 126% ↑ 8%</li>
+                <li>SSS+ = 118% ↑ 7%</li>
+                <li>SSS  = 111% ↑ 6%</li>
+                <li>SS+  = 105% ↑ 5%</li>
+                <li>SS   = 100% [Benchmark]</li>
                 <li>S+   = 95%</li>
                 <li>S    = 90%</li>
                 <li>A+   = 85%</li>
@@ -452,7 +452,7 @@ export const CharacterScoringSummary = (props: { simScoringResult: SimulationSco
 
         <Flex vertical gap={defaultGap} style={{ width: statPreviewWidth }}>
           <pre style={{ margin: 'auto' }}>
-            200% maximum basic stats
+            200% perfect basic stats
           </pre>
           <CharacterStatSummary finalStats={maximumBasicStats} elementalDmgValue={elementalDmgValue} hideCv={true} />
         </Flex>

--- a/src/components/optimizerTab/OptimizerForm.jsx
+++ b/src/components/optimizerTab/OptimizerForm.jsx
@@ -49,7 +49,6 @@ export default function OptimizerForm() {
       keys[0].startsWith('min')
       || keys[0].startsWith('max')
       || keys[0].startsWith('buff')
-      || keys[0].startsWith('weights')
       || keys[0].startsWith('statDisplay')
       || keys[0].startsWith('statSim')
       || keys[0].startsWith('teammate')
@@ -129,38 +128,38 @@ export default function OptimizerForm() {
   window.optimizerStartClicked = startClicked
 
   return (
-    <div style={{position: 'relative'}}>
+    <div style={{ position: 'relative' }}>
       <Form
         form={optimizerForm}
         layout="vertical"
         onValuesChange={onValuesChange}
       >
-        <FormSetConditionals/>
+        <FormSetConditionals />
 
         {/* Row 1 */}
 
         <FilterContainer>
           <FormRow id={OptimizerMenuIds.characterOptions}>
-            <FormCard style={{overflow: 'hidden'}}>
-              <OptimizerTabCharacterPanel/>
+            <FormCard style={{ overflow: 'hidden' }}>
+              <OptimizerTabCharacterPanel />
             </FormCard>
 
             <FormCard>
-              <CharacterSelectorDisplay/>
+              <CharacterSelectorDisplay />
             </FormCard>
 
             <FormCard>
-              <CharacterConditionalDisplayWrapper/>
+              <CharacterConditionalDisplayWrapper />
             </FormCard>
 
             <FormCard justify="space-between">
-              <LightConeConditionalDisplayWrapper/>
+              <LightConeConditionalDisplayWrapper />
 
-              <EnemyOptionsDisplay/>
+              <EnemyOptionsDisplay />
             </FormCard>
 
             <FormCard>
-              <OptimizerOptionsDisplay/>
+              <OptimizerOptionsDisplay />
             </FormCard>
           </FormRow>
 
@@ -168,39 +167,39 @@ export default function OptimizerForm() {
 
           <FormRow id={OptimizerMenuIds.relicAndStatFilters}>
             <FormCard>
-              <RelicMainSetFilters/>
+              <RelicMainSetFilters />
             </FormCard>
 
             <FormCard>
-              <SubstatWeightFilters/>
+              <SubstatWeightFilters />
             </FormCard>
 
             <FormCard>
-              <MinMaxStatFilters/>
+              <MinMaxStatFilters />
             </FormCard>
 
             <FormCard>
-              <MinMaxRatingFilters/>
+              <MinMaxRatingFilters />
             </FormCard>
 
             <FormCard>
-              <ComboFilters/>
-              <CombatBuffsFilters/>
+              <ComboFilters />
+              <CombatBuffsFilters />
             </FormCard>
           </FormRow>
 
           {/* Row 3 */}
 
           <TeammateFormRow id={OptimizerMenuIds.teammates}>
-            <TeammateCard index={0}/>
-            <TeammateCard index={1}/>
-            <TeammateCard index={2}/>
+            <TeammateCard index={0} />
+            <TeammateCard index={1} />
+            <TeammateCard index={2} />
           </TeammateFormRow>
 
           {/* Row 4 */}
 
           <FormRow id={OptimizerMenuIds.characterStatsSimulation}>
-            <StatSimulationDisplay/>
+            <StatSimulationDisplay />
           </FormRow>
         </FilterContainer>
       </Form>

--- a/src/components/optimizerTab/optimizerForm/FormStatRollSlider.jsx
+++ b/src/components/optimizerTab/optimizerForm/FormStatRollSlider.jsx
@@ -3,21 +3,22 @@ import React, { useState } from 'react'
 import styled from 'styled-components'
 import { Utils } from 'lib/utils'
 import PropTypes from 'prop-types'
+import { Parts } from 'lib/constants'
 
-let sliderWidth = 140
+const sliderWidth = 140
 const Text = styled(Typography)`
   white-space: pre-line;
 `
 
 export function FormStatRollSlider(props) {
   return (
-    <Flex gap={5} style={{ marginBottom: 0 }} align="center">
+    <Flex>
       <Flex justify="flex-start" style={{ width: 45, marginRight: 10 }}>
         <Text>
           {props.text}
         </Text>
       </Flex>
-      <Flex align="center" justify="flex-start" gap={10}>
+      <Flex align="center">
         <Form.Item name={['weights', props.name]}>
           <Slider
             min={0}
@@ -41,7 +42,25 @@ FormStatRollSlider.propTypes = {
   name: PropTypes.string,
 }
 
-export function FormStatRollSliderTopPercent() {
+const partsPerSlotIndex = {
+  0: [Parts.Head, Parts.Hands],
+  1: [Parts.Body, Parts.Feet],
+  2: [Parts.PlanarSphere, Parts.LinkRope],
+}
+
+const formNamePerSlotIndex = {
+  0: 'headHands',
+  1: 'bodyFeet',
+  2: 'sphereRope',
+}
+
+const MAX_ROLLS = 5
+
+export function FormStatRollSliderTopPercent(props) {
+  const { index } = props
+  const parts = partsPerSlotIndex[index]
+  const name = formNamePerSlotIndex[index]
+
   const [inputValue, setInputValue] = useState(1)
   const onChange = (newValue) => {
     setInputValue(newValue)
@@ -49,37 +68,28 @@ export function FormStatRollSliderTopPercent() {
 
   return (
     <Flex gap={5} style={{ marginBottom: 0 }} align="center">
-      <Form.Item name={['weights', 'topPercent']}>
-        <InputNumber
-          size="small"
-          style={{ width: 50, marginRight: 5 }}
-          controls={false}
-          min={1}
-          max={100}
-          onChange={(x) => {
-            onChange(x)
-            window.onOptimizerFormValuesChange(x, window.optimizerForm.getFieldsValue(), true)
-          }}
-          parser={(value) => value == null || value == '' ? 0 : Utils.precisionRound(value)}
-          formatter={(value) => `${Utils.precisionRound(value)}`}
-        />
-      </Form.Item>
+      <Flex gap={5} justify="flex-start" style={{ minWidth: 50 }}>
+        <img src={Assets.getPart(parts[0])} style={{ width: 18 }} />
+        <img src={Assets.getPart(parts[1])} style={{ width: 18 }} />
+      </Flex>
 
       <Flex align="center" justify="flex-start" gap={10}>
-        <Form.Item name={['weights', 'topPercent']}>
+        <Form.Item name={['weights', name]}>
           <Slider
-            min={1}
-            max={100}
-            step={1}
+            min={0}
+            max={MAX_ROLLS}
+            step={0.5}
             style={{
-              minWidth: sliderWidth,
+              minWidth: 105,
               marginTop: 0,
               marginBottom: 0,
               marginLeft: 0,
+              marginRight: 5,
             }}
+            // marks={[1, 2, 3, 4, 5, 6, 7, 9]}
             keyboard={false}
             tooltip={{
-              formatter: (value) => `${Utils.precisionRound(value)}%`,
+              formatter: (value) => `${Utils.precisionRound(value)}`,
             }}
             value={typeof inputValue === 'number' ? inputValue : 0}
             onChange={onChange}
@@ -87,6 +97,25 @@ export function FormStatRollSliderTopPercent() {
           />
         </Form.Item>
       </Flex>
+
+      <Form.Item name={['weights', name]}>
+        <InputNumber
+          size="small"
+          className="center-input-text"
+          style={{
+            width: 40,
+          }}
+          controls={false}
+          min={0}
+          max={MAX_ROLLS}
+          // variant="filled"
+          variant="borderless"
+          onChange={(x) => {
+            onChange(x)
+            window.onOptimizerFormValuesChange(x, window.optimizerForm.getFieldsValue(), true)
+          }}
+        />
+      </Form.Item>
     </Flex>
   )
 }

--- a/src/components/optimizerTab/optimizerForm/RecommendedPresetsButton.tsx
+++ b/src/components/optimizerTab/optimizerForm/RecommendedPresetsButton.tsx
@@ -215,7 +215,9 @@ export function applyMetadataPresetToForm(form, scoringMetadata) {
   form.mainPlanarSphere = scoringMetadata.parts[Constants.Parts.PlanarSphere]
   form.mainLinkRope = scoringMetadata.parts[Constants.Parts.LinkRope]
   form.weights = scoringMetadata.stats
-  form.weights.topPercent = 100
+  form.weights.headHands = form.weights.headHands || 3
+  form.weights.bodyFeet = form.weights.bodyFeet || 2
+  form.weights.sphereRope = form.weights.sphereRope || 2
 
   // Disable elemental conditions by default if the character is not of the same element
   const element = DB.getMetadata().characters[form.characterId].element

--- a/src/components/optimizerTab/optimizerForm/SubstatWeightFilters.tsx
+++ b/src/components/optimizerTab/optimizerForm/SubstatWeightFilters.tsx
@@ -2,25 +2,21 @@ import { Flex, Typography } from 'antd'
 import { HeaderText } from 'components/HeaderText.jsx'
 import { TooltipImage } from 'components/TooltipImage.jsx'
 import { Hint } from 'lib/hint.jsx'
-import {
-  FormStatRollSlider,
-  FormStatRollSliderTopPercent,
-} from 'components/optimizerTab/optimizerForm/FormStatRollSlider.jsx'
+import { FormStatRollSlider, FormStatRollSliderTopPercent } from 'components/optimizerTab/optimizerForm/FormStatRollSlider.jsx'
 import { Constants } from 'lib/constants.ts'
-import { HorizontalDivider } from 'components/Dividers.tsx'
-import { optimizerTabDefaultGap } from 'components/optimizerTab/optimizerTabConstants.ts'
 
 const { Text } = Typography
 
 export const SubstatWeightFilters = () => {
   return (
-    <Flex vertical gap={optimizerTabDefaultGap}>
-      <Flex justify="space-between" align="center">
-        <HeaderText>Substat weight filter</HeaderText>
-        <TooltipImage type={Hint.substatWeightFilter()} />
-      </Flex>
+    <Flex vertical gap={4}>
 
-      <Flex vertical gap={1}>
+      <Flex vertical gap={0}>
+        <Flex justify="space-between" align="center">
+          <HeaderText>Substat weight filter</HeaderText>
+          <TooltipImage type={Hint.substatWeightFilter()} />
+        </Flex>
+
         <FormStatRollSlider text="HP" name={Constants.Stats.HP_P} />
         <FormStatRollSlider text="ATK" name={Constants.Stats.ATK_P} />
         <FormStatRollSlider text="DEF" name={Constants.Stats.DEF_P} />
@@ -32,10 +28,14 @@ export const SubstatWeightFilters = () => {
         <FormStatRollSlider text="BE" name={Constants.Stats.BE} />
       </Flex>
 
-      <HorizontalDivider />
-
-      <Text>Top % of weighted relics</Text>
-      <FormStatRollSliderTopPercent />
+      <Flex vertical gap={3}>
+        <HeaderText>Min weighted rolls per relic</HeaderText>
+        <Flex vertical gap={5}>
+          <FormStatRollSliderTopPercent index={0} />
+          <FormStatRollSliderTopPercent index={1} />
+          <FormStatRollSliderTopPercent index={2} />
+        </Flex>
+      </Flex>
     </Flex>
   )
 }

--- a/src/lib/characterScorer.ts
+++ b/src/lib/characterScorer.ts
@@ -606,18 +606,11 @@ function computeOptimalSimulation(
     sum = sumSubstatRolls(maxSubstatRollCounts)
 
     const candidateStats = [...metadata.substats, Stats.SPD]
-    const speedRollsMax = Math.ceil(maxSubstatRollCounts[Stats.SPD])
-    let speedCount = 0
 
     const generate = (excluded: string) => {
       const substats = {}
       candidateStats.forEach((stat) => {
         if (stat != excluded) {
-          // I dont think this speed logic is needed anymore
-          if (stat == Stats.SPD) {
-            speedCount++
-            if (speedCount > speedRollsMax) return
-          }
           substats[stat] = true
         }
       })
@@ -651,6 +644,8 @@ function computeOptimalSimulation(
       .filter(([key, value]) => value > scoringParams.freeRolls)
       .map(([key]) => key)
       .filter((stat) => !excludedStats[stat])
+
+    const debug = currentSimulation.request.stats
 
     for (const stat of remainingStats) {
       // Can't reduce further so we skip
@@ -813,12 +808,9 @@ function calculateMaxSubstatRollCounts(
   maxCounts[request.simPlanarSphere] -= scoringParams.deductionPerMain
   maxCounts[request.simLinkRope] -= scoringParams.deductionPerMain
 
-  // for (const substat of metadata.substats) {
-  //   maxCounts[substat] = Math.min(maxCounts[substat], Math.max(0, scoringParams.maxPerSub - Math.ceil(partialSimulationWrapper.speedRollsDeduction)))
-  // }
-
   for (const stat of SubStats) {
-    maxCounts[stat] = Math.max(stat == Stats.SPD ? 0 : scoringParams.freeRolls, maxCounts[stat])
+    maxCounts[stat] = Math.min(maxCounts[stat], scoringParams.substatGoal - 10 * scoringParams.freeRolls - Math.ceil(partialSimulationWrapper.speedRollsDeduction))
+    maxCounts[stat] = Math.max(maxCounts[stat], scoringParams.freeRolls)
     if (metadata.maxBonusRolls?.[stat] != undefined) {
       maxCounts[stat] = Math.min(maxCounts[stat], metadata.maxBonusRolls[stat] + scoringParams.freeRolls)
     }
@@ -829,7 +821,13 @@ function calculateMaxSubstatRollCounts(
     maxCounts[Stats.HP] = scoringParams.freeRolls
     maxCounts[Stats.DEF] = scoringParams.freeRolls
   }
+
+  // Force speed
   maxCounts[Stats.SPD] = partialSimulationWrapper.speedRollsDeduction
+
+  // Overcapped 30 * 3.24 + 5 = 102.2% crit
+  // Main stat  20 * 3.24 + 32.4 + 5 = 102.2% crit
+  maxCounts[Stats.CR] = Math.min(request.simBody == Stats.CR ? 20 : 30, maxCounts[Stats.CR])
 
   return maxCounts
 }

--- a/src/lib/conditionals/lightcone/5star/CruisingInTheStellarSea.ts
+++ b/src/lib/conditionals/lightcone/5star/CruisingInTheStellarSea.ts
@@ -56,7 +56,7 @@ export default (s: SuperImpositionLevel): LightConeConditional => {
     content: () => content,
     teammateContent: () => [],
     defaults: () => ({
-      enemyHp50CrBoost: true,
+      enemyHp50CrBoost: false,
       enemyDefeatedAtkBuff: true,
     }),
     precomputeEffects: (x: PrecomputedCharacterConditional, request: Form) => {

--- a/src/lib/db.js
+++ b/src/lib/db.js
@@ -306,7 +306,11 @@ export const DB = {
   },
   updateSimulationScoreOverrides: (id, updated) => {
     const overrides = window.store.getState().scoringMetadataOverrides
-    overrides[id].simulation = updated
+    if (!overrides[id]) {
+      overrides[id] = updated
+    } else {
+      Utils.mergeDefinedValues(overrides[id], updated)
+    }
     window.store.getState().setScoringMetadataOverrides(overrides)
 
     SaveState.save()

--- a/src/lib/defaultForm.js
+++ b/src/lib/defaultForm.js
@@ -3,11 +3,16 @@ import DB from 'lib/db'
 import { StatSimTypes } from 'components/optimizerTab/optimizerForm/StatSimulationDisplay'
 import { Utils } from './utils.js'
 
-export function getDefaultForm(initialCharacter) {
-  // TODO: Clean this up
-  const scoringMetadata = DB.getMetadata().characters[initialCharacter?.id]?.scoringMetadata
-  const parts = scoringMetadata?.parts || {}
-  const weights = scoringMetadata?.stats || {
+export function getDefaultWeights(characterId) {
+  if (characterId) {
+    const scoringMetadata = Utils.clone(DB.getScoringMetadata(characterId))
+    scoringMetadata.stats.headHands = 3
+    scoringMetadata.stats.bodyFeet = 2
+    scoringMetadata.stats.sphereRope = 2
+    return scoringMetadata.stats
+  }
+
+  return {
     [Constants.Stats.HP_P]: 1,
     [Constants.Stats.ATK_P]: 1,
     [Constants.Stats.DEF_P]: 1,
@@ -25,6 +30,13 @@ export function getDefaultForm(initialCharacter) {
     bodyFeet: 2,
     sphereRope: 2,
   }
+}
+
+export function getDefaultForm(initialCharacter) {
+  // TODO: Clean this up
+  const scoringMetadata = DB.getMetadata().characters[initialCharacter?.id]?.scoringMetadata
+  const parts = scoringMetadata?.parts || {}
+  const weights = scoringMetadata?.stats || getDefaultWeights()
 
   const combatBuffs = {}
   Object.values(CombatBuffs).map((x) => combatBuffs[x.key] = 0)

--- a/src/lib/defaultForm.js
+++ b/src/lib/defaultForm.js
@@ -21,7 +21,9 @@ export function getDefaultForm(initialCharacter) {
     [Constants.Stats.EHR]: 1,
     [Constants.Stats.RES]: 1,
     [Constants.Stats.BE]: 1,
-    topPercent: 100,
+    headHands: 3,
+    bodyFeet: 2,
+    sphereRope: 2,
   }
 
   const combatBuffs = {}
@@ -72,8 +74,6 @@ export function getDefaultForm(initialCharacter) {
       BREAK: 0,
     },
   })
-
-  defaultForm.topPercent = 100
 
   // Disable elemental conditions by default if the character is not of the same element
   const element = DB.getMetadata().characters[initialCharacter?.id]?.element

--- a/src/lib/optimizerTabController.js
+++ b/src/lib/optimizerTabController.js
@@ -7,7 +7,7 @@ import { Utils } from './utils'
 import { LightConeConditionals } from './lightConeConditionals'
 import { CharacterConditionals } from './characterConditionals'
 import { CharacterStats } from './characterStats'
-import { defaultSetConditionals, defaultTeammate, getDefaultForm } from 'lib/defaultForm'
+import { defaultSetConditionals, defaultTeammate, getDefaultForm, getDefaultWeights } from 'lib/defaultForm'
 import { SavedSessionKeys } from 'lib/constantsSession'
 import { applyMetadataPresetToForm } from 'components/optimizerTab/optimizerForm/RecommendedPresetsButton'
 
@@ -402,13 +402,17 @@ export const OptimizerTabController = {
       }
     }
 
-    if (!newForm.weights?.headHands) {
+    if (!newForm.weights) {
+      newForm.weights = getDefaultWeights(newForm.characterId)
+    }
+
+    if (!newForm.weights.headHands) {
       newForm.weights.headHands = 3
     }
-    if (!newForm.weights?.bodyFeet) {
+    if (!newForm.weights.bodyFeet) {
       newForm.weights.bodyFeet = 2
     }
-    if (!newForm.weights?.sphereRope) {
+    if (!newForm.weights.sphereRope) {
       newForm.weights.sphereRope = 2
     }
 

--- a/src/lib/optimizerTabController.js
+++ b/src/lib/optimizerTabController.js
@@ -7,7 +7,6 @@ import { Utils } from './utils'
 import { LightConeConditionals } from './lightConeConditionals'
 import { CharacterConditionals } from './characterConditionals'
 import { CharacterStats } from './characterStats'
-import { StatCalculator } from './statCalculator'
 import { defaultSetConditionals, defaultTeammate, getDefaultForm } from 'lib/defaultForm'
 import { SavedSessionKeys } from 'lib/constantsSession'
 import { applyMetadataPresetToForm } from 'components/optimizerTab/optimizerForm/RecommendedPresetsButton'
@@ -395,10 +394,22 @@ export const OptimizerTabController = {
         newForm.mainPlanarSphere = scoringMetadata.parts[Constants.Parts.PlanarSphere]
         newForm.mainLinkRope = scoringMetadata.parts[Constants.Parts.LinkRope]
         newForm.weights = scoringMetadata.stats
-        newForm.weights.topPercent = 100
+        newForm.weights.headHands = 3
+        newForm.weights.bodyFeet = 2
+        newForm.weights.sphereRope = 2
 
         applyMetadataPresetToForm(newForm, scoringMetadata)
       }
+    }
+
+    if (!newForm.weights?.headHands) {
+      newForm.weights.headHands = 3
+    }
+    if (!newForm.weights?.bodyFeet) {
+      newForm.weights.bodyFeet = 2
+    }
+    if (!newForm.weights?.sphereRope) {
+      newForm.weights.sphereRope = 2
     }
 
     if (!newForm.exclude) {
@@ -440,7 +451,9 @@ export const OptimizerTabController = {
         [Constants.Stats.EHR]: 1,
         [Constants.Stats.RES]: 1,
         [Constants.Stats.BE]: 1,
-        topPercent: 100,
+        headHands: 3,
+        bodyFeet: 2,
+        sphereRope: 2,
       }
     }
 
@@ -486,17 +499,17 @@ export const OptimizerTabController = {
       return false
     }
 
-    if (!x.weights || !x.weights.topPercent) {
-      Message.error('Substat weight filter should have a Top % value greater than 0%. Make sure to set the Top % value with your substat weights.', 10)
-      console.log('Top percent')
-      return false
-    }
+    // if (!x.weights || !x.weights.topPercent) {
+    //   Message.error('Substat weight filter should have a Top % value greater than 0%. Make sure to set the Top % value with your substat weights.', 10)
+    //   console.log('Top percent')
+    //   return false
+    // }
 
-    if (x.weights.topPercent > 0 && Object.values(Constants.Stats).map((stat) => x.weights[stat]).filter((x) => !!x).length == 0) {
-      Message.error('Top % of weighted relics was selected but all weights are set to 0. Make sure to set the substat weights for your character.', 10)
-      console.log('Top percent')
-      return false
-    }
+    // if (x.weights.topPercent > 0 && Object.values(Constants.Stats).map((stat) => x.weights[stat]).filter((x) => !!x).length == 0) {
+    //   Message.error('Top % of weighted relics was selected but all weights are set to 0. Make sure to set the substat weights for your character.', 10)
+    //   console.log('Top percent')
+    //   return false
+    // }
 
     const lcMeta = DB.getMetadata().lightCones[x.lightCone]
     const charMeta = DB.getMetadata().characters[x.characterId]
@@ -797,14 +810,4 @@ function filter(filterModel) {
   }
 
   filteredIndices = indices
-}
-
-function setPinnedRow(characterId) {
-  const character = DB.getCharacterById(characterId)
-  const stats = StatCalculator.calculate(character)
-
-  // transitioning from CharacterTab to OptimizerTab, grid is not yet rendered - check or throw
-  if (window.optimizerGrid?.current?.api?.updateGridOptions !== undefined) {
-    window.optimizerGrid.current.api.updateGridOptions({ pinnedTopRowData: [stats] })
-  }
 }

--- a/src/lib/relicFilters.js
+++ b/src/lib/relicFilters.js
@@ -1,4 +1,4 @@
-import { Constants, RelicSetFilterOptions } from './constants.ts'
+import { Constants, Parts, RelicSetFilterOptions } from './constants.ts'
 import DB from './db'
 import { Utils } from './utils'
 import { StatCalculator } from 'lib/statCalculator'
@@ -48,11 +48,18 @@ export const RelicFilters = {
 
   applyTopFilter: (request, relics, originalRelics) => {
     const weights = request.weights || {}
+    const partMinRolls = {
+      [Parts.Head]: weights.headHands || 0,
+      [Parts.Hands]: weights.headHands || 0,
+      [Parts.Body]: weights.bodyFeet || 0,
+      [Parts.Feet]: weights.bodyFeet || 0,
+      [Parts.PlanarSphere]: weights.sphereRope || 0,
+      [Parts.LinkRope]: weights.sphereRope || 0,
+    }
 
     for (const part of Object.values(Constants.Parts)) {
       const partition = relics[part]
-      const index = Math.max(1, Math.floor(weights.topPercent / 100 * originalRelics[part].length))
-      relics[part] = partition.sort((a, b) => b.weightScore - a.weightScore).slice(0, index)
+      relics[part] = partition.filter((relic) => relic.weightScore > partMinRolls[part] * 6.48 * 0.8)
     }
 
     return relics

--- a/src/style/style.css
+++ b/src/style/style.css
@@ -170,7 +170,7 @@ body,
 }
 
 .ant-form-item-control-input {
-    min-height: 24px !important;
+    min-height: 22px !important;
 }
 
 .ant-cascader-menu-item {
@@ -400,3 +400,6 @@ a {
     flex-grow: 0.45 !important;
 }
 
+.center-input-text > div > input {
+    text-align: center !important;
+}


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Permute main stats on sphere for max sim
* Disable Cruising in the stellar sea CR buff by default
* Cut out some wasted sim runs
* New optimizer substat weight min rolls filter

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

