### PR TITLE
feat: adjusting main stat upgrade text and fixing it to +15 default

### DIFF
--- a/src/components/optimizerTab/optimizerForm/OptimizerOptionsDisplay.tsx
+++ b/src/components/optimizerTab/optimizerForm/OptimizerOptionsDisplay.tsx
@@ -38,34 +38,14 @@ const OptimizerOptionsDisplay = (): JSX.Element => {
       <Flex vertical gap={optimizerTabDefaultGap}>
         <Flex justify="space-between" align="center">
           <HeaderText>Optimizer options</HeaderText>
-          <TooltipImage type={Hint.optimizerOptions()}/>
-        </Flex>
-
-        <Flex align="center">
-          <Flex vertical gap={2}>
-            <HeaderText>
-              Upscale main stat
-            </HeaderText>
-            <Form.Item name="mainStatUpscaleLevel">
-              <Select
-                style={{ width: (panelWidth - optimizerTabDefaultGap) / 2 }}
-                options={[
-                  { value: 3, label: '+3' },
-                  { value: 6, label: '+6' },
-                  { value: 9, label: '+9' },
-                  { value: 12, label: '+12' },
-                  { value: 15, label: '+15' },
-                ]}
-              />
-            </Form.Item>
-          </Flex>
+          <TooltipImage type={Hint.optimizerOptions()} />
         </Flex>
 
         <Flex align="center">
           <Form.Item name="includeEquippedRelics" valuePropName="checked">
             <Switch
-              checkedChildren={<CheckOutlined/>}
-              unCheckedChildren={<CloseOutlined/>}
+              checkedChildren={<CheckOutlined />}
+              unCheckedChildren={<CloseOutlined />}
               defaultChecked
               style={{ width: 45, marginRight: 5 }}
             />
@@ -76,8 +56,8 @@ const OptimizerOptionsDisplay = (): JSX.Element => {
         <Flex align="center">
           <Form.Item name="rankFilter" valuePropName="checked">
             <Switch
-              checkedChildren={<CheckOutlined/>}
-              unCheckedChildren={<CloseOutlined/>}
+              checkedChildren={<CheckOutlined />}
+              unCheckedChildren={<CloseOutlined />}
               defaultChecked
               style={{ width: 45, marginRight: 5 }}
             />
@@ -88,8 +68,8 @@ const OptimizerOptionsDisplay = (): JSX.Element => {
         <Flex align="center">
           <Form.Item name="keepCurrentRelics" valuePropName="checked">
             <Switch
-              checkedChildren={<CheckOutlined/>}
-              unCheckedChildren={<CloseOutlined/>}
+              checkedChildren={<CheckOutlined />}
+              unCheckedChildren={<CloseOutlined />}
               defaultChecked
               style={{ width: 45, marginRight: 5 }}
             />
@@ -136,7 +116,7 @@ const OptimizerOptionsDisplay = (): JSX.Element => {
           </Flex>
         </Flex>
 
-        <Flex justify="space-between" align="center" style={{ marginTop: 10 }}>
+        <Flex justify="space-between" align="center" style={{ marginTop: 8 }}>
           <HeaderText>Relic enhance / rarity</HeaderText>
           {/* <TooltipImage type={Hint.optimizerOptions()} /> */}
         </Flex>
@@ -167,6 +147,26 @@ const OptimizerOptionsDisplay = (): JSX.Element => {
               ]}
             />
           </Form.Item>
+        </Flex>
+
+        <Flex justify="space-between" align="center" style={{ marginTop: 8 }}>
+          <Flex vertical gap={2}>
+            <HeaderText>
+              Boost main stat
+            </HeaderText>
+            <Form.Item name="mainStatUpscaleLevel">
+              <Select
+                style={{ width: (panelWidth - optimizerTabDefaultGap) / 2 }}
+                options={[
+                  { value: 3, label: '+3' },
+                  { value: 6, label: '+6' },
+                  { value: 9, label: '+9' },
+                  { value: 12, label: '+12' },
+                  { value: 15, label: '+15' },
+                ]}
+              />
+            </Form.Item>
+          </Flex>
         </Flex>
 
         {/*

--- a/src/lib/optimizerTabController.js
+++ b/src/lib/optimizerTabController.js
@@ -471,6 +471,10 @@ export const OptimizerTabController = {
       newForm.resultLimit = 100000
     }
 
+    if (!newForm.mainStatUpscaleLevel) {
+      newForm.mainStatUpscaleLevel = 15
+    }
+
     if (!newForm.statSim) {
       newForm.statSim = {}
     }

--- a/tests/CharacterPreview/double-click-to-optimizer.spec.ts
+++ b/tests/CharacterPreview/double-click-to-optimizer.spec.ts
@@ -16,7 +16,7 @@ test('Double-clicking character renders Optimizer with character in focus.', asy
   await expect(page.getByRole('main')).toContainText('Enemy options')
   await expect(page.getByRole('main')).toContainText('Elemental weakness')
   // optimizer options rendered
-  await expect(page.getByRole('main')).toContainText('Upscale main stat')
+  await expect(page.getByRole('main')).toContainText('Boost main stat')
 
   // nav back to characters
   await page.getByRole('menuitem', { name: 'Characters' }).click()
@@ -27,5 +27,5 @@ test('Double-clicking character renders Optimizer with character in focus.', asy
   await expect(page.getByRole('main')).toContainText('Hellscape state')
   await expect(page.getByRole('main')).toContainText('HP% lost total')
   await expect(page.getByRole('main')).toContainText('Elemental weakness')
-  await expect(page.getByRole('main')).toContainText('Upscale main stat')
+  await expect(page.getByRole('main')).toContainText('Boost main stat')
 })


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Reorganizing/rename the main stat upscale text
* Set to +15 default

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

<img width="296" alt="image" src="https://github.com/fribbels/hsr-optimizer/assets/7908525/9ee7fdaa-8df7-4c96-8abb-97481be1b3b0">
