### PR TITLE
fix: candidate stat generation should use best available substat weight

### DIFF
--- a/misc/beta/data.ts
+++ b/misc/beta/data.ts
@@ -1,0 +1,12497 @@
+// Auto Generated
+
+var _avatar = [
+  {
+    "_id": 1310,
+    "Ver": "2.3v5",
+    "Name": "Firefly",
+    "Desc": "A member of the Stellaron Hunters, clad in a set of mechanized armor known as \"SAM.\" Her character is marked by unwavering loyalty and steely resolve.<br>Engineered as a weapon against the Swarm, she experiences accelerated growth, but a tragically shortened lifespan.<br>She joined the Stellaron Hunters in a quest for a chance at \"life,\" seeking to defy her fated demise.",
+    "Rarity": 5,
+    "Element": "Fire",
+    "Path": "Destruction",
+    "SP": 240.0,
+    "Skills": [
+      131001,
+      131002,
+      131003,
+      131004,
+      131006,
+      131007,
+      131009,
+      131008
+    ],
+    "Ranks": [
+      131001,
+      131002,
+      131003,
+      131004,
+      131005,
+      131006
+    ],
+    "Icon": "avatarshopicon/1310",
+    "Pic": "avatardrawcard/1310.png",
+    "Mat": [
+      114013,
+      110422,
+      110183,
+      110505
+    ],
+    "Stats": {
+      "HP": 814.968,
+      "ATK": 523.908,
+      "DEF": 776.16,
+      "SPD": 104.0,
+      "Aggro": 125.0
+    },
+    "CV": [
+      "",
+      "",
+      "",
+      ""
+    ],
+    "Camp": 0,
+    "ISN": "",
+    "ISD": "",
+    "V": [
+      "v1",
+      "v2",
+      "v3",
+      "v4",
+      "v5"
+    ]
+  },
+  {
+    "_id": 1314,
+    "Ver": "2.3v5",
+    "Name": "Jade",
+    "Desc": "A senior manager in the IPC Strategic Investment Department and one of the Ten Stonehearts, known for her cornerstone \"Jade of Credit.\"<br>A cold and elegant moneylender, she is skilled at understanding the human heart, with a personal hobby called \"Bonajade Exchange.\"<br>She's willing to wait patiently for high-value acquisitions and adept at extracting value from seemingly destitute clients.",
+    "Rarity": 5,
+    "Element": "Quantum",
+    "Path": "Erudition",
+    "SP": 140.0,
+    "Skills": [
+      131401,
+      131402,
+      131403,
+      131404,
+      131406,
+      131407
+    ],
+    "Ranks": [
+      131401,
+      131402,
+      131403,
+      131404,
+      131405,
+      131406
+    ],
+    "Icon": "avatarshopicon/1314",
+    "Pic": "avatardrawcard/1314.png",
+    "Mat": [
+      114003,
+      110426,
+      110203,
+      110505
+    ],
+    "Stats": {
+      "HP": 1086.624,
+      "ATK": 659.736,
+      "DEF": 509.355,
+      "SPD": 103.0,
+      "Aggro": 75.0
+    },
+    "CV": [
+      "",
+      "",
+      "",
+      ""
+    ],
+    "Camp": 0,
+    "ISN": "",
+    "ISD": "",
+    "V": [
+      "v1",
+      "v2",
+      "v3",
+      "v4",
+      "v5"
+    ]
+  },
+  {
+    "_id": 1309,
+    "Ver": "2.2",
+    "Name": "Robin",
+    "Desc": "A Halovian singer who was born in Penacony and has risen to cosmic fame. An elegant and demure young lady.<br>This time, she has been invited home by The Family to grace everyone with song during the Charmony Festival.<br>She can use the power of \"Harmony\" to broadcast her music, manifesting \"resonance\" among not only her fans but all manner of lifeforms.",
+    "Rarity": 5,
+    "Element": "Phys",
+    "Path": "Harmony",
+    "SP": 160.0,
+    "Skills": [
+      130901,
+      130902,
+      130903,
+      130904,
+      130906,
+      130907
+    ],
+    "Ranks": [
+      130901,
+      130902,
+      130903,
+      130904,
+      130905,
+      130906
+    ],
+    "Icon": "avatarshopicon/1309",
+    "Pic": "avatardrawcard/1309.png",
+    "Mat": [
+      114003,
+      110421,
+      110233,
+      110504
+    ],
+    "Stats": {
+      "HP": 1280.664,
+      "ATK": 640.332,
+      "DEF": 485.1,
+      "SPD": 102.0,
+      "Aggro": 100.0
+    },
+    "CV": [
+      "",
+      "",
+      "",
+      ""
+    ],
+    "Camp": 0,
+    "ISN": "",
+    "ISD": "",
+    "V": [
+      "v1",
+      "v2",
+      "v3",
+      "v4",
+      "v5"
+    ]
+  },
+  {
+    "_id": 1315,
+    "Ver": "2.2",
+    "Name": "Boothill",
+    "Desc": "A cyborg cowboy drifting among the stars. Extremely optimistic and unrestrained.<br>He is a member of the Galaxy Rangers who swore to punish the wretched by any and all means...<br>His flamboyant and brash actions were all to draw the attention of the Interastral Peace Corporation — the target of his revenge.",
+    "Rarity": 5,
+    "Element": "Phys",
+    "Path": "Hunt",
+    "SP": 115.0,
+    "Skills": [
+      131501,
+      131508,
+      131502,
+      131503,
+      131504,
+      131506,
+      131507
+    ],
+    "Ranks": [
+      131501,
+      131502,
+      131503,
+      131504,
+      131505,
+      131506
+    ],
+    "Icon": "avatarshopicon/1315",
+    "Pic": "avatardrawcard/1315.png",
+    "Mat": [
+      114013,
+      110421,
+      110193,
+      110505
+    ],
+    "Stats": {
+      "HP": 1203.048,
+      "ATK": 620.928,
+      "DEF": 436.59,
+      "SPD": 107.0,
+      "Aggro": 75.0
+    },
+    "CV": [
+      "",
+      "",
+      "",
+      ""
+    ],
+    "Camp": 0,
+    "ISN": "",
+    "ISD": "",
+    "V": [
+      "v1",
+      "v2",
+      "v3",
+      "v4",
+      "v5"
+    ]
+  },
+  {
+    "_id": 8005,
+    "Ver": "2.2",
+    "Name": "Trailblazer",
+    "Desc": "A {F#girl}{M#boy} who boarded the Astral Express.<br>They chose to travel with the Astral Express to eliminate the dangers posed by the Stellaron.",
+    "Rarity": 5,
+    "Element": "Imaginary",
+    "Path": "Harmony",
+    "SP": 140.0,
+    "Skills": [
+      800501,
+      800502,
+      800503,
+      800504,
+      800506,
+      800507
+    ],
+    "Ranks": [
+      800501,
+      800502,
+      800503,
+      800504,
+      800505,
+      800506
+    ],
+    "Icon": "avatarshopicon/8005",
+    "Pic": "avatardrawcard/8005.png",
+    "Mat": [
+      111013,
+      110400,
+      110233,
+      110504
+    ],
+    "Stats": {
+      "HP": 1086.624,
+      "ATK": 446.292,
+      "DEF": 679.14,
+      "SPD": 105.0,
+      "Aggro": 100.0
+    },
+    "CV": [
+      "",
+      "",
+      "",
+      ""
+    ],
+    "Camp": 0,
+    "ISN": "",
+    "ISD": "",
+    "V": [
+      "v1",
+      "v2",
+      "v3",
+      "v4",
+      "v5"
+    ]
+  },
+  {
+    "_id": 8006,
+    "Ver": "2.2",
+    "Name": "Trailblazer",
+    "Desc": "A {F#girl}{M#boy} who boarded the Astral Express.<br>They chose to travel with the Astral Express to eliminate the dangers posed by the Stellaron.",
+    "Rarity": 5,
+    "Element": "Imaginary",
+    "Path": "Harmony",
+    "SP": 140.0,
+    "Skills": [
+      800601,
+      800602,
+      800603,
+      800604,
+      800606,
+      800607
+    ],
+    "Ranks": [
+      800601,
+      800602,
+      800603,
+      800604,
+      800605,
+      800606
+    ],
+    "Icon": "avatarshopicon/8006",
+    "Pic": "avatardrawcard/8006.png",
+    "Mat": [
+      111013,
+      110400,
+      110233,
+      110504
+    ],
+    "Stats": {
+      "HP": 1086.624,
+      "ATK": 446.292,
+      "DEF": 679.14,
+      "SPD": 105.0,
+      "Aggro": 100.0
+    },
+    "CV": [
+      "",
+      "",
+      "",
+      ""
+    ],
+    "Camp": 0,
+    "ISN": "",
+    "ISD": "",
+    "V": [
+      "v1",
+      "v2",
+      "v3",
+      "v4",
+      "v5"
+    ]
+  },
+  {
+    "_id": 1301,
+    "Ver": "2.1",
+    "Name": "Gallagher",
+    "Desc": "A security officer of the Bloodhound Family at Penacony. He is always courteous toward visiting guests but keeps his vigilance about him. He seems to carry a weight of a complicated past, yet he never voluntarily divulges any details.",
+    "Rarity": 4,
+    "Element": "Fire",
+    "Path": "Abundance",
+    "SP": 110.0,
+    "Skills": [
+      130101,
+      130108,
+      130102,
+      130103,
+      130104,
+      130106,
+      130107
+    ],
+    "Ranks": [
+      130101,
+      130102,
+      130103,
+      130104,
+      130105,
+      130106
+    ],
+    "Icon": "avatarshopicon/1301",
+    "Pic": "avatardrawcard/1301.png",
+    "Mat": [
+      114003,
+      110422,
+      110243,
+      110504
+    ],
+    "Stats": {
+      "HP": 1305.36,
+      "ATK": 529.2,
+      "DEF": 441.0,
+      "SPD": 98.0,
+      "Aggro": 100.0
+    },
+    "CV": [
+      "马语非",
+      "Erik Braa",
+      "三上哲",
+      "박상훈"
+    ],
+    "Camp": 108,
+    "ISN": "",
+    "ISD": "",
+    "V": [
+      "v1",
+      "v2",
+      "v3",
+      "v4",
+      "Live"
+    ]
+  },
+  {
+    "_id": 1304,
+    "Ver": "2.1",
+    "Name": "Aventurine",
+    "Desc": "A high-ranking executive of the IPC's Strategic Investment Department.<br>A risk-taker, his constant smile makes it difficult for people to discern his true feelings.",
+    "Rarity": 5,
+    "Element": "Imaginary",
+    "Path": "Preservation",
+    "SP": 110.0,
+    "Skills": [
+      130401,
+      130402,
+      130403,
+      130404,
+      130406,
+      130407
+    ],
+    "Ranks": [
+      130401,
+      130402,
+      130403,
+      130404,
+      130405,
+      130406
+    ],
+    "Icon": "avatarshopicon/1304",
+    "Pic": "avatardrawcard/1304.png",
+    "Mat": [
+      114013,
+      110417,
+      110213,
+      110504
+    ],
+    "Stats": {
+      "HP": 1203.048,
+      "ATK": 446.292,
+      "DEF": 654.885,
+      "SPD": 106.0,
+      "Aggro": 150.0
+    },
+    "CV": [
+      "杨超然",
+      "Camden Sutkowski",
+      "河西健吾",
+      "박준원"
+    ],
+    "Camp": 105,
+    "ISN": "",
+    "ISD": "",
+    "V": [
+      "v1",
+      "v2",
+      "v3",
+      "v4",
+      "Live"
+    ]
+  },
+  {
+    "_id": 1308,
+    "Ver": "2.1",
+    "Name": "Acheron",
+    "Desc": "A drifter claiming to be a Galaxy Ranger. Her true name is unknown.<br>She walks the cosmos alone, carrying with her a long sword.",
+    "Rarity": 5,
+    "Element": "Elec",
+    "Path": "Nihility",
+    "SP": 9.0,
+    "Skills": [
+      130801,
+      130802,
+      130803,
+      130804,
+      130814,
+      130815,
+      130816,
+      130817,
+      130806,
+      130807
+    ],
+    "Ranks": [
+      130801,
+      130802,
+      130803,
+      130804,
+      130805,
+      130806
+    ],
+    "Icon": "avatarshopicon/1308",
+    "Pic": "avatardrawcard/1308.png",
+    "Mat": [
+      114003,
+      110414,
+      110223,
+      110504
+    ],
+    "Stats": {
+      "HP": 1125.432,
+      "ATK": 698.544,
+      "DEF": 436.59,
+      "SPD": 101.0,
+      "Aggro": 100.0
+    },
+    "CV": [
+      "菊花花",
+      "Allegra Clark",
+      "沢城みゆき",
+      "박지윤"
+    ],
+    "Camp": 111,
+    "ISN": "",
+    "ISD": "",
+    "V": [
+      "v1",
+      "v2",
+      "v3",
+      "v4",
+      "Live"
+    ]
+  },
+  {
+    "_id": 1306,
+    "Ver": "2.0",
+    "Name": "Sparkle",
+    "Desc": "A member of the Masked Fools. Inscrutable and unscrupulous.<br>A dangerous maestro of theatrics, utterly engrossed in the art of performance. Adorned with innumerable masks, she is the hero with a thousand faces.<br>Wealth, status, power... None of those matters to Sparkle. The only thing that can get her attention is \"amusement.\"",
+    "Rarity": 5,
+    "Element": "Quantum",
+    "Path": "Harmony",
+    "SP": 110.0,
+    "Skills": [
+      130601,
+      130602,
+      130603,
+      130604,
+      130606,
+      130607
+    ],
+    "Ranks": [
+      130601,
+      130602,
+      130603,
+      130604,
+      130605,
+      130606
+    ],
+    "Icon": "avatarshopicon/1306",
+    "Pic": "avatardrawcard/1306.png",
+    "Mat": [
+      114013,
+      110426,
+      110233,
+      110504
+    ],
+    "Stats": {
+      "HP": 1397.088,
+      "ATK": 523.908,
+      "DEF": 485.1,
+      "SPD": 101.0,
+      "Aggro": 100.0
+    },
+    "CV": [
+      "赵爽",
+      "Lizzie Freeman",
+      "上田麗奈",
+      "성예원"
+    ],
+    "Camp": 110,
+    "ISN": "",
+    "ISD": "",
+    "V": [
+      "v5",
+      "Live"
+    ]
+  },
+  {
+    "_id": 1307,
+    "Ver": "2.0",
+    "Name": "Black Swan",
+    "Desc": "A Memokeeper of the Garden of Recollection. An indolent and mysterious soothsayer.<br>\"Remembrance\" of men are hers to heed, threads of fate are hers to tug.",
+    "Rarity": 5,
+    "Element": "Wind",
+    "Path": "Nihility",
+    "SP": 120.0,
+    "Skills": [
+      130701,
+      130702,
+      130703,
+      130704,
+      130706,
+      130707
+    ],
+    "Ranks": [
+      130701,
+      130702,
+      130703,
+      130704,
+      130705,
+      130706
+    ],
+    "Icon": "avatarshopicon/1307",
+    "Pic": "avatardrawcard/1307.png",
+    "Mat": [
+      111003,
+      110415,
+      110223,
+      110504
+    ],
+    "Stats": {
+      "HP": 1086.624,
+      "ATK": 659.736,
+      "DEF": 485.1,
+      "SPD": 102.0,
+      "Aggro": 100.0
+    },
+    "CV": [
+      "杨梦露",
+      "Arryn Zech",
+      "生天目仁美",
+      "김하영"
+    ],
+    "Camp": 109,
+    "ISN": "",
+    "ISD": "",
+    "V": [
+      "v5",
+      "Live"
+    ]
+  },
+  {
+    "_id": 1312,
+    "Ver": "2.0",
+    "Name": "Misha",
+    "Desc": "A well-behaved young man serving as a hotel bellboy in Penacony.<br>Misha has a great longing for the Nameless and dreams of one day embarking on a journey of his own.",
+    "Rarity": 4,
+    "Element": "Ice",
+    "Path": "Destruction",
+    "SP": 100.0,
+    "Skills": [
+      131201,
+      131202,
+      131203,
+      131204,
+      131206,
+      131207
+    ],
+    "Ranks": [
+      131201,
+      131202,
+      131203,
+      131204,
+      131205,
+      131206
+    ],
+    "Icon": "avatarshopicon/1312",
+    "Pic": "avatardrawcard/1312.png",
+    "Mat": [
+      114003,
+      110423,
+      110183,
+      110504
+    ],
+    "Stats": {
+      "HP": 1270.08,
+      "ATK": 599.76,
+      "DEF": 396.9,
+      "SPD": 96.0,
+      "Aggro": 125.0
+    },
+    "CV": [
+      "柳知萧",
+      "Cat Protano",
+      "松井恵理子",
+      "박신희"
+    ],
+    "Camp": 108,
+    "ISN": "",
+    "ISD": "",
+    "V": [
+      "v5",
+      "Live"
+    ]
+  },
+  {
+    "_id": 1214,
+    "Ver": "1.6",
+    "Name": "Xueyi",
+    "Desc": "Judge of the Ten-Lords Commission, which presides over the jurisdiction of life and death on the Luofu.<br>For years after her death, she inhabited a puppet body and returned to the world to fulfill her mission.",
+    "Rarity": 4,
+    "Element": "Quantum",
+    "Path": "Destruction",
+    "SP": 120.0,
+    "Skills": [
+      121401,
+      121402,
+      121403,
+      121404,
+      121406,
+      121407
+    ],
+    "Ranks": [
+      121401,
+      121402,
+      121403,
+      121404,
+      121405,
+      121406
+    ],
+    "Icon": "avatarshopicon/1214",
+    "Pic": "avatardrawcard/1214.png",
+    "Mat": [
+      111003,
+      110416,
+      110113,
+      110504
+    ],
+    "Stats": {
+      "HP": 1058.4,
+      "ATK": 599.76,
+      "DEF": 396.9,
+      "SPD": 103.0,
+      "Aggro": 125.0
+    },
+    "CV": [
+      "溯浔",
+      "Jenny Yokobori",
+      "河瀬茉希",
+      "박리나"
+    ],
+    "Camp": 104,
+    "ISN": "",
+    "ISD": "",
+    "V": [
+      "Pre"
+    ]
+  },
+  {
+    "_id": 1303,
+    "Ver": "1.6",
+    "Name": "Ruan Mei",
+    "Desc": "A member of the Genius Society and an expert in life sciences. She teamed up with Herta and others to develop the Simulated Universe.",
+    "Rarity": 5,
+    "Element": "Ice",
+    "Path": "Harmony",
+    "SP": 130.0,
+    "Skills": [
+      130301,
+      130302,
+      130303,
+      130304,
+      130306,
+      130307
+    ],
+    "Ranks": [
+      130301,
+      130302,
+      130303,
+      130304,
+      130305,
+      130306
+    ],
+    "Icon": "avatarshopicon/1303",
+    "Pic": "avatardrawcard/1303.png",
+    "Mat": [
+      113003,
+      110413,
+      110163,
+      110504
+    ],
+    "Stats": {
+      "HP": 1086.624,
+      "ATK": 659.736,
+      "DEF": 485.1,
+      "SPD": 104.0,
+      "Aggro": 100.0
+    },
+    "CV": [
+      "张文钰",
+      "Emi Lo",
+      "大西沙織",
+      "윤여진"
+    ],
+    "Camp": 102,
+    "ISN": "",
+    "ISD": "",
+    "V": [
+      "Pre"
+    ]
+  },
+  {
+    "_id": 1305,
+    "Ver": "1.6",
+    "Name": "Dr. Ratio",
+    "Desc": "Member of the Intelligentsia Guild.<br>Eccentric temperament, sharp-tongued but with an elegant demeanor.<br>The face under the strange alabaster head sculpture is apparently unexpectedly handsome.",
+    "Rarity": 5,
+    "Element": "Imaginary",
+    "Path": "Hunt",
+    "SP": 140.0,
+    "Skills": [
+      130501,
+      130502,
+      130503,
+      130504,
+      130506,
+      130507
+    ],
+    "Ranks": [
+      130501,
+      130502,
+      130503,
+      130504,
+      130505,
+      130506
+    ],
+    "Icon": "avatarshopicon/1305",
+    "Pic": "avatardrawcard/1305.png",
+    "Mat": [
+      111013,
+      110417,
+      110123,
+      110504
+    ],
+    "Stats": {
+      "HP": 1047.816,
+      "ATK": 776.16,
+      "DEF": 460.845,
+      "SPD": 103.0,
+      "Aggro": 75.0
+    },
+    "CV": [
+      "桑毓泽",
+      "Jordan Paul Haro",
+      "武内駿輔",
+      "이동훈"
+    ],
+    "Camp": 107,
+    "ISN": "",
+    "ISD": "",
+    "V": [
+      "Pre"
+    ]
+  },
+  {
+    "_id": 1215,
+    "Ver": "1.5",
+    "Name": "Hanya",
+    "Desc": "One of the judges of the Xianzhou Luofu's Ten-Lords Commission.<br>Ordained by the Ten-Lords and wielding the authority of the Oracle Brush, she reads the multitudes of human sins and transgressions, then issues punishments and karmic retribution.",
+    "Rarity": 4,
+    "Element": "Phys",
+    "Path": "Harmony",
+    "SP": 140.0,
+    "Skills": [
+      121501,
+      121502,
+      121503,
+      121504,
+      121506,
+      121507
+    ],
+    "Ranks": [
+      121501,
+      121502,
+      121503,
+      121504,
+      121505,
+      121506
+    ],
+    "Icon": "avatarshopicon/1215",
+    "Pic": "avatardrawcard/1215.png",
+    "Mat": [
+      113013,
+      110411,
+      110163,
+      110503
+    ],
+    "Stats": {
+      "HP": 917.28,
+      "ATK": 564.48,
+      "DEF": 352.8,
+      "SPD": 110.0,
+      "Aggro": 100.0
+    },
+    "CV": [
+      "张雨曦",
+      "Suzie Yeung",
+      "鈴代紗弓",
+      "윤은서"
+    ],
+    "Camp": 104,
+    "ISN": "",
+    "ISD": "",
+    "V": [
+      "Pre"
+    ]
+  },
+  {
+    "_id": 1217,
+    "Ver": "1.5",
+    "Name": "Huohuo",
+    "Desc": "A trainee Ten-Lords Commission Judge of the Xianzhou Luofu, she is a young foxian girl possessed by a heliobus.<br>She is a timid and weak girl who is afraid of all kinds of strange things, but is responsible for luring and subduing evil spirits.",
+    "Rarity": 5,
+    "Element": "Wind",
+    "Path": "Abundance",
+    "SP": 140.0,
+    "Skills": [
+      121701,
+      121702,
+      121703,
+      121704,
+      121706,
+      121707
+    ],
+    "Ranks": [
+      121701,
+      121702,
+      121703,
+      121704,
+      121705,
+      121706
+    ],
+    "Icon": "avatarshopicon/1217",
+    "Pic": "avatardrawcard/1217.png",
+    "Mat": [
+      113003,
+      110415,
+      110173,
+      110503
+    ],
+    "Stats": {
+      "HP": 1358.28,
+      "ATK": 601.524,
+      "DEF": 509.355,
+      "SPD": 98.0,
+      "Aggro": 100.0
+    },
+    "CV": [
+      "葛子瑞&刘北辰",
+      "Courtney Lin & Adam Michael Gold",
+      "長縄まりあ&平林剛",
+      "김채린&한복현"
+    ],
+    "Camp": 104,
+    "ISN": "",
+    "ISD": "",
+    "V": [
+      "Pre"
+    ]
+  },
+  {
+    "_id": 1302,
+    "Ver": "1.5",
+    "Name": "Argenti",
+    "Desc": "A paragon knight of the Knights of Beauty who is piously seeking his missing Aeon, Idrila the Beauty.<br>Forthright and candid, he wanders the cosmos espousing the virtues of Idrila's good name.",
+    "Rarity": 5,
+    "Element": "Phys",
+    "Path": "Erudition",
+    "SP": 180.0,
+    "Skills": [
+      130201,
+      130202,
+      130203,
+      130204,
+      130206,
+      130207,
+      130214
+    ],
+    "Ranks": [
+      130201,
+      130202,
+      130203,
+      130204,
+      130205,
+      130206
+    ],
+    "Icon": "avatarshopicon/1302",
+    "Pic": "avatardrawcard/1302.png",
+    "Mat": [
+      111003,
+      110411,
+      110133,
+      110503
+    ],
+    "Stats": {
+      "HP": 1047.816,
+      "ATK": 737.352,
+      "DEF": 363.825,
+      "SPD": 103.0,
+      "Aggro": 75.0
+    },
+    "CV": [
+      "梁达伟",
+      "Adam Michael Gold",
+      "立花慎之介",
+      "최승훈"
+    ],
+    "Camp": 106,
+    "ISN": "",
+    "ISD": "",
+    "V": [
+      "Pre"
+    ]
+  },
+  {
+    "_id": 1112,
+    "Ver": "1.4",
+    "Name": "Topaz & Numby",
+    "Desc": "Topaz is the Leader of the Special Debts Picket Team and high-level manager of the Strategic Investment Department under the Interastral Peace Corporation.<br>A member of the \"Ten Stonehearts\" at a young age, Topaz's foundational expertise is \"debt retrieval.\"<br>Her partner, the Warp Trotter \"Numby,\" is also capable of keenly perceiving where \"riches\" are located, ensuring that jobs based in security, debt collection, and actuarial varieties are of no great challenge.<br>At presently they are traveling the cosmos together, seeking all manner of liability disputes that might be affecting the stable progression of the IPC's businesses.",
+    "Rarity": 5,
+    "Element": "Fire",
+    "Path": "Hunt",
+    "SP": 130.0,
+    "Skills": [
+      111201,
+      111202,
+      111203,
+      111204,
+      111206,
+      111207
+    ],
+    "Ranks": [
+      111201,
+      111202,
+      111203,
+      111204,
+      111205,
+      111206
+    ],
+    "Icon": "avatarshopicon/1112",
+    "Pic": "avatardrawcard/1112.png",
+    "Mat": [
+      112003,
+      110412,
+      110123,
+      110503
+    ],
+    "Stats": {
+      "HP": 931.392,
+      "ATK": 620.928,
+      "DEF": 412.335,
+      "SPD": 110.0,
+      "Aggro": 75.0
+    },
+    "CV": [
+      "陆敏悦",
+      "Sam Slade",
+      "南條愛乃",
+      "방시우"
+    ],
+    "Camp": 105,
+    "ISN": "",
+    "ISD": "",
+    "V": [
+      "Pre"
+    ]
+  },
+  {
+    "_id": 1210,
+    "Ver": "1.4",
+    "Name": "Guinaifen",
+    "Desc": "A performance artist visiting the Xianzhou Luofu — in other words, a street performer.<br>She's chasing a new life on the Luofu when not concerned with food and shelter.",
+    "Rarity": 4,
+    "Element": "Fire",
+    "Path": "Nihility",
+    "SP": 120.0,
+    "Skills": [
+      121001,
+      121002,
+      121003,
+      121004,
+      121006,
+      121007
+    ],
+    "Ranks": [
+      121001,
+      121002,
+      121003,
+      121004,
+      121005,
+      121006
+    ],
+    "Icon": "avatarshopicon/1210",
+    "Pic": "avatardrawcard/1210.png",
+    "Mat": [
+      113013,
+      110412,
+      110153,
+      110503
+    ],
+    "Stats": {
+      "HP": 882.0,
+      "ATK": 582.12,
+      "DEF": 441.0,
+      "SPD": 106.0,
+      "Aggro": 100.0
+    },
+    "CV": [
+      "小敢",
+      "Morgan Lauré",
+      "直田姫奈",
+      "김수영"
+    ],
+    "Camp": 104,
+    "ISN": "",
+    "ISD": "",
+    "V": [
+      "Pre"
+    ]
+  },
+  {
+    "_id": 1212,
+    "Ver": "1.4",
+    "Name": "Jingliu",
+    "Desc": "Former Sword Champion of the Luofu, and the creator of the Cloud Knights' legends of undefeated might.<br>Now, her name has been wiped from the records, and she is a traitor of the Xianzhou walking on the fine line between sanity and mara-struck.",
+    "Rarity": 5,
+    "Element": "Ice",
+    "Path": "Destruction",
+    "SP": 140.0,
+    "Skills": [
+      121201,
+      121209,
+      121202,
+      121203,
+      121204,
+      121206,
+      121207
+    ],
+    "Ranks": [
+      121201,
+      121202,
+      121203,
+      121204,
+      121205,
+      121206
+    ],
+    "Icon": "avatarshopicon/1212",
+    "Pic": "avatardrawcard/1212.png",
+    "Mat": [
+      113003,
+      110413,
+      110113,
+      110503
+    ],
+    "Stats": {
+      "HP": 1435.896,
+      "ATK": 679.14,
+      "DEF": 485.1,
+      "SPD": 96.0,
+      "Aggro": 125.0
+    },
+    "CV": [
+      "杜冥鸦",
+      "AmaLee",
+      "桑島法子",
+      "박이서"
+    ],
+    "Camp": 104,
+    "ISN": "",
+    "ISD": "",
+    "V": [
+      "Pre"
+    ]
+  },
+  {
+    "_id": 1110,
+    "Ver": "1.3",
+    "Name": "Lynx",
+    "Desc": "A Belobogian Snow Plains Explorer, and the youngest of the Landau siblings.<br>Calm and collected, with a strong drive for action. Often embarks on solo adventures to explore the snowy wilderness.",
+    "Rarity": 4,
+    "Element": "Quantum",
+    "Path": "Abundance",
+    "SP": 100.0,
+    "Skills": [
+      111001,
+      111002,
+      111003,
+      111004,
+      111006,
+      111007
+    ],
+    "Ranks": [
+      111001,
+      111002,
+      111003,
+      111004,
+      111005,
+      111006
+    ],
+    "Icon": "avatarshopicon/1110",
+    "Pic": "avatardrawcard/1110.png",
+    "Mat": [
+      111003,
+      110416,
+      110173,
+      110503
+    ],
+    "Stats": {
+      "HP": 1058.4,
+      "ATK": 493.92,
+      "DEF": 551.25,
+      "SPD": 100.0,
+      "Aggro": 100.0
+    },
+    "CV": [
+      "米糊",
+      "Risa Mei",
+      "照井春佳",
+      "이은조"
+    ],
+    "Camp": 103,
+    "ISN": "",
+    "ISD": "",
+    "V": [
+      "Pre"
+    ]
+  },
+  {
+    "_id": 1208,
+    "Ver": "1.3",
+    "Name": "Fu Xuan",
+    "Desc": "Head of the Divination Commission on the Luofu.<br>The person who uses the third eye and Matrix of Prescience to foretell the route of Xianzhou and the outcomes of events.",
+    "Rarity": 5,
+    "Element": "Quantum",
+    "Path": "Preservation",
+    "SP": 135.0,
+    "Skills": [
+      120801,
+      120802,
+      120803,
+      120804,
+      120806,
+      120807
+    ],
+    "Ranks": [
+      120801,
+      120802,
+      120803,
+      120804,
+      120805,
+      120806
+    ],
+    "Icon": "avatarshopicon/1208",
+    "Pic": "avatardrawcard/1208.png",
+    "Mat": [
+      113013,
+      110416,
+      110143,
+      110503
+    ],
+    "Stats": {
+      "HP": 1474.704,
+      "ATK": 465.696,
+      "DEF": 606.375,
+      "SPD": 100.0,
+      "Aggro": 150.0
+    },
+    "CV": [
+      "花玲",
+      "Sarah Wiedenheft",
+      "伊藤美来",
+      "이지현"
+    ],
+    "Camp": 104,
+    "ISN": "",
+    "ISD": "",
+    "V": [
+      "Pre"
+    ]
+  },
+  {
+    "_id": 1213,
+    "Ver": "1.3",
+    "Name": "Dan Heng • Imbibitor Lunae",
+    "Desc": "Dan Heng's true form from his Vidyadhara lineage carries the residual power left behind by his past incarnation, the Imbibitor Lunae.<br>Upon accepting the majestic horns atop his crown, he must accept all the merits and faults attributed to that sinner.",
+    "Rarity": 5,
+    "Element": "Imaginary",
+    "Path": "Destruction",
+    "SP": 140.0,
+    "Skills": [
+      121301,
+      121308,
+      121310,
+      121312,
+      121302,
+      121303,
+      121304,
+      121306,
+      121307,
+      121309
+    ],
+    "Ranks": [
+      121301,
+      121302,
+      121303,
+      121304,
+      121305,
+      121306
+    ],
+    "Icon": "avatarshopicon/1213",
+    "Pic": "avatardrawcard/1213.png",
+    "Mat": [
+      113003,
+      110417,
+      110113,
+      110503
+    ],
+    "Stats": {
+      "HP": 1241.856,
+      "ATK": 698.544,
+      "DEF": 363.825,
+      "SPD": 102.0,
+      "Aggro": 125.0
+    },
+    "CV": [
+      "李春胤",
+      "Nicholas Leung",
+      "伊東健人",
+      "김혜성"
+    ],
+    "Camp": 104,
+    "ISN": "",
+    "ISD": "",
+    "V": [
+      "Pre"
+    ]
+  },
+  {
+    "_id": 1005,
+    "Ver": "1.2",
+    "Name": "Kafka",
+    "Desc": "A member of the Stellaron Hunters. A dashing, collected, and professional beauty.<br>Used the enchantment of Spirit Whisper to set up Trailblazer to absorb the Stellaron.<br>Her hobby is shopping for and organizing her collection of coats.",
+    "Rarity": 5,
+    "Element": "Elec",
+    "Path": "Nihility",
+    "SP": 120.0,
+    "Skills": [
+      100501,
+      100502,
+      100503,
+      100504,
+      100506,
+      100507
+    ],
+    "Ranks": [
+      100501,
+      100502,
+      100503,
+      100504,
+      100505,
+      100506
+    ],
+    "Icon": "avatarshopicon/1005",
+    "Pic": "avatardrawcard/1005.png",
+    "Mat": [
+      111013,
+      110414,
+      110153,
+      110503
+    ],
+    "Stats": {
+      "HP": 1086.624,
+      "ATK": 679.14,
+      "DEF": 485.1,
+      "SPD": 100.0,
+      "Aggro": 100.0
+    },
+    "CV": [
+      "徐慧",
+      "Cheryl Texiera",
+      "伊藤静",
+      "사문영"
+    ],
+    "Camp": 101,
+    "ISN": "",
+    "ISD": "",
+    "V": [
+      "Pre"
+    ]
+  },
+  {
+    "_id": 1111,
+    "Ver": "1.2",
+    "Name": "Luka",
+    "Desc": "The boxing champion in Belobog's Underworld, and one of Wildfire's most capable fighters.<br>The consecutive reigning champion of the Fight Club, whose enthusiasm inspires children of the Underworld to dream big.",
+    "Rarity": 4,
+    "Element": "Phys",
+    "Path": "Nihility",
+    "SP": 130.0,
+    "Skills": [
+      111101,
+      111108,
+      111102,
+      111103,
+      111104,
+      111106,
+      111107
+    ],
+    "Ranks": [
+      111101,
+      111102,
+      111103,
+      111104,
+      111105,
+      111106
+    ],
+    "Icon": "avatarshopicon/1111",
+    "Pic": "avatardrawcard/1111.png",
+    "Mat": [
+      112013,
+      110401,
+      110153,
+      110503
+    ],
+    "Stats": {
+      "HP": 917.28,
+      "ATK": 582.12,
+      "DEF": 485.1,
+      "SPD": 103.0,
+      "Aggro": 100.0
+    },
+    "CV": [
+      "萧翟",
+      "Howard Wang",
+      "梶原岳人",
+      "이주승"
+    ],
+    "Camp": 103,
+    "ISN": "",
+    "ISD": "",
+    "V": [
+      "Pre"
+    ]
+  },
+  {
+    "_id": 1205,
+    "Ver": "1.2",
+    "Name": "Blade",
+    "Desc": "A member of the Stellaron Hunters, and a swordsman who abandoned his body to become a blade.<br>Pledges loyalty to \"Destiny's Slave,\" and possesses a terrifying self-healing ability.",
+    "Rarity": 5,
+    "Element": "Wind",
+    "Path": "Destruction",
+    "SP": 130.0,
+    "Skills": [
+      120501,
+      120508,
+      120503,
+      120506,
+      120507,
+      120502,
+      120504
+    ],
+    "Ranks": [
+      120501,
+      120502,
+      120503,
+      120504,
+      120505,
+      120506
+    ],
+    "Icon": "avatarshopicon/1205",
+    "Pic": "avatardrawcard/1205.png",
+    "Mat": [
+      113003,
+      110415,
+      110113,
+      110503
+    ],
+    "Stats": {
+      "HP": 1358.28,
+      "ATK": 543.312,
+      "DEF": 485.1,
+      "SPD": 97.0,
+      "Aggro": 125.0
+    },
+    "CV": [
+      "刘以嘉",
+      "Daman Mills",
+      "三木眞一郎",
+      "곽윤상"
+    ],
+    "Camp": 101,
+    "ISN": "",
+    "ISD": "",
+    "V": [
+      "Pre"
+    ]
+  },
+  {
+    "_id": 1006,
+    "Ver": "1.1",
+    "Name": "Silver Wolf",
+    "Desc": "A member of the Stellaron Hunters and a genius hacker.<br>She sees the universe as a massive immersive simulation game and has fun with it.<br>She's mastered the skill known as \"aether editing,\" which can be used to tamper with the data of reality.",
+    "Rarity": 5,
+    "Element": "Quantum",
+    "Path": "Nihility",
+    "SP": 110.0,
+    "Skills": [
+      100601,
+      100602,
+      100603,
+      100604,
+      100606,
+      100607
+    ],
+    "Ranks": [
+      100601,
+      100602,
+      100603,
+      100604,
+      100605,
+      100606
+    ],
+    "Icon": "avatarshopicon/1006",
+    "Pic": "avatardrawcard/1006.png",
+    "Mat": [
+      112013,
+      110406,
+      110153,
+      110501
+    ],
+    "Stats": {
+      "HP": 1047.816,
+      "ATK": 640.332,
+      "DEF": 460.845,
+      "SPD": 107.0,
+      "Aggro": 100.0
+    },
+    "CV": [
+      "Hanser",
+      "Melissa Fahn",
+      "阿澄佳奈",
+      "장미"
+    ],
+    "Camp": 101,
+    "ISN": "",
+    "ISD": "",
+    "V": [
+      "Pre"
+    ]
+  },
+  {
+    "_id": 1203,
+    "Ver": "1.1",
+    "Name": "Luocha",
+    "Desc": "Carrying a coffin wherever he goes, he is a foreign trader who came from beyond the stellar seas.<br>Has excellent medical skills.",
+    "Rarity": 5,
+    "Element": "Imaginary",
+    "Path": "Abundance",
+    "SP": 100.0,
+    "Skills": [
+      120301,
+      120302,
+      120303,
+      120304,
+      120306,
+      120307
+    ],
+    "Ranks": [
+      120301,
+      120302,
+      120303,
+      120304,
+      120305,
+      120306
+    ],
+    "Icon": "avatarshopicon/1203",
+    "Pic": "avatardrawcard/1203.png",
+    "Mat": [
+      113013,
+      110407,
+      110173,
+      110502
+    ],
+    "Stats": {
+      "HP": 1280.664,
+      "ATK": 756.756,
+      "DEF": 363.825,
+      "SPD": 101.0,
+      "Aggro": 100.0
+    },
+    "CV": [
+      "赵路",
+      "Craig Lee Thomas",
+      "石田彰",
+      "신용우"
+    ],
+    "Camp": 104,
+    "ISN": "",
+    "ISD": "",
+    "V": [
+      "Pre"
+    ]
+  },
+  {
+    "_id": 1207,
+    "Ver": "1.1",
+    "Name": "Yukong",
+    "Desc": "Head of the Sky-Faring Commission on the Xianzhou Luofu. Yukong was a seasoned pilot and a deadshot.<br>Since heading up the commission, she's been buried under mountains of paperwork.",
+    "Rarity": 4,
+    "Element": "Imaginary",
+    "Path": "Harmony",
+    "SP": 130.0,
+    "Skills": [
+      120701,
+      120702,
+      120703,
+      120704,
+      120706,
+      120707
+    ],
+    "Ranks": [
+      120701,
+      120702,
+      120703,
+      120704,
+      120705,
+      120706
+    ],
+    "Icon": "avatarshopicon/1207",
+    "Pic": "avatardrawcard/1207.png",
+    "Mat": [
+      113013,
+      110407,
+      110163,
+      110501
+    ],
+    "Stats": {
+      "HP": 917.28,
+      "ATK": 599.76,
+      "DEF": 374.85,
+      "SPD": 107.0,
+      "Aggro": 100.0
+    },
+    "CV": [
+      "钟可",
+      "Dawn M. Bennett",
+      "冬馬由美",
+      "전숙경"
+    ],
+    "Camp": 104,
+    "ISN": "",
+    "ISD": "",
+    "V": [
+      "Pre"
+    ]
+  },
+  {
+    "_id": 1001,
+    "Ver": "1.0",
+    "Name": "March 7th",
+    "Desc": "A girl who once slumbered in eternal ice and knows nothing about her past.<br>To find out the truth about her origins, she decided to travel with the Astral Express.<br>As of right now, she has prepared about 67 different versions of her life story for herself.",
+    "Rarity": 4,
+    "Element": "Ice",
+    "Path": "Preservation",
+    "SP": 120.0,
+    "Skills": [
+      100101,
+      100102,
+      100103,
+      100104,
+      100106,
+      100107
+    ],
+    "Ranks": [
+      100101,
+      100102,
+      100103,
+      100104,
+      100105,
+      100106
+    ],
+    "Icon": "avatarshopicon/1001",
+    "Pic": "avatardrawcard/1001.png",
+    "Mat": [
+      111013,
+      110403,
+      110143,
+      110501
+    ],
+    "Stats": {
+      "HP": 1058.4,
+      "ATK": 511.56,
+      "DEF": 573.3,
+      "SPD": 101.0,
+      "Aggro": 150.0
+    },
+    "CV": [
+      "诺亚",
+      "Skyler Davenport",
+      "小倉唯",
+      "정혜원"
+    ],
+    "Camp": 100,
+    "ISN": "",
+    "ISD": "",
+    "V": [
+      "Pre"
+    ]
+  },
+  {
+    "_id": 1002,
+    "Ver": "1.0",
+    "Name": "Dan Heng",
+    "Desc": "A cold and reserved young man who is reticent about his past.<br>To avoid his kin, he decided to travel with the Astral Express.",
+    "Rarity": 4,
+    "Element": "Wind",
+    "Path": "Hunt",
+    "SP": 100.0,
+    "Skills": [
+      100201,
+      100202,
+      100203,
+      100204,
+      100206,
+      100207
+    ],
+    "Ranks": [
+      100201,
+      100202,
+      100203,
+      100204,
+      100205,
+      100206
+    ],
+    "Icon": "avatarshopicon/1002",
+    "Pic": "avatardrawcard/1002.png",
+    "Mat": [
+      111003,
+      110405,
+      110123,
+      110501
+    ],
+    "Stats": {
+      "HP": 882.0,
+      "ATK": 546.84,
+      "DEF": 396.9,
+      "SPD": 110.0,
+      "Aggro": 75.0
+    },
+    "CV": [
+      "李春胤",
+      "Nicholas Leung",
+      "伊東健人",
+      "김혜성"
+    ],
+    "Camp": 100,
+    "ISN": "",
+    "ISD": "",
+    "V": [
+      "Pre"
+    ]
+  },
+  {
+    "_id": 1003,
+    "Ver": "1.0",
+    "Name": "Himeko",
+    "Desc": "The one who repaired the Astral Express.<br>To witness the vast starry sky, she decided to travel with the Astral Express.<br>Her hobby is brewing hand-made coffee.",
+    "Rarity": 5,
+    "Element": "Fire",
+    "Path": "Erudition",
+    "SP": 120.0,
+    "Skills": [
+      100301,
+      100302,
+      100303,
+      100304,
+      100306,
+      100307
+    ],
+    "Ranks": [
+      100301,
+      100302,
+      100303,
+      100304,
+      100305,
+      100306
+    ],
+    "Icon": "avatarshopicon/1003",
+    "Pic": "avatardrawcard/1003.png",
+    "Mat": [
+      111003,
+      110402,
+      110133,
+      110501
+    ],
+    "Stats": {
+      "HP": 1047.816,
+      "ATK": 756.756,
+      "DEF": 436.59,
+      "SPD": 96.0,
+      "Aggro": 75.0
+    },
+    "CV": [
+      "林簌",
+      "Cia Court",
+      "田中理恵",
+      "김보나"
+    ],
+    "Camp": 100,
+    "ISN": "",
+    "ISD": "",
+    "V": [
+      "Pre"
+    ]
+  },
+  {
+    "_id": 1004,
+    "Ver": "1.0",
+    "Name": "Welt",
+    "Desc": "A seasoned member of the Express Crew.<br>The passion buried in his heart burns anew as he enjoys this fresh adventure.<br>Occasionally, he would sketch the experiences in a notebook.",
+    "Rarity": 5,
+    "Element": "Imaginary",
+    "Path": "Nihility",
+    "SP": 120.0,
+    "Skills": [
+      100401,
+      100402,
+      100403,
+      100404,
+      100406,
+      100407
+    ],
+    "Ranks": [
+      100401,
+      100402,
+      100403,
+      100404,
+      100405,
+      100406
+    ],
+    "Icon": "avatarshopicon/1004",
+    "Pic": "avatardrawcard/1004.png",
+    "Mat": [
+      112003,
+      110407,
+      110153,
+      110501
+    ],
+    "Stats": {
+      "HP": 1125.432,
+      "ATK": 620.928,
+      "DEF": 509.355,
+      "SPD": 102.0,
+      "Aggro": 100.0
+    },
+    "CV": [
+      "彭博",
+      "Corey Landis",
+      "細谷佳正",
+      "한신"
+    ],
+    "Camp": 100,
+    "ISN": "",
+    "ISD": "",
+    "V": [
+      "Pre"
+    ]
+  },
+  {
+    "_id": 1008,
+    "Ver": "1.0",
+    "Name": "Arlan",
+    "Desc": "The head of Herta Space Station's Security Department.<br>This quiet boy hopes to protect the researchers who value their pursuit of knowledge, and to help them to complete their work.",
+    "Rarity": 4,
+    "Element": "Elec",
+    "Path": "Destruction",
+    "SP": 110.0,
+    "Skills": [
+      100801,
+      100802,
+      100803,
+      100804,
+      100806,
+      100807
+    ],
+    "Ranks": [
+      100801,
+      100802,
+      100803,
+      100804,
+      100805,
+      100806
+    ],
+    "Icon": "avatarshopicon/1008",
+    "Pic": "avatardrawcard/1008.png",
+    "Mat": [
+      111003,
+      110404,
+      110113,
+      110501
+    ],
+    "Stats": {
+      "HP": 1199.52,
+      "ATK": 599.76,
+      "DEF": 330.75,
+      "SPD": 102.0,
+      "Aggro": 125.0
+    },
+    "CV": [
+      "陶典",
+      "Dani Chambers",
+      "白石涼子",
+      "김율"
+    ],
+    "Camp": 102,
+    "ISN": "",
+    "ISD": "",
+    "V": [
+      "Pre"
+    ]
+  },
+  {
+    "_id": 1009,
+    "Ver": "1.0",
+    "Name": "Asta",
+    "Desc": "The lead researcher of Herta Space Station and a lady from a renowned family.<br>She's an astronomer overflowing with curiosity, and excels at managing the disparate staff of the space station.",
+    "Rarity": 4,
+    "Element": "Fire",
+    "Path": "Harmony",
+    "SP": 120.0,
+    "Skills": [
+      100901,
+      100902,
+      100903,
+      100904,
+      100906,
+      100907
+    ],
+    "Ranks": [
+      100901,
+      100902,
+      100903,
+      100904,
+      100905,
+      100906
+    ],
+    "Icon": "avatarshopicon/1009",
+    "Pic": "avatardrawcard/1009.png",
+    "Mat": [
+      112003,
+      110402,
+      110163,
+      110501
+    ],
+    "Stats": {
+      "HP": 1023.12,
+      "ATK": 511.56,
+      "DEF": 463.05,
+      "SPD": 106.0,
+      "Aggro": 100.0
+    },
+    "CV": [
+      "龟娘",
+      "Felecia Angelle",
+      "赤﨑千夏",
+      "김현지"
+    ],
+    "Camp": 102,
+    "ISN": "",
+    "ISD": "",
+    "V": [
+      "Pre"
+    ]
+  },
+  {
+    "_id": 1013,
+    "Ver": "1.0",
+    "Name": "Herta",
+    "Desc": "Member 83 of the Genius Society. The real master of the space station.<br>An incredibly intelligent yet unsympathetic scientist.",
+    "Rarity": 4,
+    "Element": "Ice",
+    "Path": "Erudition",
+    "SP": 110.0,
+    "Skills": [
+      101301,
+      101302,
+      101303,
+      101304,
+      101306,
+      101307
+    ],
+    "Ranks": [
+      101301,
+      101302,
+      101303,
+      101304,
+      101305,
+      101306
+    ],
+    "Icon": "avatarshopicon/1013",
+    "Pic": "avatardrawcard/1013.png",
+    "Mat": [
+      111003,
+      110403,
+      110133,
+      110501
+    ],
+    "Stats": {
+      "HP": 952.56,
+      "ATK": 582.12,
+      "DEF": 396.9,
+      "SPD": 100.0,
+      "Aggro": 75.0
+    },
+    "CV": [
+      "侯小菲",
+      "PJ Mattson",
+      "山崎はるか",
+      "김서영"
+    ],
+    "Camp": 102,
+    "ISN": "",
+    "ISD": "",
+    "V": [
+      "Pre"
+    ]
+  },
+  {
+    "_id": 1101,
+    "Ver": "1.0",
+    "Name": "Bronya",
+    "Desc": "Heir apparent to the Supreme Guardian of Belobog.<br>She possesses pride befitting of a princess, but also the determination and integrity of a soldier.",
+    "Rarity": 5,
+    "Element": "Wind",
+    "Path": "Harmony",
+    "SP": 120.0,
+    "Skills": [
+      110101,
+      110102,
+      110103,
+      110104,
+      110106,
+      110107
+    ],
+    "Ranks": [
+      110101,
+      110102,
+      110103,
+      110104,
+      110105,
+      110106
+    ],
+    "Icon": "avatarshopicon/1101",
+    "Pic": "avatardrawcard/1101.png",
+    "Mat": [
+      112003,
+      110405,
+      110163,
+      110502
+    ],
+    "Stats": {
+      "HP": 1241.856,
+      "ATK": 582.12,
+      "DEF": 533.61,
+      "SPD": 99.0,
+      "Aggro": 100.0
+    },
+    "CV": [
+      "谢莹",
+      "Madeline Reiter",
+      "阿澄佳奈",
+      "이보희"
+    ],
+    "Camp": 103,
+    "ISN": "",
+    "ISD": "",
+    "V": [
+      "Pre"
+    ]
+  },
+  {
+    "_id": 1102,
+    "Ver": "1.0",
+    "Name": "Seele",
+    "Desc": "A resident of the Underworld and the backbone of Wildfire. She goes by the alias \"Babochka.\"<br>She has a frank personality, but there is a delicate and sensitive hidden side to her deep in her heart.",
+    "Rarity": 5,
+    "Element": "Quantum",
+    "Path": "Hunt",
+    "SP": 120.0,
+    "Skills": [
+      110201,
+      110202,
+      110203,
+      110204,
+      110206,
+      110207
+    ],
+    "Ranks": [
+      110201,
+      110202,
+      110203,
+      110204,
+      110205,
+      110206
+    ],
+    "Icon": "avatarshopicon/1102",
+    "Pic": "avatardrawcard/1102.png",
+    "Mat": [
+      111013,
+      110406,
+      110123,
+      110502
+    ],
+    "Stats": {
+      "HP": 931.392,
+      "ATK": 640.332,
+      "DEF": 363.825,
+      "SPD": 115.0,
+      "Aggro": 75.0
+    },
+    "CV": [
+      "唐雅菁",
+      "Molly Zhang",
+      "中原麻衣",
+      "송하림"
+    ],
+    "Camp": 103,
+    "ISN": "",
+    "ISD": "",
+    "V": [
+      "Pre"
+    ]
+  },
+  {
+    "_id": 1103,
+    "Ver": "1.0",
+    "Name": "Serval",
+    "Desc": "A Belobog mechanic who used to be a researcher for the Technology Division of the Architects.<br>As Gepard Landau's elder sister, her personality stands in stark contrast to her brother's.<br>She loves an ancient form of music known as \"rock 'n' roll\" that was popular before the Eternal Freeze.",
+    "Rarity": 4,
+    "Element": "Elec",
+    "Path": "Erudition",
+    "SP": 100.0,
+    "Skills": [
+      110301,
+      110302,
+      110303,
+      110304,
+      110306,
+      110307
+    ],
+    "Ranks": [
+      110301,
+      110302,
+      110303,
+      110304,
+      110305,
+      110306
+    ],
+    "Icon": "avatarshopicon/1103",
+    "Pic": "avatardrawcard/1103.png",
+    "Mat": [
+      112003,
+      110404,
+      110133,
+      110502
+    ],
+    "Stats": {
+      "HP": 917.28,
+      "ATK": 652.68,
+      "DEF": 374.85,
+      "SPD": 104.0,
+      "Aggro": 75.0
+    },
+    "CV": [
+      "穆雪婷",
+      "Natalie Van Sistine",
+      "愛美",
+      "민아"
+    ],
+    "Camp": 103,
+    "ISN": "",
+    "ISD": "",
+    "V": [
+      "Pre"
+    ]
+  },
+  {
+    "_id": 1104,
+    "Ver": "1.0",
+    "Name": "Gepard",
+    "Desc": "A captain in the Silvermane Guards and an outstanding warrior of Belobog.<br>He is meticulous and vigilant to the core and is always true to himself.",
+    "Rarity": 5,
+    "Element": "Ice",
+    "Path": "Preservation",
+    "SP": 100.0,
+    "Skills": [
+      110401,
+      110402,
+      110403,
+      110404,
+      110406,
+      110407
+    ],
+    "Ranks": [
+      110401,
+      110402,
+      110403,
+      110404,
+      110405,
+      110406
+    ],
+    "Icon": "avatarshopicon/1104",
+    "Pic": "avatardrawcard/1104.png",
+    "Mat": [
+      112003,
+      110403,
+      110143,
+      110502
+    ],
+    "Stats": {
+      "HP": 1397.088,
+      "ATK": 543.312,
+      "DEF": 654.885,
+      "SPD": 92.0,
+      "Aggro": 150.0
+    },
+    "CV": [
+      "马洋",
+      "Bryson Baugus",
+      "古川慎",
+      "민승우"
+    ],
+    "Camp": 103,
+    "ISN": "",
+    "ISD": "",
+    "V": [
+      "Pre"
+    ]
+  },
+  {
+    "_id": 1105,
+    "Ver": "1.0",
+    "Name": "Natasha",
+    "Desc": "A doctor from the Underworld and a caregiver of children.<br>Alongside her kindness and caring, she also has a hidden dangerous side.",
+    "Rarity": 4,
+    "Element": "Phys",
+    "Path": "Abundance",
+    "SP": 90.0,
+    "Skills": [
+      110501,
+      110502,
+      110503,
+      110504,
+      110506,
+      110507
+    ],
+    "Ranks": [
+      110501,
+      110502,
+      110503,
+      110504,
+      110505,
+      110506
+    ],
+    "Icon": "avatarshopicon/1105",
+    "Pic": "avatardrawcard/1105.png",
+    "Mat": [
+      112013,
+      110401,
+      110173,
+      110502
+    ],
+    "Stats": {
+      "HP": 1164.24,
+      "ATK": 476.28,
+      "DEF": 507.15,
+      "SPD": 98.0,
+      "Aggro": 100.0
+    },
+    "CV": [
+      "秦紫翼",
+      "Elizabeth Maxwell",
+      "内山夕実",
+      "강은애"
+    ],
+    "Camp": 103,
+    "ISN": "",
+    "ISD": "",
+    "V": [
+      "Pre"
+    ]
+  },
+  {
+    "_id": 1106,
+    "Ver": "1.0",
+    "Name": "Pela",
+    "Desc": "An intelligence officer for the Silvermane Guards.<br>She has a serious personality and is revered by other members of the Silvermane Guards.",
+    "Rarity": 4,
+    "Element": "Ice",
+    "Path": "Nihility",
+    "SP": 110.0,
+    "Skills": [
+      110601,
+      110602,
+      110603,
+      110604,
+      110606,
+      110607
+    ],
+    "Ranks": [
+      110601,
+      110602,
+      110603,
+      110604,
+      110605,
+      110606
+    ],
+    "Icon": "avatarshopicon/1106",
+    "Pic": "avatardrawcard/1106.png",
+    "Mat": [
+      111003,
+      110403,
+      110153,
+      110502
+    ],
+    "Stats": {
+      "HP": 987.84,
+      "ATK": 546.84,
+      "DEF": 463.05,
+      "SPD": 105.0,
+      "Aggro": 100.0
+    },
+    "CV": [
+      "宴宁",
+      "Xanthe Huynh",
+      "諸星すみれ",
+      "이다은"
+    ],
+    "Camp": 103,
+    "ISN": "",
+    "ISD": "",
+    "V": [
+      "Pre"
+    ]
+  },
+  {
+    "_id": 1107,
+    "Ver": "1.0",
+    "Name": "Clara",
+    "Desc": "A vagrant girl who lives with robots.<br>She is introverted, gentle, and has a pure heart.<br>She wishes for all Underworlders to become a family.",
+    "Rarity": 5,
+    "Element": "Phys",
+    "Path": "Destruction",
+    "SP": 110.0,
+    "Skills": [
+      110701,
+      110702,
+      110703,
+      110704,
+      110706,
+      110707
+    ],
+    "Ranks": [
+      110701,
+      110702,
+      110703,
+      110704,
+      110705,
+      110706
+    ],
+    "Icon": "avatarshopicon/1107",
+    "Pic": "avatardrawcard/1107.png",
+    "Mat": [
+      112013,
+      110401,
+      110113,
+      110502
+    ],
+    "Stats": {
+      "HP": 1241.856,
+      "ATK": 737.352,
+      "DEF": 485.1,
+      "SPD": 90.0,
+      "Aggro": 125.0
+    },
+    "CV": [
+      "紫苏九月&王宇航",
+      "Emily Sun & D.C. Douglas",
+      "日高里菜&安元洋貴",
+      "김예림&최낙윤"
+    ],
+    "Camp": 103,
+    "ISN": "",
+    "ISD": "",
+    "V": [
+      "Pre"
+    ]
+  },
+  {
+    "_id": 1108,
+    "Ver": "1.0",
+    "Name": "Sampo",
+    "Desc": "A merchant who freely travels between the Overworld and the Underworld.<br>He acts like he is everyone's friend, is enthusiastically humorous, and is good at bantering.",
+    "Rarity": 4,
+    "Element": "Wind",
+    "Path": "Nihility",
+    "SP": 120.0,
+    "Skills": [
+      110801,
+      110802,
+      110803,
+      110804,
+      110806,
+      110807
+    ],
+    "Ranks": [
+      110801,
+      110802,
+      110803,
+      110804,
+      110805,
+      110806
+    ],
+    "Icon": "avatarshopicon/1108",
+    "Pic": "avatardrawcard/1108.png",
+    "Mat": [
+      112013,
+      110405,
+      110153,
+      110502
+    ],
+    "Stats": {
+      "HP": 1023.12,
+      "ATK": 617.4,
+      "DEF": 396.9,
+      "SPD": 102.0,
+      "Aggro": 100.0
+    },
+    "CV": [
+      "刘圣博",
+      "Roger Rose",
+      "平川大輔",
+      "정재헌"
+    ],
+    "Camp": 103,
+    "ISN": "",
+    "ISD": "",
+    "V": [
+      "Pre"
+    ]
+  },
+  {
+    "_id": 1109,
+    "Ver": "1.0",
+    "Name": "Hook",
+    "Desc": "Boss (self-proclaimed) of an Underworld adventure squad, The Moles.<br>She loves freedom and sees life as a series of adventures.",
+    "Rarity": 4,
+    "Element": "Fire",
+    "Path": "Destruction",
+    "SP": 120.0,
+    "Skills": [
+      110901,
+      110902,
+      110903,
+      110904,
+      110906,
+      110907,
+      110909
+    ],
+    "Ranks": [
+      110901,
+      110902,
+      110903,
+      110904,
+      110905,
+      110906
+    ],
+    "Icon": "avatarshopicon/1109",
+    "Pic": "avatardrawcard/1109.png",
+    "Mat": [
+      112013,
+      110402,
+      110113,
+      110502
+    ],
+    "Stats": {
+      "HP": 1340.64,
+      "ATK": 617.4,
+      "DEF": 352.8,
+      "SPD": 94.0,
+      "Aggro": 125.0
+    },
+    "CV": [
+      "王晓彤",
+      "Felecia Angelle",
+      "徳井青空",
+      "이재현"
+    ],
+    "Camp": 103,
+    "ISN": "",
+    "ISD": "",
+    "V": [
+      "Pre"
+    ]
+  },
+  {
+    "_id": 1201,
+    "Ver": "1.0",
+    "Name": "Qingque",
+    "Desc": "Diviner of the Divination Commission on the Xianzhou Luofu, and a librarian.<br>Always slacks off and is about to be demoted to a \"door guardian.\"",
+    "Rarity": 4,
+    "Element": "Quantum",
+    "Path": "Erudition",
+    "SP": 140.0,
+    "Skills": [
+      120101,
+      120108,
+      120102,
+      120103,
+      120104,
+      120106,
+      120107
+    ],
+    "Ranks": [
+      120101,
+      120102,
+      120103,
+      120104,
+      120105,
+      120106
+    ],
+    "Icon": "avatarshopicon/1201",
+    "Pic": "avatardrawcard/1201.png",
+    "Mat": [
+      111013,
+      110406,
+      110133,
+      110502
+    ],
+    "Stats": {
+      "HP": 1023.12,
+      "ATK": 652.68,
+      "DEF": 441.0,
+      "SPD": 98.0,
+      "Aggro": 75.0
+    },
+    "CV": [
+      "刘十四",
+      "Bryn Apprill",
+      "伊達朱里紗",
+      "서다혜"
+    ],
+    "Camp": 104,
+    "ISN": "",
+    "ISD": "",
+    "V": [
+      "Pre"
+    ]
+  },
+  {
+    "_id": 1202,
+    "Ver": "1.0",
+    "Name": "Tingyun",
+    "Desc": "Amicassador of the Sky-Faring Commission of the Xianzhou Luofu.<br>She travels with business delegates, forging trade relationships and alliances with many worlds.",
+    "Rarity": 4,
+    "Element": "Elec",
+    "Path": "Harmony",
+    "SP": 130.0,
+    "Skills": [
+      120201,
+      120202,
+      120203,
+      120204,
+      120206,
+      120207
+    ],
+    "Ranks": [
+      120201,
+      120202,
+      120203,
+      120204,
+      120205,
+      120206
+    ],
+    "Icon": "avatarshopicon/1202",
+    "Pic": "avatardrawcard/1202.png",
+    "Mat": [
+      113003,
+      110404,
+      110163,
+      110501
+    ],
+    "Stats": {
+      "HP": 846.72,
+      "ATK": 529.2,
+      "DEF": 396.9,
+      "SPD": 112.0,
+      "Aggro": 100.0
+    },
+    "CV": [
+      "蒋丽",
+      "Laci Morgan",
+      "高田憂希",
+      "이명호"
+    ],
+    "Camp": 104,
+    "ISN": "",
+    "ISD": "",
+    "V": [
+      "Pre"
+    ]
+  },
+  {
+    "_id": 1204,
+    "Ver": "1.0",
+    "Name": "Jing Yuan",
+    "Desc": "The Divine Foresight, one of the Seven Arbiter-Generals of the Xianzhou Alliance, leads the Cloud Knights of the Xianzhou Luofu.<br>A student of the Luofu's previous Sword Champion, though not known for his martial prowess.",
+    "Rarity": 5,
+    "Element": "Elec",
+    "Path": "Erudition",
+    "SP": 130.0,
+    "Skills": [
+      120401,
+      120402,
+      120403,
+      120404,
+      120406,
+      120407
+    ],
+    "Ranks": [
+      120401,
+      120402,
+      120403,
+      120404,
+      120405,
+      120406
+    ],
+    "Icon": "avatarshopicon/1204",
+    "Pic": "avatardrawcard/1204.png",
+    "Mat": [
+      113003,
+      110414,
+      110133,
+      110501
+    ],
+    "Stats": {
+      "HP": 1164.24,
+      "ATK": 698.544,
+      "DEF": 485.1,
+      "SPD": 99.0,
+      "Aggro": 75.0
+    },
+    "CV": [
+      "孙晔",
+      "Alejandro Saab",
+      "小野大輔",
+      "류승곤"
+    ],
+    "Camp": 104,
+    "ISN": "",
+    "ISD": "",
+    "V": [
+      "Pre"
+    ]
+  },
+  {
+    "_id": 1206,
+    "Ver": "1.0",
+    "Name": "Sushang",
+    "Desc": "Born on the Xianzhou Yaoqing, sent to the Cloud Knights of the Luofu for military training.<br>She wields her family sword, a gift from her mother, and longs for the future she will go on to write.",
+    "Rarity": 4,
+    "Element": "Phys",
+    "Path": "Hunt",
+    "SP": 120.0,
+    "Skills": [
+      120601,
+      120602,
+      120603,
+      120604,
+      120606,
+      120607
+    ],
+    "Ranks": [
+      120601,
+      120602,
+      120603,
+      120604,
+      120605,
+      120606
+    ],
+    "Icon": "avatarshopicon/1206",
+    "Pic": "avatardrawcard/1206.png",
+    "Mat": [
+      113013,
+      110401,
+      110123,
+      110502
+    ],
+    "Stats": {
+      "HP": 917.28,
+      "ATK": 564.48,
+      "DEF": 418.95,
+      "SPD": 107.0,
+      "Aggro": 75.0
+    },
+    "CV": [
+      "陈婷婷",
+      "Anjali Kunapaneni",
+      "福圓美里",
+      "박시윤"
+    ],
+    "Camp": 104,
+    "ISN": "",
+    "ISD": "",
+    "V": [
+      "Pre"
+    ]
+  },
+  {
+    "_id": 1209,
+    "Ver": "1.0",
+    "Name": "Yanqing",
+    "Desc": "General Jing Yuan's retainer. A gifted swordsman who hasn't even come of age.<br>No one can best Yanqing when he holds a sword in hand.",
+    "Rarity": 5,
+    "Element": "Ice",
+    "Path": "Hunt",
+    "SP": 140.0,
+    "Skills": [
+      120901,
+      120902,
+      120903,
+      120904,
+      120906,
+      120907
+    ],
+    "Ranks": [
+      120901,
+      120902,
+      120903,
+      120904,
+      120905,
+      120906
+    ],
+    "Icon": "avatarshopicon/1209",
+    "Pic": "avatardrawcard/1209.png",
+    "Mat": [
+      111013,
+      110413,
+      110123,
+      110502
+    ],
+    "Stats": {
+      "HP": 892.584,
+      "ATK": 679.14,
+      "DEF": 412.335,
+      "SPD": 109.0,
+      "Aggro": 75.0
+    },
+    "CV": [
+      "喵酱",
+      "Amber May",
+      "井上麻里奈",
+      "이새아"
+    ],
+    "Camp": 104,
+    "ISN": "",
+    "ISD": "",
+    "V": [
+      "Pre"
+    ]
+  },
+  {
+    "_id": 1211,
+    "Ver": "1.0",
+    "Name": "Bailu",
+    "Desc": "The High Elder of the Vidyadhara, who is also known as the \"Healer Lady\" on the Luofu.<br>She uses her unique medical science and the medical treatment that can only be provided by the Vidyadhara dragon race to save lives.",
+    "Rarity": 5,
+    "Element": "Elec",
+    "Path": "Abundance",
+    "SP": 100.0,
+    "Skills": [
+      121101,
+      121102,
+      121103,
+      121104,
+      121106,
+      121107
+    ],
+    "Ranks": [
+      121101,
+      121102,
+      121103,
+      121104,
+      121105,
+      121106
+    ],
+    "Icon": "avatarshopicon/1211",
+    "Pic": "avatardrawcard/1211.png",
+    "Mat": [
+      111003,
+      110404,
+      110173,
+      110502
+    ],
+    "Stats": {
+      "HP": 1319.472,
+      "ATK": 562.716,
+      "DEF": 485.1,
+      "SPD": 98.0,
+      "Aggro": 100.0
+    },
+    "CV": [
+      "多多",
+      "Su Ling Chan",
+      "加藤英美里",
+      "조현정"
+    ],
+    "Camp": 104,
+    "ISN": "",
+    "ISD": "",
+    "V": [
+      "Pre"
+    ]
+  },
+  {
+    "_id": 8001,
+    "Ver": "1.0",
+    "Name": "Trailblazer",
+    "Desc": "A {F#girl}{M#boy} who boarded the Astral Express.<br>{F#She}{M#He} chose to travel with the Astral Express to eliminate the dangers posed by the Stellaron.",
+    "Rarity": 5,
+    "Element": "Phys",
+    "Path": "Destruction",
+    "SP": 120.0,
+    "Skills": [
+      800101,
+      800102,
+      800103,
+      800104,
+      800106,
+      800107,
+      800108,
+      800109
+    ],
+    "Ranks": [
+      800101,
+      800102,
+      800103,
+      800104,
+      800105,
+      800106
+    ],
+    "Icon": "avatarshopicon/8001",
+    "Pic": "avatardrawcard/8001.png",
+    "Mat": [
+      111013,
+      110400,
+      110113,
+      110501
+    ],
+    "Stats": {
+      "HP": 1203.048,
+      "ATK": 620.928,
+      "DEF": 460.845,
+      "SPD": 100.0,
+      "Aggro": 125.0
+    },
+    "CV": [
+      "秦且歌",
+      "Caleb Yen",
+      "榎木淳弥",
+      "김명준"
+    ],
+    "Camp": 100,
+    "ISN": "",
+    "ISD": "",
+    "V": [
+      "Pre"
+    ]
+  },
+  {
+    "_id": 8002,
+    "Ver": "1.0",
+    "Name": "Trailblazer",
+    "Desc": "A {F#girl}{M#boy} who boarded the Astral Express.<br>{F#She}{M#He} chose to travel with the Astral Express to eliminate the dangers posed by the Stellaron.",
+    "Rarity": 5,
+    "Element": "Phys",
+    "Path": "Destruction",
+    "SP": 120.0,
+    "Skills": [
+      800201,
+      800202,
+      800203,
+      800204,
+      800206,
+      800207,
+      800208,
+      800209
+    ],
+    "Ranks": [
+      800201,
+      800202,
+      800203,
+      800204,
+      800205,
+      800206
+    ],
+    "Icon": "avatarshopicon/8002",
+    "Pic": "avatardrawcard/8002.png",
+    "Mat": [
+      111013,
+      110400,
+      110113,
+      110501
+    ],
+    "Stats": {
+      "HP": 1203.048,
+      "ATK": 620.928,
+      "DEF": 460.845,
+      "SPD": 100.0,
+      "Aggro": 125.0
+    },
+    "CV": [
+      "陈婷婷",
+      "Rachael Chau",
+      "石川由依",
+      "김하루"
+    ],
+    "Camp": 100,
+    "ISN": "",
+    "ISD": "",
+    "V": [
+      "Pre"
+    ]
+  },
+  {
+    "_id": 8003,
+    "Ver": "1.0",
+    "Name": "Trailblazer",
+    "Desc": "A {F#girl}{M#boy} who boarded the Astral Express.<br>{F#She}{M#He} chose to travel with the Astral Express to eliminate the dangers posed by the Stellaron.",
+    "Rarity": 5,
+    "Element": "Fire",
+    "Path": "Preservation",
+    "SP": 120.0,
+    "Skills": [
+      800301,
+      800308,
+      800302,
+      800303,
+      800304,
+      800306,
+      800307
+    ],
+    "Ranks": [
+      800301,
+      800302,
+      800303,
+      800304,
+      800305,
+      800306
+    ],
+    "Icon": "avatarshopicon/8003",
+    "Pic": "avatardrawcard/8003.png",
+    "Mat": [
+      111013,
+      110400,
+      110143,
+      110501
+    ],
+    "Stats": {
+      "HP": 1241.856,
+      "ATK": 601.524,
+      "DEF": 606.375,
+      "SPD": 95.0,
+      "Aggro": 150.0
+    },
+    "CV": [
+      "",
+      "",
+      "",
+      ""
+    ],
+    "Camp": 0,
+    "ISN": "",
+    "ISD": "",
+    "V": [
+      "Pre"
+    ]
+  },
+  {
+    "_id": 8004,
+    "Ver": "1.0",
+    "Name": "Trailblazer",
+    "Desc": "A {F#girl}{M#boy} who boarded the Astral Express.<br>{F#She}{M#He} chose to travel with the Astral Express to eliminate the dangers posed by the Stellaron.",
+    "Rarity": 5,
+    "Element": "Fire",
+    "Path": "Preservation",
+    "SP": 120.0,
+    "Skills": [
+      800401,
+      800408,
+      800402,
+      800403,
+      800404,
+      800406,
+      800407
+    ],
+    "Ranks": [
+      800401,
+      800402,
+      800403,
+      800404,
+      800405,
+      800406
+    ],
+    "Icon": "avatarshopicon/8004",
+    "Pic": "avatardrawcard/8004.png",
+    "Mat": [
+      111013,
+      110400,
+      110143,
+      110501
+    ],
+    "Stats": {
+      "HP": 1241.856,
+      "ATK": 601.524,
+      "DEF": 606.375,
+      "SPD": 95.0,
+      "Aggro": 150.0
+    },
+    "CV": [
+      "",
+      "",
+      "",
+      ""
+    ],
+    "Camp": 0,
+    "ISN": "",
+    "ISD": "",
+    "V": [
+      "Pre"
+    ]
+  }
+]
+
+var _item = {
+  "110111": {
+    "Name": "Shattered Blade",
+    "Icon": "itemicon/110111.png"
+  },
+  "110112": {
+    "Name": "Lifeless Blade",
+    "Icon": "itemicon/110112.png"
+  },
+  "110113": {
+    "Name": "Worldbreaker Blade",
+    "Icon": "itemicon/110113.png"
+  },
+  "110121": {
+    "Name": "Arrow of the Beast Hunter",
+    "Icon": "itemicon/110121.png"
+  },
+  "110122": {
+    "Name": "Arrow of the Demon Slayer",
+    "Icon": "itemicon/110122.png"
+  },
+  "110123": {
+    "Name": "Arrow of the Starchaser",
+    "Icon": "itemicon/110123.png"
+  },
+  "110131": {
+    "Name": "Key of Inspiration",
+    "Icon": "itemicon/110131.png"
+  },
+  "110132": {
+    "Name": "Key of Knowledge",
+    "Icon": "itemicon/110132.png"
+  },
+  "110133": {
+    "Name": "Key of Wisdom",
+    "Icon": "itemicon/110133.png"
+  },
+  "110141": {
+    "Name": "Endurance of Bronze",
+    "Icon": "itemicon/110141.png"
+  },
+  "110142": {
+    "Name": "Oath of Steel",
+    "Icon": "itemicon/110142.png"
+  },
+  "110143": {
+    "Name": "Safeguard of Amber",
+    "Icon": "itemicon/110143.png"
+  },
+  "110151": {
+    "Name": "Obsidian of Dread",
+    "Icon": "itemicon/110151.png"
+  },
+  "110152": {
+    "Name": "Obsidian of Desolation",
+    "Icon": "itemicon/110152.png"
+  },
+  "110153": {
+    "Name": "Obsidian of Obsession",
+    "Icon": "itemicon/110153.png"
+  },
+  "110161": {
+    "Name": "Harmonic Tune",
+    "Icon": "itemicon/110161.png"
+  },
+  "110162": {
+    "Name": "Ancestral Hymn",
+    "Icon": "itemicon/110162.png"
+  },
+  "110163": {
+    "Name": "Stellaris Symphony",
+    "Icon": "itemicon/110163.png"
+  },
+  "110171": {
+    "Name": "Seed of Abundance",
+    "Icon": "itemicon/110171.png"
+  },
+  "110172": {
+    "Name": "Sprout of Life",
+    "Icon": "itemicon/110172.png"
+  },
+  "110173": {
+    "Name": "Flower of Eternity",
+    "Icon": "itemicon/110173.png"
+  },
+  "110181": {
+    "Name": "Borisin Teeth",
+    "Icon": "itemicon/110181.png"
+  },
+  "110182": {
+    "Name": "Lupitoxin Sawteeth",
+    "Icon": "itemicon/110182.png"
+  },
+  "110183": {
+    "Name": "Moon Rave Fang",
+    "Icon": "itemicon/110183.png"
+  },
+  "110191": {
+    "Name": "Meteoric Bullet",
+    "Icon": "itemicon/110191.png"
+  },
+  "110192": {
+    "Name": "Destined Expiration",
+    "Icon": "itemicon/110192.png"
+  },
+  "110193": {
+    "Name": "Countertemporal Shot",
+    "Icon": "itemicon/110193.png"
+  },
+  "110201": {
+    "Name": "Rough Sketch",
+    "Icon": "itemicon/110201.png"
+  },
+  "110202": {
+    "Name": "Dynamic Outlining",
+    "Icon": "itemicon/110202.png"
+  },
+  "110203": {
+    "Name": "Exquisite Colored Draft",
+    "Icon": "itemicon/110203.png"
+  },
+  "110211": {
+    "Name": "Scattered Stardust",
+    "Icon": "itemicon/110211.png"
+  },
+  "110212": {
+    "Name": "Crystal Meteorites",
+    "Icon": "itemicon/110212.png"
+  },
+  "110213": {
+    "Name": "Divine Amber",
+    "Icon": "itemicon/110213.png"
+  },
+  "110221": {
+    "Name": "Fiery Spirit",
+    "Icon": "itemicon/110221.png"
+  },
+  "110222": {
+    "Name": "Starfire Essence",
+    "Icon": "itemicon/110222.png"
+  },
+  "110223": {
+    "Name": "Heaven Incinerator",
+    "Icon": "itemicon/110223.png"
+  },
+  "110231": {
+    "Name": "Firmament Note",
+    "Icon": "itemicon/110231.png"
+  },
+  "110232": {
+    "Name": "Celestial Section",
+    "Icon": "itemicon/110232.png"
+  },
+  "110233": {
+    "Name": "Heavenly Melody",
+    "Icon": "itemicon/110233.png"
+  },
+  "110241": {
+    "Name": "Alien Tree Seed",
+    "Icon": "itemicon/110241.png"
+  },
+  "110242": {
+    "Name": "Nourishing Honey",
+    "Icon": "itemicon/110242.png"
+  },
+  "110243": {
+    "Name": "Myriad Fruit",
+    "Icon": "itemicon/110243.png"
+  },
+  "110400": {
+    "Name": "Enigmatic Ectostella",
+    "Icon": "itemicon/110400.png"
+  },
+  "110401": {
+    "Name": "Broken Teeth of Iron Wolf",
+    "Icon": "itemicon/110401.png"
+  },
+  "110402": {
+    "Name": "Endotherm Chitin",
+    "Icon": "itemicon/110402.png"
+  },
+  "110403": {
+    "Name": "Horn of Snow",
+    "Icon": "itemicon/110403.png"
+  },
+  "110404": {
+    "Name": "Lightning Crown of the Past Shadow",
+    "Icon": "itemicon/110404.png"
+  },
+  "110405": {
+    "Name": "Storm Eye",
+    "Icon": "itemicon/110405.png"
+  },
+  "110406": {
+    "Name": "Void Cast Iron",
+    "Icon": "itemicon/110406.png"
+  },
+  "110407": {
+    "Name": "Golden Crown of the Past Shadow",
+    "Icon": "itemicon/110407.png"
+  },
+  "110411": {
+    "Name": "Netherworld Token",
+    "Icon": "itemicon/110411.png"
+  },
+  "110412": {
+    "Name": "Searing Steel Blade",
+    "Icon": "itemicon/110412.png"
+  },
+  "110413": {
+    "Name": "Gelid Chitin",
+    "Icon": "itemicon/110413.png"
+  },
+  "110414": {
+    "Name": "Shape Shifter's Lightning Staff",
+    "Icon": "itemicon/110414.png"
+  },
+  "110415": {
+    "Name": "Ascendant Debris",
+    "Icon": "itemicon/110415.png"
+  },
+  "110416": {
+    "Name": "Nail of the Ape",
+    "Icon": "itemicon/110416.png"
+  },
+  "110417": {
+    "Name": "Suppressing Edict",
+    "Icon": "itemicon/110417.png"
+  },
+  "114002": {
+    "Name": "Dream Flow Valve",
+    "Icon": "itemicon/114002.png"
+  },
+  "114003": {
+    "Name": "Dream Making Engine",
+    "Icon": "itemicon/114003.png"
+  },
+  "114001": {
+    "Name": "Dream Collection Component",
+    "Icon": "itemicon/114001.png"
+  },
+  "110421": {
+    "Name": "IPC Work Permit",
+    "Icon": "itemicon/110421.png"
+  },
+  "110422": {
+    "Name": "Raging Heart",
+    "Icon": "itemicon/110422.png"
+  },
+  "110423": {
+    "Name": "Dream Fridge",
+    "Icon": "itemicon/110423.png"
+  },
+  "110426": {
+    "Name": "Dream Flamer",
+    "Icon": "itemicon/110426.png"
+  },
+  "114011": {
+    "Name": "Tatters of Thought",
+    "Icon": "itemicon/114011.png"
+  },
+  "114012": {
+    "Name": "Fragments of Impression",
+    "Icon": "itemicon/114012.png"
+  },
+  "114013": {
+    "Name": "Shards of Desires",
+    "Icon": "itemicon/114013.png"
+  },
+  "113001": {
+    "Name": "Immortal Scionette",
+    "Icon": "itemicon/113001.png"
+  },
+  "113002": {
+    "Name": "Immortal Aeroblossom",
+    "Icon": "itemicon/113002.png"
+  },
+  "113003": {
+    "Name": "Immortal Lumintwig",
+    "Icon": "itemicon/113003.png"
+  },
+  "113011": {
+    "Name": "Artifex's Module",
+    "Icon": "itemicon/113011.png"
+  },
+  "113012": {
+    "Name": "Artifex's Cogwheel",
+    "Icon": "itemicon/113012.png"
+  },
+  "113013": {
+    "Name": "Artifex's Gyreheart",
+    "Icon": "itemicon/113013.png"
+  },
+  "112001": {
+    "Name": "Silvermane Badge",
+    "Icon": "itemicon/112001.png"
+  },
+  "112002": {
+    "Name": "Silvermane Insignia",
+    "Icon": "itemicon/112002.png"
+  },
+  "112003": {
+    "Name": "Silvermane Medal",
+    "Icon": "itemicon/112003.png"
+  },
+  "112011": {
+    "Name": "Ancient Part",
+    "Icon": "itemicon/112011.png"
+  },
+  "112012": {
+    "Name": "Ancient Spindle",
+    "Icon": "itemicon/112012.png"
+  },
+  "112013": {
+    "Name": "Ancient Engine",
+    "Icon": "itemicon/112013.png"
+  },
+  "111001": {
+    "Name": "Extinguished Core",
+    "Icon": "itemicon/111001.png"
+  },
+  "111002": {
+    "Name": "Glimmering Core",
+    "Icon": "itemicon/111002.png"
+  },
+  "111003": {
+    "Name": "Squirming Core",
+    "Icon": "itemicon/111003.png"
+  },
+  "111011": {
+    "Name": "Thief's Instinct",
+    "Icon": "itemicon/111011.png"
+  },
+  "111012": {
+    "Name": "Usurper's Scheme",
+    "Icon": "itemicon/111012.png"
+  },
+  "110501": {
+    "Name": "Destroyer's Final Road",
+    "Icon": "itemicon/110501.png"
+  },
+  "111013": {
+    "Name": "Conqueror's Will",
+    "Icon": "itemicon/111013.png"
+  },
+  "110503": {
+    "Name": "Regret of Infinite Ochema",
+    "Icon": "itemicon/110503.png"
+  },
+  "110502": {
+    "Name": "Guardian's Lament",
+    "Icon": "itemicon/110502.png"
+  },
+  "110504": {
+    "Name": "Past Evils of the Borehole Planet Disaster",
+    "Icon": "itemicon/110504.png"
+  },
+  "110505": {
+    "Name": "Lost Echo of the Shared Wish",
+    "Icon": "itemicon/110505.png"
+  }
+}
+
+var _propiconname = {
+  "IceAddedRatio": "IconIceAddedRatio.png",
+  "DefenceAddedRatio": "IconDefence.png",
+  "StatusResistanceBase": "IconStatusResistance.png",
+  "WindAddedRatio": "IconWindAddedRatio.png",
+  "AttackAddedRatio": "IconAttack.png",
+  "FireAddedRatio": "IconFireAddedRatio.png",
+  "ImaginaryAddedRatio": "IconImaginaryAddedRatio.png",
+  "StatusProbabilityBase": "IconStatusProbability.png",
+  "HPAddedRatio": "IconMaxHP.png",
+  "QuantumAddedRatio": "IconQuantumAddedRatio.png",
+  "CriticalChanceBase": "IconCriticalChance.png",
+  "CriticalDamageBase": "IconCriticalDamage.png",
+  "PhysicalAddedRatio": "IconPhysicalAddedRatio.png",
+  "ThunderAddedRatio": "IconThunderAddedRatio.png",
+  "BreakDamageAddedRatioBase": "IconBreakUp.png",
+  "SpeedDelta": "IconSpeed.png"
+}
+
+var _propname = {
+  "IceAddedRatio": "DMG Boost: Ice",
+  "DefenceAddedRatio": "DEF Boost",
+  "StatusResistanceBase": "Effect RES Boost",
+  "WindAddedRatio": "DMG Boost: Wind",
+  "AttackAddedRatio": "ATK Boost",
+  "FireAddedRatio": "DMG Boost: Fire",
+  "ImaginaryAddedRatio": "DMG Boost: Imaginary",
+  "StatusProbabilityBase": "Effect Hit Rate Boost",
+  "HPAddedRatio": "HP Boost",
+  "QuantumAddedRatio": "DMG Boost: Quantum",
+  "CriticalChanceBase": "CRIT Rate Boost",
+  "CriticalDamageBase": "CRIT DMG Boost",
+  "PhysicalAddedRatio": "DMG Boost: Physical",
+  "ThunderAddedRatio": "DMG Boost: Lightning",
+  "BreakDamageAddedRatioBase": "Break Boost",
+  "SpeedDelta": "SPD Boost"
+}
+
+var _camp = {
+  "100": "Astral Express",
+  "101": "Stellaron Hunters",
+  "102": "Herta Space Station",
+  "103": "Belobog",
+  "104": "The Xianzhou Luofu",
+  "105": "Interastral Peace Corporation",
+  "106": "The Knights of Beauty",
+  "107": "Intelligentsia Guild",
+  "108": "Penacony",
+  "109": "Garden of Recollection",
+  "110": "Masked Fools",
+  "111": "Galaxy Ranger",
+  "112": "Self-Annihilator"
+}
+
+var _search_avatar = {
+  "1310": 0,
+  "流萤": 0,
+  "FIREFLY": 0,
+  "1314": 1,
+  "翡翠": 1,
+  "JADE": 1,
+  "1309": 2,
+  "知更鸟": 2,
+  "ROBIN": 2,
+  "1315": 3,
+  "波提欧": 3,
+  "BOOTHILL": 3,
+  "8005": 4,
+  "开拓者": 55,
+  "TRAILBLAZER": 55,
+  "8006": 5,
+  "1301": 6,
+  "加拉赫": 6,
+  "GALLAGHER": 6,
+  "1304": 7,
+  "砂金": 7,
+  "AVENTURINE": 7,
+  "1308": 8,
+  "黄泉": 8,
+  "ACHERON": 8,
+  "1306": 9,
+  "花火": 9,
+  "SPARKLE": 9,
+  "1307": 10,
+  "黑天鹅": 10,
+  "BLACKSWAN": 10,
+  "1312": 11,
+  "米沙": 11,
+  "MISHA": 11,
+  "1214": 12,
+  "雪衣": 12,
+  "XUEYI": 12,
+  "1303": 13,
+  "阮·梅": 13,
+  "RUANMEI": 13,
+  "1305": 14,
+  "真理医生": 14,
+  "DR.RATIO": 14,
+  "1215": 15,
+  "寒鸦": 15,
+  "HANYA": 15,
+  "1217": 16,
+  "藿藿": 16,
+  "HUOHUO": 16,
+  "1302": 17,
+  "银枝": 17,
+  "ARGENTI": 17,
+  "1112": 18,
+  "托帕&账账": 18,
+  "TOPAZ&NUMBY": 18,
+  "1210": 19,
+  "桂乃芬": 19,
+  "GUINAIFEN": 19,
+  "1212": 20,
+  "镜流": 20,
+  "JINGLIU": 20,
+  "1110": 21,
+  "玲可": 21,
+  "LYNX": 21,
+  "1208": 22,
+  "符玄": 22,
+  "FUXUAN": 22,
+  "1213": 23,
+  "丹恒·饮月": 23,
+  "DANHENG•IMBIBITORLUNAE": 23,
+  "1005": 24,
+  "卡芙卡": 24,
+  "KAFKA": 24,
+  "1111": 25,
+  "卢卡": 25,
+  "LUKA": 25,
+  "1205": 26,
+  "刃": 26,
+  "BLADE": 26,
+  "1006": 27,
+  "银狼": 27,
+  "SILVERWOLF": 27,
+  "1203": 28,
+  "罗刹": 28,
+  "LUOCHA": 28,
+  "1207": 29,
+  "驭空": 29,
+  "YUKONG": 29,
+  "1001": 30,
+  "三月七": 30,
+  "MARCH7TH": 30,
+  "1002": 31,
+  "丹恒": 31,
+  "DANHENG": 31,
+  "1003": 32,
+  "姬子": 32,
+  "HIMEKO": 32,
+  "1004": 33,
+  "瓦尔特": 33,
+  "WELT": 33,
+  "1008": 34,
+  "阿兰": 34,
+  "ARLAN": 34,
+  "1009": 35,
+  "艾丝妲": 35,
+  "ASTA": 35,
+  "1013": 36,
+  "黑塔": 36,
+  "HERTA": 36,
+  "1101": 37,
+  "布洛妮娅": 37,
+  "BRONYA": 37,
+  "1102": 38,
+  "希儿": 38,
+  "SEELE": 38,
+  "1103": 39,
+  "希露瓦": 39,
+  "SERVAL": 39,
+  "1104": 40,
+  "杰帕德": 40,
+  "GEPARD": 40,
+  "1105": 41,
+  "娜塔莎": 41,
+  "NATASHA": 41,
+  "1106": 42,
+  "佩拉": 42,
+  "PELA": 42,
+  "1107": 43,
+  "克拉拉": 43,
+  "CLARA": 43,
+  "1108": 44,
+  "桑博": 44,
+  "SAMPO": 44,
+  "1109": 45,
+  "虎克": 45,
+  "HOOK": 45,
+  "1201": 46,
+  "青雀": 46,
+  "QINGQUE": 46,
+  "1202": 47,
+  "停云": 47,
+  "TINGYUN": 47,
+  "1204": 48,
+  "景元": 48,
+  "JINGYUAN": 48,
+  "1206": 49,
+  "素裳": 49,
+  "SUSHANG": 49,
+  "1209": 50,
+  "彦卿": 50,
+  "YANQING": 50,
+  "1211": 51,
+  "白露": 51,
+  "BAILU": 51,
+  "8001": 52,
+  "8002": 53,
+  "8003": 54,
+  "8004": 55
+}
+
+var _search_weapon = {
+  "23028": 0,
+  "偏偏希望无价": 0,
+  "YETHOPEISPRICELESS": 0,
+  "23025": 1,
+  "梦应归于何处": 1,
+  "WHEREABOUTSSHOULDDREAMSREST": 1,
+  "24004": 2,
+  "不息的演算": 2,
+  "ETERNALCALCULUS": 2,
+  "21045": 3,
+  "谐乐静默之后": 3,
+  "AFTERTHECHARMONYFALL": 3,
+  "23027": 4,
+  "驶向第二次生命": 4,
+  "SAILINGTOWARDSASECONDLIFE": 4,
+  "23026": 5,
+  "夜色流光溢彩": 5,
+  "FLOWINGNIGHTGLOW": 5,
+  "23024": 6,
+  "行于流逝的岸": 6,
+  "ALONGTHEPASSINGSHORE": 6,
+  "23023": 7,
+  "命运从未公平": 7,
+  "INHERENTLYUNJUSTDESTINY": 7,
+  "23022": 8,
+  "重塑时光之忆": 8,
+  "REFORGEDREMEMBRANCE": 8,
+  "23021": 9,
+  "游戏尘寰": 9,
+  "EARTHLYESCAPADE": 9,
+  "23020": 10,
+  "纯粹思维的洗礼": 10,
+  "BAPTISMOFPURETHOUGHT": 10,
+  "23019": 11,
+  "镜中故我": 11,
+  "PASTSELFINMIRROR": 11,
+  "23018": 12,
+  "片刻，留在眼底": 12,
+  "ANINSTANTBEFOREAGAZE": 12,
+  "23017": 13,
+  "惊魂夜": 13,
+  "NIGHTOFFRIGHT": 13,
+  "23016": 14,
+  "烦恼着，幸福着": 14,
+  "WORRISOME,BLISSFUL": 14,
+  "23015": 15,
+  "比阳光更明亮的": 15,
+  "BRIGHTERTHANTHESUN": 15,
+  "23014": 16,
+  "此身为剑": 16,
+  "ISHALLBEMYOWNSWORD": 16,
+  "23013": 17,
+  "时节不居": 17,
+  "TIMEWAITSFORNOONE": 17,
+  "23012": 18,
+  "如泥酣眠": 18,
+  "SLEEPLIKETHEDEAD": 18,
+  "23011": 19,
+  "她已闭上双眼": 19,
+  "SHEALREADYSHUTHEREYES": 19,
+  "23010": 20,
+  "拂晓之前": 20,
+  "BEFOREDAWN": 20,
+  "23009": 21,
+  "到不了的彼岸": 21,
+  "THEUNREACHABLESIDE": 21,
+  "23008": 22,
+  "棺的回响": 22,
+  "ECHOESOFTHECOFFIN": 22,
+  "23007": 23,
+  "雨一直下": 23,
+  "INCESSANTRAIN": 23,
+  "23006": 24,
+  "只需等待": 24,
+  "PATIENCEISALLYOUNEED": 24,
+  "23005": 25,
+  "制胜的瞬间": 25,
+  "MOMENTOFVICTORY": 25,
+  "23004": 26,
+  "以世界之名": 26,
+  "INTHENAMEOFTHEWORLD": 26,
+  "23003": 27,
+  "但战斗还未结束": 27,
+  "BUTTHEBATTLEISNTOVER": 27,
+  "23002": 28,
+  "无可取代的东西": 28,
+  "SOMETHINGIRREPLACEABLE": 28,
+  "23001": 29,
+  "于夜色中": 29,
+  "INTHENIGHT": 29,
+  "23000": 30,
+  "银河铁道之夜": 30,
+  "NIGHTONTHEMILKYWAY": 30,
+  "24003": 31,
+  "孤独的疗愈": 31,
+  "SOLITARYHEALING": 31,
+  "24002": 32,
+  "记忆的质料": 32,
+  "TEXTUREOFMEMORIES": 32,
+  "24001": 33,
+  "星海巡航": 33,
+  "CRUISINGINTHESTELLARSEA": 33,
+  "24000": 34,
+  "记一位星神的陨落": 34,
+  "ONTHEFALLOFANAEON": 34,
+  "22002": 35,
+  "为了明日的旅途": 35,
+  "FORTOMORROWSJOURNEY": 35,
+  "22001": 36,
+  "嘿，我在这儿": 36,
+  "HEY,OVERHERE": 36,
+  "22000": 37,
+  "新手任务开始前": 37,
+  "BEFORETHETUTORIALMISSIONSTARTS": 37,
+  "21044": 38,
+  "无边曼舞": 38,
+  "BOUNDLESSCHOREO": 38,
+  "21043": 39,
+  "两个人的演唱会": 39,
+  "CONCERTFORTWO": 39,
+  "21042": 40,
+  "铭记于心的约定": 40,
+  "INDELIBLEPROMISE": 40,
+  "21041": 41,
+  "好戏开演": 41,
+  "ITSSHOWTIME": 41,
+  "21040": 42,
+  "银河沦陷日": 42,
+  "THEDAYTHECOSMOSFELL": 42,
+  "21039": 43,
+  "织造命运之线": 43,
+  "DESTINYSTHREADSFOREWOVEN": 43,
+  "21038": 44,
+  "在火的远处": 44,
+  "FLAMESAFAR": 44,
+  "21037": 45,
+  "最后的赢家": 45,
+  "FINALVICTOR": 45,
+  "21036": 46,
+  "美梦小镇大冒险": 46,
+  "DREAMVILLEADVENTURE": 46,
+  "21035": 47,
+  "何物为真": 47,
+  "WHATISREAL?": 47,
+  "21034": 48,
+  "今日亦是和平的一日": 48,
+  "TODAYISANOTHERPEACEFULDAY": 48,
+  "21033": 49,
+  "无处可逃": 49,
+  "NOWHERETORUN": 49,
+  "21032": 50,
+  "镂月裁云之意": 50,
+  "CARVETHEMOON,WEAVETHECLOUDS": 50,
+  "21031": 51,
+  "重返幽冥": 51,
+  "RETURNTODARKNESS": 51,
+  "21030": 52,
+  "这就是我啦！": 52,
+  "THISISME!": 52,
+  "21029": 53,
+  "后会有期": 53,
+  "WEWILLMEETAGAIN": 53,
+  "21028": 54,
+  "暖夜不会漫长": 54,
+  "WARMTHSHORTENSCOLDNIGHTS": 54,
+  "21027": 55,
+  "早餐的仪式感": 55,
+  "THESERIOUSNESSOFBREAKFAST": 55,
+  "21026": 56,
+  "汪！散步时间！": 56,
+  "WOOF!WALKTIME!": 56,
+  "21025": 57,
+  "过往未来": 57,
+  "PASTANDFUTURE": 57,
+  "21024": 58,
+  "春水初生": 58,
+  "RIVERFLOWSINSPRING": 58,
+  "21023": 59,
+  "我们是地火": 59,
+  "WEAREWILDFIRE": 59,
+  "21022": 60,
+  "延长记号": 60,
+  "FERMATA": 60,
+  "21021": 61,
+  "等价交换": 61,
+  "QUIDPROQUO": 61,
+  "21020": 62,
+  "天才们的休憩": 62,
+  "GENIUSESREPOSE": 62,
+  "21019": 63,
+  "在蓝天下": 63,
+  "UNDERTHEBLUESKY": 63,
+  "21018": 64,
+  "舞！舞！舞！": 64,
+  "DANCE!DANCE!DANCE!": 64,
+  "21017": 65,
+  "点个关注吧！": 65,
+  "SUBSCRIBEFORMORE!": 65,
+  "21016": 66,
+  "宇宙市场趋势": 66,
+  "TRENDOFTHEUNIVERSALMARKET": 66,
+  "21015": 67,
+  "决心如汗珠般闪耀": 67,
+  "RESOLUTIONSHINESASPEARLSOFSWEAT": 67,
+  "21014": 68,
+  "此时恰好": 68,
+  "PERFECTTIMING": 68,
+  "21013": 69,
+  "别让世界静下来": 69,
+  "MAKETHEWORLDCLAMOR": 69,
+  "21012": 70,
+  "秘密誓心": 70,
+  "ASECRETVOW": 70,
+  "21011": 71,
+  "与行星相会": 71,
+  "PLANETARYRENDEZVOUS": 71,
+  "21010": 72,
+  "论剑": 72,
+  "SWORDPLAY": 72,
+  "21009": 73,
+  "朗道的选择": 73,
+  "LANDAUSCHOICE": 73,
+  "21008": 74,
+  "猎物的视线": 74,
+  "EYESOFTHEPREY": 74,
+  "21007": 75,
+  "同一种心情": 75,
+  "SHAREDFEELING": 75,
+  "21006": 76,
+  "「我」的诞生": 76,
+  "THEBIRTHOFTHESELF": 76,
+  "21005": 77,
+  "鼹鼠党欢迎你": 77,
+  "THEMOLESWELCOMEYOU": 77,
+  "21004": 78,
+  "记忆中的模样": 78,
+  "MEMORIESOFTHEPAST": 78,
+  "21003": 79,
+  "唯有沉默": 79,
+  "ONLYSILENCEREMAINS": 79,
+  "21002": 80,
+  "余生的第一天": 80,
+  "DAYONEOFMYNEWLIFE": 80,
+  "21001": 81,
+  "晚安与睡颜": 81,
+  "GOODNIGHTANDSLEEPWELL": 81,
+  "21000": 82,
+  "一场术后对话": 82,
+  "POSTOPCONVERSATION": 82,
+  "20020": 83,
+  "睿见": 83,
+  "SAGACITY": 83,
+  "20019": 84,
+  "调和": 84,
+  "MEDIATION": 84,
+  "20018": 85,
+  "匿影": 85,
+  "HIDDENSHADOW": 85,
+  "20017": 86,
+  "开疆": 86,
+  "PIONEERING": 86,
+  "20016": 87,
+  "俱殁": 87,
+  "MUTUALDEMISE": 87,
+  "20015": 88,
+  "蕃息": 88,
+  "MULTIPLICATION": 88,
+  "20014": 89,
+  "相抗": 89,
+  "ADVERSARIAL": 89,
+  "20013": 90,
+  "灵钥": 90,
+  "PASSKEY": 90,
+  "20012": 91,
+  "轮契": 91,
+  "MESHINGCOGS": 91,
+  "20011": 92,
+  "渊环": 92,
+  "LOOP": 92,
+  "20010": 93,
+  "戍御": 93,
+  "DEFENSE": 93,
+  "20009": 94,
+  "乐圮": 94,
+  "SHATTEREDHOME": 94,
+  "20008": 95,
+  "嘉果": 95,
+  "FINEFRUIT": 95,
+  "20007": 96,
+  "离弦": 96,
+  "DARTINGARROW": 96,
+  "20006": 97,
+  "智库": 97,
+  "DATABANK": 97,
+  "20005": 98,
+  "齐颂": 98,
+  "CHORUS": 98,
+  "20004": 99,
+  "幽邃": 99,
+  "VOID": 99,
+  "20003": 100,
+  "琥珀": 100,
+  "AMBER": 100,
+  "20002": 101,
+  "天倾": 101,
+  "COLLAPSINGSKY": 101,
+  "20001": 102,
+  "物穰": 102,
+  "CORNUCOPIA": 102,
+  "20000": 103,
+  "锋镝": 103,
+  "ARROWS": 103
+}
+
+var _search_relic = {
+  "316": 0,
+  "劫火莲灯铸炼宫": 0,
+  "FORGEOFTHEKALPAGNILANTERN": 0,
+  "315": 1,
+  "奔狼的都蓝王朝": 1,
+  "DURAN,DYNASTYOFRUNNINGWOLVES": 1,
+  "314": 2,
+  "出云显世与高天神国": 2,
+  "IZUMOGENSEIANDTAKAMADIVINEREALM": 2,
+  "313": 3,
+  "无主荒星茨冈尼亚": 3,
+  "SIGONIA,THEUNCLAIMEDDESOLATION": 3,
+  "312": 4,
+  "梦想之地匹诺康尼": 4,
+  "PENACONY,LANDOFTHEDREAMS": 4,
+  "311": 5,
+  "苍穹战线格拉默": 5,
+  "FIRMAMENTFRONTLINE:GLAMOTH": 5,
+  "310": 6,
+  "折断的龙骨": 6,
+  "BROKENKEEL": 6,
+  "309": 7,
+  "繁星竞技场": 7,
+  "RUTILANTARENA": 7,
+  "308": 8,
+  "生命的翁瓦克": 8,
+  "SPRIGHTLYVONWACQ": 8,
+  "307": 9,
+  "盗贼公国塔利亚": 9,
+  "TALIA:KINGDOMOFBANDITRY": 9,
+  "306": 10,
+  "停转的萨尔索图": 10,
+  "INERTSALSOTTO": 10,
+  "305": 11,
+  "星体差分机": 11,
+  "CELESTIALDIFFERENTIATOR": 11,
+  "304": 12,
+  "筑城者的贝洛伯格": 12,
+  "BELOBOGOFTHEARCHITECTS": 12,
+  "303": 13,
+  "泛银河商业公司": 13,
+  "PANCOSMICCOMMERCIALENTERPRISE": 13,
+  "302": 14,
+  "不老者的仙舟": 14,
+  "FLEETOFTHEAGELESS": 14,
+  "301": 15,
+  "太空封印站": 15,
+  "SPACESEALINGSTATION": 15,
+  "120": 16,
+  "风举云飞的勇烈": 16,
+  "THEWINDSOARINGVALOROUS": 16,
+  "119": 17,
+  "荡除蠹灾的铁骑": 17,
+  "IRONCAVALRYAGAINSTTHESCOURGE": 17,
+  "118": 18,
+  "机心戏梦的钟表匠": 18,
+  "WATCHMAKER,MASTEROFDREAMMACHINATIONS": 18,
+  "117": 19,
+  "死水深潜的先驱": 19,
+  "PIONEERDIVEROFDEADWATERS": 19,
+  "116": 20,
+  "幽锁深牢的系囚": 20,
+  "PRISONERINDEEPCONFINEMENT": 20,
+  "115": 21,
+  "毁烬焚骨的大公": 21,
+  "THEASHBLAZINGGRANDDUKE": 21,
+  "114": 22,
+  "骇域漫游的信使": 22,
+  "MESSENGERTRAVERSINGHACKERSPACE": 22,
+  "113": 23,
+  "宝命长存的莳者": 23,
+  "LONGEVOUSDISCIPLE": 23,
+  "112": 24,
+  "盗匪荒漠的废土客": 24,
+  "WASTELANDEROFBANDITRYDESERT": 24,
+  "111": 25,
+  "流星追迹的怪盗": 25,
+  "THIEFOFSHOOTINGMETEOR": 25,
+  "110": 26,
+  "晨昏交界的翔鹰": 26,
+  "EAGLEOFTWILIGHTLINE": 26,
+  "109": 27,
+  "激奏雷电的乐队": 27,
+  "BANDOFSIZZLINGTHUNDER": 27,
+  "108": 28,
+  "繁星璀璨的天才": 28,
+  "GENIUSOFBRILLIANTSTARS": 28,
+  "107": 29,
+  "熔岩锻铸的火匠": 29,
+  "FIRESMITHOFLAVAFORGING": 29,
+  "106": 30,
+  "戍卫风雪的铁卫": 30,
+  "GUARDOFWUTHERINGSNOW": 30,
+  "105": 31,
+  "街头出身的拳王": 31,
+  "CHAMPIONOFSTREETWISEBOXING": 31,
+  "104": 32,
+  "密林卧雪的猎人": 32,
+  "HUNTEROFGLACIALFOREST": 32,
+  "103": 33,
+  "净庭教宗的圣骑士": 33,
+  "KNIGHTOFPURITYPALACE": 33,
+  "102": 34,
+  "野穗伴行的快枪手": 34,
+  "MUSKETEEROFWILDWHEAT": 34,
+  "101": 35,
+  "云无留迹的过客": 35,
+  "PASSERBYOFWANDERINGCLOUD": 35
+}
+
+var _changelog_avatar = {
+  "1310": {
+    "v2": [
+      "``Eidolon $2`Fixed the bug where the extra turn can still be gained from triggering a Break or Kill while not performing Enhanced Basic ATK and Enhanced Skill."
+    ],
+    "v3": [
+      "``Base Stats`ATK 757 → 524<br>SPD 92 → 104",
+      "``Eidolon $1`DEF ignore is now applied to all DMG dealt during Enhanced Skill, not only Enhanced Skill's own DMG.",
+      "``Technique`Movement SPD slightly increased from 8 to 10"
+    ]
+  },
+  "1314": {
+    "v2": [
+      "``Eidolon $1`When gaining Charges from Technique's DMG, this Eidolon's extra 1 Charge will also take effect."
+    ]
+  }
+}
+
+var _changelog_veradd = {
+  "v1": [
+    {
+      "HP": [
+        27.5,
+        32.5
+      ],
+      "Name": "Abundant Ebon Deer",
+      "_id": 2024014,
+      "Rank": 0
+    }
+  ],
+  "v3": [
+    {
+      "HP": [
+        24.0,
+        27.0
+      ],
+      "Name": "The Past, Present, and Eternal Show (Complete)",
+      "_id": 3004011,
+      "Rank": 0
+    },
+    {
+      "Stance": [
+        [
+          28.0,
+          [
+            "Phys",
+            "Fire",
+            "Ice",
+            "Imaginary"
+          ]
+        ],
+        [
+          26.0,
+          [
+            "Phys",
+            "Fire",
+            "Ice",
+            "Imaginary"
+          ]
+        ]
+      ],
+      "Name": "Silver Knight of Virtuous Gallantry",
+      "_id": 3024013,
+      "Rank": 0
+    }
+  ],
+  "v5": [
+    {
+      "Stance": [
+        [
+          26.0,
+          [
+            "Phys",
+            "Fire",
+            "Ice",
+            "Imaginary"
+          ]
+        ],
+        [
+          27.0,
+          [
+            "Phys",
+            "Fire",
+            "Ice",
+            "Imaginary"
+          ]
+        ]
+      ],
+      "Name": "Silver Knight of Virtuous Gallantry",
+      "_id": 3024013,
+      "Rank": 0
+    },
+    {
+      "HP": [
+        17.5,
+        16.0
+      ],
+      "Name": "Stellaron Hunter: Sam (Complete)",
+      "_id": 3024023,
+      "Rank": 0
+    }
+  ]
+}
+
+var _hidden = [
+  {
+    "Name": "Future Character Name Compilation",
+    "Date": "2024/05/27",
+    "Ver": "2.3v4",
+    "Notes": [
+      {
+        "Title": "Characters",
+        "Desc": "- Jiaoqiu<br>- Screwllum<br>- Feixiao<br>- Yunli<br>- March 7th New Path<br>- Moze<br>- Lingsha<br>- Rappa<br>- Aglaea<br>- Zaika"
+      },
+      {
+        "Title": "Enemies",
+        "Desc": "- Doomsday Beast (Illusion)<br>- Feixiao"
+      }
+    ]
+  },
+  {
+    "Name": "Rappa & Aglaea (Preliminary)",
+    "Date": "2024/06/07",
+    "Ver": "2.3v5",
+    "Notes": [
+      {
+        "Title": "Rappa",
+        "Desc": "Technique can block all enemy attacks. Ultimate mentioned FPS."
+      },
+      {
+        "Title": "Aglaea",
+        "Desc": "Can summon an event on the action bar."
+      }
+    ]
+  },
+  {
+    "Name": "Lingsha",
+    "Date": "2024/06/07",
+    "Ver": "2.3v5",
+    "Notes": [
+      {
+        "Title": "Skill",
+        "Desc": "Will summon events on the action bar that last for more than 1 turn. Can summon multiple such events."
+      }
+    ]
+  },
+  {
+    "Name": "Moze",
+    "Date": "2024/06/07",
+    "Ver": "2.3v5",
+    "Notes": [
+      {
+        "Title": "Technique",
+        "Desc": "Enters the Stealth state for 20s, during which cannot be detected by enemies.<br>Like Seele, the distance at which Moze can lock onto enemy targets is greatly increased during Stealth."
+      },
+      {
+        "Title": "Skill",
+        "Desc": "Can select ShadowTarget(s)"
+      }
+    ]
+  },
+  {
+    "Name": "Feixiao",
+    "Date": "2024/06/07",
+    "Ver": "2.3v5",
+    "Notes": [
+      {
+        "Title": "Recap of already released info",
+        "Desc": "General of Xianzhou Yaoqing: \"The Merlin's Claw\" Feixiao"
+      },
+      {
+        "Title": "Overview",
+        "Desc": "· Wind, Hunt<br>· Kit is related to Weakness Break and follow-up attacks.<br>· Has an Enhanced Skill.<br>· Will apply BlueDot and RedDot to targets in battle.<br>· In early testing, is teamed with Topaz, Ruan Mei, Aventurine / Topaz, Ruan Mei, Luocha / Topaz, Asta, Luocha.<br>· In early testing, she wears the lightcone Worrisome, Blissful, the relics The Wind-Soaring Valorous and Inert Salsotto. The main stats are SPD and Wind DMG Bonus."
+      },
+      {
+        "Title": "Technique",
+        "Desc": "Continuously fires missiles that will apply some effect upon hitting enemies. (Will not enter combat)<br>Summons a dimension that follows the active character (like Jingliu & Robin), which greatly increases the active character's move speed, blocks all incoming enemy attacks, and hauls all nearby enemies towards the active character."
+      },
+      {
+        "Title": "Enemy",
+        "Desc": "Feixiao will become an enemy in some patch 2.x. In combat, Feixiao will summon enemies and build connections with them.<br>There will be an R assist skill in the combat."
+      }
+    ]
+  },
+  {
+    "Name": "Yunli",
+    "Date": "2024/06/07",
+    "Ver": "2.3v5",
+    "Notes": [
+      {
+        "Title": "Recap of already released info",
+        "Desc": "Granddaughter of General Huaiyan of Xianzhou Zhuming. Of similar age as Yanqing, loves collecting all manner of swords, and has studied swordsmanship since her youth."
+      },
+      {
+        "Title": "Overview",
+        "Desc": "· Character ID: 1221 (12xx - Xianzhou character series)<br>· In early testing, is teamed with Topaz, Ruan Mei, Luocha.<br>· In early testing, she wears the relics Musketeer of Wild Wheat and Space Sealing Station. The main stats are SPD and Energy Recharge."
+      },
+      {
+        "Title": "Technique",
+        "Desc": "Provides protection to the on-field character. When attacked by an enemy, the on-field character will automatically retreat one step, and Yunli's weapon will appear to block the hit."
+      },
+      {
+        "Title": "Story Battle Assist Skill",
+        "Desc": "Should be similar to the playable character's abilities (ref. Danheng IL, Huohuo, Black Swan)<br>Yunli stands at the center of her allies, facing the opponents in front of her. She consumes all stacks of something, considers the DMG type of some attacks as another type, and launches the Super Counterattack of her Ultimate, dealing Physical follow-up DMG to a single target and adjacent targets, and then deals Physical follow-up DMG to a random enemy for a few times."
+      }
+    ]
+  },
+  {
+    "Name": "March 7th",
+    "Date": "2024/06/07",
+    "Ver": "2.3v5",
+    "Notes": [
+      {
+        "Title": "Overview",
+        "Desc": "· Character ID: 1224 (12xx - Xianzhou character series)<br>· Will appear in combat in a story, with trial.<br>· Her abilities will buff teammates' damage."
+      },
+      {
+        "Title": "Enhanced Basic ATK",
+        "Desc": "Currently I only know it triggers something with a probability.<br>In the story trial, the first Enhanced Basic ATK is guaranteed not to trigger, while the second Enhanced Basic ATK is guaranteed to trigger."
+      },
+      {
+        "Title": "Skill",
+        "Desc": "Will apply some effect to teammates."
+      },
+      {
+        "Title": "Overworld Passive",
+        "Desc": "When another character in the party uses their Technique, March 7th gains some effect, stackable."
+      }
+    ]
+  },
+  {
+    "Name": "Jiaoqiu",
+    "Date": "2024/03/22",
+    "Ver": "2.1v5",
+    "Color": "Fire",
+    "Notes": [
+      {
+        "Title": "Basic ATK",
+        "Desc": "Deals Fire DMG to a single target, and has a Base Chance to apply 1 stack of Flavour to the target."
+      },
+      {
+        "Title": "Skill",
+        "Desc": "Deals Fire DMG to a single target and adjacent targets, and has a Base Chance to apply 1 stack of Flavour to the targets.<br>The Base Chance on the central target is higher. The Base Chance on adjacent targets is equal to the chance in Basic ATK."
+      },
+      {
+        "Title": "Ultimate",
+        "Desc": "Applies Aura to delf, lasting for some turns.<br>Deals Fire DMG to all targets, and has a Base Chance to apply 1 stack of Flavour to the targets. The Base Chance is equal to the chance in Basic ATK.<br>After the application, the Flavour stack of all enemy targets will be set to the maximum number of stacks of Flavour held by enemy targets. This effect ignores RES."
+      },
+      {
+        "Title": "Talent",
+        "Desc": "<b>Flavour: </b>Decreases DEF, stackable, has upper limit. When stacking more than 1 stack, the increase in DEF reduction will be lower than the DEF reduction of the first stack.<br><b>Aura: </b>The remaining duration decreases by 1 at the start of Jiaoqiu's turn. When Aura is active, at the start of every ally's turn, this ally heals an amount of HP <color style='color:#ff77ff'>[Correction] based on Jiaoqiu's ATK</color>. During Aura, all enemies take increased Ultimate DMG.<br><b>Extra Effect: </b>When Jiaoqiu is on field, all enemies will be inflicted with an unknown debuff."
+      },
+      {
+        "Title": "Trace #1",
+        "Desc": "During Aura, at the start of any enemy's turn, Jiaoqiu deals Additional Fire DMG to this target.<br>During Aura, when any enemy takes action, Jiaoqiu has a Base Chance to apply 1 stack of Flavour to this target."
+      },
+      {
+        "Title": "Trace #2",
+        "Desc": "When casting Skill, regenerate some extra Energy."
+      },
+      {
+        "Title": "Trace #3",
+        "Desc": "During Aura, when a new enemy enters the battle:<br>- If no enemy has Flavour, or if the Flavour stack of every enemy is lower than some number, the Flavour stack of all enemy targets will be set to this number. This effect ignores RES.<br>- Otherwise, the Flavour stack of all enemy targets will be set to the maximum number of stacks of Flavour held by enemy targets. This effect ignores RES."
+      },
+      {
+        "Title": "Technique",
+        "Desc": "After using this technique, creats a dimension. After entering battle with enemies in the dimension, will ???"
+      }
+    ]
+  },
+  {
+    "Name": "Future Pure Fiction",
+    "Date": "2024/05/28",
+    "Ver": "2.3v4",
+    "Notes": [
+      {
+        "Title": "Main Blessing",
+        "Desc": "All enemies share HP: All DMG taken by enemies will be redistributed to the enemy with highest HP.<br>Every time a character triggers Weakness Break, the blessing gains 1 Charge. When Charges reach the cap, deals fixed DMG to enemies."
+      }
+    ]
+  },
+  {
+    "Name": "2.4 Apocalyptic Shadow",
+    "Date": "2024/05/27",
+    "Ver": "2.3v4",
+    "Notes": [
+      {
+        "Title": "Name",
+        "Desc": "Dominated Evils"
+      },
+      {
+        "Title": "Recommended Elements",
+        "Desc": "Upper Half: Thunder Imaginary<br>Lower Half: Ice Wind"
+      }
+    ]
+  },
+  {
+    "Name": "Doomsday Beast (Illusion)",
+    "Date": "2024/05/24",
+    "Ver": "2.3v3",
+    "Notes": [
+      {
+        "Title": "Overview",
+        "Desc": "Will appear in Apocalyptic Shadow.<br>Cannot take damage unless Dawn's Left Hand, Disaster's Right Hand and Antimatter Engine are all defeated.<br>Similar to 2.3's Apocalyptic Shadow, all enemies' DMG taken is reduced. After they are Weakness Broken, they take increased DMG and have action delayed."
+      },
+      {
+        "Title": "Marks",
+        "Desc": "In combat, enemies will randomly apply Quantum or Imaginary Marks to all characters."
+      },
+      {
+        "Title": "Quantum Mark",
+        "Desc": "- When the character attacks an enemy with Quantum Weakness, will deal extra DMG, and reduces the enemy's Toughness regardless of Weakness Types. If the type of this attack is Quantum, Toughness Reduction will be doubled. This Mark is removed after the attack.<br>- When the character attacks an enemy without Quantum Weakness, will trigger a counter attack, dealing massive Imaginary DMG to all characters.<br>- When the character takes Imaginary DMG, will take extra DMG. Then, has a base chance of being applied Entanglement, and also a base chance of being applied Imprisonment, and then this Mark is removed."
+      },
+      {
+        "Title": "Imaginary Mark",
+        "Desc": "- When the character attacks an enemy with Imaginary Weakness, will deal extra DMG, and reduces the enemy's Toughness regardless of Weakness Types. If the type of this attack is Imaginary, Toughness Reduction will be doubled. This Mark is removed after the attack.<br>- When the character attacks an enemy without Imaginary Weakness, will trigger a counter attack, dealing massive Quantum DMG to all characters.<br>- When the character takes Quantum DMG, will take extra DMG. Then, has a base chance of being applied Imprisonment, and also a base chance of being applied Entanglement, and then this Mark is removed."
+      }
+    ]
+  },
+  {
+    "Name": "2.4+ Lightcones",
+    "Date": "2024/05/08",
+    "Ver": "2.3v1",
+    "Notes": [
+      {
+        "Title": "Limited 5★",
+        "Desc": "When the wearer's attack hits an enemy:<br>· If the target does not have Fragile I, then has a base chance to apply Fragile I to the target, reducing its DEF for some turns.<br>· If the target has Fragile I, there is a base chance to upgrade it to Fragile II, which reduces even more DEF and inherits the number of remaining turns.<br>If the upgrade fails, Fragile I will be removed."
+      },
+      {
+        "Title": "Limited 5★",
+        "Desc": "When the wearer uses Ultimate, they gain 1 stack of Boost, lasting for 1 turn. Every stack of Boost increases the DMG dealt by follow-up attacks."
+      }
+    ]
+  },
+  {
+    "Name": "Feixiao",
+    "Date": "2024/05/12",
+    "Ver": "2.3v1",
+    "Notes": [
+      {
+        "Title": "Recap of already released info",
+        "Desc": "General of Xianzhou Yaoqing: \"The Merlin's Claw\" Feixiao"
+      },
+      {
+        "Title": "Overview",
+        "Desc": "Kit is related to Weakness Break and (possibly) follow-up attacks. Has an Enhanced Skill."
+      },
+      {
+        "Title": "Technique",
+        "Desc": "Continuously fires missiles that will apply some effect upon hitting enemies. (Will not enter combat)<br>Enter a special state, greatly increasing move speed, blocking all incoming attacks, and hauls all nearby enemies towards her."
+      },
+      {
+        "Title": "Enemy",
+        "Desc": "Feixiao will become an enemy in some patch 2.x. In combat, Feixiao will summon enemies and build connections with them.<br>There will be an R assist skill in the combat."
+      }
+    ]
+  },
+  {
+    "Name": "Yunli",
+    "Date": "2024/05/12",
+    "Ver": "2.3v1",
+    "Notes": [
+      {
+        "Title": "Recap of already released info",
+        "Desc": "Granddaughter of General Huaiyan of Xianzhou Zhuming. Of similar age as Yanqing, loves collecting all manner of swords, and has studied swordsmanship since her youth."
+      },
+      {
+        "Title": "Overview",
+        "Desc": "Character ID: 1221 (12xx - Xianzhou character series)"
+      },
+      {
+        "Title": "Technique",
+        "Desc": "Provides protection to the on-field character. When attacked by an enemy, the on-field character will automatically retreat one step, and Yunli's weapon will appear to block the hit."
+      },
+      {
+        "Title": "Assist",
+        "Desc": "Yunli will assist in some story battle, launching a counterattack from a defensive stance, dealing DMG to enemies."
+      }
+    ]
+  },
+  {
+    "Name": "March 7th",
+    "Date": "2024/05/09",
+    "Ver": "2.3v1",
+    "Notes": [
+      {
+        "Title": "Overview",
+        "Desc": "Character ID: 1224 (12xx - Xianzhou character series)<br>Will appear in combat in a story, with trial.<br>Her skills might buff teammates' DMG."
+      },
+      {
+        "Title": "Enhanced Basic ATK",
+        "Desc": "Currently I only know it uses some probability. In the story trial this probability is modified."
+      },
+      {
+        "Title": "Skill",
+        "Desc": "Will apply some effect to teammates."
+      },
+      {
+        "Title": "Technique",
+        "Desc": "When another character in the party uses their Technique, March 7th gains a stack of something."
+      }
+    ]
+  }
+]
+
+var cl_select = {
+  "v4 - v5": 4,
+  "v3 - v4": 3,
+  "v2 - v3": 2,
+  "v1 - v2": 1
+}
+
+var cl_vers = [
+  "v1",
+  "v2",
+  "v3",
+  "v4",
+  "v5"
+]
+
+var _diff_avatar = [
+  1310,
+  1314
+]
+
+var _diff_weapon = [
+  24004,
+  23025,
+  23028,
+  21045
+]
+
+var _weapon = [
+  {
+    "_id": 23028,
+    "Name": "Yet Hope Is Priceless",
+    "Rarity": 5,
+    "Path": "Erudition",
+    "Skill": 23028,
+    "Pic": "23028.png",
+    "Mat": [
+      114003,
+      110203
+    ],
+    "Stats": {
+      "HP": 952.56,
+      "ATK": 582.12,
+      "DEF": 529.2
+    }
+  },
+  {
+    "_id": 23025,
+    "Name": "Whereabouts Should Dreams Rest",
+    "Rarity": 5,
+    "Path": "Destruction",
+    "Skill": 23025,
+    "Pic": "23025.png",
+    "Mat": [
+      114013,
+      110183
+    ],
+    "Stats": {
+      "HP": 1164.24,
+      "ATK": 476.28,
+      "DEF": 529.2
+    }
+  },
+  {
+    "_id": 24004,
+    "Name": "Eternal Calculus",
+    "Rarity": 5,
+    "Path": "Erudition",
+    "Skill": 24004,
+    "Pic": "24004.png",
+    "Mat": [
+      111003,
+      110203
+    ],
+    "Stats": {
+      "HP": 1058.4,
+      "ATK": 529.2,
+      "DEF": 396.9
+    }
+  },
+  {
+    "_id": 21045,
+    "Name": "After the Charmony Fall",
+    "Rarity": 4,
+    "Path": "Erudition",
+    "Skill": 21045,
+    "Pic": "21045.png",
+    "Mat": [
+      114013,
+      110203
+    ],
+    "Stats": {
+      "HP": 846.72,
+      "ATK": 476.28,
+      "DEF": 396.9
+    }
+  },
+  {
+    "_id": 23027,
+    "Name": "Sailing Towards a Second Life",
+    "Rarity": 5,
+    "Path": "Hunt",
+    "Skill": 23027,
+    "Pic": "23027.png",
+    "Mat": [
+      114013,
+      110193
+    ],
+    "Stats": {
+      "HP": 1058.4,
+      "ATK": 582.12,
+      "DEF": 463.05
+    }
+  },
+  {
+    "_id": 23026,
+    "Name": "Flowing Nightglow",
+    "Rarity": 5,
+    "Path": "Harmony",
+    "Skill": 23026,
+    "Pic": "23026.png",
+    "Mat": [
+      114003,
+      110233
+    ],
+    "Stats": {
+      "HP": 952.56,
+      "ATK": 635.04,
+      "DEF": 463.05
+    }
+  },
+  {
+    "_id": 23024,
+    "Name": "Along the Passing Shore",
+    "Rarity": 5,
+    "Path": "Nihility",
+    "Skill": 23024,
+    "Pic": "23024.png",
+    "Mat": [
+      114003,
+      110223
+    ],
+    "Stats": {
+      "HP": 1058.4,
+      "ATK": 635.04,
+      "DEF": 396.9
+    }
+  },
+  {
+    "_id": 23023,
+    "Name": "Inherently Unjust Destiny",
+    "Rarity": 5,
+    "Path": "Preservation",
+    "Skill": 23023,
+    "Pic": "23023.png",
+    "Mat": [
+      114013,
+      110213
+    ],
+    "Stats": {
+      "HP": 1058.4,
+      "ATK": 423.36,
+      "DEF": 661.5
+    }
+  },
+  {
+    "_id": 23022,
+    "Name": "Reforged Remembrance",
+    "Rarity": 5,
+    "Path": "Nihility",
+    "Skill": 23022,
+    "Pic": "23022.png",
+    "Mat": [
+      111003,
+      110223
+    ],
+    "Stats": {
+      "HP": 1058.4,
+      "ATK": 582.12,
+      "DEF": 463.05
+    }
+  },
+  {
+    "_id": 23021,
+    "Name": "Earthly Escapade",
+    "Rarity": 5,
+    "Path": "Harmony",
+    "Skill": 23021,
+    "Pic": "23021.png",
+    "Mat": [
+      114013,
+      110233
+    ],
+    "Stats": {
+      "HP": 1164.24,
+      "ATK": 529.2,
+      "DEF": 463.05
+    }
+  },
+  {
+    "_id": 23020,
+    "Name": "Baptism of Pure Thought",
+    "Rarity": 5,
+    "Path": "Hunt",
+    "Skill": 23020,
+    "Pic": "23020.png",
+    "Mat": [
+      111013,
+      110123
+    ],
+    "Stats": {
+      "HP": 952.56,
+      "ATK": 582.12,
+      "DEF": 529.2
+    }
+  },
+  {
+    "_id": 23019,
+    "Name": "Past Self in Mirror",
+    "Rarity": 5,
+    "Path": "Harmony",
+    "Skill": 23019,
+    "Pic": "23019.png",
+    "Mat": [
+      113003,
+      110163
+    ],
+    "Stats": {
+      "HP": 1058.4,
+      "ATK": 529.2,
+      "DEF": 529.2
+    }
+  },
+  {
+    "_id": 23018,
+    "Name": "An Instant Before A Gaze",
+    "Rarity": 5,
+    "Path": "Erudition",
+    "Skill": 23018,
+    "Pic": "23018.png",
+    "Mat": [
+      111003,
+      110133
+    ],
+    "Stats": {
+      "HP": 1058.4,
+      "ATK": 582.12,
+      "DEF": 463.05
+    }
+  },
+  {
+    "_id": 23017,
+    "Name": "Night of Fright",
+    "Rarity": 5,
+    "Path": "Abundance",
+    "Skill": 23017,
+    "Pic": "23017.png",
+    "Mat": [
+      113003,
+      110173
+    ],
+    "Stats": {
+      "HP": 1164.24,
+      "ATK": 476.28,
+      "DEF": 529.2
+    }
+  },
+  {
+    "_id": 23016,
+    "Name": "Worrisome, Blissful",
+    "Rarity": 5,
+    "Path": "Hunt",
+    "Skill": 23016,
+    "Pic": "23016.png",
+    "Mat": [
+      112003,
+      110123
+    ],
+    "Stats": {
+      "HP": 1058.4,
+      "ATK": 582.12,
+      "DEF": 463.05
+    }
+  },
+  {
+    "_id": 23015,
+    "Name": "Brighter Than the Sun",
+    "Rarity": 5,
+    "Path": "Destruction",
+    "Skill": 23015,
+    "Pic": "23015.png",
+    "Mat": [
+      113003,
+      110113
+    ],
+    "Stats": {
+      "HP": 1058.4,
+      "ATK": 635.04,
+      "DEF": 396.9
+    }
+  },
+  {
+    "_id": 23014,
+    "Name": "I Shall Be My Own Sword",
+    "Rarity": 5,
+    "Path": "Destruction",
+    "Skill": 23014,
+    "Pic": "23014.png",
+    "Mat": [
+      113003,
+      110113
+    ],
+    "Stats": {
+      "HP": 1164.24,
+      "ATK": 582.12,
+      "DEF": 396.9
+    }
+  },
+  {
+    "_id": 23013,
+    "Name": "Time Waits for No One",
+    "Rarity": 5,
+    "Path": "Abundance",
+    "Skill": 23013,
+    "Pic": "23013.png",
+    "Mat": [
+      111003,
+      110173
+    ],
+    "Stats": {
+      "HP": 1270.08,
+      "ATK": 476.28,
+      "DEF": 463.05
+    }
+  },
+  {
+    "_id": 23012,
+    "Name": "Sleep Like the Dead",
+    "Rarity": 5,
+    "Path": "Hunt",
+    "Skill": 23012,
+    "Pic": "23012.png",
+    "Mat": [
+      111013,
+      110123
+    ],
+    "Stats": {
+      "HP": 1058.4,
+      "ATK": 582.12,
+      "DEF": 463.05
+    }
+  },
+  {
+    "_id": 23011,
+    "Name": "She Already Shut Her Eyes",
+    "Rarity": 5,
+    "Path": "Preservation",
+    "Skill": 23011,
+    "Pic": "23011.png",
+    "Mat": [
+      113013,
+      110143
+    ],
+    "Stats": {
+      "HP": 1270.08,
+      "ATK": 423.36,
+      "DEF": 529.2
+    }
+  },
+  {
+    "_id": 23010,
+    "Name": "Before Dawn",
+    "Rarity": 5,
+    "Path": "Erudition",
+    "Skill": 23010,
+    "Pic": "23010.png",
+    "Mat": [
+      113003,
+      110133
+    ],
+    "Stats": {
+      "HP": 1058.4,
+      "ATK": 582.12,
+      "DEF": 463.05
+    }
+  },
+  {
+    "_id": 23009,
+    "Name": "The Unreachable Side",
+    "Rarity": 5,
+    "Path": "Destruction",
+    "Skill": 23009,
+    "Pic": "23009.png",
+    "Mat": [
+      113003,
+      110113
+    ],
+    "Stats": {
+      "HP": 1270.08,
+      "ATK": 582.12,
+      "DEF": 330.75
+    }
+  },
+  {
+    "_id": 23008,
+    "Name": "Echoes of the Coffin",
+    "Rarity": 5,
+    "Path": "Abundance",
+    "Skill": 23008,
+    "Pic": "23008.png",
+    "Mat": [
+      113013,
+      110173
+    ],
+    "Stats": {
+      "HP": 1164.24,
+      "ATK": 582.12,
+      "DEF": 396.9
+    }
+  },
+  {
+    "_id": 23007,
+    "Name": "Incessant Rain",
+    "Rarity": 5,
+    "Path": "Nihility",
+    "Skill": 23007,
+    "Pic": "23007.png",
+    "Mat": [
+      112013,
+      110153
+    ],
+    "Stats": {
+      "HP": 1058.4,
+      "ATK": 582.12,
+      "DEF": 463.05
+    }
+  },
+  {
+    "_id": 23006,
+    "Name": "Patience Is All You Need",
+    "Rarity": 5,
+    "Path": "Nihility",
+    "Skill": 23006,
+    "Pic": "23006.png",
+    "Mat": [
+      111013,
+      110153
+    ],
+    "Stats": {
+      "HP": 1058.4,
+      "ATK": 582.12,
+      "DEF": 463.05
+    }
+  },
+  {
+    "_id": 23005,
+    "Name": "Moment of Victory",
+    "Rarity": 5,
+    "Path": "Preservation",
+    "Skill": 23005,
+    "Pic": "23005.png",
+    "Mat": [
+      112003,
+      110143
+    ],
+    "Stats": {
+      "HP": 1058.4,
+      "ATK": 476.28,
+      "DEF": 595.35
+    }
+  },
+  {
+    "_id": 23004,
+    "Name": "In the Name of the World",
+    "Rarity": 5,
+    "Path": "Nihility",
+    "Skill": 23004,
+    "Pic": "23004.png",
+    "Mat": [
+      112003,
+      110153
+    ],
+    "Stats": {
+      "HP": 1058.4,
+      "ATK": 582.12,
+      "DEF": 463.05
+    }
+  },
+  {
+    "_id": 23003,
+    "Name": "But the Battle Isn't Over",
+    "Rarity": 5,
+    "Path": "Harmony",
+    "Skill": 23003,
+    "Pic": "23003.png",
+    "Mat": [
+      112003,
+      110163
+    ],
+    "Stats": {
+      "HP": 1164.24,
+      "ATK": 529.2,
+      "DEF": 463.05
+    }
+  },
+  {
+    "_id": 23002,
+    "Name": "Something Irreplaceable",
+    "Rarity": 5,
+    "Path": "Destruction",
+    "Skill": 23002,
+    "Pic": "23002.png",
+    "Mat": [
+      112013,
+      110113
+    ],
+    "Stats": {
+      "HP": 1164.24,
+      "ATK": 582.12,
+      "DEF": 396.9
+    }
+  },
+  {
+    "_id": 23001,
+    "Name": "In the Night",
+    "Rarity": 5,
+    "Path": "Hunt",
+    "Skill": 23001,
+    "Pic": "23001.png",
+    "Mat": [
+      111013,
+      110123
+    ],
+    "Stats": {
+      "HP": 1058.4,
+      "ATK": 582.12,
+      "DEF": 463.05
+    }
+  },
+  {
+    "_id": 23000,
+    "Name": "Night on the Milky Way",
+    "Rarity": 5,
+    "Path": "Erudition",
+    "Skill": 23000,
+    "Pic": "23000.png",
+    "Mat": [
+      111003,
+      110133
+    ],
+    "Stats": {
+      "HP": 1164.24,
+      "ATK": 582.12,
+      "DEF": 396.9
+    }
+  },
+  {
+    "_id": 24003,
+    "Name": "Solitary Healing",
+    "Rarity": 5,
+    "Path": "Nihility",
+    "Skill": 24003,
+    "Pic": "24003.png",
+    "Mat": [
+      111003,
+      110153
+    ],
+    "Stats": {
+      "HP": 1058.4,
+      "ATK": 529.2,
+      "DEF": 396.9
+    }
+  },
+  {
+    "_id": 24002,
+    "Name": "Texture of Memories",
+    "Rarity": 5,
+    "Path": "Preservation",
+    "Skill": 24002,
+    "Pic": "24002.png",
+    "Mat": [
+      111003,
+      110143
+    ],
+    "Stats": {
+      "HP": 1058.4,
+      "ATK": 423.36,
+      "DEF": 529.2
+    }
+  },
+  {
+    "_id": 24001,
+    "Name": "Cruising in the Stellar Sea",
+    "Rarity": 5,
+    "Path": "Hunt",
+    "Skill": 24001,
+    "Pic": "24001.png",
+    "Mat": [
+      111003,
+      110123
+    ],
+    "Stats": {
+      "HP": 952.56,
+      "ATK": 529.2,
+      "DEF": 463.05
+    }
+  },
+  {
+    "_id": 24000,
+    "Name": "On the Fall of an Aeon",
+    "Rarity": 5,
+    "Path": "Destruction",
+    "Skill": 24000,
+    "Pic": "24000.png",
+    "Mat": [
+      111003,
+      110113
+    ],
+    "Stats": {
+      "HP": 1058.4,
+      "ATK": 529.2,
+      "DEF": 396.9
+    }
+  },
+  {
+    "_id": 22002,
+    "Name": "For Tomorrow's Journey",
+    "Rarity": 4,
+    "Path": "Harmony",
+    "Skill": 22002,
+    "Pic": "22002.png",
+    "Mat": [
+      114003,
+      110233
+    ],
+    "Stats": {
+      "HP": 952.56,
+      "ATK": 476.28,
+      "DEF": 330.75
+    }
+  },
+  {
+    "_id": 22001,
+    "Name": "Hey, Over Here",
+    "Rarity": 4,
+    "Path": "Abundance",
+    "Skill": 22001,
+    "Pic": "22001.png",
+    "Mat": [
+      113013,
+      110173
+    ],
+    "Stats": {
+      "HP": 952.56,
+      "ATK": 423.36,
+      "DEF": 396.9
+    }
+  },
+  {
+    "_id": 22000,
+    "Name": "Before the Tutorial Mission Starts",
+    "Rarity": 4,
+    "Path": "Nihility",
+    "Skill": 22000,
+    "Pic": "22000.png",
+    "Mat": [
+      111003,
+      110153
+    ],
+    "Stats": {
+      "HP": 952.56,
+      "ATK": 476.28,
+      "DEF": 330.75
+    }
+  },
+  {
+    "_id": 21044,
+    "Name": "Boundless Choreo",
+    "Rarity": 4,
+    "Path": "Nihility",
+    "Skill": 21044,
+    "Pic": "21044.png",
+    "Mat": [
+      114013,
+      110223
+    ],
+    "Stats": {
+      "HP": 952.56,
+      "ATK": 476.28,
+      "DEF": 330.75
+    }
+  },
+  {
+    "_id": 21043,
+    "Name": "Concert for Two",
+    "Rarity": 4,
+    "Path": "Preservation",
+    "Skill": 21043,
+    "Pic": "21043.png",
+    "Mat": [
+      114013,
+      110213
+    ],
+    "Stats": {
+      "HP": 952.56,
+      "ATK": 370.44,
+      "DEF": 463.05
+    }
+  },
+  {
+    "_id": 21042,
+    "Name": "Indelible Promise",
+    "Rarity": 4,
+    "Path": "Destruction",
+    "Skill": 21042,
+    "Pic": "21042.png",
+    "Mat": [
+      114003,
+      110183
+    ],
+    "Stats": {
+      "HP": 952.56,
+      "ATK": 476.28,
+      "DEF": 330.75
+    }
+  },
+  {
+    "_id": 21041,
+    "Name": "It's Showtime",
+    "Rarity": 4,
+    "Path": "Nihility",
+    "Skill": 21041,
+    "Pic": "21041.png",
+    "Mat": [
+      111003,
+      110223
+    ],
+    "Stats": {
+      "HP": 1058.4,
+      "ATK": 476.28,
+      "DEF": 264.6
+    }
+  },
+  {
+    "_id": 21040,
+    "Name": "The Day The Cosmos Fell",
+    "Rarity": 4,
+    "Path": "Erudition",
+    "Skill": 21040,
+    "Pic": "21040.png",
+    "Mat": [
+      114003,
+      110133
+    ],
+    "Stats": {
+      "HP": 952.56,
+      "ATK": 476.28,
+      "DEF": 330.75
+    }
+  },
+  {
+    "_id": 21039,
+    "Name": "Destiny's Threads Forewoven",
+    "Rarity": 4,
+    "Path": "Preservation",
+    "Skill": 21039,
+    "Pic": "21039.png",
+    "Mat": [
+      114013,
+      110143
+    ],
+    "Stats": {
+      "HP": 952.56,
+      "ATK": 370.44,
+      "DEF": 463.05
+    }
+  },
+  {
+    "_id": 21038,
+    "Name": "Flames Afar",
+    "Rarity": 4,
+    "Path": "Destruction",
+    "Skill": 21038,
+    "Pic": "21038.png",
+    "Mat": [
+      114003,
+      110183
+    ],
+    "Stats": {
+      "HP": 1058.4,
+      "ATK": 476.28,
+      "DEF": 264.6
+    }
+  },
+  {
+    "_id": 21037,
+    "Name": "Final Victor",
+    "Rarity": 4,
+    "Path": "Hunt",
+    "Skill": 21037,
+    "Pic": "21037.png",
+    "Mat": [
+      114013,
+      110123
+    ],
+    "Stats": {
+      "HP": 952.56,
+      "ATK": 476.28,
+      "DEF": 330.75
+    }
+  },
+  {
+    "_id": 21036,
+    "Name": "Dreamville Adventure",
+    "Rarity": 4,
+    "Path": "Harmony",
+    "Skill": 21036,
+    "Pic": "21036.png",
+    "Mat": [
+      114003,
+      110233
+    ],
+    "Stats": {
+      "HP": 952.56,
+      "ATK": 423.36,
+      "DEF": 396.9
+    }
+  },
+  {
+    "_id": 21035,
+    "Name": "What Is Real?",
+    "Rarity": 4,
+    "Path": "Abundance",
+    "Skill": 21035,
+    "Pic": "21035.png",
+    "Mat": [
+      114003,
+      110173
+    ],
+    "Stats": {
+      "HP": 1058.4,
+      "ATK": 423.36,
+      "DEF": 330.75
+    }
+  },
+  {
+    "_id": 21034,
+    "Name": "Today Is Another Peaceful Day",
+    "Rarity": 4,
+    "Path": "Erudition",
+    "Skill": 21034,
+    "Pic": "21034.png",
+    "Mat": [
+      113003,
+      110133
+    ],
+    "Stats": {
+      "HP": 846.72,
+      "ATK": 529.2,
+      "DEF": 330.75
+    }
+  },
+  {
+    "_id": 21033,
+    "Name": "Nowhere to Run",
+    "Rarity": 4,
+    "Path": "Destruction",
+    "Skill": 21033,
+    "Pic": "21033.png",
+    "Mat": [
+      112003,
+      110113
+    ],
+    "Stats": {
+      "HP": 952.56,
+      "ATK": 529.2,
+      "DEF": 264.6
+    }
+  },
+  {
+    "_id": 21032,
+    "Name": "Carve the Moon, Weave the Clouds",
+    "Rarity": 4,
+    "Path": "Harmony",
+    "Skill": 21032,
+    "Pic": "21032.png",
+    "Mat": [
+      111013,
+      110163
+    ],
+    "Stats": {
+      "HP": 952.56,
+      "ATK": 476.28,
+      "DEF": 330.75
+    }
+  },
+  {
+    "_id": 21031,
+    "Name": "Return to Darkness",
+    "Rarity": 4,
+    "Path": "Hunt",
+    "Skill": 21031,
+    "Pic": "21031.png",
+    "Mat": [
+      113003,
+      110123
+    ],
+    "Stats": {
+      "HP": 846.72,
+      "ATK": 529.2,
+      "DEF": 330.75
+    }
+  },
+  {
+    "_id": 21030,
+    "Name": "This Is Me!",
+    "Rarity": 4,
+    "Path": "Preservation",
+    "Skill": 21030,
+    "Pic": "21030.png",
+    "Mat": [
+      111013,
+      110143
+    ],
+    "Stats": {
+      "HP": 846.72,
+      "ATK": 370.44,
+      "DEF": 529.2
+    }
+  },
+  {
+    "_id": 21029,
+    "Name": "We Will Meet Again",
+    "Rarity": 4,
+    "Path": "Nihility",
+    "Skill": 21029,
+    "Pic": "21029.png",
+    "Mat": [
+      112013,
+      110153
+    ],
+    "Stats": {
+      "HP": 846.72,
+      "ATK": 529.2,
+      "DEF": 330.75
+    }
+  },
+  {
+    "_id": 21028,
+    "Name": "Warmth Shortens Cold Nights",
+    "Rarity": 4,
+    "Path": "Abundance",
+    "Skill": 21028,
+    "Pic": "21028.png",
+    "Mat": [
+      111003,
+      110173
+    ],
+    "Stats": {
+      "HP": 1058.4,
+      "ATK": 370.44,
+      "DEF": 396.9
+    }
+  },
+  {
+    "_id": 21027,
+    "Name": "The Seriousness of Breakfast",
+    "Rarity": 4,
+    "Path": "Erudition",
+    "Skill": 21027,
+    "Pic": "21027.png",
+    "Mat": [
+      111003,
+      110133
+    ],
+    "Stats": {
+      "HP": 846.72,
+      "ATK": 476.28,
+      "DEF": 396.9
+    }
+  },
+  {
+    "_id": 21026,
+    "Name": "Woof! Walk Time!",
+    "Rarity": 4,
+    "Path": "Destruction",
+    "Skill": 21026,
+    "Pic": "21026.png",
+    "Mat": [
+      111003,
+      110113
+    ],
+    "Stats": {
+      "HP": 952.56,
+      "ATK": 476.28,
+      "DEF": 330.75
+    }
+  },
+  {
+    "_id": 21025,
+    "Name": "Past and Future",
+    "Rarity": 4,
+    "Path": "Harmony",
+    "Skill": 21025,
+    "Pic": "21025.png",
+    "Mat": [
+      111003,
+      110163
+    ],
+    "Stats": {
+      "HP": 952.56,
+      "ATK": 423.36,
+      "DEF": 396.9
+    }
+  },
+  {
+    "_id": 21024,
+    "Name": "River Flows in Spring",
+    "Rarity": 4,
+    "Path": "Hunt",
+    "Skill": 21024,
+    "Pic": "21024.png",
+    "Mat": [
+      112013,
+      110123
+    ],
+    "Stats": {
+      "HP": 846.72,
+      "ATK": 476.28,
+      "DEF": 396.9
+    }
+  },
+  {
+    "_id": 21023,
+    "Name": "We Are Wildfire",
+    "Rarity": 4,
+    "Path": "Preservation",
+    "Skill": 21023,
+    "Pic": "21023.png",
+    "Mat": [
+      112013,
+      110143
+    ],
+    "Stats": {
+      "HP": 740.88,
+      "ATK": 476.28,
+      "DEF": 463.05
+    }
+  },
+  {
+    "_id": 21022,
+    "Name": "Fermata",
+    "Rarity": 4,
+    "Path": "Nihility",
+    "Skill": 21022,
+    "Pic": "21022.png",
+    "Mat": [
+      112003,
+      110153
+    ],
+    "Stats": {
+      "HP": 952.56,
+      "ATK": 476.28,
+      "DEF": 330.75
+    }
+  },
+  {
+    "_id": 21021,
+    "Name": "Quid Pro Quo",
+    "Rarity": 4,
+    "Path": "Abundance",
+    "Skill": 21021,
+    "Pic": "21021.png",
+    "Mat": [
+      112003,
+      110173
+    ],
+    "Stats": {
+      "HP": 952.56,
+      "ATK": 423.36,
+      "DEF": 396.9
+    }
+  },
+  {
+    "_id": 21020,
+    "Name": "Geniuses' Repose",
+    "Rarity": 4,
+    "Path": "Erudition",
+    "Skill": 21020,
+    "Pic": "21020.png",
+    "Mat": [
+      113003,
+      110133
+    ],
+    "Stats": {
+      "HP": 846.72,
+      "ATK": 476.28,
+      "DEF": 396.9
+    }
+  },
+  {
+    "_id": 21019,
+    "Name": "Under the Blue Sky",
+    "Rarity": 4,
+    "Path": "Destruction",
+    "Skill": 21019,
+    "Pic": "21019.png",
+    "Mat": [
+      113003,
+      110113
+    ],
+    "Stats": {
+      "HP": 952.56,
+      "ATK": 476.28,
+      "DEF": 330.75
+    }
+  },
+  {
+    "_id": 21018,
+    "Name": "Dance! Dance! Dance!",
+    "Rarity": 4,
+    "Path": "Harmony",
+    "Skill": 21018,
+    "Pic": "21018.png",
+    "Mat": [
+      113013,
+      110163
+    ],
+    "Stats": {
+      "HP": 952.56,
+      "ATK": 423.36,
+      "DEF": 396.9
+    }
+  },
+  {
+    "_id": 21017,
+    "Name": "Subscribe for More!",
+    "Rarity": 4,
+    "Path": "Hunt",
+    "Skill": 21017,
+    "Pic": "21017.png",
+    "Mat": [
+      113013,
+      110123
+    ],
+    "Stats": {
+      "HP": 952.56,
+      "ATK": 476.28,
+      "DEF": 330.75
+    }
+  },
+  {
+    "_id": 21016,
+    "Name": "Trend of the Universal Market",
+    "Rarity": 4,
+    "Path": "Preservation",
+    "Skill": 21016,
+    "Pic": "21016.png",
+    "Mat": [
+      113003,
+      110143
+    ],
+    "Stats": {
+      "HP": 1058.4,
+      "ATK": 370.44,
+      "DEF": 396.9
+    }
+  },
+  {
+    "_id": 21015,
+    "Name": "Resolution Shines As Pearls of Sweat",
+    "Rarity": 4,
+    "Path": "Nihility",
+    "Skill": 21015,
+    "Pic": "21015.png",
+    "Mat": [
+      113013,
+      110153
+    ],
+    "Stats": {
+      "HP": 952.56,
+      "ATK": 476.28,
+      "DEF": 330.75
+    }
+  },
+  {
+    "_id": 21014,
+    "Name": "Perfect Timing",
+    "Rarity": 4,
+    "Path": "Abundance",
+    "Skill": 21014,
+    "Pic": "21014.png",
+    "Mat": [
+      113013,
+      110173
+    ],
+    "Stats": {
+      "HP": 952.56,
+      "ATK": 423.36,
+      "DEF": 396.9
+    }
+  },
+  {
+    "_id": 21013,
+    "Name": "Make the World Clamor",
+    "Rarity": 4,
+    "Path": "Erudition",
+    "Skill": 21013,
+    "Pic": "21013.png",
+    "Mat": [
+      112013,
+      110133
+    ],
+    "Stats": {
+      "HP": 846.72,
+      "ATK": 476.28,
+      "DEF": 396.9
+    }
+  },
+  {
+    "_id": 21012,
+    "Name": "A Secret Vow",
+    "Rarity": 4,
+    "Path": "Destruction",
+    "Skill": 21012,
+    "Pic": "21012.png",
+    "Mat": [
+      112003,
+      110113
+    ],
+    "Stats": {
+      "HP": 1058.4,
+      "ATK": 476.28,
+      "DEF": 264.6
+    }
+  },
+  {
+    "_id": 21011,
+    "Name": "Planetary Rendezvous",
+    "Rarity": 4,
+    "Path": "Harmony",
+    "Skill": 21011,
+    "Pic": "21011.png",
+    "Mat": [
+      111013,
+      110163
+    ],
+    "Stats": {
+      "HP": 1058.4,
+      "ATK": 423.36,
+      "DEF": 330.75
+    }
+  },
+  {
+    "_id": 21010,
+    "Name": "Swordplay",
+    "Rarity": 4,
+    "Path": "Hunt",
+    "Skill": 21010,
+    "Pic": "21010.png",
+    "Mat": [
+      111003,
+      110123
+    ],
+    "Stats": {
+      "HP": 952.56,
+      "ATK": 476.28,
+      "DEF": 330.75
+    }
+  },
+  {
+    "_id": 21009,
+    "Name": "Landau's Choice",
+    "Rarity": 4,
+    "Path": "Preservation",
+    "Skill": 21009,
+    "Pic": "21009.png",
+    "Mat": [
+      111003,
+      110143
+    ],
+    "Stats": {
+      "HP": 952.56,
+      "ATK": 423.36,
+      "DEF": 396.9
+    }
+  },
+  {
+    "_id": 21008,
+    "Name": "Eyes of the Prey",
+    "Rarity": 4,
+    "Path": "Nihility",
+    "Skill": 21008,
+    "Pic": "21008.png",
+    "Mat": [
+      112013,
+      110153
+    ],
+    "Stats": {
+      "HP": 952.56,
+      "ATK": 476.28,
+      "DEF": 330.75
+    }
+  },
+  {
+    "_id": 21007,
+    "Name": "Shared Feeling",
+    "Rarity": 4,
+    "Path": "Abundance",
+    "Skill": 21007,
+    "Pic": "21007.png",
+    "Mat": [
+      113013,
+      110173
+    ],
+    "Stats": {
+      "HP": 952.56,
+      "ATK": 423.36,
+      "DEF": 396.9
+    }
+  },
+  {
+    "_id": 21006,
+    "Name": "The Birth of the Self",
+    "Rarity": 4,
+    "Path": "Erudition",
+    "Skill": 21006,
+    "Pic": "21006.png",
+    "Mat": [
+      112013,
+      110133
+    ],
+    "Stats": {
+      "HP": 952.56,
+      "ATK": 476.28,
+      "DEF": 330.75
+    }
+  },
+  {
+    "_id": 21005,
+    "Name": "The Moles Welcome You",
+    "Rarity": 4,
+    "Path": "Destruction",
+    "Skill": 21005,
+    "Pic": "21005.png",
+    "Mat": [
+      111013,
+      110113
+    ],
+    "Stats": {
+      "HP": 1058.4,
+      "ATK": 476.28,
+      "DEF": 264.6
+    }
+  },
+  {
+    "_id": 21004,
+    "Name": "Memories of the Past",
+    "Rarity": 4,
+    "Path": "Harmony",
+    "Skill": 21004,
+    "Pic": "21004.png",
+    "Mat": [
+      112003,
+      110163
+    ],
+    "Stats": {
+      "HP": 952.56,
+      "ATK": 423.36,
+      "DEF": 396.9
+    }
+  },
+  {
+    "_id": 21003,
+    "Name": "Only Silence Remains",
+    "Rarity": 4,
+    "Path": "Hunt",
+    "Skill": 21003,
+    "Pic": "21003.png",
+    "Mat": [
+      112003,
+      110123
+    ],
+    "Stats": {
+      "HP": 952.56,
+      "ATK": 476.28,
+      "DEF": 330.75
+    }
+  },
+  {
+    "_id": 21002,
+    "Name": "Day One of My New Life",
+    "Rarity": 4,
+    "Path": "Preservation",
+    "Skill": 21002,
+    "Pic": "21002.png",
+    "Mat": [
+      111003,
+      110143
+    ],
+    "Stats": {
+      "HP": 952.56,
+      "ATK": 370.44,
+      "DEF": 463.05
+    }
+  },
+  {
+    "_id": 21001,
+    "Name": "Good Night and Sleep Well",
+    "Rarity": 4,
+    "Path": "Nihility",
+    "Skill": 21001,
+    "Pic": "21001.png",
+    "Mat": [
+      112003,
+      110153
+    ],
+    "Stats": {
+      "HP": 952.56,
+      "ATK": 476.28,
+      "DEF": 330.75
+    }
+  },
+  {
+    "_id": 21000,
+    "Name": "Post-Op Conversation",
+    "Rarity": 4,
+    "Path": "Abundance",
+    "Skill": 21000,
+    "Pic": "21000.png",
+    "Mat": [
+      111003,
+      110173
+    ],
+    "Stats": {
+      "HP": 1058.4,
+      "ATK": 423.36,
+      "DEF": 330.75
+    }
+  },
+  {
+    "_id": 20020,
+    "Name": "Sagacity",
+    "Rarity": 3,
+    "Path": "Erudition",
+    "Skill": 20020,
+    "Pic": "20020.png",
+    "Mat": [
+      111013,
+      110133
+    ],
+    "Stats": {
+      "HP": 740.88,
+      "ATK": 370.44,
+      "DEF": 264.6
+    }
+  },
+  {
+    "_id": 20019,
+    "Name": "Mediation",
+    "Rarity": 3,
+    "Path": "Harmony",
+    "Skill": 20019,
+    "Pic": "20019.png",
+    "Mat": [
+      111003,
+      110163
+    ],
+    "Stats": {
+      "HP": 846.72,
+      "ATK": 317.52,
+      "DEF": 264.6
+    }
+  },
+  {
+    "_id": 20018,
+    "Name": "Hidden Shadow",
+    "Rarity": 3,
+    "Path": "Nihility",
+    "Skill": 20018,
+    "Pic": "20018.png",
+    "Mat": [
+      113013,
+      110153
+    ],
+    "Stats": {
+      "HP": 846.72,
+      "ATK": 317.52,
+      "DEF": 264.6
+    }
+  },
+  {
+    "_id": 20017,
+    "Name": "Pioneering",
+    "Rarity": 3,
+    "Path": "Preservation",
+    "Skill": 20017,
+    "Pic": "20017.png",
+    "Mat": [
+      111003,
+      110143
+    ],
+    "Stats": {
+      "HP": 952.56,
+      "ATK": 264.6,
+      "DEF": 264.6
+    }
+  },
+  {
+    "_id": 20016,
+    "Name": "Mutual Demise",
+    "Rarity": 3,
+    "Path": "Destruction",
+    "Skill": 20016,
+    "Pic": "20016.png",
+    "Mat": [
+      112003,
+      110113
+    ],
+    "Stats": {
+      "HP": 846.72,
+      "ATK": 370.44,
+      "DEF": 198.45
+    }
+  },
+  {
+    "_id": 20015,
+    "Name": "Multiplication",
+    "Rarity": 3,
+    "Path": "Abundance",
+    "Skill": 20015,
+    "Pic": "20015.png",
+    "Mat": [
+      113003,
+      110173
+    ],
+    "Stats": {
+      "HP": 952.56,
+      "ATK": 317.52,
+      "DEF": 198.45
+    }
+  },
+  {
+    "_id": 20014,
+    "Name": "Adversarial",
+    "Rarity": 3,
+    "Path": "Hunt",
+    "Skill": 20014,
+    "Pic": "20014.png",
+    "Mat": [
+      112013,
+      110123
+    ],
+    "Stats": {
+      "HP": 740.88,
+      "ATK": 370.44,
+      "DEF": 264.6
+    }
+  },
+  {
+    "_id": 20013,
+    "Name": "Passkey",
+    "Rarity": 3,
+    "Path": "Erudition",
+    "Skill": 20013,
+    "Pic": "20013.png",
+    "Mat": [
+      111003,
+      110133
+    ],
+    "Stats": {
+      "HP": 740.88,
+      "ATK": 370.44,
+      "DEF": 264.6
+    }
+  },
+  {
+    "_id": 20012,
+    "Name": "Meshing Cogs",
+    "Rarity": 3,
+    "Path": "Harmony",
+    "Skill": 20012,
+    "Pic": "20012.png",
+    "Mat": [
+      112003,
+      110163
+    ],
+    "Stats": {
+      "HP": 846.72,
+      "ATK": 317.52,
+      "DEF": 264.6
+    }
+  },
+  {
+    "_id": 20011,
+    "Name": "Loop",
+    "Rarity": 3,
+    "Path": "Nihility",
+    "Skill": 20011,
+    "Pic": "20011.png",
+    "Mat": [
+      112013,
+      110153
+    ],
+    "Stats": {
+      "HP": 846.72,
+      "ATK": 317.52,
+      "DEF": 264.6
+    }
+  },
+  {
+    "_id": 20010,
+    "Name": "Defense",
+    "Rarity": 3,
+    "Path": "Preservation",
+    "Skill": 20010,
+    "Pic": "20010.png",
+    "Mat": [
+      111013,
+      110143
+    ],
+    "Stats": {
+      "HP": 952.56,
+      "ATK": 264.6,
+      "DEF": 264.6
+    }
+  },
+  {
+    "_id": 20009,
+    "Name": "Shattered Home",
+    "Rarity": 3,
+    "Path": "Destruction",
+    "Skill": 20009,
+    "Pic": "20009.png",
+    "Mat": [
+      111003,
+      110113
+    ],
+    "Stats": {
+      "HP": 846.72,
+      "ATK": 370.44,
+      "DEF": 198.45
+    }
+  },
+  {
+    "_id": 20008,
+    "Name": "Fine Fruit",
+    "Rarity": 3,
+    "Path": "Abundance",
+    "Skill": 20008,
+    "Pic": "20008.png",
+    "Mat": [
+      111003,
+      110173
+    ],
+    "Stats": {
+      "HP": 952.56,
+      "ATK": 317.52,
+      "DEF": 198.45
+    }
+  },
+  {
+    "_id": 20007,
+    "Name": "Darting Arrow",
+    "Rarity": 3,
+    "Path": "Hunt",
+    "Skill": 20007,
+    "Pic": "20007.png",
+    "Mat": [
+      112003,
+      110123
+    ],
+    "Stats": {
+      "HP": 740.88,
+      "ATK": 370.44,
+      "DEF": 264.6
+    }
+  },
+  {
+    "_id": 20006,
+    "Name": "Data Bank",
+    "Rarity": 3,
+    "Path": "Erudition",
+    "Skill": 20006,
+    "Pic": "20006.png",
+    "Mat": [
+      111003,
+      110133
+    ],
+    "Stats": {
+      "HP": 740.88,
+      "ATK": 370.44,
+      "DEF": 264.6
+    }
+  },
+  {
+    "_id": 20005,
+    "Name": "Chorus",
+    "Rarity": 3,
+    "Path": "Harmony",
+    "Skill": 20005,
+    "Pic": "20005.png",
+    "Mat": [
+      112003,
+      110163
+    ],
+    "Stats": {
+      "HP": 846.72,
+      "ATK": 317.52,
+      "DEF": 264.6
+    }
+  },
+  {
+    "_id": 20004,
+    "Name": "Void",
+    "Rarity": 3,
+    "Path": "Nihility",
+    "Skill": 20004,
+    "Pic": "20004.png",
+    "Mat": [
+      112013,
+      110153
+    ],
+    "Stats": {
+      "HP": 846.72,
+      "ATK": 317.52,
+      "DEF": 264.6
+    }
+  },
+  {
+    "_id": 20003,
+    "Name": "Amber",
+    "Rarity": 3,
+    "Path": "Preservation",
+    "Skill": 20003,
+    "Pic": "20003.png",
+    "Mat": [
+      111003,
+      110143
+    ],
+    "Stats": {
+      "HP": 846.72,
+      "ATK": 264.6,
+      "DEF": 330.75
+    }
+  },
+  {
+    "_id": 20002,
+    "Name": "Collapsing Sky",
+    "Rarity": 3,
+    "Path": "Destruction",
+    "Skill": 20002,
+    "Pic": "20002.png",
+    "Mat": [
+      111013,
+      110113
+    ],
+    "Stats": {
+      "HP": 846.72,
+      "ATK": 370.44,
+      "DEF": 198.45
+    }
+  },
+  {
+    "_id": 20001,
+    "Name": "Cornucopia",
+    "Rarity": 3,
+    "Path": "Abundance",
+    "Skill": 20001,
+    "Pic": "20001.png",
+    "Mat": [
+      112003,
+      110173
+    ],
+    "Stats": {
+      "HP": 952.56,
+      "ATK": 264.6,
+      "DEF": 264.6
+    }
+  },
+  {
+    "_id": 20000,
+    "Name": "Arrows",
+    "Rarity": 3,
+    "Path": "Hunt",
+    "Skill": 20000,
+    "Pic": "20000.png",
+    "Mat": [
+      111013,
+      110123
+    ],
+    "Stats": {
+      "HP": 846.72,
+      "ATK": 317.52,
+      "DEF": 264.6
+    }
+  }
+]
+
+var _relic = [
+  {
+    "_id": 316,
+    "Name": "Forge of the Kalpagni Lantern",
+    "Icon": "71035.png",
+    "Skills": [
+      "Increase the wearer's SPD by <b>6.0%</b>. When the wearer hits enemy targets with Fire Weakness, the wearer's Break Effect increases by <b>40.0%</b>, lasting for <b>1.0</b> turn(s)."
+    ]
+  },
+  {
+    "_id": 315,
+    "Name": "Duran, Dynasty of Running Wolves",
+    "Icon": "71034.png",
+    "Skills": [
+      "When allies use follow-up attacks, the wearer receives 1 stack of Merit, stacking up to <b>5.0</b> times. Every stack of Merit increases the DMG dealt by the wearer's follow-up attacks by <b>5.0%</b>. When there are <b>5.0</b> stacks, additionally increases the wearer's CRIT DMG by <b>25.0%</b>."
+    ]
+  },
+  {
+    "_id": 314,
+    "Name": "Izumo Gensei and Takama Divine Realm",
+    "Icon": "71031.png",
+    "Skills": [
+      "Increases the wearer's ATK by <b>12.0%</b>. When entering battle, if at least one other ally follows the same Path as the wearer, then the wearer's CRIT Rate increases by <b>12.0%</b>."
+    ]
+  },
+  {
+    "_id": 313,
+    "Name": "Sigonia, the Unclaimed Desolation",
+    "Icon": "71030.png",
+    "Skills": [
+      "Increases the wearer's CRIT Rate by <b>4.0%</b>. When an enemy target gets defeated, the wearer's CRIT DMG increases by <b>4.0%</b>, stacking up to <b>10.0</b> time(s)."
+    ]
+  },
+  {
+    "_id": 312,
+    "Name": "Penacony, Land of the Dreams",
+    "Icon": "71027.png",
+    "Skills": [
+      "Increases wearer's Energy Regeneration Rate by <b>5.0%</b>. Increases DMG by <b>10.0%</b> for all other allies that are of the same Type as the wearer."
+    ]
+  },
+  {
+    "_id": 311,
+    "Name": "Firmament Frontline: Glamoth",
+    "Icon": "71026.png",
+    "Skills": [
+      "Increases the wearer's ATK by <b>12.0%</b>. When the wearer's SPD is equal to or higher than <b>135.0</b>/<b>160.0</b>, the wearer deals <b>12.0%</b>/<b>18.0%</b> more DMG."
+    ]
+  },
+  {
+    "_id": 310,
+    "Name": "Broken Keel",
+    "Icon": "71023.png",
+    "Skills": [
+      "Increases the wearer's Effect RES by <b>10.0%</b>. When the wearer's Effect RES is at <b>30.0%</b> or higher, all allies' CRIT DMG increases by <b>10.0%</b>."
+    ]
+  },
+  {
+    "_id": 309,
+    "Name": "Rutilant Arena",
+    "Icon": "71022.png",
+    "Skills": [
+      "Increases the wearer's CRIT Rate by <b>8.0%</b>. When the wearer's current CRIT Rate reaches <b>70.0%</b> or higher, the wearer's Basic ATK and Skill DMG increase by <b>20.0%</b>."
+    ]
+  },
+  {
+    "_id": 308,
+    "Name": "Sprightly Vonwacq",
+    "Icon": "71019.png",
+    "Skills": [
+      "Increases the wearer's Energy Regeneration Rate by <b>5.0%</b>. When the wearer's SPD reaches <b>120.0</b> or higher, the wearer's action is Advanced Forward by <b>40.0%</b> immediately upon entering battle."
+    ]
+  },
+  {
+    "_id": 307,
+    "Name": "Talia: Kingdom of Banditry",
+    "Icon": "71018.png",
+    "Skills": [
+      "Increases the wearer's Break Effect by <b>16.0%</b>. When the wearer's SPD reaches <b>145.0</b> or higher, the wearer's Break Effect increases by an extra <b>20.0%</b>."
+    ]
+  },
+  {
+    "_id": 306,
+    "Name": "Inert Salsotto",
+    "Icon": "71017.png",
+    "Skills": [
+      "Increases the wearer's CRIT Rate by <b>8.0%</b>. When the wearer's current CRIT Rate reaches <b>50.0%</b> or higher, the wearer's Ultimate and follow-up attack DMG increases by <b>15.0%</b>."
+    ]
+  },
+  {
+    "_id": 305,
+    "Name": "Celestial Differentiator",
+    "Icon": "71016.png",
+    "Skills": [
+      "Increases the wearer's CRIT DMG by <b>16.0%</b>. When the wearer's current CRIT DMG reaches <b>120.0%</b> or higher, after entering battle, the wearer's CRIT Rate increases by <b>60.0%</b> until the end of their first attack."
+    ]
+  },
+  {
+    "_id": 304,
+    "Name": "Belobog of the Architects",
+    "Icon": "71015.png",
+    "Skills": [
+      "Increases the wearer's DEF by <b>15.0%</b>. When the wearer's Effect Hit Rate is <b>50.0%</b> or higher, the wearer gains an extra <b>15.0%</b> DEF."
+    ]
+  },
+  {
+    "_id": 303,
+    "Name": "Pan-Cosmic Commercial Enterprise",
+    "Icon": "71014.png",
+    "Skills": [
+      "Increases the wearer's Effect Hit Rate by <b>10.0%</b>. Meanwhile, the wearer's ATK increases by an amount that is equal to <b>25.0%</b> of the current Effect Hit Rate, up to a maximum of <b>25.0%</b>."
+    ]
+  },
+  {
+    "_id": 302,
+    "Name": "Fleet of the Ageless",
+    "Icon": "71013.png",
+    "Skills": [
+      "Increases the wearer's Max HP by <b>12.0%</b>. When the wearer's SPD reaches <b>120.0</b> or higher, all allies' ATK increases by <b>8.0%</b>."
+    ]
+  },
+  {
+    "_id": 301,
+    "Name": "Space Sealing Station",
+    "Icon": "71012.png",
+    "Skills": [
+      "Increases the wearer's ATK by <b>12.0%</b>. When the wearer's SPD reaches <b>120.0</b> or higher, the wearer's ATK increases by an extra <b>12.0%</b>."
+    ]
+  },
+  {
+    "_id": 120,
+    "Name": "The Wind-Soaring Valorous",
+    "Icon": "71033.png",
+    "Skills": [
+      "ATK increases by <b>12.0%</b>.",
+      "Increases the wearer's CRIT Rate by <b>6.0%</b>. When the wearer uses a follow-up attack, increase the DMG dealt by their Ultimate by <b>36.0%</b>, lasting for <b>1.0</b> turn(s)."
+    ]
+  },
+  {
+    "_id": 119,
+    "Name": "Iron Cavalry Against the Scourge",
+    "Icon": "71032.png",
+    "Skills": [
+      "Increases Break Effect by <b>16.0%</b>.",
+      "If the wearer's Break Effect is <b>150.0%</b> or higher, ignores <b>10.0%</b> of the enemy target's DEF when dealing Break DMG to them. When the wearer's Break Effect is <b>250.0%</b> or higher, the Super Break DMG they deal to enemy targets additionally ignores <b>15.0%</b> of the targets' DEF."
+    ]
+  },
+  {
+    "_id": 118,
+    "Name": "Watchmaker, Master of Dream Machinations",
+    "Icon": "71029.png",
+    "Skills": [
+      "Increases Break Effect by <b>16.0%</b>.",
+      "When the wearer uses their Ultimate on an ally, all allies' Break Effect increases by <b>30.0%</b> for <b>2.0</b> turn(s). This effect cannot be stacked."
+    ]
+  },
+  {
+    "_id": 117,
+    "Name": "Pioneer Diver of Dead Waters",
+    "Icon": "71028.png",
+    "Skills": [
+      "Increases DMG dealt to enemies with debuffs by <b>12.0%</b>.",
+      "Increases CRIT Rate by <b>4.0%</b>. The wearer deals <b>8.0%</b>/<b>12.0%</b> increased CRIT DMG to enemies with at least <b>2.0</b>/<b>3.0</b> debuffs. After the wearer inflicts a debuff on enemy targets, the aforementioned effects increase by <b>100%</b>, lasting for <b>1.0</b> turn(s)."
+    ]
+  },
+  {
+    "_id": 116,
+    "Name": "Prisoner in Deep Confinement",
+    "Icon": "71025.png",
+    "Skills": [
+      "ATK increases by <b>12.0%</b>.",
+      "For every DoT the target enemy is afflicted with, the wearer will ignore <b>6.0%</b> of its DEF when dealing DMG to it. This effect is valid for a max of <b>3.0</b> DoTs."
+    ]
+  },
+  {
+    "_id": 115,
+    "Name": "The Ashblazing Grand Duke",
+    "Icon": "71024.png",
+    "Skills": [
+      "Increases the DMG dealt by follow-up attacks by <b>20.0%</b>.",
+      "When the wearer uses follow-up attacks, increases the wearer's ATK by <b>6.0%</b> for every time the follow-up attack deals DMG. This effect can stack up to <b>8.0</b> time(s) and lasts for <b>3.0</b> turn(s). This effect is removed the next time the wearer uses a follow-up attack."
+    ]
+  },
+  {
+    "_id": 114,
+    "Name": "Messenger Traversing Hackerspace",
+    "Icon": "71021.png",
+    "Skills": [
+      "Increases SPD by <b>6.0%</b>.",
+      "When the wearer uses their Ultimate on an ally, SPD for all allies increases by <b>12.0%</b> for <b>1.0</b> turn(s). This effect cannot be stacked."
+    ]
+  },
+  {
+    "_id": 113,
+    "Name": "Longevous Disciple",
+    "Icon": "71020.png",
+    "Skills": [
+      "Increases Max HP by <b>12.0%</b>.",
+      "When the wearer is hit or has their HP consumed by an ally or themselves, their CRIT Rate increases by <b>8.0%</b> for <b>2.0</b> turn(s) and up to <b>2.0</b> stacks."
+    ]
+  },
+  {
+    "_id": 112,
+    "Name": "Wastelander of Banditry Desert",
+    "Icon": "71011.png",
+    "Skills": [
+      "Increases Imaginary DMG by <b>10.0%</b>.",
+      "When attacking debuffed enemies, the wearer's CRIT Rate increases by <b>10.0%</b>, and their CRIT DMG increases by <b>20.0%</b> against Imprisoned enemies."
+    ]
+  },
+  {
+    "_id": 111,
+    "Name": "Thief of Shooting Meteor",
+    "Icon": "71010.png",
+    "Skills": [
+      "Increases Break Effect by <b>16.0%</b>.",
+      "Increases the wearer's Break Effect by <b>16.0%</b>. After the wearer inflicts Weakness Break on an enemy, regenerates <b>3.0</b> Energy."
+    ]
+  },
+  {
+    "_id": 110,
+    "Name": "Eagle of Twilight Line",
+    "Icon": "71009.png",
+    "Skills": [
+      "Increases Wind DMG by <b>10.0%</b>.",
+      "After the wearer uses their Ultimate, their action is Advanced Forward by <b>25.0%</b>."
+    ]
+  },
+  {
+    "_id": 109,
+    "Name": "Band of Sizzling Thunder",
+    "Icon": "71008.png",
+    "Skills": [
+      "Increases Lightning DMG by <b>10.0%</b>.",
+      "When the wearer uses their Skill, increases the wearer's ATK by <b>20.0%</b> for <b>1.0</b> turn(s)."
+    ]
+  },
+  {
+    "_id": 108,
+    "Name": "Genius of Brilliant Stars",
+    "Icon": "71007.png",
+    "Skills": [
+      "Increases Quantum DMG by <b>10.0%</b>.",
+      "When the wearer deals DMG to the target enemy, ignores <b>10.0%</b> DEF. If the target enemy has Quantum Weakness, the wearer additionally ignores <b>10.0%</b> DEF."
+    ]
+  },
+  {
+    "_id": 107,
+    "Name": "Firesmith of Lava-Forging",
+    "Icon": "71006.png",
+    "Skills": [
+      "Increases Fire DMG by <b>10.0%</b>.",
+      "Increases the wearer's Skill DMG by <b>12.0%</b>. After unleashing Ultimate, increases the wearer's Fire DMG by <b>12.0%</b> for the next attack."
+    ]
+  },
+  {
+    "_id": 106,
+    "Name": "Guard of Wuthering Snow",
+    "Icon": "71005.png",
+    "Skills": [
+      "Reduces DMG taken by <b>8.0%</b>.",
+      "At the beginning of the turn, if the wearer's HP is equal to or less than <b>50.0%</b>, restores HP equal to <b>8.0%</b> of their Max HP and regenerates <b>5.0</b> Energy."
+    ]
+  },
+  {
+    "_id": 105,
+    "Name": "Champion of Streetwise Boxing",
+    "Icon": "71004.png",
+    "Skills": [
+      "Increases Physical DMG by <b>10.0%</b>.",
+      "After the wearer attacks or is hit, their ATK increases by <b>5.0%</b> for the rest of the battle. This effect can stack up to <b>5.0</b> time(s)."
+    ]
+  },
+  {
+    "_id": 104,
+    "Name": "Hunter of Glacial Forest",
+    "Icon": "71003.png",
+    "Skills": [
+      "Increases Ice DMG by <b>10.0%</b>.",
+      "After the wearer uses their Ultimate, their CRIT DMG increases by <b>25.0%</b> for <b>2.0</b> turn(s)."
+    ]
+  },
+  {
+    "_id": 103,
+    "Name": "Knight of Purity Palace",
+    "Icon": "71002.png",
+    "Skills": [
+      "Increases DEF by <b>15.0%</b>.",
+      "Increases the max DMG that can be absorbed by the Shield created by the wearer by <b>20.0%</b>."
+    ]
+  },
+  {
+    "_id": 102,
+    "Name": "Musketeer of Wild Wheat",
+    "Icon": "71001.png",
+    "Skills": [
+      "ATK increases by <b>12.0%</b>.",
+      "The wearer's SPD increases by <b>6.0%</b> and Basic ATK DMG increases by <b>10.0%</b>."
+    ]
+  },
+  {
+    "_id": 101,
+    "Name": "Passerby of Wandering Cloud",
+    "Icon": "71000.png",
+    "Skills": [
+      "Increases Outgoing Healing by <b>10.0%</b>.",
+      "At the start of the battle, immediately regenerates 1 Skill Point."
+    ]
+  }
+]
+
+var _avatarskill = {
+  "131001": {
+    "v1": {
+      "Name": "Order: Flare Propulsion",
+      "MaxLevel": 9,
+      "Type": "Basic ATK",
+      "Tag": "Single Target",
+      "Desc": "Deals Fire DMG equal to @<b>#1[p]</b># of SAM's ATK to a single target enemy.",
+      "Params": [
+        [
+          0.5
+        ],
+        [
+          0.6
+        ],
+        [
+          0.7
+        ],
+        [
+          0.8
+        ],
+        [
+          0.9
+        ],
+        [
+          1.0
+        ],
+        [
+          1.1
+        ],
+        [
+          1.2
+        ],
+        [
+          1.3
+        ]
+      ],
+      "BP": 1,
+      "SPAdd": 20.0,
+      "AttackType": "Normal",
+      "Stance": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1310_Normal"
+    },
+    "v2": {
+      "Name": "Order: Flare Propulsion",
+      "MaxLevel": 9,
+      "Type": "Basic ATK",
+      "Tag": "Single Target",
+      "Desc": "Deals Fire DMG equal to @<b>#1[p]</b># of SAM's ATK to a single target enemy.",
+      "Params": [
+        [
+          0.5
+        ],
+        [
+          0.6
+        ],
+        [
+          0.7
+        ],
+        [
+          0.8
+        ],
+        [
+          0.9
+        ],
+        [
+          1.0
+        ],
+        [
+          1.1
+        ],
+        [
+          1.2
+        ],
+        [
+          1.3
+        ]
+      ],
+      "BP": 1,
+      "SPAdd": 20.0,
+      "AttackType": "Normal",
+      "Stance": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1310_Normal"
+    },
+    "v3": {
+      "Name": "Order: Flare Propulsion",
+      "MaxLevel": 9,
+      "Type": "Basic ATK",
+      "Tag": "Single Target",
+      "Desc": "Deals Fire DMG equal to @<b>#1[p]</b># of SAM's ATK to a single target enemy.",
+      "Params": [
+        [
+          0.5
+        ],
+        [
+          0.6
+        ],
+        [
+          0.7
+        ],
+        [
+          0.8
+        ],
+        [
+          0.9
+        ],
+        [
+          1.0
+        ],
+        [
+          1.1
+        ],
+        [
+          1.2
+        ],
+        [
+          1.3
+        ]
+      ],
+      "BP": 1,
+      "SPAdd": 20.0,
+      "AttackType": "Normal",
+      "Stance": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1310_Normal"
+    },
+    "v4": {
+      "Name": "Order: Flare Propulsion",
+      "MaxLevel": 9,
+      "Type": "Basic ATK",
+      "Tag": "Single Target",
+      "Desc": "Deals Fire DMG equal to @<b>#1[p]</b># of SAM's ATK to a single target enemy.",
+      "Params": [
+        [
+          0.5
+        ],
+        [
+          0.6
+        ],
+        [
+          0.7
+        ],
+        [
+          0.8
+        ],
+        [
+          0.9
+        ],
+        [
+          1.0
+        ],
+        [
+          1.1
+        ],
+        [
+          1.2
+        ],
+        [
+          1.3
+        ]
+      ],
+      "BP": 1,
+      "SPAdd": 20.0,
+      "AttackType": "Normal",
+      "Stance": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1310_Normal"
+    },
+    "v5": {
+      "Name": "Order: Flare Propulsion",
+      "MaxLevel": 9,
+      "Type": "Basic ATK",
+      "Tag": "Single Target",
+      "Desc": "Deals Fire DMG equal to @<b>#1[p]</b># of SAM's ATK to a single target enemy.",
+      "Params": [
+        [
+          0.5
+        ],
+        [
+          0.6
+        ],
+        [
+          0.7
+        ],
+        [
+          0.8
+        ],
+        [
+          0.9
+        ],
+        [
+          1.0
+        ],
+        [
+          1.1
+        ],
+        [
+          1.2
+        ],
+        [
+          1.3
+        ]
+      ],
+      "BP": 1,
+      "SPAdd": 20.0,
+      "AttackType": "Normal",
+      "Stance": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1310_Normal"
+    }
+  },
+  "131002": {
+    "v1": {
+      "Name": "Order: Aerial Bombardment",
+      "MaxLevel": 15,
+      "Type": "Skill",
+      "Tag": "Single Target",
+      "Desc": "Consumes SAM's HP equal to <b>#2[p]</b> of SAM's Max HP and regenerates a fixed amount of Energy equal to <b>#2[p]</b> of SAM's Max Energy. Deals Fire DMG equal to @<b>#1[p]</b># of SAM's ATK to a single target enemy. If the current HP is not sufficient, then SAM's HP is reduced to 1 when using this Skill.",
+      "Params": [
+        [
+          1.25,
+          0.5
+        ],
+        [
+          1.375,
+          0.5
+        ],
+        [
+          1.5,
+          0.5
+        ],
+        [
+          1.625,
+          0.5
+        ],
+        [
+          1.75,
+          0.5
+        ],
+        [
+          1.875,
+          0.5
+        ],
+        [
+          2.03125,
+          0.5
+        ],
+        [
+          2.1875,
+          0.5
+        ],
+        [
+          2.34375,
+          0.5
+        ],
+        [
+          2.5,
+          0.5
+        ],
+        [
+          2.625,
+          0.5
+        ],
+        [
+          2.75,
+          0.5
+        ],
+        [
+          2.875,
+          0.5
+        ],
+        [
+          3.0,
+          0.5
+        ],
+        [
+          3.125,
+          0.5
+        ]
+      ],
+      "BP": -1,
+      "SPAdd": 0,
+      "AttackType": "BPSkill",
+      "Stance": [
+        2.0,
+        0.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1310_BP"
+    },
+    "v2": {
+      "Name": "Order: Aerial Bombardment",
+      "MaxLevel": 15,
+      "Type": "Skill",
+      "Tag": "Single Target",
+      "Desc": "Consumes SAM's HP equal to <b>#2[p]</b> of SAM's Max HP and regenerates a fixed amount of Energy equal to <b>#2[p]</b> of SAM's Max Energy. Deals Fire DMG equal to @<b>#1[p]</b># of SAM's ATK to a single target enemy. If the current HP is not sufficient, then SAM's HP is reduced to 1 when using this Skill.",
+      "Params": [
+        [
+          1.25,
+          0.5
+        ],
+        [
+          1.375,
+          0.5
+        ],
+        [
+          1.5,
+          0.5
+        ],
+        [
+          1.625,
+          0.5
+        ],
+        [
+          1.75,
+          0.5
+        ],
+        [
+          1.875,
+          0.5
+        ],
+        [
+          2.03125,
+          0.5
+        ],
+        [
+          2.1875,
+          0.5
+        ],
+        [
+          2.34375,
+          0.5
+        ],
+        [
+          2.5,
+          0.5
+        ],
+        [
+          2.625,
+          0.5
+        ],
+        [
+          2.75,
+          0.5
+        ],
+        [
+          2.875,
+          0.5
+        ],
+        [
+          3.0,
+          0.5
+        ],
+        [
+          3.125,
+          0.5
+        ]
+      ],
+      "BP": -1,
+      "SPAdd": 0,
+      "AttackType": "BPSkill",
+      "Stance": [
+        2.0,
+        0.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1310_BP"
+    },
+    "v3": {
+      "Name": "Order: Aerial Bombardment",
+      "MaxLevel": 15,
+      "Type": "Skill",
+      "Tag": "Single Target",
+      "Desc": "Consumes SAM's HP equal to <b>#2[p]</b> of SAM's Max HP and regenerates a fixed amount of Energy equal to <b>#3[p]</b> of SAM's Max Energy. Deals Fire DMG equal to @<b>#1[p]</b># of SAM's ATK to a single target enemy. If the current HP is not sufficient, then SAM's HP is reduced to 1 when using this Skill. Causes character's next <u>Action to be Advanced</u> by <b>#4[p]</b>.<br><br>@<b>Action advanced</b>#<br>Reduces the target's waiting interval before the next action.",
+      "Params": [
+        [
+          1.0,
+          0.4,
+          0.6,
+          0.25
+        ],
+        [
+          1.1,
+          0.4,
+          0.6,
+          0.25
+        ],
+        [
+          1.2,
+          0.4,
+          0.6,
+          0.25
+        ],
+        [
+          1.3,
+          0.4,
+          0.6,
+          0.25
+        ],
+        [
+          1.4,
+          0.4,
+          0.6,
+          0.25
+        ],
+        [
+          1.5,
+          0.4,
+          0.6,
+          0.25
+        ],
+        [
+          1.625,
+          0.4,
+          0.6,
+          0.25
+        ],
+        [
+          1.75,
+          0.4,
+          0.6,
+          0.25
+        ],
+        [
+          1.875,
+          0.4,
+          0.6,
+          0.25
+        ],
+        [
+          2.0,
+          0.4,
+          0.6,
+          0.25
+        ],
+        [
+          2.1,
+          0.4,
+          0.6,
+          0.25
+        ],
+        [
+          2.2,
+          0.4,
+          0.6,
+          0.25
+        ],
+        [
+          2.3,
+          0.4,
+          0.6,
+          0.25
+        ],
+        [
+          2.4,
+          0.4,
+          0.6,
+          0.25
+        ],
+        [
+          2.5,
+          0.4,
+          0.6,
+          0.25
+        ]
+      ],
+      "BP": -1,
+      "SPAdd": 0,
+      "AttackType": "BPSkill",
+      "Stance": [
+        2.0,
+        0.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1310_BP"
+    },
+    "v4": {
+      "Name": "Order: Aerial Bombardment",
+      "MaxLevel": 15,
+      "Type": "Skill",
+      "Tag": "Single Target",
+      "Desc": "Consumes SAM's HP equal to <b>#2[p]</b> of SAM's Max HP and regenerates a fixed amount of Energy equal to <b>#3[p]</b> of SAM's Max Energy. Deals Fire DMG equal to @<b>#1[p]</b># of SAM's ATK to a single target enemy. If the current HP is not sufficient, then SAM's HP is reduced to 1 when using this Skill. Enables this unit's next <u>Action to be Advanced</u> by <b>#4[p]</b>.<br><br>@<b>Action advanced</b>#<br>Reduces the target's waiting interval before the next action.",
+      "Params": [
+        [
+          1.0,
+          0.4,
+          0.5,
+          0.25
+        ],
+        [
+          1.1,
+          0.4,
+          0.51,
+          0.25
+        ],
+        [
+          1.2,
+          0.4,
+          0.52,
+          0.25
+        ],
+        [
+          1.3,
+          0.4,
+          0.53,
+          0.25
+        ],
+        [
+          1.4,
+          0.4,
+          0.54,
+          0.25
+        ],
+        [
+          1.5,
+          0.4,
+          0.55,
+          0.25
+        ],
+        [
+          1.625,
+          0.4,
+          0.5625,
+          0.25
+        ],
+        [
+          1.75,
+          0.4,
+          0.575,
+          0.25
+        ],
+        [
+          1.875,
+          0.4,
+          0.5875,
+          0.25
+        ],
+        [
+          2.0,
+          0.4,
+          0.6,
+          0.25
+        ],
+        [
+          2.1,
+          0.4,
+          0.61,
+          0.25
+        ],
+        [
+          2.2,
+          0.4,
+          0.62,
+          0.25
+        ],
+        [
+          2.3,
+          0.4,
+          0.63,
+          0.25
+        ],
+        [
+          2.4,
+          0.4,
+          0.64,
+          0.25
+        ],
+        [
+          2.5,
+          0.4,
+          0.65,
+          0.25
+        ]
+      ],
+      "BP": -1,
+      "SPAdd": 0,
+      "AttackType": "BPSkill",
+      "Stance": [
+        2.0,
+        0.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1310_BP"
+    },
+    "v5": {
+      "Name": "Order: Aerial Bombardment",
+      "MaxLevel": 15,
+      "Type": "Skill",
+      "Tag": "Single Target",
+      "Desc": "Consumes SAM's HP equal to <b>#2[p]</b> of SAM's Max HP and regenerates a fixed amount of Energy equal to <b>#3[p]</b> of SAM's Max Energy. Deals Fire DMG equal to @<b>#1[p]</b># of SAM's ATK to a single target enemy. If the current HP is not sufficient, then SAM's HP is reduced to 1 when using this Skill. Enables this unit's next <u>Action to be Advanced</u> by <b>#4[p]</b>.<br><br>@<b>Action advanced</b>#<br>Reduces the target's waiting interval before the next action.",
+      "Params": [
+        [
+          1.0,
+          0.4,
+          0.5,
+          0.25
+        ],
+        [
+          1.1,
+          0.4,
+          0.51,
+          0.25
+        ],
+        [
+          1.2,
+          0.4,
+          0.52,
+          0.25
+        ],
+        [
+          1.3,
+          0.4,
+          0.53,
+          0.25
+        ],
+        [
+          1.4,
+          0.4,
+          0.54,
+          0.25
+        ],
+        [
+          1.5,
+          0.4,
+          0.55,
+          0.25
+        ],
+        [
+          1.625,
+          0.4,
+          0.5625,
+          0.25
+        ],
+        [
+          1.75,
+          0.4,
+          0.575,
+          0.25
+        ],
+        [
+          1.875,
+          0.4,
+          0.5875,
+          0.25
+        ],
+        [
+          2.0,
+          0.4,
+          0.6,
+          0.25
+        ],
+        [
+          2.1,
+          0.4,
+          0.61,
+          0.25
+        ],
+        [
+          2.2,
+          0.4,
+          0.62,
+          0.25
+        ],
+        [
+          2.3,
+          0.4,
+          0.63,
+          0.25
+        ],
+        [
+          2.4,
+          0.4,
+          0.64,
+          0.25
+        ],
+        [
+          2.5,
+          0.4,
+          0.65,
+          0.25
+        ]
+      ],
+      "BP": -1,
+      "SPAdd": 0,
+      "AttackType": "BPSkill",
+      "Stance": [
+        2.0,
+        0.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1310_BP"
+    }
+  },
+  "131003": {
+    "v1": {
+      "Name": "Firefly Type-IV: Complete Combustion",
+      "MaxLevel": 15,
+      "Type": "Ultimate",
+      "Tag": "Enhance",
+      "Desc": "Upon entering the Complete Combustion state, Advances SAM's Action by <b>100%</b> and gains Enhanced Basic ATK and Enhanced Skill. While in Complete Combustion, increases SPD by @<b>#3[f]</b>#, and when using the Enhanced Basic ATK or Enhanced Skill, increases SAM's Weakness Break efficiency by <b>#2[p]</b>, increases the DMG the <u>Weakness Broken</u> enemy target receives by @<b>#1[p]</b>#, lasting until the current attack ends.<br>A countdown timer for the Complete Combustion state appears on the Action Order. When the countdown turn starts, SAM exits the Complete Combustion state. The countdown has a fixed SPD of <b>#4[f]</b>.<br>SAM cannot use Ultimate while in Complete Combustion.<br><br>@<b>Weakness Break State</b>#<br>When enemy targets' Toughness is reduced to 0, they will enter the Weakness Break State, which delays their actions.",
+      "Params": [
+        [
+          0.072,
+          0.5,
+          25.0,
+          90.0
+        ],
+        [
+          0.0768,
+          0.5,
+          27.5,
+          90.0
+        ],
+        [
+          0.0816,
+          0.5,
+          30.0,
+          90.0
+        ],
+        [
+          0.0864,
+          0.5,
+          32.5,
+          90.0
+        ],
+        [
+          0.0912,
+          0.5,
+          35.0,
+          90.0
+        ],
+        [
+          0.096,
+          0.5,
+          37.5,
+          90.0
+        ],
+        [
+          0.102,
+          0.5,
+          40.625,
+          90.0
+        ],
+        [
+          0.108,
+          0.5,
+          43.75,
+          90.0
+        ],
+        [
+          0.114,
+          0.5,
+          46.875,
+          90.0
+        ],
+        [
+          0.12,
+          0.5,
+          50.0,
+          90.0
+        ],
+        [
+          0.1248,
+          0.5,
+          52.5,
+          90.0
+        ],
+        [
+          0.1296,
+          0.5,
+          55.0,
+          90.0
+        ],
+        [
+          0.1344,
+          0.5,
+          57.5,
+          90.0
+        ],
+        [
+          0.1392,
+          0.5,
+          60.0,
+          90.0
+        ],
+        [
+          0.144,
+          0.5,
+          62.5,
+          90.0
+        ]
+      ],
+      "BP": 0,
+      "SPAdd": 5.0,
+      "SPNeed": 240.0,
+      "AttackType": "Ultra",
+      "Stance": [
+        0.0,
+        0.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1310_Ultra"
+    },
+    "v2": {
+      "Name": "Firefly Type-IV: Complete Combustion",
+      "MaxLevel": 15,
+      "Type": "Ultimate",
+      "Tag": "Enhance",
+      "Desc": "Upon entering the Complete Combustion state, Advances SAM's Action by <b>100%</b> and gains Enhanced Basic ATK and Enhanced Skill. While in Complete Combustion, increases SPD by @<b>#3[f]</b>#, and when using the Enhanced Basic ATK or Enhanced Skill, increases SAM's Weakness Break efficiency by <b>#2[p]</b>, increases the DMG the <u>Weakness Broken</u> enemy target receives by @<b>#1[p]</b>#, lasting until the current attack ends.<br>A countdown timer for the Complete Combustion state appears on the Action Order. When the countdown turn starts, SAM exits the Complete Combustion state. The countdown has a fixed SPD of <b>#4[f]</b>.<br>SAM cannot use Ultimate while in Complete Combustion.<br><br>@<b>Weakness Break State</b>#<br>When enemy targets' Toughness is reduced to 0, they will enter the Weakness Break State, which delays their actions.",
+      "Params": [
+        [
+          0.072,
+          0.5,
+          25.0,
+          90.0
+        ],
+        [
+          0.0768,
+          0.5,
+          27.5,
+          90.0
+        ],
+        [
+          0.0816,
+          0.5,
+          30.0,
+          90.0
+        ],
+        [
+          0.0864,
+          0.5,
+          32.5,
+          90.0
+        ],
+        [
+          0.0912,
+          0.5,
+          35.0,
+          90.0
+        ],
+        [
+          0.096,
+          0.5,
+          37.5,
+          90.0
+        ],
+        [
+          0.102,
+          0.5,
+          40.625,
+          90.0
+        ],
+        [
+          0.108,
+          0.5,
+          43.75,
+          90.0
+        ],
+        [
+          0.114,
+          0.5,
+          46.875,
+          90.0
+        ],
+        [
+          0.12,
+          0.5,
+          50.0,
+          90.0
+        ],
+        [
+          0.1248,
+          0.5,
+          52.5,
+          90.0
+        ],
+        [
+          0.1296,
+          0.5,
+          55.0,
+          90.0
+        ],
+        [
+          0.1344,
+          0.5,
+          57.5,
+          90.0
+        ],
+        [
+          0.1392,
+          0.5,
+          60.0,
+          90.0
+        ],
+        [
+          0.144,
+          0.5,
+          62.5,
+          90.0
+        ]
+      ],
+      "BP": 0,
+      "SPAdd": 5.0,
+      "SPNeed": 240.0,
+      "AttackType": "Ultra",
+      "Stance": [
+        0.0,
+        0.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1310_Ultra"
+    },
+    "v3": {
+      "Name": "Fyrefly Type-IV: Complete Combustion",
+      "MaxLevel": 15,
+      "Type": "Ultimate",
+      "Tag": "Enhance",
+      "Desc": "Upon entering the Complete Combustion state, Advances SAM's Action by <b>100%</b> and gains Enhanced Basic ATK and Enhanced Skill. While in Complete Combustion, increases SPD by @<b>#3[f]</b>#, and when using the Enhanced Basic ATK or Enhanced Skill, increases SAM's Weakness Break efficiency by <b>#2[p]</b>, increases the Break DMG enemy targets receive by @<b>#1[p]</b>#, lasting until the current attack ends.<br>A countdown timer for the Complete Combustion state appears on the Action Order. When the countdown turn starts, SAM exits the Complete Combustion state. The countdown has a fixed SPD of <b>#4[f]</b>.<br>SAM cannot use Ultimate while in Complete Combustion.",
+      "Params": [
+        [
+          0.1,
+          0.5,
+          30.0,
+          70.0
+        ],
+        [
+          0.11,
+          0.5,
+          33.0,
+          70.0
+        ],
+        [
+          0.12,
+          0.5,
+          36.0,
+          70.0
+        ],
+        [
+          0.13,
+          0.5,
+          39.0,
+          70.0
+        ],
+        [
+          0.14,
+          0.5,
+          42.0,
+          70.0
+        ],
+        [
+          0.15,
+          0.5,
+          45.0,
+          70.0
+        ],
+        [
+          0.1625,
+          0.5,
+          48.75,
+          70.0
+        ],
+        [
+          0.175,
+          0.5,
+          52.5,
+          70.0
+        ],
+        [
+          0.1875,
+          0.5,
+          56.25,
+          70.0
+        ],
+        [
+          0.2,
+          0.5,
+          60.0,
+          70.0
+        ],
+        [
+          0.21,
+          0.5,
+          63.0,
+          70.0
+        ],
+        [
+          0.22,
+          0.5,
+          66.0,
+          70.0
+        ],
+        [
+          0.23,
+          0.5,
+          69.0,
+          70.0
+        ],
+        [
+          0.24,
+          0.5,
+          72.0,
+          70.0
+        ],
+        [
+          0.25,
+          0.5,
+          75.0,
+          70.0
+        ]
+      ],
+      "BP": 0,
+      "SPAdd": 5.0,
+      "SPNeed": 240.0,
+      "AttackType": "Ultra",
+      "Stance": [
+        0.0,
+        0.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1310_Ultra"
+    },
+    "v4": {
+      "Name": "Fyrefly Type-IV: Complete Combustion",
+      "MaxLevel": 15,
+      "Type": "Ultimate",
+      "Tag": "Enhance",
+      "Desc": "Upon entering the Complete Combustion state, Advances SAM's Action by <b>100%</b> and gains Enhanced Basic ATK and Enhanced Skill. While in Complete Combustion, increases SPD by @<b>#3[f]</b>#, and when using the Enhanced Basic ATK or Enhanced Skill, increases this unit's Weakness Break efficiency by <b>#2[p]</b> and the Break DMG received by the enemy targets by @<b>#1[p]</b>#, lasting until the current attack ends.<br>A countdown timer for the Complete Combustion state appears on the Action Order. When the countdown turn starts, SAM exits the Complete Combustion state. The countdown has a fixed SPD of <b>#4[f]</b>.<br>SAM cannot use Ultimate while in Complete Combustion.",
+      "Params": [
+        [
+          0.1,
+          0.5,
+          30.0,
+          70.0
+        ],
+        [
+          0.11,
+          0.5,
+          33.0,
+          70.0
+        ],
+        [
+          0.12,
+          0.5,
+          36.0,
+          70.0
+        ],
+        [
+          0.13,
+          0.5,
+          39.0,
+          70.0
+        ],
+        [
+          0.14,
+          0.5,
+          42.0,
+          70.0
+        ],
+        [
+          0.15,
+          0.5,
+          45.0,
+          70.0
+        ],
+        [
+          0.1625,
+          0.5,
+          48.75,
+          70.0
+        ],
+        [
+          0.175,
+          0.5,
+          52.5,
+          70.0
+        ],
+        [
+          0.1875,
+          0.5,
+          56.25,
+          70.0
+        ],
+        [
+          0.2,
+          0.5,
+          60.0,
+          70.0
+        ],
+        [
+          0.21,
+          0.5,
+          63.0,
+          70.0
+        ],
+        [
+          0.22,
+          0.5,
+          66.0,
+          70.0
+        ],
+        [
+          0.23,
+          0.5,
+          69.0,
+          70.0
+        ],
+        [
+          0.24,
+          0.5,
+          72.0,
+          70.0
+        ],
+        [
+          0.25,
+          0.5,
+          75.0,
+          70.0
+        ]
+      ],
+      "BP": 0,
+      "SPAdd": 5.0,
+      "SPNeed": 240.0,
+      "AttackType": "Ultra",
+      "Stance": [
+        0.0,
+        0.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1310_Ultra"
+    },
+    "v5": {
+      "Name": "Fyrefly Type-IV: Complete Combustion",
+      "MaxLevel": 15,
+      "Type": "Ultimate",
+      "Tag": "Enhance",
+      "Desc": "Upon entering the Complete Combustion state, Advances SAM's Action by <b>100%</b> and gains Enhanced Basic ATK and Enhanced Skill. While in Complete Combustion, increases SPD by @<b>#3[f]</b>#, and when using the Enhanced Basic ATK or Enhanced Skill, increases this unit's Weakness Break efficiency by <b>#2[p]</b> and the Break DMG received by the enemy targets by @<b>#1[p]</b>#, lasting until the current attack ends.<br>A countdown timer for the Complete Combustion state appears on the Action Order. When the countdown turn starts, SAM exits the Complete Combustion state. The countdown has a fixed SPD of <b>#4[f]</b>.<br>SAM cannot use Ultimate while in Complete Combustion.",
+      "Params": [
+        [
+          0.1,
+          0.5,
+          30.0,
+          70.0
+        ],
+        [
+          0.11,
+          0.5,
+          33.0,
+          70.0
+        ],
+        [
+          0.12,
+          0.5,
+          36.0,
+          70.0
+        ],
+        [
+          0.13,
+          0.5,
+          39.0,
+          70.0
+        ],
+        [
+          0.14,
+          0.5,
+          42.0,
+          70.0
+        ],
+        [
+          0.15,
+          0.5,
+          45.0,
+          70.0
+        ],
+        [
+          0.1625,
+          0.5,
+          48.75,
+          70.0
+        ],
+        [
+          0.175,
+          0.5,
+          52.5,
+          70.0
+        ],
+        [
+          0.1875,
+          0.5,
+          56.25,
+          70.0
+        ],
+        [
+          0.2,
+          0.5,
+          60.0,
+          70.0
+        ],
+        [
+          0.21,
+          0.5,
+          63.0,
+          70.0
+        ],
+        [
+          0.22,
+          0.5,
+          66.0,
+          70.0
+        ],
+        [
+          0.23,
+          0.5,
+          69.0,
+          70.0
+        ],
+        [
+          0.24,
+          0.5,
+          72.0,
+          70.0
+        ],
+        [
+          0.25,
+          0.5,
+          75.0,
+          70.0
+        ]
+      ],
+      "BP": 0,
+      "SPAdd": 5.0,
+      "SPNeed": 240.0,
+      "AttackType": "Ultra",
+      "Stance": [
+        0.0,
+        0.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1310_Ultra"
+    }
+  },
+  "131004": {
+    "v1": {
+      "Name": "Chrysalid Pyronexus",
+      "MaxLevel": 15,
+      "Type": "Talent",
+      "Tag": "Talent",
+      "Desc": "The lower the HP, the lower the DMG received. When HP is <b>#3[p]</b> or lower, the DMG Reduction reaches its maximum effect, reducing up to a maximum of @<b>#1[p]</b>#. During the Complete Combustion, the DMG Reduction remains at its maximum effect, and the Effect RES increases by @<b>#4[p]</b>#.<br>If Energy is lower than <b>#2[p]</b> when the battle starts, regenerates Energy to <b>#2[p]</b>. Once Energy is regenerated to its maximum, dispels all <u>debuffs</u> on SAM.<br><br>@<b>Debuff</b>#<br>Debuffs are negative status effects that render units weaker. Unless otherwise specified, debuffs can be dispelled.",
+      "Params": [
+        [
+          0.2,
+          0.5,
+          0.2,
+          0.1
+        ],
+        [
+          0.22,
+          0.5,
+          0.2,
+          0.115
+        ],
+        [
+          0.24,
+          0.5,
+          0.2,
+          0.13
+        ],
+        [
+          0.26,
+          0.5,
+          0.2,
+          0.145
+        ],
+        [
+          0.28,
+          0.5,
+          0.2,
+          0.16
+        ],
+        [
+          0.3,
+          0.5,
+          0.2,
+          0.175
+        ],
+        [
+          0.325,
+          0.5,
+          0.2,
+          0.19375
+        ],
+        [
+          0.35,
+          0.5,
+          0.2,
+          0.2125
+        ],
+        [
+          0.375,
+          0.5,
+          0.2,
+          0.23125
+        ],
+        [
+          0.4,
+          0.5,
+          0.2,
+          0.25
+        ],
+        [
+          0.42,
+          0.5,
+          0.2,
+          0.265
+        ],
+        [
+          0.44,
+          0.5,
+          0.2,
+          0.28
+        ],
+        [
+          0.46,
+          0.5,
+          0.2,
+          0.295
+        ],
+        [
+          0.48,
+          0.5,
+          0.2,
+          0.31
+        ],
+        [
+          0.5,
+          0.5,
+          0.2,
+          0.325
+        ]
+      ],
+      "BP": 0,
+      "SPAdd": 0,
+      "Stance": [
+        0.0,
+        0.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1310_Passive"
+    },
+    "v2": {
+      "Name": "Chrysalid Pyronexus",
+      "MaxLevel": 15,
+      "Type": "Talent",
+      "Tag": "Talent",
+      "Desc": "The lower the HP, the lower the DMG received. When HP is <b>#3[p]</b> or lower, the DMG Reduction reaches its maximum effect, reducing up to a maximum of @<b>#1[p]</b>#. During the Complete Combustion, the DMG Reduction remains at its maximum effect, and the Effect RES increases by @<b>#4[p]</b>#.<br>If Energy is lower than <b>#2[p]</b> when the battle starts, regenerates Energy to <b>#2[p]</b>. Once Energy is regenerated to its maximum, dispels all <u>debuffs</u> on SAM.<br><br>@<b>Debuff</b>#<br>Debuffs are negative status effects that render units weaker. Unless otherwise specified, debuffs can be dispelled.",
+      "Params": [
+        [
+          0.2,
+          0.5,
+          0.2,
+          0.1
+        ],
+        [
+          0.22,
+          0.5,
+          0.2,
+          0.115
+        ],
+        [
+          0.24,
+          0.5,
+          0.2,
+          0.13
+        ],
+        [
+          0.26,
+          0.5,
+          0.2,
+          0.145
+        ],
+        [
+          0.28,
+          0.5,
+          0.2,
+          0.16
+        ],
+        [
+          0.3,
+          0.5,
+          0.2,
+          0.175
+        ],
+        [
+          0.325,
+          0.5,
+          0.2,
+          0.19375
+        ],
+        [
+          0.35,
+          0.5,
+          0.2,
+          0.2125
+        ],
+        [
+          0.375,
+          0.5,
+          0.2,
+          0.23125
+        ],
+        [
+          0.4,
+          0.5,
+          0.2,
+          0.25
+        ],
+        [
+          0.42,
+          0.5,
+          0.2,
+          0.265
+        ],
+        [
+          0.44,
+          0.5,
+          0.2,
+          0.28
+        ],
+        [
+          0.46,
+          0.5,
+          0.2,
+          0.295
+        ],
+        [
+          0.48,
+          0.5,
+          0.2,
+          0.31
+        ],
+        [
+          0.5,
+          0.5,
+          0.2,
+          0.325
+        ]
+      ],
+      "BP": 0,
+      "SPAdd": 0,
+      "Stance": [
+        0.0,
+        0.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1310_Passive"
+    },
+    "v3": {
+      "Name": "Chrysalid Pyronexus",
+      "MaxLevel": 15,
+      "Type": "Talent",
+      "Tag": "Defense",
+      "Desc": "The lower the HP, the lower the DMG received. When HP is <b>#3[p]</b> or lower, the DMG Reduction reaches its maximum effect, reducing up to a maximum of @<b>#1[p]</b>#. During the Complete Combustion, the DMG Reduction remains at its maximum effect, and the Effect RES increases by @<b>#4[p]</b>#.<br>If Energy is lower than <b>#2[p]</b> when the battle starts, regenerates Energy to <b>#2[p]</b>. Once Energy is regenerated to its maximum, dispels all <u>debuffs</u> on SAM.<br><br>@<b>Debuff</b>#<br>Debuffs are negative status effects that render units weaker. Unless otherwise specified, debuffs can be dispelled.",
+      "Params": [
+        [
+          0.2,
+          0.5,
+          0.2,
+          0.1
+        ],
+        [
+          0.22,
+          0.5,
+          0.2,
+          0.12
+        ],
+        [
+          0.24,
+          0.5,
+          0.2,
+          0.14
+        ],
+        [
+          0.26,
+          0.5,
+          0.2,
+          0.16
+        ],
+        [
+          0.28,
+          0.5,
+          0.2,
+          0.18
+        ],
+        [
+          0.3,
+          0.5,
+          0.2,
+          0.2
+        ],
+        [
+          0.325,
+          0.5,
+          0.2,
+          0.225
+        ],
+        [
+          0.35,
+          0.5,
+          0.2,
+          0.25
+        ],
+        [
+          0.375,
+          0.5,
+          0.2,
+          0.275
+        ],
+        [
+          0.4,
+          0.5,
+          0.2,
+          0.3
+        ],
+        [
+          0.42,
+          0.5,
+          0.2,
+          0.32
+        ],
+        [
+          0.44,
+          0.5,
+          0.2,
+          0.34
+        ],
+        [
+          0.46,
+          0.5,
+          0.2,
+          0.36
+        ],
+        [
+          0.48,
+          0.5,
+          0.2,
+          0.38
+        ],
+        [
+          0.5,
+          0.5,
+          0.2,
+          0.4
+        ]
+      ],
+      "BP": 0,
+      "SPAdd": 0,
+      "Stance": [
+        0.0,
+        0.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1310_Passive"
+    },
+    "v4": {
+      "Name": "Chrysalid Pyronexus",
+      "MaxLevel": 15,
+      "Type": "Talent",
+      "Tag": "Defense",
+      "Desc": "The lower the HP, the lower the DMG received. When HP is <b>#3[p]</b> or lower, the DMG Reduction reaches its maximum effect, reducing up to a maximum of @<b>#1[p]</b>#. During the Complete Combustion, the DMG Reduction remains at its maximum effect, and the Effect RES increases by @<b>#4[p]</b>#.<br>If Energy is lower than <b>#2[p]</b> when the battle starts, regenerates Energy to <b>#2[p]</b>. Once Energy is regenerated to its maximum, dispels all <u>debuffs</u> on SAM.<br><br>@<b>Debuff</b>#<br>Debuffs are negative status effects that render units weaker. Unless otherwise specified, debuffs can be dispelled.",
+      "Params": [
+        [
+          0.2,
+          0.5,
+          0.2,
+          0.1
+        ],
+        [
+          0.22,
+          0.5,
+          0.2,
+          0.12
+        ],
+        [
+          0.24,
+          0.5,
+          0.2,
+          0.14
+        ],
+        [
+          0.26,
+          0.5,
+          0.2,
+          0.16
+        ],
+        [
+          0.28,
+          0.5,
+          0.2,
+          0.18
+        ],
+        [
+          0.3,
+          0.5,
+          0.2,
+          0.2
+        ],
+        [
+          0.325,
+          0.5,
+          0.2,
+          0.225
+        ],
+        [
+          0.35,
+          0.5,
+          0.2,
+          0.25
+        ],
+        [
+          0.375,
+          0.5,
+          0.2,
+          0.275
+        ],
+        [
+          0.4,
+          0.5,
+          0.2,
+          0.3
+        ],
+        [
+          0.42,
+          0.5,
+          0.2,
+          0.32
+        ],
+        [
+          0.44,
+          0.5,
+          0.2,
+          0.34
+        ],
+        [
+          0.46,
+          0.5,
+          0.2,
+          0.36
+        ],
+        [
+          0.48,
+          0.5,
+          0.2,
+          0.38
+        ],
+        [
+          0.5,
+          0.5,
+          0.2,
+          0.4
+        ]
+      ],
+      "BP": 0,
+      "SPAdd": 0,
+      "Stance": [
+        0.0,
+        0.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1310_Passive"
+    },
+    "v5": {
+      "Name": "Chrysalid Pyronexus",
+      "MaxLevel": 15,
+      "Type": "Talent",
+      "Tag": "Defense",
+      "Desc": "The lower the HP, the less DMG received. When HP is <b>#3[p]</b> or lower, the DMG Reduction reaches its maximum effect, reducing up to @<b>#1[p]</b>#. During the Complete Combustion, the DMG Reduction remains at its maximum effect, and the Effect RES increases by @<b>#4[p]</b>#.<br>If Energy is lower than <b>#2[p]</b> when the battle starts, regenerates Energy to <b>#2[p]</b>. Once Energy is regenerated to its maximum, dispels all <u>debuffs</u> on this unit.<br><br>@<b>Debuff</b>#<br>Debuffs are negative status effects that render units weaker. Unless otherwise specified, debuffs can be dispelled.",
+      "Params": [
+        [
+          0.2,
+          0.5,
+          0.2,
+          0.1
+        ],
+        [
+          0.22,
+          0.5,
+          0.2,
+          0.12
+        ],
+        [
+          0.24,
+          0.5,
+          0.2,
+          0.14
+        ],
+        [
+          0.26,
+          0.5,
+          0.2,
+          0.16
+        ],
+        [
+          0.28,
+          0.5,
+          0.2,
+          0.18
+        ],
+        [
+          0.3,
+          0.5,
+          0.2,
+          0.2
+        ],
+        [
+          0.325,
+          0.5,
+          0.2,
+          0.225
+        ],
+        [
+          0.35,
+          0.5,
+          0.2,
+          0.25
+        ],
+        [
+          0.375,
+          0.5,
+          0.2,
+          0.275
+        ],
+        [
+          0.4,
+          0.5,
+          0.2,
+          0.3
+        ],
+        [
+          0.42,
+          0.5,
+          0.2,
+          0.32
+        ],
+        [
+          0.44,
+          0.5,
+          0.2,
+          0.34
+        ],
+        [
+          0.46,
+          0.5,
+          0.2,
+          0.36
+        ],
+        [
+          0.48,
+          0.5,
+          0.2,
+          0.38
+        ],
+        [
+          0.5,
+          0.5,
+          0.2,
+          0.4
+        ]
+      ],
+      "BP": 0,
+      "SPAdd": 0,
+      "Stance": [
+        0.0,
+        0.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1310_Passive"
+    }
+  },
+  "131006": {
+    "v1": {
+      "Name": "Attack",
+      "MaxLevel": 1,
+      "Type": "",
+      "Tag": "",
+      "Desc": "Attacks an enemy, and when the battle starts, reduces their Toughness of the corresponding Type.",
+      "Params": [
+        []
+      ],
+      "BP": 0,
+      "SPAdd": 0,
+      "AttackType": "MazeNormal",
+      "Stance": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1310_Normal"
+    },
+    "v2": {
+      "Name": "Attack",
+      "MaxLevel": 1,
+      "Type": "",
+      "Tag": "",
+      "Desc": "Attacks an enemy, and when the battle starts, reduces their Toughness of the corresponding Type.",
+      "Params": [
+        []
+      ],
+      "BP": 0,
+      "SPAdd": 0,
+      "AttackType": "MazeNormal",
+      "Stance": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1310_Normal02"
+    },
+    "v3": {
+      "Name": "Attack",
+      "MaxLevel": 1,
+      "Type": "",
+      "Tag": "",
+      "Desc": "Attacks an enemy, and when the battle starts, reduces their Toughness of the corresponding Type.",
+      "Params": [
+        []
+      ],
+      "BP": 0,
+      "SPAdd": 0,
+      "AttackType": "MazeNormal",
+      "Stance": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1310_Normal02"
+    },
+    "v4": {
+      "Name": "Attack",
+      "MaxLevel": 1,
+      "Type": "",
+      "Tag": "",
+      "Desc": "Attacks an enemy, and when the battle starts, reduces their Toughness of the corresponding Type.",
+      "Params": [
+        []
+      ],
+      "BP": 0,
+      "SPAdd": 0,
+      "AttackType": "MazeNormal",
+      "Stance": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1310_Normal02"
+    },
+    "v5": {
+      "Name": "Attack",
+      "MaxLevel": 1,
+      "Type": "",
+      "Tag": "",
+      "Desc": "Attacks an enemy, and when the battle starts, reduces their Toughness of the corresponding Type.",
+      "Params": [
+        []
+      ],
+      "BP": 0,
+      "SPAdd": 0,
+      "AttackType": "MazeNormal",
+      "Stance": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1310_Normal02"
+    }
+  },
+  "131007": {
+    "v1": {
+      "Name": "Δ Order: Meteoric Incineration",
+      "MaxLevel": 1,
+      "Type": "Technique",
+      "Tag": "",
+      "Desc": "Leaps into the air and moves without restrictions for <b>#1[f]</b> seconds, which can be ended early by launching a Plunging Attack. When this duration ends, SAM descends and immediately attacks all enemies within a set area. At the start of each wave, applies a Fire Weakness to enemies without one, lasting for <b>#3[f]</b> turn(s). Then, deals Fire DMG equal to <b>#2[p]</b> of SAM's ATK to all enemies.",
+      "Params": [
+        [
+          5.0,
+          2.0,
+          2.0
+        ]
+      ],
+      "BP": 0,
+      "SPAdd": 0,
+      "AttackType": "Maze",
+      "Stance": [
+        2.0,
+        0.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1310_Maze"
+    },
+    "v2": {
+      "Name": "Δ Order: Meteoric Incineration",
+      "MaxLevel": 1,
+      "Type": "Technique",
+      "Tag": "",
+      "Desc": "Leaps into the air and moves without restrictions for <b>#1[f]</b> seconds, which can be ended early by launching a Plunging Attack. When this duration ends, SAM descends and immediately attacks all enemies within a set area. At the start of each wave, applies a Fire Weakness to enemies without one, lasting for <b>#3[f]</b> turn(s). Then, deals Fire DMG equal to <b>#2[p]</b> of SAM's ATK to all enemies.",
+      "Params": [
+        [
+          5.0,
+          2.0,
+          2.0
+        ]
+      ],
+      "BP": 0,
+      "SPAdd": 0,
+      "AttackType": "Maze",
+      "Stance": [
+        2.0,
+        0.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1310_Maze"
+    },
+    "v3": {
+      "Name": "Δ Order: Meteoric Incineration",
+      "MaxLevel": 1,
+      "Type": "Technique",
+      "Tag": "",
+      "Desc": "Leaps into the air and moves without restrictions for <b>#1[f]</b> seconds, which can be ended early by launching a Plunging Attack. When this duration ends, SAM descends and immediately attacks all enemies within a set area. At the start of each wave, applies a Fire Weakness to all enemies, lasting for <b>#3[f]</b> turn(s). Then, deals Fire DMG equal to <b>#2[p]</b> of SAM's ATK to all enemies.",
+      "Params": [
+        [
+          5.0,
+          2.0,
+          2.0
+        ]
+      ],
+      "BP": 0,
+      "SPAdd": 0,
+      "AttackType": "Maze",
+      "Stance": [
+        2.0,
+        0.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1310_Maze"
+    },
+    "v4": {
+      "Name": "Δ Order: Meteoric Incineration",
+      "MaxLevel": 1,
+      "Type": "Technique",
+      "Tag": "",
+      "Desc": "Leaps into the air and moves without restrictions for <b>#1[f]</b> seconds, which can be ended early by launching a plunging attack. When this duration ends, SAM descends and immediately attacks all enemies within a set area. At the start of each wave, applies a Fire Weakness to all enemies, lasting for <b>#3[f]</b> turn(s). Then, deals Fire DMG equal to <b>#2[p]</b> of SAM's ATK to all enemies.",
+      "Params": [
+        [
+          5.0,
+          2.0,
+          2.0
+        ]
+      ],
+      "BP": 0,
+      "SPAdd": 0,
+      "AttackType": "Maze",
+      "Stance": [
+        2.0,
+        0.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1310_Maze"
+    },
+    "v5": {
+      "Name": "Δ Order: Meteoric Incineration",
+      "MaxLevel": 1,
+      "Type": "Technique",
+      "Tag": "",
+      "Desc": "Leaps into the air and moves about freely for <b>#1[f]</b> seconds, which can be ended early by launching a plunging attack. When the duration ends, plunges and immediately attacks all enemies within a set area. At the start of each wave, applies a Fire Weakness to all enemies, lasting for <b>#3[f]</b> turn(s). Then, deals Fire DMG equal to <b>#2[p]</b> of SAM's ATK to all enemies.",
+      "Params": [
+        [
+          5.0,
+          2.0,
+          2.0
+        ]
+      ],
+      "BP": 0,
+      "SPAdd": 0,
+      "AttackType": "Maze",
+      "Stance": [
+        2.0,
+        0.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1310_Maze"
+    }
+  },
+  "131009": {
+    "v1": {
+      "Name": "Firefly Type-IV: Deathstar Overload",
+      "MaxLevel": 15,
+      "Type": "Skill",
+      "Tag": "Blast",
+      "Desc": "Restores HP by an amount equal to <b>#3[p]</b> of this unit's Max HP. Applies Fire Weakness to a single target enemy if it does not already have one, lasting for <b>#4[f]</b> turn(s). Deals Fire DMG equal to <b>#5[f]</b> × Break Effect + @<b>#1[p]</b># of SAM's ATK to the target enemy. At the same time, deals Fire DMG equal to <b>#6[f]</b> × Break Effect + @<b>#2[p]</b># of SAM's ATK to adjacent targets. The Break Effect taken into the calculation is capped at <b>#7[p]</b>.",
+      "Params": [
+        [
+          2.4,
+          1.2,
+          0.35,
+          2.0,
+          0.5,
+          0.25,
+          3.6
+        ],
+        [
+          2.56,
+          1.28,
+          0.35,
+          2.0,
+          0.5,
+          0.25,
+          3.6
+        ],
+        [
+          2.72,
+          1.36,
+          0.35,
+          2.0,
+          0.5,
+          0.25,
+          3.6
+        ],
+        [
+          2.88,
+          1.44,
+          0.35,
+          2.0,
+          0.5,
+          0.25,
+          3.6
+        ],
+        [
+          3.04,
+          1.52,
+          0.35,
+          2.0,
+          0.5,
+          0.25,
+          3.6
+        ],
+        [
+          3.2,
+          1.6,
+          0.35,
+          2.0,
+          0.5,
+          0.25,
+          3.6
+        ],
+        [
+          3.4,
+          1.7,
+          0.35,
+          2.0,
+          0.5,
+          0.25,
+          3.6
+        ],
+        [
+          3.6,
+          1.8,
+          0.35,
+          2.0,
+          0.5,
+          0.25,
+          3.6
+        ],
+        [
+          3.8,
+          1.9,
+          0.35,
+          2.0,
+          0.5,
+          0.25,
+          3.6
+        ],
+        [
+          4.0,
+          2.0,
+          0.35,
+          2.0,
+          0.5,
+          0.25,
+          3.6
+        ],
+        [
+          4.16,
+          2.08,
+          0.35,
+          2.0,
+          0.5,
+          0.25,
+          3.6
+        ],
+        [
+          4.32,
+          2.16,
+          0.35,
+          2.0,
+          0.5,
+          0.25,
+          3.6
+        ],
+        [
+          4.48,
+          2.24,
+          0.35,
+          2.0,
+          0.5,
+          0.25,
+          3.6
+        ],
+        [
+          4.64,
+          2.32,
+          0.35,
+          2.0,
+          0.5,
+          0.25,
+          3.6
+        ],
+        [
+          4.8,
+          2.4,
+          0.35,
+          2.0,
+          0.5,
+          0.25,
+          3.6
+        ]
+      ],
+      "BP": -1,
+      "SPAdd": 0,
+      "AttackType": "BPSkill",
+      "Stance": [
+        3.0,
+        0.0,
+        1.5
+      ],
+      "Icon": "SkillIcon_1310_BP02"
+    },
+    "v2": {
+      "Name": "Firefly Type-IV: Deathstar Overload",
+      "MaxLevel": 15,
+      "Type": "Skill",
+      "Tag": "Blast",
+      "Desc": "Restores HP by <b>#3[p]</b> of Firefly's Max HP. Applies Fire Weakness to a single enemy if the target enemy does not already have it, lasting for <b>#4[f]</b> turn(s). Deals Fire DMG equal to <b>#5[f]</b> × Break Effect + @<b>#1[p]</b># of SAM's ATK to the target enemy. At the same time, deals Fire DMG equal to <b>#6[f]</b> × Break Effect + @<b>#2[p]</b># of SAM's ATK to adjacent enemies. A maximum of <b>#7[p]</b> Break Effect is calculated.",
+      "Params": [
+        [
+          2.4,
+          1.2,
+          0.35,
+          2.0,
+          0.5,
+          0.25,
+          3.6
+        ],
+        [
+          2.56,
+          1.28,
+          0.35,
+          2.0,
+          0.5,
+          0.25,
+          3.6
+        ],
+        [
+          2.72,
+          1.36,
+          0.35,
+          2.0,
+          0.5,
+          0.25,
+          3.6
+        ],
+        [
+          2.88,
+          1.44,
+          0.35,
+          2.0,
+          0.5,
+          0.25,
+          3.6
+        ],
+        [
+          3.04,
+          1.52,
+          0.35,
+          2.0,
+          0.5,
+          0.25,
+          3.6
+        ],
+        [
+          3.2,
+          1.6,
+          0.35,
+          2.0,
+          0.5,
+          0.25,
+          3.6
+        ],
+        [
+          3.4,
+          1.7,
+          0.35,
+          2.0,
+          0.5,
+          0.25,
+          3.6
+        ],
+        [
+          3.6,
+          1.8,
+          0.35,
+          2.0,
+          0.5,
+          0.25,
+          3.6
+        ],
+        [
+          3.8,
+          1.9,
+          0.35,
+          2.0,
+          0.5,
+          0.25,
+          3.6
+        ],
+        [
+          4.0,
+          2.0,
+          0.35,
+          2.0,
+          0.5,
+          0.25,
+          3.6
+        ],
+        [
+          4.16,
+          2.08,
+          0.35,
+          2.0,
+          0.5,
+          0.25,
+          3.6
+        ],
+        [
+          4.32,
+          2.16,
+          0.35,
+          2.0,
+          0.5,
+          0.25,
+          3.6
+        ],
+        [
+          4.48,
+          2.24,
+          0.35,
+          2.0,
+          0.5,
+          0.25,
+          3.6
+        ],
+        [
+          4.64,
+          2.32,
+          0.35,
+          2.0,
+          0.5,
+          0.25,
+          3.6
+        ],
+        [
+          4.8,
+          2.4,
+          0.35,
+          2.0,
+          0.5,
+          0.25,
+          3.6
+        ]
+      ],
+      "BP": -1,
+      "SPAdd": 0,
+      "AttackType": "BPSkill",
+      "Stance": [
+        3.0,
+        0.0,
+        1.5
+      ],
+      "Icon": "SkillIcon_1310_BP02"
+    },
+    "v3": {
+      "Name": "Fyrefly Type-IV: Deathstar Overload",
+      "MaxLevel": 15,
+      "Type": "Skill",
+      "Tag": "Blast",
+      "Desc": "Restores HP by <b>#3[p]</b> of this unit's Max HP. Applies Fire Weakness to a single enemy, lasting for <b>#4[f]</b> turn(s). Deals Fire DMG equal to <b>#5[f]</b> × Break Effect + @<b>#1[p]</b># of SAM's ATK to the target enemy. At the same time, deals Fire DMG equal to <b>#6[f]</b> × Break Effect + @<b>#2[p]</b># of SAM's ATK to adjacent enemies. A maximum of <b>#7[p]</b> Break Effect is calculated.",
+      "Params": [
+        [
+          1.0,
+          0.5,
+          0.35,
+          2.0,
+          0.2,
+          0.1,
+          3.6
+        ],
+        [
+          1.1,
+          0.55,
+          0.35,
+          2.0,
+          0.2,
+          0.1,
+          3.6
+        ],
+        [
+          1.2,
+          0.6,
+          0.35,
+          2.0,
+          0.2,
+          0.1,
+          3.6
+        ],
+        [
+          1.3,
+          0.65,
+          0.35,
+          2.0,
+          0.2,
+          0.1,
+          3.6
+        ],
+        [
+          1.4,
+          0.7,
+          0.35,
+          2.0,
+          0.2,
+          0.1,
+          3.6
+        ],
+        [
+          1.5,
+          0.75,
+          0.35,
+          2.0,
+          0.2,
+          0.1,
+          3.6
+        ],
+        [
+          1.625,
+          0.8125,
+          0.35,
+          2.0,
+          0.2,
+          0.1,
+          3.6
+        ],
+        [
+          1.75,
+          0.875,
+          0.35,
+          2.0,
+          0.2,
+          0.1,
+          3.6
+        ],
+        [
+          1.875,
+          0.9375,
+          0.35,
+          2.0,
+          0.2,
+          0.1,
+          3.6
+        ],
+        [
+          2.0,
+          1.0,
+          0.35,
+          2.0,
+          0.2,
+          0.1,
+          3.6
+        ],
+        [
+          2.1,
+          1.05,
+          0.35,
+          2.0,
+          0.2,
+          0.1,
+          3.6
+        ],
+        [
+          2.2,
+          1.1,
+          0.35,
+          2.0,
+          0.2,
+          0.1,
+          3.6
+        ],
+        [
+          2.3,
+          1.15,
+          0.35,
+          2.0,
+          0.2,
+          0.1,
+          3.6
+        ],
+        [
+          2.4,
+          1.2,
+          0.35,
+          2.0,
+          0.2,
+          0.1,
+          3.6
+        ],
+        [
+          2.5,
+          1.25,
+          0.35,
+          2.0,
+          0.2,
+          0.1,
+          3.6
+        ]
+      ],
+      "BP": -1,
+      "SPAdd": 0,
+      "AttackType": "BPSkill",
+      "Stance": [
+        3.0,
+        0.0,
+        1.5
+      ],
+      "Icon": "SkillIcon_1310_BP02"
+    },
+    "v4": {
+      "Name": "Fyrefly Type-IV: Deathstar Overload",
+      "MaxLevel": 15,
+      "Type": "Skill",
+      "Tag": "Blast",
+      "Desc": "Restores HP by <b>#3[p]</b> of this unit's Max HP. Applies Fire Weakness to a single enemy, lasting for <b>#4[f]</b> turn(s). Deals Fire DMG equal to <b>#5[f]</b> × Break Effect + @<b>#1[p]</b># of SAM's ATK to the target enemy. At the same time, deals Fire DMG equal to <b>#6[f]</b> × Break Effect + @<b>#2[p]</b># of SAM's ATK to adjacent enemies. A maximum of <b>#7[p]</b> Break Effect is calculated.",
+      "Params": [
+        [
+          1.0,
+          0.5,
+          0.25,
+          2.0,
+          0.2,
+          0.1,
+          3.6
+        ],
+        [
+          1.1,
+          0.55,
+          0.25,
+          2.0,
+          0.2,
+          0.1,
+          3.6
+        ],
+        [
+          1.2,
+          0.6,
+          0.25,
+          2.0,
+          0.2,
+          0.1,
+          3.6
+        ],
+        [
+          1.3,
+          0.65,
+          0.25,
+          2.0,
+          0.2,
+          0.1,
+          3.6
+        ],
+        [
+          1.4,
+          0.7,
+          0.25,
+          2.0,
+          0.2,
+          0.1,
+          3.6
+        ],
+        [
+          1.5,
+          0.75,
+          0.25,
+          2.0,
+          0.2,
+          0.1,
+          3.6
+        ],
+        [
+          1.625,
+          0.8125,
+          0.25,
+          2.0,
+          0.2,
+          0.1,
+          3.6
+        ],
+        [
+          1.75,
+          0.875,
+          0.25,
+          2.0,
+          0.2,
+          0.1,
+          3.6
+        ],
+        [
+          1.875,
+          0.9375,
+          0.25,
+          2.0,
+          0.2,
+          0.1,
+          3.6
+        ],
+        [
+          2.0,
+          1.0,
+          0.25,
+          2.0,
+          0.2,
+          0.1,
+          3.6
+        ],
+        [
+          2.1,
+          1.05,
+          0.25,
+          2.0,
+          0.2,
+          0.1,
+          3.6
+        ],
+        [
+          2.2,
+          1.1,
+          0.25,
+          2.0,
+          0.2,
+          0.1,
+          3.6
+        ],
+        [
+          2.3,
+          1.15,
+          0.25,
+          2.0,
+          0.2,
+          0.1,
+          3.6
+        ],
+        [
+          2.4,
+          1.2,
+          0.25,
+          2.0,
+          0.2,
+          0.1,
+          3.6
+        ],
+        [
+          2.5,
+          1.25,
+          0.25,
+          2.0,
+          0.2,
+          0.1,
+          3.6
+        ]
+      ],
+      "BP": -1,
+      "SPAdd": 0,
+      "AttackType": "BPSkill",
+      "Stance": [
+        3.0,
+        0.0,
+        1.5
+      ],
+      "Icon": "SkillIcon_1310_BP02"
+    },
+    "v5": {
+      "Name": "Fyrefly Type-IV: Deathstar Overload",
+      "MaxLevel": 15,
+      "Type": "Skill",
+      "Tag": "Blast",
+      "Desc": "Restores HP by an amount equal to <b>#3[p]</b> of this unit's Max HP. Applies Fire Weakness to a single target enemy, lasting for <b>#4[f]</b> turn(s). Deals Fire DMG equal to (<b>#5[f]</b> × Break Effect + @<b>#1[p]</b>#) of SAM's ATK to this target. At the same time, deals Fire DMG equal to (<b>#6[f]</b> × Break Effect + @<b>#2[p]</b>#) of SAM's ATK to adjacent targets. The Break Effect taken into the calculation is capped at <b>#7[p]</b>.",
+      "Params": [
+        [
+          1.0,
+          0.5,
+          0.25,
+          2.0,
+          0.2,
+          0.1,
+          3.6
+        ],
+        [
+          1.1,
+          0.55,
+          0.25,
+          2.0,
+          0.2,
+          0.1,
+          3.6
+        ],
+        [
+          1.2,
+          0.6,
+          0.25,
+          2.0,
+          0.2,
+          0.1,
+          3.6
+        ],
+        [
+          1.3,
+          0.65,
+          0.25,
+          2.0,
+          0.2,
+          0.1,
+          3.6
+        ],
+        [
+          1.4,
+          0.7,
+          0.25,
+          2.0,
+          0.2,
+          0.1,
+          3.6
+        ],
+        [
+          1.5,
+          0.75,
+          0.25,
+          2.0,
+          0.2,
+          0.1,
+          3.6
+        ],
+        [
+          1.625,
+          0.8125,
+          0.25,
+          2.0,
+          0.2,
+          0.1,
+          3.6
+        ],
+        [
+          1.75,
+          0.875,
+          0.25,
+          2.0,
+          0.2,
+          0.1,
+          3.6
+        ],
+        [
+          1.875,
+          0.9375,
+          0.25,
+          2.0,
+          0.2,
+          0.1,
+          3.6
+        ],
+        [
+          2.0,
+          1.0,
+          0.25,
+          2.0,
+          0.2,
+          0.1,
+          3.6
+        ],
+        [
+          2.1,
+          1.05,
+          0.25,
+          2.0,
+          0.2,
+          0.1,
+          3.6
+        ],
+        [
+          2.2,
+          1.1,
+          0.25,
+          2.0,
+          0.2,
+          0.1,
+          3.6
+        ],
+        [
+          2.3,
+          1.15,
+          0.25,
+          2.0,
+          0.2,
+          0.1,
+          3.6
+        ],
+        [
+          2.4,
+          1.2,
+          0.25,
+          2.0,
+          0.2,
+          0.1,
+          3.6
+        ],
+        [
+          2.5,
+          1.25,
+          0.25,
+          2.0,
+          0.2,
+          0.1,
+          3.6
+        ]
+      ],
+      "BP": -1,
+      "SPAdd": 0,
+      "AttackType": "BPSkill",
+      "Stance": [
+        3.0,
+        0.0,
+        1.5
+      ],
+      "Icon": "SkillIcon_1310_BP02"
+    }
+  },
+  "131008": {
+    "v1": {
+      "Name": "Firefly Type-IV: Pyrogenic Decimation",
+      "MaxLevel": 9,
+      "Type": "Basic ATK",
+      "Tag": "Single Target",
+      "Desc": "Restores HP by an amount equal to <b>#2[p]</b> of this unit's Max HP. Deals Fire DMG equal to @<b>#1[p]</b># of SAM's ATK to a single target enemy.",
+      "Params": [
+        [
+          1.5,
+          0.2
+        ],
+        [
+          1.7,
+          0.2
+        ],
+        [
+          1.9,
+          0.2
+        ],
+        [
+          2.1,
+          0.2
+        ],
+        [
+          2.3,
+          0.2
+        ],
+        [
+          2.5,
+          0.2
+        ],
+        [
+          2.7,
+          0.2
+        ],
+        [
+          2.9,
+          0.2
+        ],
+        [
+          3.1,
+          0.2
+        ]
+      ],
+      "BP": 1,
+      "SPAdd": 0,
+      "AttackType": "Normal",
+      "Stance": [
+        1.5,
+        0.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1310_Normal02"
+    },
+    "v2": {
+      "Name": "Firefly Type-IV: Pyrogenic Decimation",
+      "MaxLevel": 9,
+      "Type": "Basic ATK",
+      "Tag": "Single Target",
+      "Desc": "Restores HP by an amount equal to <b>#2[p]</b> of this unit's Max HP. Deals Fire DMG equal to @<b>#1[p]</b># of SAM's ATK to a single target enemy.",
+      "Params": [
+        [
+          1.5,
+          0.2
+        ],
+        [
+          1.7,
+          0.2
+        ],
+        [
+          1.9,
+          0.2
+        ],
+        [
+          2.1,
+          0.2
+        ],
+        [
+          2.3,
+          0.2
+        ],
+        [
+          2.5,
+          0.2
+        ],
+        [
+          2.7,
+          0.2
+        ],
+        [
+          2.9,
+          0.2
+        ],
+        [
+          3.1,
+          0.2
+        ]
+      ],
+      "BP": 1,
+      "SPAdd": 0,
+      "AttackType": "Normal",
+      "Stance": [
+        1.5,
+        0.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1310_Normal02"
+    },
+    "v3": {
+      "Name": "Fyrefly Type-IV: Pyrogenic Decimation",
+      "MaxLevel": 9,
+      "Type": "Basic ATK",
+      "Tag": "Single Target",
+      "Desc": "Restores HP by an amount equal to <b>#2[p]</b> of this unit's Max HP. Deals Fire DMG equal to @<b>#1[p]</b># of SAM's ATK to a single target enemy.",
+      "Params": [
+        [
+          1.0,
+          0.2
+        ],
+        [
+          1.2,
+          0.2
+        ],
+        [
+          1.4,
+          0.2
+        ],
+        [
+          1.6,
+          0.2
+        ],
+        [
+          1.8,
+          0.2
+        ],
+        [
+          2.0,
+          0.2
+        ],
+        [
+          2.2,
+          0.2
+        ],
+        [
+          2.4,
+          0.2
+        ],
+        [
+          2.6,
+          0.2
+        ]
+      ],
+      "BP": 1,
+      "SPAdd": 0,
+      "AttackType": "Normal",
+      "Stance": [
+        1.5,
+        0.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1310_Normal02"
+    },
+    "v4": {
+      "Name": "Fyrefly Type-IV: Pyrogenic Decimation",
+      "MaxLevel": 9,
+      "Type": "Basic ATK",
+      "Tag": "Single Target",
+      "Desc": "Restores HP by an amount equal to <b>#2[p]</b> of this unit's Max HP. Deals Fire DMG equal to @<b>#1[p]</b># of SAM's ATK to a single target enemy.",
+      "Params": [
+        [
+          1.0,
+          0.2
+        ],
+        [
+          1.2,
+          0.2
+        ],
+        [
+          1.4,
+          0.2
+        ],
+        [
+          1.6,
+          0.2
+        ],
+        [
+          1.8,
+          0.2
+        ],
+        [
+          2.0,
+          0.2
+        ],
+        [
+          2.2,
+          0.2
+        ],
+        [
+          2.4,
+          0.2
+        ],
+        [
+          2.6,
+          0.2
+        ]
+      ],
+      "BP": 1,
+      "SPAdd": 0,
+      "AttackType": "Normal",
+      "Stance": [
+        1.5,
+        0.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1310_Normal02"
+    },
+    "v5": {
+      "Name": "Fyrefly Type-IV: Pyrogenic Decimation",
+      "MaxLevel": 9,
+      "Type": "Basic ATK",
+      "Tag": "Single Target",
+      "Desc": "Restores HP by an amount equal to <b>#2[p]</b> of this unit's Max HP. Deals Fire DMG equal to @<b>#1[p]</b># of SAM's ATK to a single target enemy.",
+      "Params": [
+        [
+          1.0,
+          0.2
+        ],
+        [
+          1.2,
+          0.2
+        ],
+        [
+          1.4,
+          0.2
+        ],
+        [
+          1.6,
+          0.2
+        ],
+        [
+          1.8,
+          0.2
+        ],
+        [
+          2.0,
+          0.2
+        ],
+        [
+          2.2,
+          0.2
+        ],
+        [
+          2.4,
+          0.2
+        ],
+        [
+          2.6,
+          0.2
+        ]
+      ],
+      "BP": 1,
+      "SPAdd": 0,
+      "AttackType": "Normal",
+      "Stance": [
+        1.5,
+        0.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1310_Normal02"
+    }
+  },
+  "131401": {
+    "v1": {
+      "Name": "Lash of Riches",
+      "MaxLevel": 9,
+      "Type": "Basic ATK",
+      "Tag": "Blast",
+      "Desc": "Deals Quantum DMG equal to @<b>#1[p]</b># of Jade's ATK to a single target enemy, and Quantum DMG equal to @<b>#2[p]</b># of Jade's ATK to adjacent enemies.",
+      "Params": [
+        [
+          0.45,
+          0.15
+        ],
+        [
+          0.54,
+          0.18
+        ],
+        [
+          0.63,
+          0.21
+        ],
+        [
+          0.72,
+          0.24
+        ],
+        [
+          0.81,
+          0.27
+        ],
+        [
+          0.9,
+          0.3
+        ],
+        [
+          0.99,
+          0.33
+        ],
+        [
+          1.08,
+          0.36
+        ],
+        [
+          1.17,
+          0.39
+        ]
+      ],
+      "BP": 1,
+      "SPAdd": 20.0,
+      "AttackType": "Normal",
+      "Stance": [
+        1.0,
+        0.0,
+        0.5
+      ],
+      "Icon": "SkillIcon_1314_Normal"
+    },
+    "v2": {
+      "Name": "Lash of Riches",
+      "MaxLevel": 9,
+      "Type": "Basic ATK",
+      "Tag": "Blast",
+      "Desc": "Deals Quantum DMG equal to @<b>#1[p]</b># of Jade's ATK to a single target enemy, and Quantum DMG equal to @<b>#2[p]</b># of Jade's ATK to adjacent enemies.",
+      "Params": [
+        [
+          0.45,
+          0.15
+        ],
+        [
+          0.54,
+          0.18
+        ],
+        [
+          0.63,
+          0.21
+        ],
+        [
+          0.72,
+          0.24
+        ],
+        [
+          0.81,
+          0.27
+        ],
+        [
+          0.9,
+          0.3
+        ],
+        [
+          0.99,
+          0.33
+        ],
+        [
+          1.08,
+          0.36
+        ],
+        [
+          1.17,
+          0.39
+        ]
+      ],
+      "BP": 1,
+      "SPAdd": 20.0,
+      "AttackType": "Normal",
+      "Stance": [
+        1.0,
+        0.0,
+        0.5
+      ],
+      "Icon": "SkillIcon_1314_Normal"
+    },
+    "v3": {
+      "Name": "Lash of Riches",
+      "MaxLevel": 9,
+      "Type": "Basic ATK",
+      "Tag": "Blast",
+      "Desc": "Deals Quantum DMG equal to @<b>#1[p]</b># of Jade's ATK to a single target enemy, and Quantum DMG equal to @<b>#2[p]</b># of Jade's ATK to adjacent enemies.",
+      "Params": [
+        [
+          0.45,
+          0.15
+        ],
+        [
+          0.54,
+          0.18
+        ],
+        [
+          0.63,
+          0.21
+        ],
+        [
+          0.72,
+          0.24
+        ],
+        [
+          0.81,
+          0.27
+        ],
+        [
+          0.9,
+          0.3
+        ],
+        [
+          0.99,
+          0.33
+        ],
+        [
+          1.08,
+          0.36
+        ],
+        [
+          1.17,
+          0.39
+        ]
+      ],
+      "BP": 1,
+      "SPAdd": 20.0,
+      "AttackType": "Normal",
+      "Stance": [
+        1.0,
+        0.0,
+        0.5
+      ],
+      "Icon": "SkillIcon_1314_Normal"
+    },
+    "v4": {
+      "Name": "Lash of Riches",
+      "MaxLevel": 9,
+      "Type": "Basic ATK",
+      "Tag": "Blast",
+      "Desc": "Deals Quantum DMG equal to @<b>#1[p]</b># of Jade's ATK to a single target enemy, and Quantum DMG equal to @<b>#2[p]</b># of Jade's ATK to adjacent enemies.",
+      "Params": [
+        [
+          0.45,
+          0.15
+        ],
+        [
+          0.54,
+          0.18
+        ],
+        [
+          0.63,
+          0.21
+        ],
+        [
+          0.72,
+          0.24
+        ],
+        [
+          0.81,
+          0.27
+        ],
+        [
+          0.9,
+          0.3
+        ],
+        [
+          0.99,
+          0.33
+        ],
+        [
+          1.08,
+          0.36
+        ],
+        [
+          1.17,
+          0.39
+        ]
+      ],
+      "BP": 1,
+      "SPAdd": 20.0,
+      "AttackType": "Normal",
+      "Stance": [
+        1.0,
+        0.0,
+        0.5
+      ],
+      "Icon": "SkillIcon_1314_Normal"
+    },
+    "v5": {
+      "Name": "Lash of Riches",
+      "MaxLevel": 9,
+      "Type": "Basic ATK",
+      "Tag": "Blast",
+      "Desc": "Deals Quantum DMG equal to @<b>#1[p]</b># of Jade's ATK to a single target enemy, and Quantum DMG equal to @<b>#2[p]</b># of Jade's ATK to adjacent enemies.",
+      "Params": [
+        [
+          0.45,
+          0.15
+        ],
+        [
+          0.54,
+          0.18
+        ],
+        [
+          0.63,
+          0.21
+        ],
+        [
+          0.72,
+          0.24
+        ],
+        [
+          0.81,
+          0.27
+        ],
+        [
+          0.9,
+          0.3
+        ],
+        [
+          0.99,
+          0.33
+        ],
+        [
+          1.08,
+          0.36
+        ],
+        [
+          1.17,
+          0.39
+        ]
+      ],
+      "BP": 1,
+      "SPAdd": 20.0,
+      "AttackType": "Normal",
+      "Stance": [
+        1.0,
+        0.0,
+        0.5
+      ],
+      "Icon": "SkillIcon_1314_Normal"
+    }
+  },
+  "131402": {
+    "v1": {
+      "Name": "Acquisition Surety",
+      "MaxLevel": 15,
+      "Type": "Skill",
+      "Tag": "Enhance",
+      "Desc": "Makes a single target ally become a Debt Collector and increases their SPD by <b>#1[f]</b>, lasting for <b>#4[f]</b> turn(s).<br>After a Debt Collector attacks, deals 1 instance of <u>Additional</u> Quantum DMG equal to @<b>#3[p]</b># of Jade's ATK to each enemy target hit, and consumes the Debt Collector's HP by an amount equal to <b>#2[p]</b> of their Max HP. If their current HP is insufficient, reduces their HP to 1.<br>If Jade becomes a Debt Collector, she cannot gain the SPD boost effect, and her attacks do not consume HP.<br>When a Debt Collector exists on the field, Jade cannot use her Skill. At the start of Jade's every turn, the Debt Collector's duration reduces by 1.",
+      "Params": [
+        [
+          30.0,
+          0.05,
+          0.1,
+          3.0
+        ],
+        [
+          30.0,
+          0.05,
+          0.11,
+          3.0
+        ],
+        [
+          30.0,
+          0.05,
+          0.12,
+          3.0
+        ],
+        [
+          30.0,
+          0.05,
+          0.13,
+          3.0
+        ],
+        [
+          30.0,
+          0.05,
+          0.14,
+          3.0
+        ],
+        [
+          30.0,
+          0.05,
+          0.15,
+          3.0
+        ],
+        [
+          30.0,
+          0.05,
+          0.1625,
+          3.0
+        ],
+        [
+          30.0,
+          0.05,
+          0.175,
+          3.0
+        ],
+        [
+          30.0,
+          0.05,
+          0.1875,
+          3.0
+        ],
+        [
+          30.0,
+          0.05,
+          0.2,
+          3.0
+        ],
+        [
+          30.0,
+          0.05,
+          0.21,
+          3.0
+        ],
+        [
+          30.0,
+          0.05,
+          0.22,
+          3.0
+        ],
+        [
+          30.0,
+          0.05,
+          0.23,
+          3.0
+        ],
+        [
+          30.0,
+          0.05,
+          0.24,
+          3.0
+        ],
+        [
+          30.0,
+          0.05,
+          0.25,
+          3.0
+        ]
+      ],
+      "BP": -1,
+      "SPAdd": 30.0,
+      "AttackType": "BPSkill",
+      "Stance": [
+        0.0,
+        0.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1314_BP"
+    },
+    "v2": {
+      "Name": "Acquisition Surety",
+      "MaxLevel": 15,
+      "Type": "Skill",
+      "Tag": "Enhance",
+      "Desc": "Makes a single target ally become a Debt Collector and increases their SPD by <b>#1[f]</b>, lasting for <b>#4[f]</b> turn(s).<br>After a Debt Collector attacks, deals 1 instance of <u>Additional</u> Quantum DMG equal to @<b>#3[p]</b># of Jade's ATK to each enemy target hit, and consumes the Debt Collector's HP by an amount equal to <b>#2[p]</b> of their Max HP. If their current HP is insufficient, reduces their HP to 1.<br>If Jade becomes a Debt Collector, she cannot gain the SPD boost effect, and her attacks do not consume HP.<br>When a Debt Collector exists on the field, Jade cannot use her Skill. At the start of Jade's every turn, the Debt Collector's duration reduces by 1.<br><br>@<b>Additional DMG</b>#<br>Causes the target being hit to take extra DMG, which is not considered an attack.",
+      "Params": [
+        [
+          30.0,
+          0.05,
+          0.1,
+          3.0
+        ],
+        [
+          30.0,
+          0.05,
+          0.11,
+          3.0
+        ],
+        [
+          30.0,
+          0.05,
+          0.12,
+          3.0
+        ],
+        [
+          30.0,
+          0.05,
+          0.13,
+          3.0
+        ],
+        [
+          30.0,
+          0.05,
+          0.14,
+          3.0
+        ],
+        [
+          30.0,
+          0.05,
+          0.15,
+          3.0
+        ],
+        [
+          30.0,
+          0.05,
+          0.1625,
+          3.0
+        ],
+        [
+          30.0,
+          0.05,
+          0.175,
+          3.0
+        ],
+        [
+          30.0,
+          0.05,
+          0.1875,
+          3.0
+        ],
+        [
+          30.0,
+          0.05,
+          0.2,
+          3.0
+        ],
+        [
+          30.0,
+          0.05,
+          0.21,
+          3.0
+        ],
+        [
+          30.0,
+          0.05,
+          0.22,
+          3.0
+        ],
+        [
+          30.0,
+          0.05,
+          0.23,
+          3.0
+        ],
+        [
+          30.0,
+          0.05,
+          0.24,
+          3.0
+        ],
+        [
+          30.0,
+          0.05,
+          0.25,
+          3.0
+        ]
+      ],
+      "BP": -1,
+      "SPAdd": 30.0,
+      "AttackType": "BPSkill",
+      "Stance": [
+        0.0,
+        0.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1314_BP"
+    },
+    "v3": {
+      "Name": "Acquisition Surety",
+      "MaxLevel": 15,
+      "Type": "Skill",
+      "Tag": "Enhance",
+      "Desc": "Makes a single target ally become a Debt Collector and increases their SPD by <b>#1[f]</b>, lasting for <b>#4[f]</b> turn(s).<br>After a Debt Collector attacks, deals 1 instance of <u>Additional</u> Quantum DMG equal to @<b>#3[p]</b># of Jade's ATK to each enemy target hit, and consumes the Debt Collector's HP by an amount equal to <b>#2[p]</b> of their Max HP. If their current HP is insufficient, reduces their HP to 1.<br>If Jade becomes a Debt Collector, she cannot gain the SPD boost effect, and her attacks do not consume HP.<br>When a Debt Collector exists on the field, Jade cannot use her Skill. At the start of Jade's every turn, the Debt Collector's duration reduces by 1.<br><br>@<b>Additional DMG</b>#<br>Causes the target being hit to take extra DMG, which is not considered an attack.",
+      "Params": [
+        [
+          30.0,
+          0.02,
+          0.15,
+          3.0
+        ],
+        [
+          30.0,
+          0.02,
+          0.16,
+          3.0
+        ],
+        [
+          30.0,
+          0.02,
+          0.17,
+          3.0
+        ],
+        [
+          30.0,
+          0.02,
+          0.18,
+          3.0
+        ],
+        [
+          30.0,
+          0.02,
+          0.19,
+          3.0
+        ],
+        [
+          30.0,
+          0.02,
+          0.2,
+          3.0
+        ],
+        [
+          30.0,
+          0.02,
+          0.2125,
+          3.0
+        ],
+        [
+          30.0,
+          0.02,
+          0.225,
+          3.0
+        ],
+        [
+          30.0,
+          0.02,
+          0.2375,
+          3.0
+        ],
+        [
+          30.0,
+          0.02,
+          0.25,
+          3.0
+        ],
+        [
+          30.0,
+          0.02,
+          0.26,
+          3.0
+        ],
+        [
+          30.0,
+          0.02,
+          0.27,
+          3.0
+        ],
+        [
+          30.0,
+          0.02,
+          0.28,
+          3.0
+        ],
+        [
+          30.0,
+          0.02,
+          0.29,
+          3.0
+        ],
+        [
+          30.0,
+          0.02,
+          0.3,
+          3.0
+        ]
+      ],
+      "BP": -1,
+      "SPAdd": 30.0,
+      "AttackType": "BPSkill",
+      "Stance": [
+        0.0,
+        0.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1314_BP"
+    },
+    "v4": {
+      "Name": "Acquisition Surety",
+      "MaxLevel": 15,
+      "Type": "Skill",
+      "Tag": "Support",
+      "Desc": "Makes a single target ally become a Debt Collector and increases their SPD by <b>#1[f]</b>, lasting for <b>#4[f]</b> turn(s).<br>After a Debt Collector attacks, deals 1 instance of <u>Additional</u> Quantum DMG equal to @<b>#3[p]</b># of Jade's ATK to each enemy target hit, and consumes the Debt Collector's HP by an amount equal to <b>#2[p]</b> of their Max HP. If their current HP is insufficient, reduces their HP to 1.<br>If Jade becomes a Debt Collector, she cannot gain the SPD boost effect, and her attacks do not consume HP.<br>When a Debt Collector exists on the field, Jade cannot use her Skill. At the start of Jade's every turn, the Debt Collector's duration reduces by 1.<br><br>@<b>Additional DMG</b>#<br>Causes the target being hit to take extra DMG, which is not considered an attack.",
+      "Params": [
+        [
+          30.0,
+          0.02,
+          0.15,
+          3.0
+        ],
+        [
+          30.0,
+          0.02,
+          0.16,
+          3.0
+        ],
+        [
+          30.0,
+          0.02,
+          0.17,
+          3.0
+        ],
+        [
+          30.0,
+          0.02,
+          0.18,
+          3.0
+        ],
+        [
+          30.0,
+          0.02,
+          0.19,
+          3.0
+        ],
+        [
+          30.0,
+          0.02,
+          0.2,
+          3.0
+        ],
+        [
+          30.0,
+          0.02,
+          0.2125,
+          3.0
+        ],
+        [
+          30.0,
+          0.02,
+          0.225,
+          3.0
+        ],
+        [
+          30.0,
+          0.02,
+          0.2375,
+          3.0
+        ],
+        [
+          30.0,
+          0.02,
+          0.25,
+          3.0
+        ],
+        [
+          30.0,
+          0.02,
+          0.26,
+          3.0
+        ],
+        [
+          30.0,
+          0.02,
+          0.27,
+          3.0
+        ],
+        [
+          30.0,
+          0.02,
+          0.28,
+          3.0
+        ],
+        [
+          30.0,
+          0.02,
+          0.29,
+          3.0
+        ],
+        [
+          30.0,
+          0.02,
+          0.3,
+          3.0
+        ]
+      ],
+      "BP": -1,
+      "SPAdd": 30.0,
+      "AttackType": "BPSkill",
+      "Stance": [
+        0.0,
+        0.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1314_BP"
+    },
+    "v5": {
+      "Name": "Acquisition Surety",
+      "MaxLevel": 15,
+      "Type": "Skill",
+      "Tag": "Support",
+      "Desc": "Makes a single target ally become a Debt Collector and increases their SPD by <b>#1[f]</b>, lasting for <b>#4[f]</b> turn(s).<br>After a Debt Collector attacks, deals 1 instance of <u>Additional</u> Quantum DMG equal to @<b>#3[p]</b># of Jade's ATK to each enemy target hit, and consumes the Debt Collector's HP by an amount equal to <b>#2[p]</b> of their Max HP. If their current HP is insufficient, reduces their HP to 1.<br>If Jade becomes a Debt Collector, she cannot gain the SPD boost effect, and her attacks do not consume HP.<br>When a Debt Collector exists on the field, Jade cannot use her Skill. At the start of Jade's every turn, the Debt Collector's duration reduces by 1.<br><br>@<b>Additional DMG</b>#<br>Causes the target being hit to take extra DMG, which is not considered an attack.",
+      "Params": [
+        [
+          30.0,
+          0.02,
+          0.15,
+          3.0
+        ],
+        [
+          30.0,
+          0.02,
+          0.16,
+          3.0
+        ],
+        [
+          30.0,
+          0.02,
+          0.17,
+          3.0
+        ],
+        [
+          30.0,
+          0.02,
+          0.18,
+          3.0
+        ],
+        [
+          30.0,
+          0.02,
+          0.19,
+          3.0
+        ],
+        [
+          30.0,
+          0.02,
+          0.2,
+          3.0
+        ],
+        [
+          30.0,
+          0.02,
+          0.2125,
+          3.0
+        ],
+        [
+          30.0,
+          0.02,
+          0.225,
+          3.0
+        ],
+        [
+          30.0,
+          0.02,
+          0.2375,
+          3.0
+        ],
+        [
+          30.0,
+          0.02,
+          0.25,
+          3.0
+        ],
+        [
+          30.0,
+          0.02,
+          0.26,
+          3.0
+        ],
+        [
+          30.0,
+          0.02,
+          0.27,
+          3.0
+        ],
+        [
+          30.0,
+          0.02,
+          0.28,
+          3.0
+        ],
+        [
+          30.0,
+          0.02,
+          0.29,
+          3.0
+        ],
+        [
+          30.0,
+          0.02,
+          0.3,
+          3.0
+        ]
+      ],
+      "BP": -1,
+      "SPAdd": 30.0,
+      "AttackType": "BPSkill",
+      "Stance": [
+        0.0,
+        0.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1314_BP"
+    }
+  },
+  "131403": {
+    "v1": {
+      "Name": "Vow of the Deep",
+      "MaxLevel": 15,
+      "Type": "Ultimate",
+      "Tag": "AoE",
+      "Desc": "Deals Quantum DMG equal to @<b>#3[p]</b># of Jade's ATK to all enemies. At the same time, enhances <u>follow-up attack</u> from Jade's Talent, increasing the follow-up attack's DMG multiplier by @<b>#1[p]</b>#. This enhancing effect can activate <b>#2[f]</b> time(s).<br><br>@<b>Follow-Up Attack</b>#<br>Unleashes an extra attack on the target. This effect is triggered automatically when requirements are met.",
+      "Params": [
+        [
+          0.4,
+          2.0,
+          1.2
+        ],
+        [
+          0.44,
+          2.0,
+          1.32
+        ],
+        [
+          0.48,
+          2.0,
+          1.44
+        ],
+        [
+          0.52,
+          2.0,
+          1.56
+        ],
+        [
+          0.56,
+          2.0,
+          1.68
+        ],
+        [
+          0.6,
+          2.0,
+          1.8
+        ],
+        [
+          0.65,
+          2.0,
+          1.95
+        ],
+        [
+          0.7,
+          2.0,
+          2.1
+        ],
+        [
+          0.75,
+          2.0,
+          2.25
+        ],
+        [
+          0.8,
+          2.0,
+          2.4
+        ],
+        [
+          0.84,
+          2.0,
+          2.52
+        ],
+        [
+          0.88,
+          2.0,
+          2.64
+        ],
+        [
+          0.92,
+          2.0,
+          2.76
+        ],
+        [
+          0.96,
+          2.0,
+          2.88
+        ],
+        [
+          1.0,
+          2.0,
+          3.0
+        ]
+      ],
+      "BP": 0,
+      "SPAdd": 5.0,
+      "SPNeed": 140.0,
+      "AttackType": "Ultra",
+      "Stance": [
+        0.0,
+        2.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1314_Ultra"
+    },
+    "v2": {
+      "Name": "Vow of the Deep",
+      "MaxLevel": 15,
+      "Type": "Ultimate",
+      "Tag": "AoE",
+      "Desc": "Deals Quantum DMG equal to @<b>#3[p]</b># of Jade's ATK to all enemies. At the same time, enhances <u>follow-up attack</u> from Jade's Talent, increasing the follow-up attack's DMG multiplier by @<b>#1[p]</b>#. This enhancing effect can activate <b>#2[f]</b> time(s).<br><br>@<b>Follow-Up Attack</b>#<br>Unleashes an extra attack on the target. This effect is triggered automatically when requirements are met.",
+      "Params": [
+        [
+          0.4,
+          2.0,
+          1.2
+        ],
+        [
+          0.44,
+          2.0,
+          1.32
+        ],
+        [
+          0.48,
+          2.0,
+          1.44
+        ],
+        [
+          0.52,
+          2.0,
+          1.56
+        ],
+        [
+          0.56,
+          2.0,
+          1.68
+        ],
+        [
+          0.6,
+          2.0,
+          1.8
+        ],
+        [
+          0.65,
+          2.0,
+          1.95
+        ],
+        [
+          0.7,
+          2.0,
+          2.1
+        ],
+        [
+          0.75,
+          2.0,
+          2.25
+        ],
+        [
+          0.8,
+          2.0,
+          2.4
+        ],
+        [
+          0.84,
+          2.0,
+          2.52
+        ],
+        [
+          0.88,
+          2.0,
+          2.64
+        ],
+        [
+          0.92,
+          2.0,
+          2.76
+        ],
+        [
+          0.96,
+          2.0,
+          2.88
+        ],
+        [
+          1.0,
+          2.0,
+          3.0
+        ]
+      ],
+      "BP": 0,
+      "SPAdd": 5.0,
+      "SPNeed": 140.0,
+      "AttackType": "Ultra",
+      "Stance": [
+        0.0,
+        2.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1314_Ultra"
+    },
+    "v3": {
+      "Name": "Vow of the Deep",
+      "MaxLevel": 15,
+      "Type": "Ultimate",
+      "Tag": "AoE",
+      "Desc": "Deals Quantum DMG equal to @<b>#3[p]</b># of Jade's ATK to all enemies. At the same time, enhances <u>follow-up attack</u> from Jade's Talent, increasing the follow-up attack's DMG multiplier by @<b>#1[p]</b>#. This enhancing effect can activate <b>#2[f]</b> time(s).<br><br>@<b>Follow-Up Attack</b>#<br>Unleashes an extra attack on the target. This effect is triggered automatically when requirements are met.",
+      "Params": [
+        [
+          0.4,
+          2.0,
+          1.2
+        ],
+        [
+          0.44,
+          2.0,
+          1.32
+        ],
+        [
+          0.48,
+          2.0,
+          1.44
+        ],
+        [
+          0.52,
+          2.0,
+          1.56
+        ],
+        [
+          0.56,
+          2.0,
+          1.68
+        ],
+        [
+          0.6,
+          2.0,
+          1.8
+        ],
+        [
+          0.65,
+          2.0,
+          1.95
+        ],
+        [
+          0.7,
+          2.0,
+          2.1
+        ],
+        [
+          0.75,
+          2.0,
+          2.25
+        ],
+        [
+          0.8,
+          2.0,
+          2.4
+        ],
+        [
+          0.84,
+          2.0,
+          2.52
+        ],
+        [
+          0.88,
+          2.0,
+          2.64
+        ],
+        [
+          0.92,
+          2.0,
+          2.76
+        ],
+        [
+          0.96,
+          2.0,
+          2.88
+        ],
+        [
+          1.0,
+          2.0,
+          3.0
+        ]
+      ],
+      "BP": 0,
+      "SPAdd": 5.0,
+      "SPNeed": 140.0,
+      "AttackType": "Ultra",
+      "Stance": [
+        0.0,
+        2.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1314_Ultra"
+    },
+    "v4": {
+      "Name": "Vow of the Deep",
+      "MaxLevel": 15,
+      "Type": "Ultimate",
+      "Tag": "AoE",
+      "Desc": "Deals Quantum DMG equal to @<b>#3[p]</b># of Jade's ATK to all enemies. At the same time, enhances <u>follow-up attack</u> from Jade's Talent, increasing the follow-up attack's DMG multiplier by @<b>#1[p]</b>#. This enhancing effect can activate <b>#2[f]</b> time(s).<br><br>@<b>Follow-Up Attack</b>#<br>Unleashes an extra attack on the target. This effect is triggered automatically when requirements are met.",
+      "Params": [
+        [
+          0.4,
+          2.0,
+          1.2
+        ],
+        [
+          0.44,
+          2.0,
+          1.32
+        ],
+        [
+          0.48,
+          2.0,
+          1.44
+        ],
+        [
+          0.52,
+          2.0,
+          1.56
+        ],
+        [
+          0.56,
+          2.0,
+          1.68
+        ],
+        [
+          0.6,
+          2.0,
+          1.8
+        ],
+        [
+          0.65,
+          2.0,
+          1.95
+        ],
+        [
+          0.7,
+          2.0,
+          2.1
+        ],
+        [
+          0.75,
+          2.0,
+          2.25
+        ],
+        [
+          0.8,
+          2.0,
+          2.4
+        ],
+        [
+          0.84,
+          2.0,
+          2.52
+        ],
+        [
+          0.88,
+          2.0,
+          2.64
+        ],
+        [
+          0.92,
+          2.0,
+          2.76
+        ],
+        [
+          0.96,
+          2.0,
+          2.88
+        ],
+        [
+          1.0,
+          2.0,
+          3.0
+        ]
+      ],
+      "BP": 0,
+      "SPAdd": 5.0,
+      "SPNeed": 140.0,
+      "AttackType": "Ultra",
+      "Stance": [
+        0.0,
+        2.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1314_Ultra"
+    },
+    "v5": {
+      "Name": "Vow of the Deep",
+      "MaxLevel": 15,
+      "Type": "Ultimate",
+      "Tag": "AoE",
+      "Desc": "Deals Quantum DMG equal to @<b>#3[p]</b># of Jade's ATK to all enemies. At the same time, enhances <u>follow-up attack</u> from Jade's Talent, increasing the follow-up attack's DMG multiplier by @<b>#1[p]</b>#. This enhancing effect can activate <b>#2[f]</b> time(s).<br><br>@<b>Follow-Up Attack</b>#<br>Unleashes an extra attack on the target. This effect is triggered automatically when requirements are met.",
+      "Params": [
+        [
+          0.4,
+          2.0,
+          1.2
+        ],
+        [
+          0.44,
+          2.0,
+          1.32
+        ],
+        [
+          0.48,
+          2.0,
+          1.44
+        ],
+        [
+          0.52,
+          2.0,
+          1.56
+        ],
+        [
+          0.56,
+          2.0,
+          1.68
+        ],
+        [
+          0.6,
+          2.0,
+          1.8
+        ],
+        [
+          0.65,
+          2.0,
+          1.95
+        ],
+        [
+          0.7,
+          2.0,
+          2.1
+        ],
+        [
+          0.75,
+          2.0,
+          2.25
+        ],
+        [
+          0.8,
+          2.0,
+          2.4
+        ],
+        [
+          0.84,
+          2.0,
+          2.52
+        ],
+        [
+          0.88,
+          2.0,
+          2.64
+        ],
+        [
+          0.92,
+          2.0,
+          2.76
+        ],
+        [
+          0.96,
+          2.0,
+          2.88
+        ],
+        [
+          1.0,
+          2.0,
+          3.0
+        ]
+      ],
+      "BP": 0,
+      "SPAdd": 5.0,
+      "SPNeed": 140.0,
+      "AttackType": "Ultra",
+      "Stance": [
+        0.0,
+        2.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1314_Ultra"
+    }
+  },
+  "131404": {
+    "v1": {
+      "Name": "Fang of Flare Flaying",
+      "MaxLevel": 15,
+      "Type": "Talent",
+      "Tag": "Talent",
+      "Desc": "After Jade or an ally that had become the Debt Collector attacks, Jade gains 1 Charge for each enemy target attacked. When the Charge reaches <b>#3[f]</b>, consume <b>#3[f]</b> Charges to launch <u>follow-up attack</u> 1 time, dealing Quantum DMG equal to @<b>#5[p]</b># of Jade's ATK to all enemies. This <u>follow-up attack</u> does not generate Charge.<br>Jade immediately gains <b>#4[f]</b> stack(s) of Pawned Asset when launching her Talent's <u>follow-up attack</u>, with each stack of Pawned Asset increasing her CRIT DMG by @<b>#1[p]</b>#. This effect can stack up to <b>#2[f]</b> times.",
+      "Params": [
+        [
+          0.012,
+          50.0,
+          8.0,
+          5.0,
+          0.6
+        ],
+        [
+          0.0132,
+          50.0,
+          8.0,
+          5.0,
+          0.66
+        ],
+        [
+          0.0144,
+          50.0,
+          8.0,
+          5.0,
+          0.72
+        ],
+        [
+          0.0156,
+          50.0,
+          8.0,
+          5.0,
+          0.78
+        ],
+        [
+          0.0168,
+          50.0,
+          8.0,
+          5.0,
+          0.84
+        ],
+        [
+          0.018,
+          50.0,
+          8.0,
+          5.0,
+          0.9
+        ],
+        [
+          0.0195,
+          50.0,
+          8.0,
+          5.0,
+          0.975
+        ],
+        [
+          0.021,
+          50.0,
+          8.0,
+          5.0,
+          1.05
+        ],
+        [
+          0.0225,
+          50.0,
+          8.0,
+          5.0,
+          1.125
+        ],
+        [
+          0.024,
+          50.0,
+          8.0,
+          5.0,
+          1.2
+        ],
+        [
+          0.0252,
+          50.0,
+          8.0,
+          5.0,
+          1.26
+        ],
+        [
+          0.0264,
+          50.0,
+          8.0,
+          5.0,
+          1.32
+        ],
+        [
+          0.0276,
+          50.0,
+          8.0,
+          5.0,
+          1.38
+        ],
+        [
+          0.0288,
+          50.0,
+          8.0,
+          5.0,
+          1.44
+        ],
+        [
+          0.03,
+          50.0,
+          8.0,
+          5.0,
+          1.5
+        ]
+      ],
+      "BP": 0,
+      "SPAdd": 10.0,
+      "Stance": [
+        0.0,
+        1.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1314_Passive"
+    },
+    "v2": {
+      "Name": "Fang of Flare Flaying",
+      "MaxLevel": 15,
+      "Type": "Talent",
+      "Tag": "Talent",
+      "Desc": "After Jade or an ally that had become the Debt Collector attacks, Jade gains 1 Charge for each enemy target attacked. When the Charge reaches <b>#3[f]</b>, consume <b>#3[f]</b> Charges to launch <u>follow-up attack</u> 1 time, dealing Quantum DMG equal to @<b>#5[p]</b># of Jade's ATK to all enemies. This <u>follow-up attack</u> does not generate Charge.<br>Jade immediately gains <b>#4[f]</b> stack(s) of Pawned Asset when launching her Talent's <u>follow-up attack</u>, with each stack of Pawned Asset increasing her CRIT DMG by @<b>#1[p]</b>#. This effect can stack up to <b>#2[f]</b> times.",
+      "Params": [
+        [
+          0.012,
+          50.0,
+          8.0,
+          5.0,
+          0.6
+        ],
+        [
+          0.0132,
+          50.0,
+          8.0,
+          5.0,
+          0.66
+        ],
+        [
+          0.0144,
+          50.0,
+          8.0,
+          5.0,
+          0.72
+        ],
+        [
+          0.0156,
+          50.0,
+          8.0,
+          5.0,
+          0.78
+        ],
+        [
+          0.0168,
+          50.0,
+          8.0,
+          5.0,
+          0.84
+        ],
+        [
+          0.018,
+          50.0,
+          8.0,
+          5.0,
+          0.9
+        ],
+        [
+          0.0195,
+          50.0,
+          8.0,
+          5.0,
+          0.975
+        ],
+        [
+          0.021,
+          50.0,
+          8.0,
+          5.0,
+          1.05
+        ],
+        [
+          0.0225,
+          50.0,
+          8.0,
+          5.0,
+          1.125
+        ],
+        [
+          0.024,
+          50.0,
+          8.0,
+          5.0,
+          1.2
+        ],
+        [
+          0.0252,
+          50.0,
+          8.0,
+          5.0,
+          1.26
+        ],
+        [
+          0.0264,
+          50.0,
+          8.0,
+          5.0,
+          1.32
+        ],
+        [
+          0.0276,
+          50.0,
+          8.0,
+          5.0,
+          1.38
+        ],
+        [
+          0.0288,
+          50.0,
+          8.0,
+          5.0,
+          1.44
+        ],
+        [
+          0.03,
+          50.0,
+          8.0,
+          5.0,
+          1.5
+        ]
+      ],
+      "BP": 0,
+      "SPAdd": 10.0,
+      "Stance": [
+        0.0,
+        1.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1314_Passive"
+    },
+    "v3": {
+      "Name": "Fang of Flare Flaying",
+      "MaxLevel": 15,
+      "Type": "Talent",
+      "Tag": "AoE",
+      "Desc": "After Jade or an ally that had become the Debt Collector attacks, Jade gains 1 Charge for each enemy target attacked. When the Charge reaches <b>#3[f]</b>, consume <b>#3[f]</b> Charges to launch <u>follow-up attack</u> 1 time, dealing Quantum DMG equal to @<b>#5[p]</b># of Jade's ATK to all enemies. This <u>follow-up attack</u> does not generate Charge.<br>Jade immediately gains <b>#4[f]</b> stack(s) of Pawned Asset when launching her Talent's <u>follow-up attack</u>, with each stack of Pawned Asset increasing her CRIT DMG by @<b>#1[p]</b>#. This effect can stack up to <b>#2[f]</b> times.",
+      "Params": [
+        [
+          0.012,
+          50.0,
+          8.0,
+          5.0,
+          0.6
+        ],
+        [
+          0.0132,
+          50.0,
+          8.0,
+          5.0,
+          0.66
+        ],
+        [
+          0.0144,
+          50.0,
+          8.0,
+          5.0,
+          0.72
+        ],
+        [
+          0.0156,
+          50.0,
+          8.0,
+          5.0,
+          0.78
+        ],
+        [
+          0.0168,
+          50.0,
+          8.0,
+          5.0,
+          0.84
+        ],
+        [
+          0.018,
+          50.0,
+          8.0,
+          5.0,
+          0.9
+        ],
+        [
+          0.0195,
+          50.0,
+          8.0,
+          5.0,
+          0.975
+        ],
+        [
+          0.021,
+          50.0,
+          8.0,
+          5.0,
+          1.05
+        ],
+        [
+          0.0225,
+          50.0,
+          8.0,
+          5.0,
+          1.125
+        ],
+        [
+          0.024,
+          50.0,
+          8.0,
+          5.0,
+          1.2
+        ],
+        [
+          0.0252,
+          50.0,
+          8.0,
+          5.0,
+          1.26
+        ],
+        [
+          0.0264,
+          50.0,
+          8.0,
+          5.0,
+          1.32
+        ],
+        [
+          0.0276,
+          50.0,
+          8.0,
+          5.0,
+          1.38
+        ],
+        [
+          0.0288,
+          50.0,
+          8.0,
+          5.0,
+          1.44
+        ],
+        [
+          0.03,
+          50.0,
+          8.0,
+          5.0,
+          1.5
+        ]
+      ],
+      "BP": 0,
+      "SPAdd": 10.0,
+      "Stance": [
+        0.0,
+        1.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1314_Passive"
+    },
+    "v4": {
+      "Name": "Fang of Flare Flaying",
+      "MaxLevel": 15,
+      "Type": "Talent",
+      "Tag": "AoE",
+      "Desc": "After Jade or an ally that had become the Debt Collector attacks, Jade gains 1 Charge for each enemy target attacked. When the Charge reaches <b>#3[f]</b>, consume <b>#3[f]</b> Charges to launch <u>follow-up attack</u> 1 time, dealing Quantum DMG equal to @<b>#5[p]</b># of Jade's ATK to all enemies. This <u>follow-up attack</u> does not generate Charge.<br>Jade immediately gains <b>#4[f]</b> stack(s) of Pawned Asset when launching her Talent's <u>follow-up attack</u>, with each stack of Pawned Asset increasing her CRIT DMG by @<b>#1[p]</b>#. This effect can stack up to <b>#2[f]</b> times.",
+      "Params": [
+        [
+          0.012,
+          50.0,
+          8.0,
+          5.0,
+          0.6
+        ],
+        [
+          0.0132,
+          50.0,
+          8.0,
+          5.0,
+          0.66
+        ],
+        [
+          0.0144,
+          50.0,
+          8.0,
+          5.0,
+          0.72
+        ],
+        [
+          0.0156,
+          50.0,
+          8.0,
+          5.0,
+          0.78
+        ],
+        [
+          0.0168,
+          50.0,
+          8.0,
+          5.0,
+          0.84
+        ],
+        [
+          0.018,
+          50.0,
+          8.0,
+          5.0,
+          0.9
+        ],
+        [
+          0.0195,
+          50.0,
+          8.0,
+          5.0,
+          0.975
+        ],
+        [
+          0.021,
+          50.0,
+          8.0,
+          5.0,
+          1.05
+        ],
+        [
+          0.0225,
+          50.0,
+          8.0,
+          5.0,
+          1.125
+        ],
+        [
+          0.024,
+          50.0,
+          8.0,
+          5.0,
+          1.2
+        ],
+        [
+          0.0252,
+          50.0,
+          8.0,
+          5.0,
+          1.26
+        ],
+        [
+          0.0264,
+          50.0,
+          8.0,
+          5.0,
+          1.32
+        ],
+        [
+          0.0276,
+          50.0,
+          8.0,
+          5.0,
+          1.38
+        ],
+        [
+          0.0288,
+          50.0,
+          8.0,
+          5.0,
+          1.44
+        ],
+        [
+          0.03,
+          50.0,
+          8.0,
+          5.0,
+          1.5
+        ]
+      ],
+      "BP": 0,
+      "SPAdd": 10.0,
+      "Stance": [
+        0.0,
+        1.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1314_Passive"
+    },
+    "v5": {
+      "Name": "Fang of Flare Flaying",
+      "MaxLevel": 15,
+      "Type": "Talent",
+      "Tag": "AoE",
+      "Desc": "After Jade or an ally that had become the Debt Collector attacks, Jade gains 1 Charge for each enemy target attacked. When the Charge reaches <b>#3[f]</b>, consume <b>#3[f]</b> Charges to launch <u>follow-up attack</u> 1 time, dealing Quantum DMG equal to @<b>#5[p]</b># of Jade's ATK to all enemies. This <u>follow-up attack</u> does not generate Charge.<br>Jade immediately gains <b>#4[f]</b> stack(s) of Pawned Asset when launching her Talent's <u>follow-up attack</u>, with each stack of Pawned Asset increasing her CRIT DMG by @<b>#1[p]</b>#. This effect can stack up to <b>#2[f]</b> times.",
+      "Params": [
+        [
+          0.012,
+          50.0,
+          8.0,
+          5.0,
+          0.6
+        ],
+        [
+          0.0132,
+          50.0,
+          8.0,
+          5.0,
+          0.66
+        ],
+        [
+          0.0144,
+          50.0,
+          8.0,
+          5.0,
+          0.72
+        ],
+        [
+          0.0156,
+          50.0,
+          8.0,
+          5.0,
+          0.78
+        ],
+        [
+          0.0168,
+          50.0,
+          8.0,
+          5.0,
+          0.84
+        ],
+        [
+          0.018,
+          50.0,
+          8.0,
+          5.0,
+          0.9
+        ],
+        [
+          0.0195,
+          50.0,
+          8.0,
+          5.0,
+          0.975
+        ],
+        [
+          0.021,
+          50.0,
+          8.0,
+          5.0,
+          1.05
+        ],
+        [
+          0.0225,
+          50.0,
+          8.0,
+          5.0,
+          1.125
+        ],
+        [
+          0.024,
+          50.0,
+          8.0,
+          5.0,
+          1.2
+        ],
+        [
+          0.0252,
+          50.0,
+          8.0,
+          5.0,
+          1.26
+        ],
+        [
+          0.0264,
+          50.0,
+          8.0,
+          5.0,
+          1.32
+        ],
+        [
+          0.0276,
+          50.0,
+          8.0,
+          5.0,
+          1.38
+        ],
+        [
+          0.0288,
+          50.0,
+          8.0,
+          5.0,
+          1.44
+        ],
+        [
+          0.03,
+          50.0,
+          8.0,
+          5.0,
+          1.5
+        ]
+      ],
+      "BP": 0,
+      "SPAdd": 10.0,
+      "Stance": [
+        0.0,
+        1.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1314_Passive"
+    }
+  },
+  "131406": {
+    "v1": {
+      "Name": "Attack",
+      "MaxLevel": 1,
+      "Type": "",
+      "Tag": "",
+      "Desc": "Attacks an enemy, and when the battle starts, reduces their Toughness of the corresponding Type.",
+      "Params": [
+        []
+      ],
+      "BP": 0,
+      "SPAdd": 0,
+      "AttackType": "MazeNormal",
+      "Stance": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1314_Normal"
+    },
+    "v2": {
+      "Name": "Attack",
+      "MaxLevel": 1,
+      "Type": "",
+      "Tag": "",
+      "Desc": "Attacks an enemy, and when the battle starts, reduces their Toughness of the corresponding Type.",
+      "Params": [
+        []
+      ],
+      "BP": 0,
+      "SPAdd": 0,
+      "AttackType": "MazeNormal",
+      "Stance": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1314_Normal"
+    },
+    "v3": {
+      "Name": "Attack",
+      "MaxLevel": 1,
+      "Type": "",
+      "Tag": "",
+      "Desc": "Attacks an enemy, and when the battle starts, reduces their Toughness of the corresponding Type.",
+      "Params": [
+        []
+      ],
+      "BP": 0,
+      "SPAdd": 0,
+      "AttackType": "MazeNormal",
+      "Stance": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1314_Normal"
+    },
+    "v4": {
+      "Name": "Attack",
+      "MaxLevel": 1,
+      "Type": "",
+      "Tag": "",
+      "Desc": "Attacks an enemy, and when the battle starts, reduces their Toughness of the corresponding Type.",
+      "Params": [
+        []
+      ],
+      "BP": 0,
+      "SPAdd": 0,
+      "AttackType": "MazeNormal",
+      "Stance": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1314_Normal"
+    },
+    "v5": {
+      "Name": "Attack",
+      "MaxLevel": 1,
+      "Type": "",
+      "Tag": "",
+      "Desc": "Attacks an enemy, and when the battle starts, reduces their Toughness of the corresponding Type.",
+      "Params": [
+        []
+      ],
+      "BP": 0,
+      "SPAdd": 0,
+      "AttackType": "MazeNormal",
+      "Stance": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1314_Normal"
+    }
+  },
+  "131407": {
+    "v1": {
+      "Name": "Visionary Predation",
+      "MaxLevel": 1,
+      "Type": "Technique",
+      "Tag": "",
+      "Desc": "After using the Technique, inflicts enemies within a set area with Blind Fealty for <b>#1[f]</b> second(s). Enemies inflicted with Blind Fealty will not actively attack allies. When entering battle via actively attacking enemies inflicted with Blind Fealty, all enemies with Blind Fealty will enter combat simultaneously. Deals Quantum DMG equal to <b>#2[p]</b> of Jade's ATK to all enemies, and immediately gains <b>#3[f]</b> stack(s) of Pawned Asset.",
+      "Params": [
+        [
+          10.0,
+          0.5,
+          15.0
+        ]
+      ],
+      "BP": 0,
+      "SPAdd": 0,
+      "AttackType": "Maze",
+      "Stance": [
+        0.0,
+        0.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1314_Maze"
+    },
+    "v2": {
+      "Name": "Visionary Predation",
+      "MaxLevel": 1,
+      "Type": "Technique",
+      "Tag": "",
+      "Desc": "After using the Technique, inflicts enemies within a set area with Blind Fealty for <b>#1[f]</b> second(s). Enemies inflicted with Blind Fealty will not actively attack allies. When entering battle via actively attacking enemies inflicted with Blind Fealty, all enemies with Blind Fealty will enter combat simultaneously. Deals Quantum DMG equal to <b>#2[p]</b> of Jade's ATK to all enemies, and immediately gains <b>#3[f]</b> stack(s) of Pawned Asset.",
+      "Params": [
+        [
+          10.0,
+          0.5,
+          15.0
+        ]
+      ],
+      "BP": 0,
+      "SPAdd": 0,
+      "AttackType": "Maze",
+      "Stance": [
+        0.0,
+        0.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1314_Maze"
+    },
+    "v3": {
+      "Name": "Visionary Predation",
+      "MaxLevel": 1,
+      "Type": "Technique",
+      "Tag": "Impair",
+      "Desc": "After using the Technique, inflicts enemies within a set area with Blind Fealty for <b>#1[f]</b> second(s). Enemies inflicted with Blind Fealty will not actively attack allies. When entering battle via actively attacking enemies inflicted with Blind Fealty, all enemies with Blind Fealty will enter combat simultaneously. Deals Quantum DMG equal to <b>#2[p]</b> of Jade's ATK to all enemies, and immediately gains <b>#3[f]</b> stack(s) of Pawned Asset.",
+      "Params": [
+        [
+          10.0,
+          0.5,
+          15.0
+        ]
+      ],
+      "BP": 0,
+      "SPAdd": 0,
+      "AttackType": "Maze",
+      "Stance": [
+        0.0,
+        0.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1314_Maze"
+    },
+    "v4": {
+      "Name": "Visionary Predation",
+      "MaxLevel": 1,
+      "Type": "Technique",
+      "Tag": "Impair",
+      "Desc": "After using the Technique, inflicts enemies within a set area with Blind Fealty for <b>#1[f]</b> second(s). Enemies inflicted with Blind Fealty will not actively attack allies. When entering battle via actively attacking enemies inflicted with Blind Fealty, all enemies with Blind Fealty will enter combat simultaneously. Deals Quantum DMG equal to <b>#2[p]</b> of Jade's ATK to all enemies, and immediately gains <b>#3[f]</b> stack(s) of Pawned Asset.",
+      "Params": [
+        [
+          10.0,
+          0.5,
+          15.0
+        ]
+      ],
+      "BP": 0,
+      "SPAdd": 0,
+      "AttackType": "Maze",
+      "Stance": [
+        0.0,
+        0.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1314_Maze"
+    },
+    "v5": {
+      "Name": "Visionary Predation",
+      "MaxLevel": 1,
+      "Type": "Technique",
+      "Tag": "Impair",
+      "Desc": "After using the Technique, inflicts enemies within a set area with Blind Fealty for <b>#1[f]</b> second(s). Enemies inflicted with Blind Fealty will not actively attack allies. When entering battle via actively attacking enemies inflicted with Blind Fealty, all enemies with Blind Fealty will enter combat simultaneously. Deals Quantum DMG equal to <b>#2[p]</b> of Jade's ATK to all enemies, and immediately gains <b>#3[f]</b> stack(s) of Pawned Asset.",
+      "Params": [
+        [
+          10.0,
+          0.5,
+          15.0
+        ]
+      ],
+      "BP": 0,
+      "SPAdd": 0,
+      "AttackType": "Maze",
+      "Stance": [
+        0.0,
+        0.0,
+        0.0
+      ],
+      "Icon": "SkillIcon_1314_Maze"
+    }
+  }
+}
+
+var _avatarskilltree = {
+  "1310": {
+    "v1": {
+      "Add": {
+        "BreakDamageAddedRatioBase": 0.373,
+        "StatusResistanceBase": 0.18,
+        "SpeedDelta": 5.0
+      },
+      "Tree1": {
+        "Name": "Module α: Antilag Outburst",
+        "Desc": "While in Complete Combustion, attacking enemies without Fire Weakness can also reduce Toughness by an amount equal to <b><color style='color:#f29e38'>55.0%</color></b> of the original ability's Toughness Reduction.",
+        "Icon": "SkillIcon_1310_SkillTree1"
+      },
+      "Tree2": {
+        "Name": "Module β: Autoreactive Armor",
+        "Desc": "For every <b><color style='color:#f29e38'>100.0</color></b> of SAM's ATK that exceeds <b><color style='color:#f29e38'>2400.0</color></b>, increases SAM's Break Effect by <b><color style='color:#f29e38'>6.0%</color></b>, up to a maximum increase of <b><color style='color:#f29e38'>60.0%</color></b>.",
+        "Icon": "SkillIcon_1310_SkillTree2"
+      },
+      "Tree3": {
+        "Name": "Module γ: Core Overload",
+        "Desc": "If SAM is in Complete Combustion with a Break Effect that is <b><color style='color:#f29e38'>250.0%</color></b>/<b><color style='color:#f29e38'>360.0%</color></b> or higher, additionally ignores <b><color style='color:#f29e38'>30.0%</color></b>/<b><color style='color:#f29e38'>40.0%</color></b> of the target's DEF when attacking.",
+        "Icon": "SkillIcon_1310_SkillTree3"
+      }
+    },
+    "v2": {
+      "Add": {
+        "BreakDamageAddedRatioBase": 0.373,
+        "StatusResistanceBase": 0.18,
+        "SpeedDelta": 5.0
+      },
+      "Tree1": {
+        "Name": "Module α: Antilag Outburst",
+        "Desc": "While in Complete Combustion, attacking enemies without Fire Weakness can also reduce Toughness by an amount equal to <b><color style='color:#f29e38'>55.0%</color></b> of the original ability's Toughness Reduction.",
+        "Icon": "SkillIcon_1310_SkillTree1"
+      },
+      "Tree2": {
+        "Name": "Module β: Autoreactive Armor",
+        "Desc": "For every <b><color style='color:#f29e38'>100.0</color></b> of SAM's ATK that exceeds <b><color style='color:#f29e38'>2400.0</color></b>, increases SAM's Break Effect by <b><color style='color:#f29e38'>6.0%</color></b>, up to a maximum increase of <b><color style='color:#f29e38'>60.0%</color></b>.",
+        "Icon": "SkillIcon_1310_SkillTree2"
+      },
+      "Tree3": {
+        "Name": "Module γ: Core Overload",
+        "Desc": "If SAM is in Complete Combustion with a Break Effect that is <b><color style='color:#f29e38'>250.0%</color></b>/<b><color style='color:#f29e38'>360.0%</color></b> or higher, additionally ignores <b><color style='color:#f29e38'>30.0%</color></b>/<b><color style='color:#f29e38'>40.0%</color></b> of the target's DEF when attacking.",
+        "Icon": "SkillIcon_1310_SkillTree3"
+      }
+    },
+    "v3": {
+      "Add": {
+        "BreakDamageAddedRatioBase": 0.373,
+        "StatusResistanceBase": 0.18,
+        "SpeedDelta": 5.0
+      },
+      "Tree1": {
+        "Name": "Module α: Antilag Outburst",
+        "Desc": "While in Complete Combustion, attacking enemies without Fire Weakness can also reduce Toughness by an amount equal to <b><color style='color:#f29e38'>55.0%</color></b> of the original ability's Toughness Reduction.",
+        "Icon": "SkillIcon_1310_SkillTree1"
+      },
+      "Tree2": {
+        "Name": "Module β: Autoreactive Armor",
+        "Desc": "Under Complete Combustion, when SAM's Break Effect is equal to or greater than <b><color style='color:#f29e38'>200.0%</color></b>/<b><color style='color:#f29e38'>360.0%</color></b>, attacking a Weakness-Broken enemy target will convert the Toughness Reduction of this attack into 1 instance of <b><color style='color:#f29e38'>35.0%</color></b>/<b><color style='color:#f29e38'>50.0%</color></b> Super Break DMG.",
+        "Icon": "SkillIcon_1310_SkillTree2"
+      },
+      "Tree3": {
+        "Name": "Module γ: Core Overload",
+        "Desc": "For every <b><color style='color:#f29e38'>100.0</color></b> of SAM's ATK that exceeds <b><color style='color:#f29e38'>1600.0</color></b>, increases SAM's Break Effect by <b><color style='color:#f29e38'>10.0%</color></b>.",
+        "Icon": "SkillIcon_1310_SkillTree3"
+      }
+    },
+    "v4": {
+      "Add": {
+        "BreakDamageAddedRatioBase": 0.373,
+        "StatusResistanceBase": 0.18,
+        "SpeedDelta": 5.0
+      },
+      "Tree1": {
+        "Name": "Module α: Antilag Outburst",
+        "Desc": "While in Complete Combustion, attacking enemies without Fire Weakness can also reduce Toughness by an amount equal to <b><color style='color:#f29e38'>55.0%</color></b> of the original ability's Toughness Reduction.",
+        "Icon": "SkillIcon_1310_SkillTree1"
+      },
+      "Tree2": {
+        "Name": "Module β: Autoreactive Armor",
+        "Desc": "Under Complete Combustion, when SAM's Break Effect is equal to or greater than <b><color style='color:#f29e38'>200.0%</color></b>/<b><color style='color:#f29e38'>360.0%</color></b>, attacking a Weakness-Broken enemy target will convert the Toughness Reduction of this attack into 1 instance of <b><color style='color:#f29e38'>35.0%</color></b>/<b><color style='color:#f29e38'>50.0%</color></b> Super Break DMG.",
+        "Icon": "SkillIcon_1310_SkillTree2"
+      },
+      "Tree3": {
+        "Name": "Module γ: Core Overload",
+        "Desc": "For every <b><color style='color:#f29e38'>10.0</color></b> of SAM's ATK that exceeds <b><color style='color:#f29e38'>1800.0</color></b>, increases SAM's Break Effect by <b><color style='color:#f29e38'>0.8%</color></b>.",
+        "Icon": "SkillIcon_1310_SkillTree3"
+      }
+    },
+    "v5": {
+      "Add": {
+        "BreakDamageAddedRatioBase": 0.373,
+        "StatusResistanceBase": 0.18,
+        "SpeedDelta": 5.0
+      },
+      "Tree1": {
+        "Name": "Module α: Antilag Outburst",
+        "Desc": "During the Complete Combustion, attacking enemies that have no Fire Weakness can also reduce their Toughness, with the effect being equivalent to <b><color style='color:#f29e38'>55.0%</color></b> of the original Toughness Reduction from abilities.",
+        "Icon": "SkillIcon_1310_SkillTree1"
+      },
+      "Tree2": {
+        "Name": "Module β: Autoreactive Armor",
+        "Desc": "When SAM is in Complete Combustion with a Break Effect that is equal to or greater than <b><color style='color:#f29e38'>200.0%</color></b>/<b><color style='color:#f29e38'>360.0%</color></b>, attacking a Weakness-Broken enemy target will convert the Toughness Reduction of this attack into 1 instance of <b><color style='color:#f29e38'>35.0%</color></b>/<b><color style='color:#f29e38'>50.0%</color></b> Super Break DMG.",
+        "Icon": "SkillIcon_1310_SkillTree2"
+      },
+      "Tree3": {
+        "Name": "Module γ: Core Overload",
+        "Desc": "For every <b><color style='color:#f29e38'>10.0</color></b> of SAM's ATK that exceeds <b><color style='color:#f29e38'>1800.0</color></b>, increases SAM's Break Effect by <b><color style='color:#f29e38'>0.8%</color></b>.",
+        "Icon": "SkillIcon_1310_SkillTree3"
+      }
+    }
+  },
+  "1314": {
+    "v1": {
+      "Add": {
+        "QuantumAddedRatio": 0.224,
+        "AttackAddedRatio": 0.18,
+        "StatusResistanceBase": 0.1
+      },
+      "Tree1": {
+        "Name": "Reverse Repo",
+        "Desc": "When enemy targets enter combat, Jade gains <b><color style='color:#f29e38'>1.0</color></b> stack(s) of Pawned Asset. When a Debt Collector ally's turn starts, Jade additionally gains <b><color style='color:#f29e38'>3.0</color></b> stack(s) of Pawned Asset.",
+        "Icon": "SkillIcon_1314_SkillTree1"
+      },
+      "Tree2": {
+        "Name": "Collateral Ticket",
+        "Desc": "When the battle starts, Jade's action is advanced forward by <b><color style='color:#f29e38'>50.0%</color></b>.",
+        "Icon": "SkillIcon_1314_SkillTree2"
+      },
+      "Tree3": {
+        "Name": "Asset Forfeiture",
+        "Desc": "Each stack of the Talent's Pawned Asset additionally increases Jade's ATK by <b><color style='color:#f29e38'>0.5%</color></b>.",
+        "Icon": "SkillIcon_1314_SkillTree3"
+      }
+    },
+    "v2": {
+      "Add": {
+        "QuantumAddedRatio": 0.224,
+        "AttackAddedRatio": 0.18,
+        "StatusResistanceBase": 0.1
+      },
+      "Tree1": {
+        "Name": "Reverse Repo",
+        "Desc": "When enemy targets enter combat, Jade gains <b><color style='color:#f29e38'>1.0</color></b> stack(s) of Pawned Asset. When a Debt Collector ally's turn starts, Jade additionally gains <b><color style='color:#f29e38'>3.0</color></b> stack(s) of Pawned Asset.",
+        "Icon": "SkillIcon_1314_SkillTree1"
+      },
+      "Tree2": {
+        "Name": "Collateral Ticket",
+        "Desc": "When the battle starts, Jade's action is advanced forward by <b><color style='color:#f29e38'>50.0%</color></b>.",
+        "Icon": "SkillIcon_1314_SkillTree2"
+      },
+      "Tree3": {
+        "Name": "Asset Forfeiture",
+        "Desc": "Each stack of the Talent's Pawned Asset additionally increases Jade's ATK by <b><color style='color:#f29e38'>0.5%</color></b>.",
+        "Icon": "SkillIcon_1314_SkillTree3"
+      }
+    },
+    "v3": {
+      "Add": {
+        "QuantumAddedRatio": 0.224,
+        "AttackAddedRatio": 0.18,
+        "StatusResistanceBase": 0.1
+      },
+      "Tree1": {
+        "Name": "Reverse Repo",
+        "Desc": "When enemy targets enter combat, Jade gains <b><color style='color:#f29e38'>1.0</color></b> stack(s) of Pawned Asset. When a Debt Collector ally's turn starts, Jade additionally gains <b><color style='color:#f29e38'>3.0</color></b> stack(s) of Pawned Asset.",
+        "Icon": "SkillIcon_1314_SkillTree1"
+      },
+      "Tree2": {
+        "Name": "Collateral Ticket",
+        "Desc": "When the battle starts, Jade's action is advanced forward by <b><color style='color:#f29e38'>50.0%</color></b>.",
+        "Icon": "SkillIcon_1314_SkillTree2"
+      },
+      "Tree3": {
+        "Name": "Asset Forfeiture",
+        "Desc": "Each stack of the Talent's Pawned Asset additionally increases Jade's ATK by <b><color style='color:#f29e38'>0.5%</color></b>.",
+        "Icon": "SkillIcon_1314_SkillTree3"
+      }
+    },
+    "v4": {
+      "Add": {
+        "QuantumAddedRatio": 0.224,
+        "AttackAddedRatio": 0.18,
+        "StatusResistanceBase": 0.1
+      },
+      "Tree1": {
+        "Name": "Reverse Repo",
+        "Desc": "When enemy targets enter combat, Jade gains <b><color style='color:#f29e38'>1.0</color></b> stack(s) of Pawned Asset. When a Debt Collector ally's turn starts, Jade additionally gains <b><color style='color:#f29e38'>3.0</color></b> stack(s) of Pawned Asset.",
+        "Icon": "SkillIcon_1314_SkillTree1"
+      },
+      "Tree2": {
+        "Name": "Collateral Ticket",
+        "Desc": "When the battle starts, Jade's action is advanced forward by <b><color style='color:#f29e38'>50.0%</color></b>.",
+        "Icon": "SkillIcon_1314_SkillTree2"
+      },
+      "Tree3": {
+        "Name": "Asset Forfeiture",
+        "Desc": "Each stack of the Talent's Pawned Asset additionally increases Jade's ATK by <b><color style='color:#f29e38'>0.5%</color></b>.",
+        "Icon": "SkillIcon_1314_SkillTree3"
+      }
+    },
+    "v5": {
+      "Add": {
+        "QuantumAddedRatio": 0.224,
+        "AttackAddedRatio": 0.18,
+        "StatusResistanceBase": 0.1
+      },
+      "Tree1": {
+        "Name": "Reverse Repo",
+        "Desc": "When enemy targets enter combat, Jade gains <b><color style='color:#f29e38'>1.0</color></b> stack(s) of Pawned Asset. When a Debt Collector ally's turn starts, Jade additionally gains <b><color style='color:#f29e38'>3.0</color></b> stack(s) of Pawned Asset.",
+        "Icon": "SkillIcon_1314_SkillTree1"
+      },
+      "Tree2": {
+        "Name": "Collateral Ticket",
+        "Desc": "When the battle starts, Jade's action is advanced forward by <b><color style='color:#f29e38'>50.0%</color></b>.",
+        "Icon": "SkillIcon_1314_SkillTree2"
+      },
+      "Tree3": {
+        "Name": "Asset Forfeiture",
+        "Desc": "Each stack of the Talent's Pawned Asset additionally increases Jade's ATK by <b><color style='color:#f29e38'>0.5%</color></b>.",
+        "Icon": "SkillIcon_1314_SkillTree3"
+      }
+    }
+  }
+}
+
+var _avatarrank = {
+  "131001": {
+    "v1": {
+      "Rank": 1,
+      "Name": "In Reddened Chrysalis, I Once Rest",
+      "Desc": "When using the Enhanced Skill, ignores <b><color style='color:#f29e38'>15.0%</color></b> of the target's DEF. And the Enhanced Skill does not consume Skill Points.",
+      "Icon": "SkillIcon_1310_Rank1"
+    },
+    "v2": {
+      "Rank": 1,
+      "Name": "In Reddened Chrysalis, I Once Rest",
+      "Desc": "When using the Enhanced Skill, ignores <b><color style='color:#f29e38'>15.0%</color></b> of the target's DEF. And the Enhanced Skill does not consume Skill Points.",
+      "Icon": "SkillIcon_1310_Rank1"
+    },
+    "v3": {
+      "Rank": 1,
+      "Name": "In Reddened Chrysalis, I Once Rest",
+      "Desc": "When using the Enhanced Skill, ignores <b><color style='color:#f29e38'>15.0%</color></b> of the target's DEF. And the Enhanced Skill does not consume Skill Points.",
+      "Icon": "SkillIcon_1310_Rank1"
+    },
+    "v4": {
+      "Rank": 1,
+      "Name": "In Reddened Chrysalis, I Once Rest",
+      "Desc": "When using the Enhanced Skill, ignore <b><color style='color:#f29e38'>15.0%</color></b> of the target's DEF, and the Enhanced Skill does not consume Skill Points.",
+      "Icon": "SkillIcon_1310_Rank1"
+    },
+    "v5": {
+      "Rank": 1,
+      "Name": "In Reddened Chrysalis, I Once Rest",
+      "Desc": "When using the Enhanced Skill, ignores <b><color style='color:#f29e38'>15.0%</color></b> of the target's DEF. And the Enhanced Skill does not consume Skill Points.",
+      "Icon": "SkillIcon_1310_Rank1"
+    }
+  },
+  "131002": {
+    "v1": {
+      "Rank": 2,
+      "Name": "From Shattered Sky, I Free Fall",
+      "Desc": "When using the Enhanced Basic ATK or the Enhanced Skill in Complete Combustion state to defeat an enemy target or cause them to be Weakness Broken, SAM immediately gains 1 extra turn. This effect can trigger again after <b><color style='color:#f29e38'>1.0</color></b> turn(s).<br><br>Hidden Stat: 1.0",
+      "Icon": "SkillIcon_1310_Rank2"
+    },
+    "v2": {
+      "Rank": 2,
+      "Name": "From Shattered Sky, I Free Fall",
+      "Desc": "When using the Enhanced Basic ATK or the Enhanced Skill in Complete Combustion state to defeat an enemy target or cause them to be Weakness Broken, SAM immediately gains 1 extra turn. This effect can trigger again after <b><color style='color:#f29e38'>1.0</color></b> turn(s).<br><br>Hidden Stat: 1.0",
+      "Icon": "SkillIcon_1310_Rank2"
+    },
+    "v3": {
+      "Rank": 2,
+      "Name": "From Shattered Sky, I Free Fall",
+      "Desc": "When using the Enhanced Basic ATK or the Enhanced Skill in Complete Combustion state to defeat an enemy target or cause them to be Weakness Broken, SAM immediately gains 1 extra turn. This effect can trigger again after <b><color style='color:#f29e38'>1.0</color></b> turn(s).<br><br>Hidden Stat: 1.0",
+      "Icon": "SkillIcon_1310_Rank2"
+    },
+    "v4": {
+      "Rank": 2,
+      "Name": "From Shattered Sky, I Free Fall",
+      "Desc": "When using the Enhanced Basic ATK or the Enhanced Skill in Complete Combustion state to defeat an enemy target or cause them to be Weakness Broken, SAM immediately gains 1 extra turn. This effect can trigger again after <b><color style='color:#f29e38'>1.0</color></b> turn(s).<br><br>Hidden Stat: 1.0",
+      "Icon": "SkillIcon_1310_Rank2"
+    },
+    "v5": {
+      "Rank": 2,
+      "Name": "From Shattered Sky, I Free Fall",
+      "Desc": "When using the Enhanced Basic ATK or the Enhanced Skill in Complete Combustion state to defeat an enemy target or cause them to be Weakness Broken, SAM immediately gains 1 extra turn. This effect can trigger again after <b><color style='color:#f29e38'>1.0</color></b> turn(s).<br><br>Hidden Stat: 1.0",
+      "Icon": "SkillIcon_1310_Rank2"
+    }
+  },
+  "131003": {
+    "v1": {
+      "Rank": 3,
+      "Name": "Amidst Silenced Stars, I Deep Sleep",
+      "Desc": "Skill Lv. +2, up to a maximum of Lv. <b><color style='color:#f29e38'>15</color></b>.<br>Basic ATK Lv. +1, up to a maximum of Lv. <b><color style='color:#f29e38'>10</color></b>.",
+      "Icon": "SkillIcon_1310_BP"
+    },
+    "v2": {
+      "Rank": 3,
+      "Name": "Amidst Silenced Stars, I Deep Sleep",
+      "Desc": "Skill Lv. +2, up to a maximum of Lv. <b><color style='color:#f29e38'>15</color></b>.<br>Basic ATK Lv. +1, up to a maximum of Lv. <b><color style='color:#f29e38'>10</color></b>.",
+      "Icon": "SkillIcon_1310_BP"
+    },
+    "v3": {
+      "Rank": 3,
+      "Name": "Amidst Silenced Stars, I Deep Sleep",
+      "Desc": "Skill Lv. +2, up to a maximum of Lv. <b><color style='color:#f29e38'>15</color></b>.<br>Basic ATK Lv. +1, up to a maximum of Lv. <b><color style='color:#f29e38'>10</color></b>.",
+      "Icon": "SkillIcon_1310_BP"
+    },
+    "v4": {
+      "Rank": 3,
+      "Name": "Amidst Silenced Stars, I Deep Sleep",
+      "Desc": "Skill Lv. +2, up to a maximum of Lv. <b><color style='color:#f29e38'>15</color></b>.<br>Basic ATK Lv. +1, up to a maximum of Lv. <b><color style='color:#f29e38'>10</color></b>.",
+      "Icon": "SkillIcon_1310_BP"
+    },
+    "v5": {
+      "Rank": 3,
+      "Name": "Amidst Silenced Stars, I Deep Sleep",
+      "Desc": "Skill Lv. +2, up to a maximum of Lv. <b><color style='color:#f29e38'>15</color></b>.<br>Basic ATK Lv. +1, up to a maximum of Lv. <b><color style='color:#f29e38'>10</color></b>.",
+      "Icon": "SkillIcon_1310_BP"
+    }
+  },
+  "131004": {
+    "v1": {
+      "Rank": 4,
+      "Name": "Upon Lighted Firefly, I Soon Gaze",
+      "Desc": "While in Complete Combustion, SAM is immune to Crowd Control debuffs. This effect can only trigger <b><color style='color:#f29e38'>2.0</color></b> time(s) during each Complete Combustion.",
+      "Icon": "SkillIcon_1310_Rank4"
+    },
+    "v2": {
+      "Rank": 4,
+      "Name": "Upon Lighted Firefly, I Soon Gaze",
+      "Desc": "While in Complete Combustion, SAM is immune to Crowd Control debuffs. This effect can only trigger <b><color style='color:#f29e38'>2.0</color></b> time(s) during each Complete Combustion.",
+      "Icon": "SkillIcon_1310_Rank4"
+    },
+    "v3": {
+      "Rank": 4,
+      "Name": "Upon Lighted Fyrefly, I Soon Gaze",
+      "Desc": "When in the Complete Combustion state, increases SAM's Effect RES by <b><color style='color:#f29e38'>50.0%</color></b>.",
+      "Icon": "SkillIcon_1310_Rank4"
+    },
+    "v4": {
+      "Rank": 4,
+      "Name": "Upon Lighted Fyrefly, I Soon Gaze",
+      "Desc": "When in the Complete Combustion state, increases SAM's Effect RES by <b><color style='color:#f29e38'>50.0%</color></b>.",
+      "Icon": "SkillIcon_1310_Rank4"
+    },
+    "v5": {
+      "Rank": 4,
+      "Name": "Upon Lighted Fyrefly, I Soon Gaze",
+      "Desc": "While in Complete Combustion, increases SAM's Effect RES by <b><color style='color:#f29e38'>50.0%</color></b>.",
+      "Icon": "SkillIcon_1310_Rank4"
+    }
+  },
+  "131005": {
+    "v1": {
+      "Rank": 5,
+      "Name": "From Undreamt Night, I Thence Shine",
+      "Desc": "Ultimate Lv. +2, up to a maximum of Lv. <b><color style='color:#f29e38'>15</color></b>.<br>Talent Lv. +2, up to a maximum of Lv. <b><color style='color:#f29e38'>15</color></b>.",
+      "Icon": "SkillIcon_1310_Ultra"
+    },
+    "v2": {
+      "Rank": 5,
+      "Name": "From Undreamt Night, I Thence Shine",
+      "Desc": "Ultimate Lv. +2, up to a maximum of Lv. <b><color style='color:#f29e38'>15</color></b>.<br>Talent Lv. +2, up to a maximum of Lv. <b><color style='color:#f29e38'>15</color></b>.",
+      "Icon": "SkillIcon_1310_Ultra"
+    },
+    "v3": {
+      "Rank": 5,
+      "Name": "From Undreamt Night, I Thence Shine",
+      "Desc": "Ultimate Lv. +2, up to a maximum of Lv. <b><color style='color:#f29e38'>15</color></b>.<br>Talent Lv. +2, up to a maximum of Lv. <b><color style='color:#f29e38'>15</color></b>.",
+      "Icon": "SkillIcon_1310_Ultra"
+    },
+    "v4": {
+      "Rank": 5,
+      "Name": "From Undreamt Night, I Thence Shine",
+      "Desc": "Ultimate Lv. +2, up to a maximum of Lv. <b><color style='color:#f29e38'>15</color></b>.<br>Talent Lv. +2, up to a maximum of Lv. <b><color style='color:#f29e38'>15</color></b>.",
+      "Icon": "SkillIcon_1310_Ultra"
+    },
+    "v5": {
+      "Rank": 5,
+      "Name": "From Undreamt Night, I Thence Shine",
+      "Desc": "Ultimate Lv. +2, up to a maximum of Lv. <b><color style='color:#f29e38'>15</color></b>.<br>Talent Lv. +2, up to a maximum of Lv. <b><color style='color:#f29e38'>15</color></b>.",
+      "Icon": "SkillIcon_1310_Ultra"
+    }
+  },
+  "131006": {
+    "v1": {
+      "Rank": 6,
+      "Name": "In Finalized Morrow, I Full Bloom",
+      "Desc": "While in Complete Combustion, increases SAM's Fire RES PEN by <b><color style='color:#f29e38'>12.0%</color></b>. When using the Enhanced Basic ATK or Enhanced Skill, increases the Weakness Break efficiency by <b><color style='color:#f29e38'>50.0%</color></b>.",
+      "Icon": "SkillIcon_1310_Rank6"
+    },
+    "v2": {
+      "Rank": 6,
+      "Name": "In Finalized Morrow, I Full Bloom",
+      "Desc": "While in Complete Combustion, increases SAM's Fire RES PEN by <b><color style='color:#f29e38'>12.0%</color></b>. When using the Enhanced Basic ATK or Enhanced Skill, increases the Weakness Break efficiency by <b><color style='color:#f29e38'>50.0%</color></b>.",
+      "Icon": "SkillIcon_1310_Rank6"
+    },
+    "v3": {
+      "Rank": 6,
+      "Name": "In Finalized Morrow, I Full Bloom",
+      "Desc": "While in Complete Combustion, increases SAM's Fire RES PEN by <b><color style='color:#f29e38'>20.0%</color></b>. When using the Enhanced Basic ATK or Enhanced Skill, increases the Weakness Break efficiency by <b><color style='color:#f29e38'>50.0%</color></b>.",
+      "Icon": "SkillIcon_1310_Rank6"
+    },
+    "v4": {
+      "Rank": 6,
+      "Name": "In Finalized Morrow, I Full Bloom",
+      "Desc": "While in Complete Combustion, increases SAM's Fire RES PEN by <b><color style='color:#f29e38'>20.0%</color></b>. When using the Enhanced Basic ATK or Enhanced Skill, increases the Weakness Break efficiency by <b><color style='color:#f29e38'>50.0%</color></b>.",
+      "Icon": "SkillIcon_1310_Rank6"
+    },
+    "v5": {
+      "Rank": 6,
+      "Name": "In Finalized Morrow, I Full Bloom",
+      "Desc": "While in Complete Combustion, increases SAM's Fire RES PEN by <b><color style='color:#f29e38'>20.0%</color></b>. When using the Enhanced Basic ATK or Enhanced Skill, increases the Weakness Break efficiency by <b><color style='color:#f29e38'>50.0%</color></b>.",
+      "Icon": "SkillIcon_1310_Rank6"
+    }
+  },
+  "131401": {
+    "v1": {
+      "Rank": 1,
+      "Name": "Altruism? Nevertheless Tradable",
+      "Desc": "The follow-up attack DMG from Jade's Talent increases by <b><color style='color:#f29e38'>20.0%</color></b>. Every time Jade gets Charged, she additionally gains <b><color style='color:#f29e38'>1.0</color></b> point(s) of Charge.",
+      "Icon": "SkillIcon_1314_Rank1"
+    },
+    "v2": {
+      "Rank": 1,
+      "Name": "Altruism? Nevertheless Tradable",
+      "Desc": "The follow-up attack DMG from Jade's Talent increases by <b><color style='color:#f29e38'>20.0%</color></b>. Every time Jade gets Charged, she additionally gains <b><color style='color:#f29e38'>1.0</color></b> point(s) of Charge.",
+      "Icon": "SkillIcon_1314_Rank1"
+    },
+    "v3": {
+      "Rank": 1,
+      "Name": "Altruism? Nevertheless Tradable",
+      "Desc": "The follow-up attack DMG from Jade's Talent increases by <b><color style='color:#f29e38'>32.0%</color></b>. After the character with the Debt Collector state uses an attack and hits 2/1 enemy target(s), Jade additionally gains <b><color style='color:#f29e38'>1.0</color></b>/<b><color style='color:#f29e38'>2.0</color></b> point(s) of Charge.",
+      "Icon": "SkillIcon_1314_Rank1"
+    },
+    "v4": {
+      "Rank": 1,
+      "Name": "Altruism? Nevertheless Tradable",
+      "Desc": "The follow-up attack DMG from Jade's Talent increases by <b><color style='color:#f29e38'>32.0%</color></b>. After the character with the Debt Collector state uses an attack and hits 2/1 enemy target(s), Jade additionally gains <b><color style='color:#f29e38'>1.0</color></b>/<b><color style='color:#f29e38'>2.0</color></b> point(s) of Charge.",
+      "Icon": "SkillIcon_1314_Rank1"
+    },
+    "v5": {
+      "Rank": 1,
+      "Name": "Altruism? Nevertheless Tradable",
+      "Desc": "The follow-up attack DMG from Jade's Talent increases by <b><color style='color:#f29e38'>32.0%</color></b>. After the character with the Debt Collector state uses an attack and hits 2/1 enemy target(s), Jade additionally gains <b><color style='color:#f29e38'>1.0</color></b>/<b><color style='color:#f29e38'>2.0</color></b> point(s) of Charge.",
+      "Icon": "SkillIcon_1314_Rank1"
+    }
+  },
+  "131402": {
+    "v1": {
+      "Rank": 2,
+      "Name": "Morality? Herein Authenticated",
+      "Desc": "When there are <b><color style='color:#f29e38'>15.0</color></b> stacks of Pawned Asset, Jade's CRIT Rate increases by <b><color style='color:#f29e38'>18.0%</color></b>.",
+      "Icon": "SkillIcon_1314_Rank2"
+    },
+    "v2": {
+      "Rank": 2,
+      "Name": "Morality? Herein Authenticated",
+      "Desc": "When there are <b><color style='color:#f29e38'>15.0</color></b> stacks of Pawned Asset, Jade's CRIT Rate increases by <b><color style='color:#f29e38'>18.0%</color></b>.",
+      "Icon": "SkillIcon_1314_Rank2"
+    },
+    "v3": {
+      "Rank": 2,
+      "Name": "Morality? Herein Authenticated",
+      "Desc": "When there are <b><color style='color:#f29e38'>15.0</color></b> stacks of Pawned Asset, Jade's CRIT Rate increases by <b><color style='color:#f29e38'>18.0%</color></b>.",
+      "Icon": "SkillIcon_1314_Rank2"
+    },
+    "v4": {
+      "Rank": 2,
+      "Name": "Morality? Herein Authenticated",
+      "Desc": "When there are <b><color style='color:#f29e38'>15.0</color></b> stacks of Pawned Asset, Jade's CRIT Rate increases by <b><color style='color:#f29e38'>18.0%</color></b>.",
+      "Icon": "SkillIcon_1314_Rank2"
+    },
+    "v5": {
+      "Rank": 2,
+      "Name": "Morality? Herein Authenticated",
+      "Desc": "When there are <b><color style='color:#f29e38'>15.0</color></b> stacks of Pawned Asset, Jade's CRIT Rate increases by <b><color style='color:#f29e38'>18.0%</color></b>.",
+      "Icon": "SkillIcon_1314_Rank2"
+    }
+  },
+  "131403": {
+    "v1": {
+      "Rank": 3,
+      "Name": "Honesty? Soon Mortgaged",
+      "Desc": "Skill Lv. +2, up to a maximum of Lv. <b><color style='color:#f29e38'>15</color></b>.<br>Talent Lv. +2, up to a maximum of Lv. <b><color style='color:#f29e38'>15</color></b>.",
+      "Icon": "SkillIcon_1314_BP"
+    },
+    "v2": {
+      "Rank": 3,
+      "Name": "Honesty? Soon Mortgaged",
+      "Desc": "Skill Lv. +2, up to a maximum of Lv. <b><color style='color:#f29e38'>15</color></b>.<br>Talent Lv. +2, up to a maximum of Lv. <b><color style='color:#f29e38'>15</color></b>.",
+      "Icon": "SkillIcon_1314_BP"
+    },
+    "v3": {
+      "Rank": 3,
+      "Name": "Honesty? Soon Mortgaged",
+      "Desc": "Skill Lv. +2, up to a maximum of Lv. <b><color style='color:#f29e38'>15</color></b>.<br>Talent Lv. +2, up to a maximum of Lv. <b><color style='color:#f29e38'>15</color></b>.",
+      "Icon": "SkillIcon_1314_BP"
+    },
+    "v4": {
+      "Rank": 3,
+      "Name": "Honesty? Soon Mortgaged",
+      "Desc": "Skill Lv. +2, up to a maximum of Lv. <b><color style='color:#f29e38'>15</color></b>.<br>Talent Lv. +2, up to a maximum of Lv. <b><color style='color:#f29e38'>15</color></b>.",
+      "Icon": "SkillIcon_1314_BP"
+    },
+    "v5": {
+      "Rank": 3,
+      "Name": "Honesty? Soon Mortgaged",
+      "Desc": "Skill Lv. +2, up to a maximum of Lv. <b><color style='color:#f29e38'>15</color></b>.<br>Talent Lv. +2, up to a maximum of Lv. <b><color style='color:#f29e38'>15</color></b>.",
+      "Icon": "SkillIcon_1314_BP"
+    }
+  },
+  "131404": {
+    "v1": {
+      "Rank": 4,
+      "Name": "Sincerity? Put Option Only",
+      "Desc": "When using Ultimate, the DMG Jade deals ignores <b><color style='color:#f29e38'>12.0%</color></b> of enemy targets' DEF, lasting for <b><color style='color:#f29e38'>3.0</color></b> turn(s).",
+      "Icon": "SkillIcon_1314_Rank4"
+    },
+    "v2": {
+      "Rank": 4,
+      "Name": "Sincerity? Put Option Only",
+      "Desc": "When using Ultimate, the DMG Jade deals ignores <b><color style='color:#f29e38'>12.0%</color></b> of enemy targets' DEF, lasting for <b><color style='color:#f29e38'>3.0</color></b> turn(s).",
+      "Icon": "SkillIcon_1314_Rank4"
+    },
+    "v3": {
+      "Rank": 4,
+      "Name": "Sincerity? Put Option Only",
+      "Desc": "When using Ultimate, the DMG Jade deals ignores <b><color style='color:#f29e38'>12.0%</color></b> of enemy targets' DEF, lasting for <b><color style='color:#f29e38'>3.0</color></b> turn(s).",
+      "Icon": "SkillIcon_1314_Rank4"
+    },
+    "v4": {
+      "Rank": 4,
+      "Name": "Sincerity? Put Option Only",
+      "Desc": "When using Ultimate, the DMG Jade deals ignores <b><color style='color:#f29e38'>12.0%</color></b> of enemy targets' DEF, lasting for <b><color style='color:#f29e38'>3.0</color></b> turn(s).",
+      "Icon": "SkillIcon_1314_Rank4"
+    },
+    "v5": {
+      "Rank": 4,
+      "Name": "Sincerity? Put Option Only",
+      "Desc": "When using Ultimate, the DMG Jade deals ignores <b><color style='color:#f29e38'>12.0%</color></b> of enemy targets' DEF, lasting for <b><color style='color:#f29e38'>3.0</color></b> turn(s).",
+      "Icon": "SkillIcon_1314_Rank4"
+    }
+  },
+  "131405": {
+    "v1": {
+      "Rank": 5,
+      "Name": "Hope? Hitherto Forfeited",
+      "Desc": "Ultimate Lv. +2, up to a maximum of Lv. <b><color style='color:#f29e38'>15</color></b>.<br>Basic ATK Lv. +1, up to a maximum of Lv. <b><color style='color:#f29e38'>10</color></b>.",
+      "Icon": "SkillIcon_1314_Ultra"
+    },
+    "v2": {
+      "Rank": 5,
+      "Name": "Hope? Hitherto Forfeited",
+      "Desc": "Ultimate Lv. +2, up to a maximum of Lv. <b><color style='color:#f29e38'>15</color></b>.<br>Basic ATK Lv. +1, up to a maximum of Lv. <b><color style='color:#f29e38'>10</color></b>.",
+      "Icon": "SkillIcon_1314_Ultra"
+    },
+    "v3": {
+      "Rank": 5,
+      "Name": "Hope? Hitherto Forfeited",
+      "Desc": "Ultimate Lv. +2, up to a maximum of Lv. <b><color style='color:#f29e38'>15</color></b>.<br>Basic ATK Lv. +1, up to a maximum of Lv. <b><color style='color:#f29e38'>10</color></b>.",
+      "Icon": "SkillIcon_1314_Ultra"
+    },
+    "v4": {
+      "Rank": 5,
+      "Name": "Hope? Hitherto Forfeited",
+      "Desc": "Ultimate Lv. +2, up to a maximum of Lv. <b><color style='color:#f29e38'>15</color></b>.<br>Basic ATK Lv. +1, up to a maximum of Lv. <b><color style='color:#f29e38'>10</color></b>.",
+      "Icon": "SkillIcon_1314_Ultra"
+    },
+    "v5": {
+      "Rank": 5,
+      "Name": "Hope? Hitherto Forfeited",
+      "Desc": "Ultimate Lv. +2, up to a maximum of Lv. <b><color style='color:#f29e38'>15</color></b>.<br>Basic ATK Lv. +1, up to a maximum of Lv. <b><color style='color:#f29e38'>10</color></b>.",
+      "Icon": "SkillIcon_1314_Ultra"
+    }
+  },
+  "131406": {
+    "v1": {
+      "Rank": 6,
+      "Name": "Equity? Pending Sponsorship",
+      "Desc": "When there are Debt Collector allies on the field, Jade's Quantum RES PEN increases by <b><color style='color:#f29e38'>20.0%</color></b>, and Jade gains the Debt Collector state.",
+      "Icon": "SkillIcon_1314_Rank6"
+    },
+    "v2": {
+      "Rank": 6,
+      "Name": "Equity? Pending Sponsorship",
+      "Desc": "When there are Debt Collector allies on the field, Jade's Quantum RES PEN increases by <b><color style='color:#f29e38'>20.0%</color></b>, and Jade gains the Debt Collector state.",
+      "Icon": "SkillIcon_1314_Rank6"
+    },
+    "v3": {
+      "Rank": 6,
+      "Name": "Equity? Pending Sponsorship",
+      "Desc": "When there are Debt Collector allies on the field, Jade's Quantum RES PEN increases by <b><color style='color:#f29e38'>20.0%</color></b>, and Jade gains the Debt Collector state.",
+      "Icon": "SkillIcon_1314_Rank6"
+    },
+    "v4": {
+      "Rank": 6,
+      "Name": "Equity? Pending Sponsorship",
+      "Desc": "When there are Debt Collector allies on the field, Jade's Quantum RES PEN increases by <b><color style='color:#f29e38'>20.0%</color></b>, and Jade gains the Debt Collector state.",
+      "Icon": "SkillIcon_1314_Rank6"
+    },
+    "v5": {
+      "Rank": 6,
+      "Name": "Equity? Pending Sponsorship",
+      "Desc": "When there are Debt Collector allies on the field, Jade's Quantum RES PEN increases by <b><color style='color:#f29e38'>20.0%</color></b>, and Jade gains the Debt Collector state.",
+      "Icon": "SkillIcon_1314_Rank6"
+    }
+  }
+}
+
+var _story = {
+  "1310": [],
+  "1314": []
+}
+
+var _voice = {
+  "1310": [],
+  "1314": []
+}
+
+var _changelog2 = {
+  "1310": [
+    "<b>DMG Split</b><br>Basic ATK: 1<br>Enhanced Basic ATK: 0.15x4+0.4<br>Skill: 0.4+0.6<br>Enhanced Skill: 0.15x4+0.4",
+    "The Super Break DMG dealt via Trace #2 cannot be buffed by Harmony Trailblazer's Trace's 20% ~ 60% independent boost.",
+    "<b>(v3 Change)</b>Eidolon #1's DEF ignore is applied to all DMG dealt during Enhanced Skill, not only Enhanced Skill's own DMG.",
+    "<b>(Fixed in v3)</b><s>Trace #1 will convert Sam's Toughness Reduction against enemies without Fire Weakness to 55% of the original value. This still takes effect when the enemy is Weakness Broken, thus Super Break DMG will be reduced to 55% of the original DMG without this Trace.</s>",
+    "Trace #3's ATK conversion to Break Effect does not include ATK converted by ratio from another source. That is, it will not include ATK boosts from Robin's Ultimate or the Hunt blessing Blessed Bow and Arrow.",
+    "Under Complete Combustion, the 12% increased DMG to Weakness Broken enemies is added to the <b>defender's DMG taken multiplier</b>. The CN description is incorrect; the EN description is correct. This error has been officially corrected in v2.",
+    "The direct DMG that Sam deals do not count as Break DMG. Super Break DMG counts as Break DMG. The relic set Iron Cavalry Against the Scourge will only let Sam's ordinary Break DMG and Super Break DMG ignore DEF."
+  ],
+  "1314": [
+    "The HP consumption of the Debt Collector is only triggered once per attack performed, regardless of the number of targets attacked or the number of instances of DMG dealt.",
+    "If Jade is under Crowd Control, the Passive's follow-up attack will not be triggered. If Charges reach the cap then the follow-up attack will be triggered immediately after the Control debuff is gone.<br>Charges can exceed the cap, and the follow-up attack will only consume the cap number of Charges. The Charges exceeding the cap will be retained.",
+    "When the Debt Collector performs an attack, they deal instance 1 Additional DMG to all targets attacked, regardless of the number of DMG instances of the original attack. At most 5 targets are counted."
+  ]
+}
+
+var _notes = {}
+
+var _adiff = {}
+
+var _weapondesc = {
+  "23028": "<i>\"Lady Bonajade, if it weren't for your continuous supply of goods and donations, the orphanage would probably...\"</i><br>She gently stroked the children's heads, cutting off the director's words.<br><i>\"As long as I'm here, there's no need to worry about the days ahead... And there's no need to say these things to the children, it only adds to their worries.\"</i><br><br>The children looked up, chattering with her about recent happenings, their worries, and their dreams.<br><i>\"Lady Bonajade, when will you come next time?\"</i><br><i>\"Don't overwork yourself, make sure to get enough rest...\"</i><br><i>\"Lady Bonajade, when I grow up, I want to be someone like you!\"</i><br>She looked at the children's clear eyes and paused for a moment.<br><i>\"Someone like me...\"</i><br>The child handed her an apple, <i>\"Yes! Someone who brings light and hope to others!\"</i><br><br>Poverty, demerits, sorrow, suffering... She walked among the galaxies, taking others' pledges and giving equivalent returns.<br>Life exists because of desire, runs because of desire, and dies because of desire — this is an irrefutable law, as well as an inevitability of life.<br>A philanthropist with a hidden agenda, a villain who mortgages souls... She was given various identities by the world, but only she understood the morality behind these actions.",
+  "23025": "This is the edge of the Asdana system. The ocean of memoria roars with mountainous waves and she, like a singular tiny spark, may be doused at any moment in the storm.<br><i>\"For one who cannot dream to enter the Synesthesia Dreamscape, they would have to pay a price comparable to death.\"</i><br>She can still hear her companion's concerned voice next to her ears. She takes a deep breath and dives into the Memory Zone.<br>As the vehicle silently sinks into the depth of the Memory Zone, small pinpricks of firefly lights dissipate from the cracks and are then immediately swallowed up by the endless darkness.<br><br><i>\"Wherefore do you hurtle unto death?\"</i><br>In the ocean of memoria that grows deeper and deeper, the weak light emitted by the Memory Zone creatures are like faraway eyes that nonchalantly glance at her.<br><br>Dreams remained too distant for her. She gazes emptily out at the boundless darkness, her body and soul having reached the breakdown threshold long ago under the heavy pressure of memoria. Though she realizes her consciousness is gradually fading, only those remaining memories are playing over and over in her brain —<br>The Swarm that covered the sky tore through the frontline defenses as she flew towards the Swarm while enveloped in fire. The charred ash of the Swarm faded like snow, under which lies the pitch-black carcasses of the knights.<br>She didn't even have the time to take a bouquet and offer her final acknowledgement to knights, who were dying one after another. Their lives bloomed in the blink of an eye and went out equally fleetingly. Like a string of genetic code, they never possessed names and only had numbers allotted instead.<br><br><i>\"Wherefore do you live?\"</i><br>In the deathly silence, like flames dissolving in the sea, she is reduced to a singular spot of fire and unendingly progresses towards the light...<br>She opens her eyes after what seems to be forever. She sees the \"future\" looking like a pearl, radiating with a soft and vague light. Tears stream down her face —<br><i>\"I do it to find... my own 'dream'...\"</i>",
+  "24004": "Eternally suspended in the void,<br>Streams of shimmering data flood into THEIR mind.<br>Turning all things past and future into symbols,<br>THEY deduce the end from the beginning.<br>Knowledge, answers, truths...<br>In the mist of information, a brilliant light arises,<br>And everything becomes clear to THEM.",
+  "21045": "The eternal dream he longed for vanished in an instant. As he plummeted towards the earth, he felt no sadness, only the desire to close his eyes.<br><br>The old path he treaded upon has now crumbled, yet the future remains shrouded in mist.<br><i>\"After awakening, the world continues its cycle of suffering, with no escape, as before...\"</i><br>With burdens of the past on his shoulders, he turns his back to his homeland, continuing to move towards that nonexistent paradise.<br><br>So, why do people sleep? Why do they wake up?<br>...As planets streak past outside the window, this answer now needs to be given new meaning.<br><i>\"Perhaps... perhaps I can still...\"</i>"
+}
+
+var _weaponskill = {
+  "23028": {
+    "v1": {
+      "Name": "Promise",
+      "Desc": [
+        "Increases the wearer's CRIT Rate by <color style='color:#f29e38;'>16.0%</color> / <color style='color:#f29e38;'>19.0%</color> / <color style='color:#f29e38;'>22.0%</color> / <color style='color:#f29e38;'>25.0%</color> / <color style='color:#f29e38;'>28.0%</color> . While the wearer is in battle, for every <b>20.0%</b> CRIT DMG that exceeds <b>120.0%</b>, the DMG of the wearer's follow-up attack is increased by <color style='color:#f29e38;'>16.0%</color> / <color style='color:#f29e38;'>19.0%</color> / <color style='color:#f29e38;'>22.0%</color> / <color style='color:#f29e38;'>25.0%</color> / <color style='color:#f29e38;'>28.0%</color> . This effect can stack up to <b>4.0</b> time(s). When the battle starts or after the wearer uses their Basic ATK, enables the Ultimate and the follow-up attack to ignore <color style='color:#f29e38;'>16.0%</color> / <color style='color:#f29e38;'>19.0%</color> / <color style='color:#f29e38;'>22.0%</color> / <color style='color:#f29e38;'>25.0%</color> / <color style='color:#f29e38;'>28.0%</color>  of the target's DEF, lasting for <b>2.0</b> turn(s)."
+      ]
+    },
+    "v2": {
+      "Name": "Promise",
+      "Desc": [
+        "Increases the wearer's CRIT Rate by <color style='color:#f29e38;'>16.0%</color> / <color style='color:#f29e38;'>19.0%</color> / <color style='color:#f29e38;'>22.0%</color> / <color style='color:#f29e38;'>25.0%</color> / <color style='color:#f29e38;'>28.0%</color> . While the wearer is in battle, for every <b>20.0%</b> CRIT DMG that exceeds <b>120.0%</b>, the DMG of the wearer's follow-up attack is increased by <color style='color:#f29e38;'>16.0%</color> / <color style='color:#f29e38;'>19.0%</color> / <color style='color:#f29e38;'>22.0%</color> / <color style='color:#f29e38;'>25.0%</color> / <color style='color:#f29e38;'>28.0%</color> . This effect can stack up to <b>4.0</b> time(s). When the battle starts or after the wearer uses their Basic ATK, enables the Ultimate and the follow-up attack to ignore <color style='color:#f29e38;'>16.0%</color> / <color style='color:#f29e38;'>19.0%</color> / <color style='color:#f29e38;'>22.0%</color> / <color style='color:#f29e38;'>25.0%</color> / <color style='color:#f29e38;'>28.0%</color>  of the target's DEF, lasting for <b>2.0</b> turn(s)."
+      ]
+    },
+    "v3": {
+      "Name": "Promise",
+      "Desc": [
+        "Increases the wearer's CRIT Rate by <color style='color:#f29e38;'>16.0%</color> / <color style='color:#f29e38;'>19.0%</color> / <color style='color:#f29e38;'>22.0%</color> / <color style='color:#f29e38;'>25.0%</color> / <color style='color:#f29e38;'>28.0%</color> . While the wearer is in battle, for every <b>20.0%</b> CRIT DMG that exceeds <b>120.0%</b>, the DMG of the wearer's follow-up attack is increased by <color style='color:#f29e38;'>12.0%</color> / <color style='color:#f29e38;'>14.0%</color> / <color style='color:#f29e38;'>16.0%</color> / <color style='color:#f29e38;'>18.0%</color> / <color style='color:#f29e38;'>20.0%</color> . This effect can stack up to <b>4.0</b> time(s). When the battle starts or after the wearer uses their Basic ATK, enables the Ultimate and the follow-up attack to ignore <color style='color:#f29e38;'>20.0%</color> / <color style='color:#f29e38;'>24.0%</color> / <color style='color:#f29e38;'>28.0%</color> / <color style='color:#f29e38;'>32.0%</color> / <color style='color:#f29e38;'>36.0%</color>  of the target's DEF, lasting for <b>2.0</b> turn(s)."
+      ]
+    },
+    "v4": {
+      "Name": "Promise",
+      "Desc": [
+        "Increases the wearer's CRIT Rate by <color style='color:#f29e38;'>16.0%</color> / <color style='color:#f29e38;'>19.0%</color> / <color style='color:#f29e38;'>22.0%</color> / <color style='color:#f29e38;'>25.0%</color> / <color style='color:#f29e38;'>28.0%</color> . While the wearer is in battle, for every <b>20.0%</b> CRIT DMG that exceeds <b>120.0%</b>, the DMG of the wearer's follow-up attack is increased by <color style='color:#f29e38;'>12.0%</color> / <color style='color:#f29e38;'>14.0%</color> / <color style='color:#f29e38;'>16.0%</color> / <color style='color:#f29e38;'>18.0%</color> / <color style='color:#f29e38;'>20.0%</color> . This effect can stack up to <b>4.0</b> time(s). When the battle starts or after the wearer uses their Basic ATK, enables the Ultimate and the follow-up attack to ignore <color style='color:#f29e38;'>20.0%</color> / <color style='color:#f29e38;'>24.0%</color> / <color style='color:#f29e38;'>28.0%</color> / <color style='color:#f29e38;'>32.0%</color> / <color style='color:#f29e38;'>36.0%</color>  of the target's DEF, lasting for <b>2.0</b> turn(s)."
+      ]
+    },
+    "v5": {
+      "Name": "Promise",
+      "Desc": [
+        "Increases the wearer's CRIT Rate by <color style='color:#f29e38;'>16.0%</color> / <color style='color:#f29e38;'>19.0%</color> / <color style='color:#f29e38;'>22.0%</color> / <color style='color:#f29e38;'>25.0%</color> / <color style='color:#f29e38;'>28.0%</color> . While the wearer is in battle, for every <b>20.0%</b> CRIT DMG that exceeds <b>120.0%</b>, the DMG of the wearer's follow-up attack is increased by <color style='color:#f29e38;'>12.0%</color> / <color style='color:#f29e38;'>14.0%</color> / <color style='color:#f29e38;'>16.0%</color> / <color style='color:#f29e38;'>18.0%</color> / <color style='color:#f29e38;'>20.0%</color> . This effect can stack up to <b>4.0</b> time(s). When the battle starts or after the wearer uses their Basic ATK, enables the Ultimate and the follow-up attack to ignore <color style='color:#f29e38;'>20.0%</color> / <color style='color:#f29e38;'>24.0%</color> / <color style='color:#f29e38;'>28.0%</color> / <color style='color:#f29e38;'>32.0%</color> / <color style='color:#f29e38;'>36.0%</color>  of the target's DEF, lasting for <b>2.0</b> turn(s)."
+      ]
+    }
+  },
+  "23025": {
+    "v1": {
+      "Name": "Metamorphosis",
+      "Desc": [
+        "Increases the wearer's Break Effect by <color style='color:#f29e38;'>60.0%</color> / <color style='color:#f29e38;'>70.0%</color> / <color style='color:#f29e38;'>80.0%</color> / <color style='color:#f29e38;'>90.0%</color> / <color style='color:#f29e38;'>100.0%</color> . When the wearer deals Break DMG to an enemy target, inflicts Routed on the enemy, lasting for <b>2.0</b> turn(s). Targets afflicted with Routed receive <color style='color:#f29e38;'>15.0%</color> / <color style='color:#f29e38;'>17.5%</color> / <color style='color:#f29e38;'>20.0%</color> / <color style='color:#f29e38;'>22.5%</color> / <color style='color:#f29e38;'>25.0%</color>  increased DMG, and their SPD reduces by <b>15.0%</b>. Effects of the same type cannot stack."
+      ]
+    },
+    "v2": {
+      "Name": "Metamorphosis",
+      "Desc": [
+        "Increases the wearer's Break Effect by <color style='color:#f29e38;'>60.0%</color> / <color style='color:#f29e38;'>70.0%</color> / <color style='color:#f29e38;'>80.0%</color> / <color style='color:#f29e38;'>90.0%</color> / <color style='color:#f29e38;'>100.0%</color> . When the wearer deals Break DMG to an enemy target, inflicts Routed on the enemy, lasting for <b>2.0</b> turn(s). Targets afflicted with Routed receive <color style='color:#f29e38;'>15.0%</color> / <color style='color:#f29e38;'>17.5%</color> / <color style='color:#f29e38;'>20.0%</color> / <color style='color:#f29e38;'>22.5%</color> / <color style='color:#f29e38;'>25.0%</color>  increased DMG, and their SPD reduces by <b>15.0%</b>. Effects of the same type cannot stack."
+      ]
+    },
+    "v3": {
+      "Name": "Metamorphosis",
+      "Desc": [
+        "Increases the wearer's Break Effect by <color style='color:#f29e38;'>60.0%</color> / <color style='color:#f29e38;'>70.0%</color> / <color style='color:#f29e38;'>80.0%</color> / <color style='color:#f29e38;'>90.0%</color> / <color style='color:#f29e38;'>100.0%</color> . When the wearer deals Break DMG to an enemy target, inflicts Routed on the enemy, lasting for <b>2.0</b> turn(s). Targets afflicted with Routed receive <color style='color:#f29e38;'>24.0%</color> / <color style='color:#f29e38;'>28.0%</color> / <color style='color:#f29e38;'>32.0%</color> / <color style='color:#f29e38;'>36.0%</color> / <color style='color:#f29e38;'>40.0%</color>  increased Break DMG from the wearer, and their SPD is lowered by <b>20.0%</b>."
+      ]
+    },
+    "v4": {
+      "Name": "Metamorphosis",
+      "Desc": [
+        "Increases the wearer's Break Effect by <color style='color:#f29e38;'>60.0%</color> / <color style='color:#f29e38;'>70.0%</color> / <color style='color:#f29e38;'>80.0%</color> / <color style='color:#f29e38;'>90.0%</color> / <color style='color:#f29e38;'>100.0%</color> . When the wearer deals Break DMG to an enemy target, inflicts Routed on the enemy, lasting for <b>2.0</b> turn(s). Targets afflicted with Routed receive <color style='color:#f29e38;'>24.0%</color> / <color style='color:#f29e38;'>28.0%</color> / <color style='color:#f29e38;'>32.0%</color> / <color style='color:#f29e38;'>36.0%</color> / <color style='color:#f29e38;'>40.0%</color>  increased Break DMG from the wearer, and their SPD is lowered by <b>20.0%</b>."
+      ]
+    },
+    "v5": {
+      "Name": "Metamorphosis",
+      "Desc": [
+        "Increases the wearer's Break Effect by <color style='color:#f29e38;'>60.0%</color> / <color style='color:#f29e38;'>70.0%</color> / <color style='color:#f29e38;'>80.0%</color> / <color style='color:#f29e38;'>90.0%</color> / <color style='color:#f29e38;'>100.0%</color> . When the wearer deals Break DMG to an enemy target, inflicts Routed on the enemy, lasting for <b>2.0</b> turn(s). Targets afflicted with Routed receive <color style='color:#f29e38;'>24.0%</color> / <color style='color:#f29e38;'>28.0%</color> / <color style='color:#f29e38;'>32.0%</color> / <color style='color:#f29e38;'>36.0%</color> / <color style='color:#f29e38;'>40.0%</color>  increased Break DMG from the wearer, and their SPD is lowered by <b>20.0%</b>."
+      ]
+    }
+  },
+  "24004": {
+    "v1": {
+      "Name": "Boundless Thought",
+      "Desc": [
+        "Increases the wearer's ATK by <color style='color:#f29e38;'>8.0%</color> / <color style='color:#f29e38;'>9.0%</color> / <color style='color:#f29e38;'>10.0%</color> / <color style='color:#f29e38;'>11.0%</color> / <color style='color:#f29e38;'>12.0%</color> . After using an attack, for each enemy target hit, additionally increases ATK by <color style='color:#f29e38;'>4.0%</color> / <color style='color:#f29e38;'>5.0%</color> / <color style='color:#f29e38;'>6.0%</color> / <color style='color:#f29e38;'>7.0%</color> / <color style='color:#f29e38;'>8.0%</color> . This effect can stack 5 times and lasts until the next attack. If there are <b>3.0</b> or more enemy targets hit, this unit's SPD increases by <color style='color:#f29e38;'>8.0%</color> / <color style='color:#f29e38;'>10.0%</color> / <color style='color:#f29e38;'>12.0%</color> / <color style='color:#f29e38;'>14.0%</color> / <color style='color:#f29e38;'>16.0%</color> , lasting for <b>1.0</b> turn(s)."
+      ]
+    },
+    "v2": {
+      "Name": "Boundless Thought",
+      "Desc": [
+        "Increases the wearer's ATK by <color style='color:#f29e38;'>8.0%</color> / <color style='color:#f29e38;'>9.0%</color> / <color style='color:#f29e38;'>10.0%</color> / <color style='color:#f29e38;'>11.0%</color> / <color style='color:#f29e38;'>12.0%</color> . After using an attack, for each enemy target hit, additionally increases ATK by <color style='color:#f29e38;'>4.0%</color> / <color style='color:#f29e38;'>5.0%</color> / <color style='color:#f29e38;'>6.0%</color> / <color style='color:#f29e38;'>7.0%</color> / <color style='color:#f29e38;'>8.0%</color> . This effect can stack 5 times and lasts until the next attack. If there are <b>3.0</b> or more enemy targets hit, this unit's SPD increases by <color style='color:#f29e38;'>8.0%</color> / <color style='color:#f29e38;'>10.0%</color> / <color style='color:#f29e38;'>12.0%</color> / <color style='color:#f29e38;'>14.0%</color> / <color style='color:#f29e38;'>16.0%</color> , lasting for <b>1.0</b> turn(s)."
+      ]
+    },
+    "v3": {
+      "Name": "Boundless Thought",
+      "Desc": [
+        "Increases the wearer's ATK by <color style='color:#f29e38;'>8.0%</color> / <color style='color:#f29e38;'>9.0%</color> / <color style='color:#f29e38;'>10.0%</color> / <color style='color:#f29e38;'>11.0%</color> / <color style='color:#f29e38;'>12.0%</color> . After using an attack, for each enemy target hit, additionally increases ATK by <color style='color:#f29e38;'>4.0%</color> / <color style='color:#f29e38;'>5.0%</color> / <color style='color:#f29e38;'>6.0%</color> / <color style='color:#f29e38;'>7.0%</color> / <color style='color:#f29e38;'>8.0%</color> . This effect can stack 5 times and lasts until the next attack. If there are <b>3.0</b> or more enemy targets hit, this unit's SPD increases by <color style='color:#f29e38;'>8.0%</color> / <color style='color:#f29e38;'>10.0%</color> / <color style='color:#f29e38;'>12.0%</color> / <color style='color:#f29e38;'>14.0%</color> / <color style='color:#f29e38;'>16.0%</color> , lasting for <b>1.0</b> turn(s)."
+      ]
+    },
+    "v4": {
+      "Name": "Boundless Thought",
+      "Desc": [
+        "Increases the wearer's ATK by <color style='color:#f29e38;'>8.0%</color> / <color style='color:#f29e38;'>9.0%</color> / <color style='color:#f29e38;'>10.0%</color> / <color style='color:#f29e38;'>11.0%</color> / <color style='color:#f29e38;'>12.0%</color> . After using an attack, for each enemy target hit, additionally increases ATK by <color style='color:#f29e38;'>4.0%</color> / <color style='color:#f29e38;'>5.0%</color> / <color style='color:#f29e38;'>6.0%</color> / <color style='color:#f29e38;'>7.0%</color> / <color style='color:#f29e38;'>8.0%</color> . This effect can stack 5 times and lasts until the next attack. If there are <b>3.0</b> or more enemy targets hit, this unit's SPD increases by <color style='color:#f29e38;'>8.0%</color> / <color style='color:#f29e38;'>10.0%</color> / <color style='color:#f29e38;'>12.0%</color> / <color style='color:#f29e38;'>14.0%</color> / <color style='color:#f29e38;'>16.0%</color> , lasting for <b>1.0</b> turn(s)."
+      ]
+    },
+    "v5": {
+      "Name": "Boundless Thought",
+      "Desc": [
+        "Increases the wearer's ATK by <color style='color:#f29e38;'>8.0%</color> / <color style='color:#f29e38;'>9.0%</color> / <color style='color:#f29e38;'>10.0%</color> / <color style='color:#f29e38;'>11.0%</color> / <color style='color:#f29e38;'>12.0%</color> . After using an attack, for each enemy target hit, additionally increases ATK by <color style='color:#f29e38;'>4.0%</color> / <color style='color:#f29e38;'>5.0%</color> / <color style='color:#f29e38;'>6.0%</color> / <color style='color:#f29e38;'>7.0%</color> / <color style='color:#f29e38;'>8.0%</color> . This effect can stack 5 times and lasts until the next attack. If there are <b>3.0</b> or more enemy targets hit, this unit's SPD increases by <color style='color:#f29e38;'>8.0%</color> / <color style='color:#f29e38;'>10.0%</color> / <color style='color:#f29e38;'>12.0%</color> / <color style='color:#f29e38;'>14.0%</color> / <color style='color:#f29e38;'>16.0%</color> , lasting for <b>1.0</b> turn(s)."
+      ]
+    }
+  },
+  "21045": {
+    "v1": {
+      "Name": "Quiescence",
+      "Desc": [
+        "Increases the wearer's Break Effect by <color style='color:#f29e38;'>28.0%</color> / <color style='color:#f29e38;'>35.0%</color> / <color style='color:#f29e38;'>42.0%</color> / <color style='color:#f29e38;'>49.0%</color> / <color style='color:#f29e38;'>56.0%</color> . After the wearer uses their Ultimate, increases their SPD by <color style='color:#f29e38;'>8.0%</color> / <color style='color:#f29e38;'>10.0%</color> / <color style='color:#f29e38;'>12.0%</color> / <color style='color:#f29e38;'>14.0%</color> / <color style='color:#f29e38;'>16.0%</color> , lasting for <b>2.0</b> turn(s)."
+      ]
+    },
+    "v2": {
+      "Name": "Quiescence",
+      "Desc": [
+        "Increases the wearer's Break Effect by <color style='color:#f29e38;'>28.0%</color> / <color style='color:#f29e38;'>35.0%</color> / <color style='color:#f29e38;'>42.0%</color> / <color style='color:#f29e38;'>49.0%</color> / <color style='color:#f29e38;'>56.0%</color> . After the wearer uses their Ultimate, increases their SPD by <color style='color:#f29e38;'>8.0%</color> / <color style='color:#f29e38;'>10.0%</color> / <color style='color:#f29e38;'>12.0%</color> / <color style='color:#f29e38;'>14.0%</color> / <color style='color:#f29e38;'>16.0%</color> , lasting for <b>2.0</b> turn(s)."
+      ]
+    },
+    "v3": {
+      "Name": "Quiescence",
+      "Desc": [
+        "Increases the wearer's Break Effect by <color style='color:#f29e38;'>28.0%</color> / <color style='color:#f29e38;'>35.0%</color> / <color style='color:#f29e38;'>42.0%</color> / <color style='color:#f29e38;'>49.0%</color> / <color style='color:#f29e38;'>56.0%</color> . After the wearer uses their Ultimate, increases their SPD by <color style='color:#f29e38;'>8.0%</color> / <color style='color:#f29e38;'>10.0%</color> / <color style='color:#f29e38;'>12.0%</color> / <color style='color:#f29e38;'>14.0%</color> / <color style='color:#f29e38;'>16.0%</color> , lasting for <b>2.0</b> turn(s)."
+      ]
+    },
+    "v4": {
+      "Name": "Quiescence",
+      "Desc": [
+        "Increases the wearer's Break Effect by <color style='color:#f29e38;'>28.0%</color> / <color style='color:#f29e38;'>35.0%</color> / <color style='color:#f29e38;'>42.0%</color> / <color style='color:#f29e38;'>49.0%</color> / <color style='color:#f29e38;'>56.0%</color> . After the wearer uses their Ultimate, increases their SPD by <color style='color:#f29e38;'>8.0%</color> / <color style='color:#f29e38;'>10.0%</color> / <color style='color:#f29e38;'>12.0%</color> / <color style='color:#f29e38;'>14.0%</color> / <color style='color:#f29e38;'>16.0%</color> , lasting for <b>2.0</b> turn(s)."
+      ]
+    },
+    "v5": {
+      "Name": "Quiescence",
+      "Desc": [
+        "Increases the wearer's Break Effect by <color style='color:#f29e38;'>28.0%</color> / <color style='color:#f29e38;'>35.0%</color> / <color style='color:#f29e38;'>42.0%</color> / <color style='color:#f29e38;'>49.0%</color> / <color style='color:#f29e38;'>56.0%</color> . After the wearer uses their Ultimate, increases their SPD by <color style='color:#f29e38;'>8.0%</color> / <color style='color:#f29e38;'>10.0%</color> / <color style='color:#f29e38;'>12.0%</color> / <color style='color:#f29e38;'>14.0%</color> / <color style='color:#f29e38;'>16.0%</color> , lasting for <b>2.0</b> turn(s)."
+      ]
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "dependencies": {
         "@ant-design/icons": "^5.2.6",
         "@js-sdsl/priority-queue": "^4.4.0",
-        "ag-grid-community": "^31.2.1",
-        "ag-grid-react": "^31.2.1",
+        "ag-grid-community": "^31.3.2",
+        "ag-grid-react": "^31.3.2",
         "antd": "^5.16.2",
         "btoa": "^1.2.1",
         "fast-sort": "^3.4.0",
@@ -2816,16 +2816,16 @@
       }
     },
     "node_modules/ag-grid-community": {
-      "version": "31.2.1",
-      "resolved": "https://registry.npmjs.org/ag-grid-community/-/ag-grid-community-31.2.1.tgz",
-      "integrity": "sha512-D+gnUQ4dHZ/EQJmupQnDqcEKiCEeuK5ZxlsIpdPKgHg/23dmW+aEdivtB9nLpSc2IEK0RUpchcSxeUT37Boo5A=="
+      "version": "31.3.2",
+      "resolved": "https://registry.npmjs.org/ag-grid-community/-/ag-grid-community-31.3.2.tgz",
+      "integrity": "sha512-GxqFRD0OcjaVRE1gwLgoP0oERNPH8Lk8wKJ1txulsxysEQ5dZWHhiIoXXSiHjvOCVMkK/F5qzY6HNrn6VeDMTQ=="
     },
     "node_modules/ag-grid-react": {
-      "version": "31.2.1",
-      "resolved": "https://registry.npmjs.org/ag-grid-react/-/ag-grid-react-31.2.1.tgz",
-      "integrity": "sha512-9UH3xxXRwZfW97oz58KboyCJl4t+zdetopieeHVcttsXX1DvGFDUIEz7A1sQaG8e1DAXLMf3IxoIPrfWheH4XA==",
+      "version": "31.3.2",
+      "resolved": "https://registry.npmjs.org/ag-grid-react/-/ag-grid-react-31.3.2.tgz",
+      "integrity": "sha512-SFHN05bsXp901rIT00Fa6iQLCtyavoJiKaXEDUtAU5LMu+GTkjs/FPQBQ8754omgdDFr4NsS3Ri6QbqBne3rug==",
       "dependencies": {
-        "ag-grid-community": "31.2.1",
+        "ag-grid-community": "31.3.2",
         "prop-types": "^15.8.1"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "dependencies": {
     "@ant-design/icons": "^5.2.6",
     "@js-sdsl/priority-queue": "^4.4.0",
-    "ag-grid-community": "^31.2.1",
-    "ag-grid-react": "^31.2.1",
+    "ag-grid-community": "^31.3.2",
+    "ag-grid-react": "^31.3.2",
     "antd": "^5.16.2",
     "btoa": "^1.2.1",
     "fast-sort": "^3.4.0",

--- a/src/components/RelicFilterBar.jsx
+++ b/src/components/RelicFilterBar.jsx
@@ -169,10 +169,11 @@ export default function RelicFilterBar(props) {
       }
     }
 
-    DB.setRelics(relics)
+    // Clone the relics to refresh the sort
+    DB.setRelics(Utils.clone(relics))
 
     if (id && window.relicsGrid?.current?.api) {
-      const isSorted = window.relicsGrid.current.columnApi.getColumnState().filter((s) => s.sort !== null)
+      const isSorted = window.relicsGrid.current.api.getColumnState().filter((s) => s.sort !== null)
 
       if (!isSorted) {
         window.relicsGrid.current.api.applyColumnState({

--- a/src/components/RelicsTab.jsx
+++ b/src/components/RelicsTab.jsx
@@ -272,7 +272,14 @@ export default function RelicsTab() {
     })
     .sort((a, b) => a[0] - b[0])
     .map(([_i, field]) => (
-      { field: field.value, headerName: field.column, cellStyle: Gradient.getRelicGradient, valueFormatter: field.percent ? Renderer.hideNaNAndFloorPercent : Renderer.hideNaNAndFloor, filter: 'agNumberColumnFilter', width: 75 }
+      {
+        field: field.value,
+        headerName: field.column,
+        cellStyle: Gradient.getRelicGradient,
+        valueFormatter: field.percent ? Renderer.hideNaNAndFloorPercent : Renderer.hideNaNAndFloor,
+        filter: 'agNumberColumnFilter',
+        width: 75,
+      }
     )),
   ), [flatValueColumnOptions, valueColumns])
 

--- a/src/lib/relicScorer.ts
+++ b/src/lib/relicScorer.ts
@@ -376,9 +376,9 @@ export class RelicScorer {
       maxWeight -= mainStatFreeRoll(relic.part, relic.main.stat, this.getRelicScoreMeta(id))
     }
     return {
-      bestPct: Math.max(0, 100 * Utils.precisionRound(score.best) / maxWeight),
-      averagePct: Math.max(0, 100 * Utils.precisionRound(score.average) / maxWeight),
-      worstPct: Math.max(0, 100 * Utils.precisionRound(score.worst) / maxWeight),
+      bestPct: Math.max(0, Utils.precisionRound(100 * score.best / maxWeight)),
+      averagePct: Math.max(0, Utils.precisionRound(100 * score.average / maxWeight)),
+      worstPct: Math.max(0, Utils.precisionRound(100 * score.worst / maxWeight)),
       meta: score.meta,
     }
   }
@@ -486,6 +486,11 @@ export class RelicScorer {
     for (let i = relic.substats.length; i < 4; i++) {
       fakesubs[i].stat = remainingSubStats[0][0]
       fakesubs[i].value = (averageScore * (1 + remainingRolls / 4) / (remainingSubStats[0][1] * scaling[remainingSubStats[0][0]]))
+
+      // This is a band-aid patch for the case where all the remainingSubStats with value are taken up by the existing subs
+      // So the denominator is 0. We should set it to 0 in this case?
+      // TODO: Rewrite/clean up the scoring logic
+      fakesubs[i].value = isNaN(fakesubs[i].value) ? 0 : fakesubs[i].value
     }
     const averageCase = parseFloat(this.score(fakeRelic(relic.grade, relic.enhance, relic.part, relic.main.stat, generateSubStats(
       relic.grade, fakesubs[0], fakesubs[1], fakesubs[2], fakesubs[3],

--- a/src/lib/relicScorer.ts
+++ b/src/lib/relicScorer.ts
@@ -521,13 +521,15 @@ export class RelicScorer {
       }
       const candidateSubstats: [string, number][] = scoringMetadata.sortedSubstats.filter((x) => relic.main.stat !== x[0]) // All substats that could possibly exist on the relic
       const bestRolledSubstats: string[] = [] // Array of all substats possibly on relic sharing highest weight
-      const bestWeight = candidateSubstats[0][1]
 
       const validUpgrades = {
         ...Utils.arrayToMap(relic.substats, 'stat'),
         ...Utils.stringArrayToMap(bestNewSubstats),
       }
-      for (const [stat, weight] of candidateSubstats) {
+
+      const upgradeCandidates = candidateSubstats.filter((candidateSubstats) => validUpgrades[candidateSubstats[0]])
+      const bestWeight = upgradeCandidates[0][1]
+      for (const [stat, weight] of upgradeCandidates) {
         if (validUpgrades[stat] && weight >= bestWeight) {
           bestRolledSubstats.push(stat)
         }


### PR DESCRIPTION

# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Fixing a bug where no stats are showing for upgrades when non 1 weight is max

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

<img width="614" alt="image" src="https://github.com/fribbels/hsr-optimizer/assets/7908525/7d9dd8e4-7b72-492e-846b-00eb5dda22a4">
