### PR TITLE
fix: added catch for 0 upgraded substats

### DIFF
--- a/src/lib/relicScorer.ts
+++ b/src/lib/relicScorer.ts
@@ -532,7 +532,12 @@ export class RelicScorer {
           bestRolledSubstats.push(stat)
         }
       }
-
+      if (!bestRolledSubstats.length) { // the above section only finds substats if they have the max weight, this gives substats of non max weight if max weight rolls are impossible
+        const weight = scoringMetadata.stats[relic.substats[findHighestWeight(relic.substats, scoringMetadata)].stat]
+        for (const substat of relic.substats) {
+          if (scoringMetadata.stats[substat.stat] >= weight) bestRolledSubstats.push(substat.stat)
+        }
+      }
       meta = {
         bestNewSubstats: bestNewSubstats,
         bestRolledSubstats: bestRolledSubstats,


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Previous fix would only show upgraded substats if they were of the highest weight, this adds a catch for when that isn't possible (4 lines with 0 max weight subs)

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* #433 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->
![firefox_2024-06-16_00-21-02](https://github.com/fribbels/hsr-optimizer/assets/122728302/d5796e0b-cd3b-457f-92ed-28d490ed357d)

