### PR TITLE
hotfix: bug where empty sets were being calculated incorrectly in optimizer top row

### DIFF
--- a/src/components/CharacterPreview.jsx
+++ b/src/components/CharacterPreview.jsx
@@ -654,7 +654,7 @@ export function CharacterPreview(props) {
                 </Flex>
 
                 <CharacterStatSummary
-                  finalStats={simScoringResult ? simScoringResult.originalSimResult : finalStats}
+                  finalStats={finalStats}
                   elementalDmgValue={elementalDmgValue}
                   cv={finalStats.CV}
                   simScore={simScoringResult ? simScoringResult.originalSimResult.simScore : undefined}

--- a/src/lib/optimizer/calculateBuild.js
+++ b/src/lib/optimizer/calculateBuild.js
@@ -21,6 +21,17 @@ export function calculateBuildByCharacterEquippedIds(character) {
   return calculateBuild(request, relics)
 }
 
+function generateUnusedSets(relics) {
+  const usedSets = new Set([
+    RelicSetToIndex[relics.Head.set],
+    RelicSetToIndex[relics.Hands.set],
+    RelicSetToIndex[relics.Body.set],
+    RelicSetToIndex[relics.Feet.set],
+    RelicSetToIndex[relics.PlanarSphere.set],
+    RelicSetToIndex[relics.LinkRope.set],
+  ])
+  return [0, 1, 2, 3, 4, 5].filter((x) => !usedSets.has(x))
+}
 export function calculateBuild(request, relics) {
   request = Utils.clone(request)
 
@@ -34,12 +45,16 @@ export function calculateBuild(request, relics) {
   const { Head, Hands, Body, Feet, PlanarSphere, LinkRope } = extractRelics(relics)
   RelicFilters.calculateWeightScore(request, [Head, Hands, Body, Feet, PlanarSphere, LinkRope])
 
-  const setH = RelicSetToIndex[relics.Head.set]
-  const setG = RelicSetToIndex[relics.Hands.set]
-  const setB = RelicSetToIndex[relics.Body.set]
-  const setF = RelicSetToIndex[relics.Feet.set]
-  const setP = OrnamentSetToIndex[relics.PlanarSphere.set]
-  const setL = OrnamentSetToIndex[relics.LinkRope.set]
+  // When the relic is empty / has no set, we have to use an unused set index to simulate a broken set
+  const unusedSets = generateUnusedSets(relics)
+  let unusedSetCounter = 0
+
+  const setH = RelicSetToIndex[relics.Head.set] || unusedSets[unusedSetCounter++]
+  const setG = RelicSetToIndex[relics.Hands.set] || unusedSets[unusedSetCounter++]
+  const setB = RelicSetToIndex[relics.Body.set] || unusedSets[unusedSetCounter++]
+  const setF = RelicSetToIndex[relics.Feet.set] || unusedSets[unusedSetCounter++]
+  const setP = OrnamentSetToIndex[relics.PlanarSphere.set] || unusedSets[unusedSetCounter++]
+  const setL = OrnamentSetToIndex[relics.LinkRope.set] || unusedSets[unusedSetCounter++]
 
   const relicSetIndex = setH + setB * RelicSetCount + setG * RelicSetCount * RelicSetCount + setF * RelicSetCount * RelicSetCount * RelicSetCount
   const ornamentSetIndex = setP + setL * OrnamentSetCount


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Fixing a bug where empty sets were detected as space sealing station. Correcting it by selecting unused sets for empty set slots
* Fixing a bug where empty sets on the sim score card were using their +15 main stats for hands/head

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* #447

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

<img width="1244" alt="image" src="https://github.com/fribbels/hsr-optimizer/assets/7908525/c4dab03d-3f21-4caa-b9fe-26c2d203d8e5">
<img width="998" alt="image" src="https://github.com/fribbels/hsr-optimizer/assets/7908525/effdf0ab-c175-4879-85f1-db8da0d091f4">
