### PR TITLE
fix (kelzFormatParser): TB id lookup and TB LCs

### DIFF
--- a/src/lib/importer/kelzFormatParser.jsx
+++ b/src/lib/importer/kelzFormatParser.jsx
@@ -91,7 +91,8 @@ function readCharacter(character, lightCones, trailblazer, path) {
   let lightCone = undefined
   if (lightCones) {
     if (character.key.startsWith('Trailblazer')) {
-      lightCone = lightCones.find((x) => x.location.startsWith('Trailblazer'))
+      lightCone = lightCones.find((x) => x.location === character.key)
+        || lightCones.find((x) => x.location.startsWith('Trailblazer'))
     } else {
       lightCone = lightCones.find((x) => x.location === character.key)
     }
@@ -332,26 +333,25 @@ function lowerAlphaNumeric(str) {
 }
 
 function getTrailblazerId(name, trailblazer, path) {
-  let id = '8002'
   if (name === 'TrailblazerDestruction') {
-    id = trailblazer === 'Stelle' ? '8002' : '8001'
+    return trailblazer === 'Stelle' ? '8002' : '8001'
   }
   if (name === 'TrailblazerPreservation') {
-    id = trailblazer === 'Stelle' ? '8004' : '8003'
+    return trailblazer === 'Stelle' ? '8004' : '8003'
   }
   if (name === 'TrailblazerHarmony') {
-    id = trailblazer === 'Stelle' ? '8006' : '8005'
+    return trailblazer === 'Stelle' ? '8006' : '8005'
   }
 
   if (path === 'Destruction') {
-    id = trailblazer === 'Stelle' ? '8002' : '8001'
+    return trailblazer === 'Stelle' ? '8002' : '8001'
   }
   if (path === 'Preservation') {
-    id = trailblazer === 'Stelle' ? '8004' : '8003'
+    return trailblazer === 'Stelle' ? '8004' : '8003'
   }
   if (path === 'Harmony') {
-    id = trailblazer === 'Stelle' ? '8006' : '8005'
+    return trailblazer === 'Stelle' ? '8006' : '8005'
   }
 
-  return id
+  return '8002'
 }


### PR DESCRIPTION
# Pull Request

## Description

* LC search will prefer direct key matching for all trailblazer builds, the same behavior as searching for other characters. This will fix the issue of the same LC being used across all builds seen in the linked issue. The previous `.startsWith()` search is left in place as a fallback to prevent the current state from degrading further
* Without appropriate breaks (in this case early returns) the current `getTrailblazerId()` implementation will always fall through to the final matching current path regardless of name. This results in duplicate builds as seen in the screenshot below

## Related Issue
Closes #416 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
![image](https://github.com/fribbels/hsr-optimizer/assets/3262183/2650831e-6ed4-4c3e-ac6d-352733696765)
