### PR TITLE
hotfix: duran beta cap, change default to 5

### DIFF
--- a/src/components/characterPreview/CharacterScoringSummary.tsx
+++ b/src/components/characterPreview/CharacterScoringSummary.tsx
@@ -447,8 +447,8 @@ export const CharacterScoringSummary = (props: { simScoringResult: SimulationSco
           <Flex gap={defaultGap} justify="space-around">
             <Flex vertical gap={10}>
               <ScoringStat stat={StatsToReadable[request.simBody]} part={Parts.Body} />
-              <ScoringStat stat={StatsToReadable[request.simPlanarSphere]} part={Parts.PlanarSphere} />
               <ScoringStat stat={StatsToReadable[request.simFeet]} part={Parts.Feet} />
+              <ScoringStat stat={StatsToReadable[request.simPlanarSphere]} part={Parts.PlanarSphere} />
               <ScoringStat stat={StatsToReadable[request.simLinkRope]} part={Parts.LinkRope} />
             </Flex>
           </Flex>

--- a/src/lib/db.js
+++ b/src/lib/db.js
@@ -2,7 +2,7 @@ import { create } from 'zustand'
 import objectHash from 'object-hash'
 import { OptimizerTabController } from 'lib/optimizerTabController'
 import { RelicAugmenter } from 'lib/relicAugmenter'
-import { Constants, CURRENT_OPTIMIZER_VERSION, DEFAULT_STAT_DISPLAY, RelicSetFilterOptions, SIMULATION_SCORE } from 'lib/constants.ts'
+import { Constants, CURRENT_OPTIMIZER_VERSION, DEFAULT_STAT_DISPLAY, RelicSetFilterOptions, Sets, SIMULATION_SCORE } from 'lib/constants.ts'
 import { SavedSessionKeys } from 'lib/constantsSession'
 import { getDefaultForm } from 'lib/defaultForm'
 import { Utils } from 'lib/utils'
@@ -372,6 +372,11 @@ export const DB = {
       // Deduplicate main stat filter values
       for (const part of Object.keys(Constants.Parts)) {
         character.form['main' + part] = deduplicateArray(character.form['main' + part])
+      }
+
+      // In beta, Duran maxed out at 6
+      if (character.form.setConditionals?.[Sets.DuranDynastyOfRunningWolves]?.[1] > 5) {
+        character.form.setConditionals[Sets.DuranDynastyOfRunningWolves][1] = 5
       }
     }
 

--- a/src/lib/defaultForm.js
+++ b/src/lib/defaultForm.js
@@ -161,6 +161,6 @@ export const defaultSetConditionals = {
   [Constants.Sets.PenaconyLandOfTheDreams]: [undefined, true],
   [Constants.Sets.SigoniaTheUnclaimedDesolation]: [undefined, 4],
   [Constants.Sets.IzumoGenseiAndTakamaDivineRealm]: [undefined, true],
-  [Constants.Sets.DuranDynastyOfRunningWolves]: [undefined, 4],
+  [Constants.Sets.DuranDynastyOfRunningWolves]: [undefined, 5],
   [Constants.Sets.ForgeOfTheKalpagniLantern]: [undefined, false],
 }

--- a/src/lib/optimizer/calculateStats.js
+++ b/src/lib/optimizer/calculateStats.js
@@ -2,8 +2,6 @@ import { Stats } from 'lib/constants.ts'
 import { p2, p4 } from 'lib/optimizer/optimizerUtils'
 import { calculatePassiveStatConversions } from 'lib/optimizer/calculateDamage.js'
 
-const statValues = Object.values(Stats)
-
 export function calculateSetCounts(c, setH, setG, setB, setF, setP, setL) {
   c.sets = {
     PasserbyOfWanderingCloud: (1 >> (setH ^ 0)) + (1 >> (setG ^ 0)) + (1 >> (setB ^ 0)) + (1 >> (setF ^ 0)),


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Duran in beta was capped at 6 instead of 5, fixing some users saves that were using that 6 value
* Setting the default for duran to 5 stacks by default

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

