### PR TITLE
hotfix: add BE link rope and cavalry set to simulation if break effect team

### DIFF
--- a/src/lib/characterScorer.ts
+++ b/src/lib/characterScorer.ts
@@ -1,6 +1,6 @@
 import { Character } from 'types/Character'
 import { StatSimTypes } from 'components/optimizerTab/optimizerForm/StatSimulationDisplay'
-import { CUSTOM_TEAM, Parts, Stats, SubStats } from 'lib/constants'
+import { CUSTOM_TEAM, Parts, Sets, Stats, SubStats } from 'lib/constants'
 import { calculateOrnamentSets, calculateRelicSets, convertRelicsToSimulation, runSimulations, Simulation, SimulationRequest, SimulationStats } from 'lib/statSimulationController'
 import { getDefaultForm } from 'lib/defaultForm'
 import { CharacterConditionals } from 'lib/characterConditionals'
@@ -262,6 +262,14 @@ export function scoreCharacterSimulation(
   }
   if (addBreakEffect && !substats.includes(Stats.BE)) {
     substats.push(Stats.BE)
+  }
+  if (addBreakEffect && !metadata.parts[Parts.LinkRope].includes(Stats.BE)) {
+    metadata.parts[Parts.LinkRope].push(Stats.BE)
+  }
+  if (addBreakEffect
+    && !metadata.relicSets.find((sets) =>
+      sets[0] == sets[1] && sets[1] == Sets.IronCavalryAgainstTheScourge)) {
+    metadata.relicSets.push([Sets.IronCavalryAgainstTheScourge, Sets.IronCavalryAgainstTheScourge])
   }
 
   // Set up default request


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Currently if HMC is on the team, the sim has trouble deciding between crit builds and BE builds. We need to allow break rope on characters that dont necessarily want break by default if hmc is there.
* Add Iron Cavalry as acceptable set option too for super break teams

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

<img width="667" alt="image" src="https://github.com/fribbels/hsr-optimizer/assets/7908525/f6560352-74d2-4621-96ca-bdc0bcfa2b85">
