### PR TITLE
feature: new logic for ability type buffs

### DIFF
--- a/src/components/optimizerTab/optimizerTabConstants.ts
+++ b/src/components/optimizerTab/optimizerTabConstants.ts
@@ -161,7 +161,8 @@ export const combatColumnDefs = [
   { field: 'xERR', valueFormatter: Renderer.x100Tenths, width: DIGITS_3, headerName: 'Σ ERR' },
 
   { field: 'xELEMENTAL_DMG', valueFormatter: Renderer.x100Tenths, width: DIGITS_4, headerName: 'Σ DMG' },
-  { field: 'EHP', valueFormatter: Renderer.floor, width: DIGITS_4, headerName: 'EHP' },
+  { field: 'EHP', valueFormatter: Renderer.floor, width: 102, headerName: 'EHP' },
+  // { field: 'EHP', valueFormatter: Renderer.floor, width: DIGITS_4, headerName: 'EHP' },
 
   { field: 'BASIC', valueFormatter: Renderer.floor, width: DIGITS_5, headerName: 'BASIC' },
   { field: 'SKILL', valueFormatter: Renderer.floor, width: DIGITS_5, headerName: 'SKILL' },

--- a/src/components/optimizerTab/optimizerTabConstants.ts
+++ b/src/components/optimizerTab/optimizerTabConstants.ts
@@ -161,8 +161,7 @@ export const combatColumnDefs = [
   { field: 'xERR', valueFormatter: Renderer.x100Tenths, width: DIGITS_3, headerName: 'Σ ERR' },
 
   { field: 'xELEMENTAL_DMG', valueFormatter: Renderer.x100Tenths, width: DIGITS_4, headerName: 'Σ DMG' },
-  { field: 'EHP', valueFormatter: Renderer.floor, width: 102, headerName: 'EHP' },
-  // { field: 'EHP', valueFormatter: Renderer.floor, width: DIGITS_4, headerName: 'EHP' },
+  { field: 'EHP', valueFormatter: Renderer.floor, width: DIGITS_4, headerName: 'EHP' },
 
   { field: 'BASIC', valueFormatter: Renderer.floor, width: DIGITS_5, headerName: 'BASIC' },
   { field: 'SKILL', valueFormatter: Renderer.floor, width: DIGITS_5, headerName: 'SKILL' },

--- a/src/lib/conditionals/character/Acheron.ts
+++ b/src/lib/conditionals/character/Acheron.ts
@@ -1,10 +1,17 @@
 import { AbilityEidolon, findContentId, precisionRound } from 'lib/conditionals/utils'
-import { baseComputedStatsObject, ComputedStatsObject } from 'lib/conditionals/conditionalConstants.ts'
+import {
+  baseComputedStatsObject,
+  BASIC_TYPE,
+  ComputedStatsObject,
+  SKILL_TYPE,
+  ULT_TYPE
+} from 'lib/conditionals/conditionalConstants.ts'
 import { Eidolon } from 'types/Character'
 import { ContentItem } from 'types/Conditionals'
 import { CharacterConditional, PrecomputedCharacterConditional } from 'types/CharacterConditional'
 import { Form } from 'types/Form'
 import { Stats } from 'lib/constants.ts'
+import { buffDmgTypeResShred, buffDmgTypeVulnerability } from 'lib/optimizer/calculateBuffs'
 
 const Acheron = (e: Eidolon): CharacterConditional => {
   const { basic, skill, ult, talent } = AbilityEidolon.ULT_BASIC_3_SKILL_TALENT_5
@@ -132,11 +139,16 @@ const Acheron = (e: Eidolon): CharacterConditional => {
       const r = request.characterConditionals
       const x: ComputedStatsObject = Object.assign({}, baseComputedStatsObject)
 
+      if (e >= 6 && r.e6UltBuffs) {
+        x.BASIC_DMG_TYPE = ULT_TYPE | BASIC_TYPE
+        x.SKILL_DMG_TYPE = ULT_TYPE | SKILL_TYPE
+      }
+
       x[Stats.CR] += (e >= 1 && r.e1EnemyDebuffed) ? 0.18 : 0
 
-      x.ULT_RES_PEN += talentResPen
       x.ELEMENTAL_DMG += (r.thunderCoreStacks) * 0.30
-      x.ULT_RES_PEN += (e >= 6 && r.e6UltBuffs) ? 0.20 : 0
+      buffDmgTypeResShred(x, [ULT_TYPE], talentResPen)
+      e >= 6 && r.e6UltBuffs && buffDmgTypeResShred(x, [ULT_TYPE], 0.20)
 
       const originalDmgBoost = nihilityTeammateScaling[r.nihilityTeammates]
       x.BASIC_ORIGINAL_DMG_BOOST += originalDmgBoost
@@ -161,7 +173,7 @@ const Acheron = (e: Eidolon): CharacterConditional => {
     precomputeMutualEffects: (x: ComputedStatsObject, request: Form) => {
       const m = request.characterConditionals
 
-      x.ULT_VULNERABILITY += (e >= 4 && m.e4UltVulnerability) ? 0.08 : 0
+      e >= 4 && m.e4UltVulnerability && buffDmgTypeVulnerability(x, [ULT_TYPE], 0.08)
     },
     calculateBaseMultis: (c: PrecomputedCharacterConditional, request: Form) => {
       const r = request.characterConditionals
@@ -170,22 +182,6 @@ const Acheron = (e: Eidolon): CharacterConditional => {
       x.BASIC_DMG += x.BASIC_SCALING * x[Stats.ATK]
       x.SKILL_DMG += x.SKILL_SCALING * x[Stats.ATK]
       x.ULT_DMG += x.ULT_SCALING * x[Stats.ATK]
-
-      if (e >= 6 && r.e6UltBuffs) {
-        x.BASIC_BOOST += x.ULT_BOOST
-        x.BASIC_CD_BOOST += x.ULT_CD_BOOST
-        x.BASIC_CR_BOOST += x.ULT_CR_BOOST
-        x.BASIC_VULNERABILITY = x.ULT_VULNERABILITY
-        x.BASIC_DEF_PEN = x.ULT_DEF_PEN
-        x.BASIC_RES_PEN = x.ULT_RES_PEN
-
-        x.SKILL_BOOST += x.ULT_BOOST
-        x.SKILL_CD_BOOST += x.ULT_CD_BOOST
-        x.SKILL_CR_BOOST += x.ULT_CR_BOOST
-        x.SKILL_VULNERABILITY = x.ULT_VULNERABILITY
-        x.SKILL_DEF_PEN = x.ULT_DEF_PEN
-        x.SKILL_RES_PEN = x.ULT_RES_PEN
-      }
     },
   }
 }

--- a/src/lib/conditionals/character/Acheron.ts
+++ b/src/lib/conditionals/character/Acheron.ts
@@ -148,7 +148,7 @@ const Acheron = (e: Eidolon): CharacterConditional => {
 
       x.ELEMENTAL_DMG += (r.thunderCoreStacks) * 0.30
       buffAbilityResShred(x, [ULT_TYPE], talentResPen)
-      e >= 6 && r.e6UltBuffs && buffAbilityResShred(x, [ULT_TYPE], 0.20)
+      buffAbilityResShred(x, [ULT_TYPE], 0.20, (e >= 6 && r.e6UltBuffs))
 
       const originalDmgBoost = nihilityTeammateScaling[r.nihilityTeammates]
       x.BASIC_ORIGINAL_DMG_BOOST += originalDmgBoost
@@ -173,7 +173,7 @@ const Acheron = (e: Eidolon): CharacterConditional => {
     precomputeMutualEffects: (x: ComputedStatsObject, request: Form) => {
       const m = request.characterConditionals
 
-      e >= 4 && m.e4UltVulnerability && buffAbilityVulnerability(x, [ULT_TYPE], 0.08)
+      buffAbilityVulnerability(x, [ULT_TYPE], 0.08, (e >= 4 && m.e4UltVulnerability))
     },
     calculateBaseMultis: (c: PrecomputedCharacterConditional, request: Form) => {
       const r = request.characterConditionals

--- a/src/lib/conditionals/character/Acheron.ts
+++ b/src/lib/conditionals/character/Acheron.ts
@@ -147,8 +147,8 @@ const Acheron = (e: Eidolon): CharacterConditional => {
       x[Stats.CR] += (e >= 1 && r.e1EnemyDebuffed) ? 0.18 : 0
 
       x.ELEMENTAL_DMG += (r.thunderCoreStacks) * 0.30
-      buffAbilityResShred(x, [ULT_TYPE], talentResPen)
-      buffAbilityResShred(x, [ULT_TYPE], 0.20, (e >= 6 && r.e6UltBuffs))
+      buffAbilityResShred(x, ULT_TYPE, talentResPen)
+      buffAbilityResShred(x, ULT_TYPE, 0.20, (e >= 6 && r.e6UltBuffs))
 
       const originalDmgBoost = nihilityTeammateScaling[r.nihilityTeammates]
       x.BASIC_ORIGINAL_DMG_BOOST += originalDmgBoost
@@ -173,7 +173,7 @@ const Acheron = (e: Eidolon): CharacterConditional => {
     precomputeMutualEffects: (x: ComputedStatsObject, request: Form) => {
       const m = request.characterConditionals
 
-      buffAbilityVulnerability(x, [ULT_TYPE], 0.08, (e >= 4 && m.e4UltVulnerability))
+      buffAbilityVulnerability(x, ULT_TYPE, 0.08, (e >= 4 && m.e4UltVulnerability))
     },
     calculateBaseMultis: (c: PrecomputedCharacterConditional, request: Form) => {
       const r = request.characterConditionals

--- a/src/lib/conditionals/character/Acheron.ts
+++ b/src/lib/conditionals/character/Acheron.ts
@@ -11,7 +11,7 @@ import { ContentItem } from 'types/Conditionals'
 import { CharacterConditional, PrecomputedCharacterConditional } from 'types/CharacterConditional'
 import { Form } from 'types/Form'
 import { Stats } from 'lib/constants.ts'
-import { buffDmgTypeResShred, buffDmgTypeVulnerability } from 'lib/optimizer/calculateBuffs'
+import { buffAbilityResShred, buffAbilityVulnerability } from 'lib/optimizer/calculateBuffs'
 
 const Acheron = (e: Eidolon): CharacterConditional => {
   const { basic, skill, ult, talent } = AbilityEidolon.ULT_BASIC_3_SKILL_TALENT_5
@@ -147,8 +147,8 @@ const Acheron = (e: Eidolon): CharacterConditional => {
       x[Stats.CR] += (e >= 1 && r.e1EnemyDebuffed) ? 0.18 : 0
 
       x.ELEMENTAL_DMG += (r.thunderCoreStacks) * 0.30
-      buffDmgTypeResShred(x, [ULT_TYPE], talentResPen)
-      e >= 6 && r.e6UltBuffs && buffDmgTypeResShred(x, [ULT_TYPE], 0.20)
+      buffAbilityResShred(x, [ULT_TYPE], talentResPen)
+      e >= 6 && r.e6UltBuffs && buffAbilityResShred(x, [ULT_TYPE], 0.20)
 
       const originalDmgBoost = nihilityTeammateScaling[r.nihilityTeammates]
       x.BASIC_ORIGINAL_DMG_BOOST += originalDmgBoost
@@ -173,7 +173,7 @@ const Acheron = (e: Eidolon): CharacterConditional => {
     precomputeMutualEffects: (x: ComputedStatsObject, request: Form) => {
       const m = request.characterConditionals
 
-      e >= 4 && m.e4UltVulnerability && buffDmgTypeVulnerability(x, [ULT_TYPE], 0.08)
+      e >= 4 && m.e4UltVulnerability && buffAbilityVulnerability(x, [ULT_TYPE], 0.08)
     },
     calculateBaseMultis: (c: PrecomputedCharacterConditional, request: Form) => {
       const r = request.characterConditionals

--- a/src/lib/conditionals/character/Argenti.ts
+++ b/src/lib/conditionals/character/Argenti.ts
@@ -103,7 +103,7 @@ export default (e: Eidolon): CharacterConditional => {
       // BOOST
       x.ELEMENTAL_DMG += (r.enemyHp50) ? 0.15 : 0
       // Argenti's e6 ult buff is actually a cast type buff, not dmg type but we'll do it like this anyways
-      buffAbilityDefShred(x, [ULT_TYPE], 0.30, (e >= 6))
+      buffAbilityDefShred(x, ULT_TYPE, 0.30, (e >= 6))
 
       x.BASIC_TOUGHNESS_DMG += 30
       x.SKILL_TOUGHNESS_DMG += 30

--- a/src/lib/conditionals/character/Argenti.ts
+++ b/src/lib/conditionals/character/Argenti.ts
@@ -1,11 +1,12 @@
 import { Stats } from 'lib/constants'
-import { baseComputedStatsObject, ComputedStatsObject } from 'lib/conditionals/conditionalConstants.ts'
+import { baseComputedStatsObject, ComputedStatsObject, ULT_TYPE } from 'lib/conditionals/conditionalConstants.ts'
 import { AbilityEidolon, precisionRound } from 'lib/conditionals/utils'
 
 import { Eidolon } from 'types/Character'
 import { CharacterConditional, PrecomputedCharacterConditional } from 'types/CharacterConditional'
 import { Form } from 'types/Form'
 import { ContentItem } from 'types/Conditionals'
+import { buffAbilityDefShred } from 'lib/optimizer/calculateBuffs'
 
 export default (e: Eidolon): CharacterConditional => {
   const { basic, skill, ult, talent } = AbilityEidolon.SKILL_TALENT_3_ULT_BASIC_5
@@ -101,8 +102,8 @@ export default (e: Eidolon): CharacterConditional => {
 
       // BOOST
       x.ELEMENTAL_DMG += (r.enemyHp50) ? 0.15 : 0
-      // Argenti's e6 ult buff is a cast type buff, not dmg type
-      x.ULT_DEF_PEN += (e >= 6) ? 0.30 : 0
+      // Argenti's e6 ult buff is actually a cast type buff, not dmg type but we'll do it like this anyways
+      buffAbilityDefShred(x, [ULT_TYPE], 0.30, (e >= 6))
 
       x.BASIC_TOUGHNESS_DMG += 30
       x.SKILL_TOUGHNESS_DMG += 30

--- a/src/lib/conditionals/character/Argenti.ts
+++ b/src/lib/conditionals/character/Argenti.ts
@@ -101,6 +101,7 @@ export default (e: Eidolon): CharacterConditional => {
 
       // BOOST
       x.ELEMENTAL_DMG += (r.enemyHp50) ? 0.15 : 0
+      // Argenti's e6 ult buff is a cast type buff, not dmg type
       x.ULT_DEF_PEN += (e >= 6) ? 0.30 : 0
 
       x.BASIC_TOUGHNESS_DMG += 30

--- a/src/lib/conditionals/character/Arlan.ts
+++ b/src/lib/conditionals/character/Arlan.ts
@@ -1,11 +1,17 @@
 import { Stats } from 'lib/constants'
-import { baseComputedStatsObject, ComputedStatsObject } from 'lib/conditionals/conditionalConstants.ts'
+import {
+  baseComputedStatsObject,
+  ComputedStatsObject,
+  SKILL_TYPE,
+  ULT_TYPE
+} from 'lib/conditionals/conditionalConstants.ts'
 import { AbilityEidolon, precisionRound } from 'lib/conditionals/utils'
 
 import { Eidolon } from 'types/Character'
 import { CharacterConditional, PrecomputedCharacterConditional } from 'types/CharacterConditional'
 import { Form } from 'types/Form'
 import { ContentItem } from 'types/Conditionals'
+import { buffAbilityDmg } from 'lib/optimizer/calculateBuffs'
 
 export default (e: Eidolon): CharacterConditional => {
   const { basic, skill, ult, talent } = AbilityEidolon.SKILL_BASIC_3_ULT_TALENT_5
@@ -49,8 +55,8 @@ export default (e: Eidolon): CharacterConditional => {
       x.ULT_SCALING += ultScaling
 
       // Boost
-      x.SKILL_BOOST += (e >= 1 && r.selfCurrentHpPercent <= 0.50) ? 0.10 : 0
-      x.ULT_BOOST += (e >= 6 && r.selfCurrentHpPercent <= 0.50) ? 0.20 : 0
+      e >= 1 && r.selfCurrentHpPercent <= 0.50 && buffAbilityDmg(x, [SKILL_TYPE], 0.10)
+      e >= 6 && r.selfCurrentHpPercent <= 0.50 && buffAbilityDmg(x, [ULT_TYPE], 0.20)
 
       x.BASIC_TOUGHNESS_DMG += 30
       x.SKILL_TOUGHNESS_DMG += 60

--- a/src/lib/conditionals/character/Arlan.ts
+++ b/src/lib/conditionals/character/Arlan.ts
@@ -55,8 +55,8 @@ export default (e: Eidolon): CharacterConditional => {
       x.ULT_SCALING += ultScaling
 
       // Boost
-      buffAbilityDmg(x, [SKILL_TYPE], 0.10, (e >= 1 && r.selfCurrentHpPercent <= 0.50))
-      buffAbilityDmg(x, [ULT_TYPE], 0.20, (e >= 6 && r.selfCurrentHpPercent <= 0.50))
+      buffAbilityDmg(x, SKILL_TYPE, 0.10, (e >= 1 && r.selfCurrentHpPercent <= 0.50))
+      buffAbilityDmg(x, ULT_TYPE, 0.20, (e >= 6 && r.selfCurrentHpPercent <= 0.50))
 
       x.BASIC_TOUGHNESS_DMG += 30
       x.SKILL_TOUGHNESS_DMG += 60

--- a/src/lib/conditionals/character/Arlan.ts
+++ b/src/lib/conditionals/character/Arlan.ts
@@ -55,8 +55,8 @@ export default (e: Eidolon): CharacterConditional => {
       x.ULT_SCALING += ultScaling
 
       // Boost
-      e >= 1 && r.selfCurrentHpPercent <= 0.50 && buffAbilityDmg(x, [SKILL_TYPE], 0.10)
-      e >= 6 && r.selfCurrentHpPercent <= 0.50 && buffAbilityDmg(x, [ULT_TYPE], 0.20)
+      buffAbilityDmg(x, [SKILL_TYPE], 0.10, (e >= 1 && r.selfCurrentHpPercent <= 0.50))
+      buffAbilityDmg(x, [ULT_TYPE], 0.20, (e >= 6 && r.selfCurrentHpPercent <= 0.50))
 
       x.BASIC_TOUGHNESS_DMG += 30
       x.SKILL_TOUGHNESS_DMG += 60

--- a/src/lib/conditionals/character/BlackSwan.ts
+++ b/src/lib/conditionals/character/BlackSwan.ts
@@ -104,7 +104,7 @@ When there are 3 or more Arcana stacks, deals Wind DoT to adjacent targets. When
       x.ULT_SCALING += ultScaling
       x.DOT_SCALING += dotScaling + arcanaStackMultiplier * r.arcanaStacks
 
-      r.arcanaStacks >= 7 && buffAbilityDefShred(x, [DOT_TYPE], 0.20)
+      buffAbilityDefShred(x, [DOT_TYPE], 0.20, (r.arcanaStacks >= 7))
 
       x.BASIC_TOUGHNESS_DMG += 30
       x.SKILL_TOUGHNESS_DMG += 60
@@ -120,7 +120,7 @@ When there are 3 or more Arcana stacks, deals Wind DoT to adjacent targets. When
       const m = request.characterConditionals
 
       // TODO: Technically this isnt a DoT vulnerability but rather vulnerability to damage on the enemy's turn which includes ults/etc.
-      m.epiphanyDebuff && buffAbilityVulnerability(x, [DOT_TYPE], epiphanyDmgTakenBoost)
+      buffAbilityVulnerability(x, [DOT_TYPE], epiphanyDmgTakenBoost, (m.epiphanyDebuff))
 
       x.DEF_SHRED += (m.defDecreaseDebuff) ? defShredValue : 0
       x.WIND_RES_PEN += (e >= 1 && m.e1ResReduction) ? 0.25 : 0

--- a/src/lib/conditionals/character/BlackSwan.ts
+++ b/src/lib/conditionals/character/BlackSwan.ts
@@ -1,11 +1,12 @@
 import { Stats } from 'lib/constants'
-import { baseComputedStatsObject, ComputedStatsObject } from 'lib/conditionals/conditionalConstants.ts'
+import { baseComputedStatsObject, ComputedStatsObject, DOT_TYPE } from 'lib/conditionals/conditionalConstants.ts'
 import { AbilityEidolon, findContentId, precisionRound } from 'lib/conditionals/utils'
 
 import { Eidolon } from 'types/Character'
 import { CharacterConditional, PrecomputedCharacterConditional } from 'types/CharacterConditional'
 import { Form } from 'types/Form'
 import { ContentItem } from 'types/Conditionals'
+import { buffDmgTypeDefShred, buffDmgTypeVulnerability } from 'lib/optimizer/calculateBuffs'
 
 export default (e: Eidolon): CharacterConditional => {
   const {basic, skill, ult, talent} = AbilityEidolon.SKILL_TALENT_3_ULT_BASIC_5
@@ -103,7 +104,7 @@ When there are 3 or more Arcana stacks, deals Wind DoT to adjacent targets. When
       x.ULT_SCALING += ultScaling
       x.DOT_SCALING += dotScaling + arcanaStackMultiplier * r.arcanaStacks
 
-      x.DOT_DEF_PEN += (r.arcanaStacks >= 7) ? 0.20 : 0
+      r.arcanaStacks >= 7 && buffDmgTypeDefShred(x, [DOT_TYPE], 0.20)
 
       x.BASIC_TOUGHNESS_DMG += 30
       x.SKILL_TOUGHNESS_DMG += 60
@@ -119,7 +120,8 @@ When there are 3 or more Arcana stacks, deals Wind DoT to adjacent targets. When
       const m = request.characterConditionals
 
       // TODO: Technically this isnt a DoT vulnerability but rather vulnerability to damage on the enemy's turn which includes ults/etc.
-      x.DOT_VULNERABILITY += (m.epiphanyDebuff) ? epiphanyDmgTakenBoost : 0
+      m.epiphanyDebuff && buffDmgTypeVulnerability(x, [DOT_TYPE], epiphanyDmgTakenBoost)
+
       x.DEF_SHRED += (m.defDecreaseDebuff) ? defShredValue : 0
       x.WIND_RES_PEN += (e >= 1 && m.e1ResReduction) ? 0.25 : 0
       x.FIRE_RES_PEN += (e >= 1 && m.e1ResReduction) ? 0.25 : 0

--- a/src/lib/conditionals/character/BlackSwan.ts
+++ b/src/lib/conditionals/character/BlackSwan.ts
@@ -104,7 +104,7 @@ When there are 3 or more Arcana stacks, deals Wind DoT to adjacent targets. When
       x.ULT_SCALING += ultScaling
       x.DOT_SCALING += dotScaling + arcanaStackMultiplier * r.arcanaStacks
 
-      buffAbilityDefShred(x, [DOT_TYPE], 0.20, (r.arcanaStacks >= 7))
+      buffAbilityDefShred(x, DOT_TYPE, 0.20, (r.arcanaStacks >= 7))
 
       x.BASIC_TOUGHNESS_DMG += 30
       x.SKILL_TOUGHNESS_DMG += 60
@@ -120,7 +120,7 @@ When there are 3 or more Arcana stacks, deals Wind DoT to adjacent targets. When
       const m = request.characterConditionals
 
       // TODO: Technically this isnt a DoT vulnerability but rather vulnerability to damage on the enemy's turn which includes ults/etc.
-      buffAbilityVulnerability(x, [DOT_TYPE], epiphanyDmgTakenBoost, (m.epiphanyDebuff))
+      buffAbilityVulnerability(x, DOT_TYPE, epiphanyDmgTakenBoost, (m.epiphanyDebuff))
 
       x.DEF_SHRED += (m.defDecreaseDebuff) ? defShredValue : 0
       x.WIND_RES_PEN += (e >= 1 && m.e1ResReduction) ? 0.25 : 0

--- a/src/lib/conditionals/character/BlackSwan.ts
+++ b/src/lib/conditionals/character/BlackSwan.ts
@@ -6,7 +6,7 @@ import { Eidolon } from 'types/Character'
 import { CharacterConditional, PrecomputedCharacterConditional } from 'types/CharacterConditional'
 import { Form } from 'types/Form'
 import { ContentItem } from 'types/Conditionals'
-import { buffDmgTypeDefShred, buffDmgTypeVulnerability } from 'lib/optimizer/calculateBuffs'
+import { buffAbilityDefShred, buffAbilityVulnerability } from 'lib/optimizer/calculateBuffs'
 
 export default (e: Eidolon): CharacterConditional => {
   const {basic, skill, ult, talent} = AbilityEidolon.SKILL_TALENT_3_ULT_BASIC_5
@@ -104,7 +104,7 @@ When there are 3 or more Arcana stacks, deals Wind DoT to adjacent targets. When
       x.ULT_SCALING += ultScaling
       x.DOT_SCALING += dotScaling + arcanaStackMultiplier * r.arcanaStacks
 
-      r.arcanaStacks >= 7 && buffDmgTypeDefShred(x, [DOT_TYPE], 0.20)
+      r.arcanaStacks >= 7 && buffAbilityDefShred(x, [DOT_TYPE], 0.20)
 
       x.BASIC_TOUGHNESS_DMG += 30
       x.SKILL_TOUGHNESS_DMG += 60
@@ -120,7 +120,7 @@ When there are 3 or more Arcana stacks, deals Wind DoT to adjacent targets. When
       const m = request.characterConditionals
 
       // TODO: Technically this isnt a DoT vulnerability but rather vulnerability to damage on the enemy's turn which includes ults/etc.
-      m.epiphanyDebuff && buffDmgTypeVulnerability(x, [DOT_TYPE], epiphanyDmgTakenBoost)
+      m.epiphanyDebuff && buffAbilityVulnerability(x, [DOT_TYPE], epiphanyDmgTakenBoost)
 
       x.DEF_SHRED += (m.defDecreaseDebuff) ? defShredValue : 0
       x.WIND_RES_PEN += (e >= 1 && m.e1ResReduction) ? 0.25 : 0

--- a/src/lib/conditionals/character/Blade.ts
+++ b/src/lib/conditionals/character/Blade.ts
@@ -2,7 +2,8 @@ import { Stats } from 'lib/constants'
 import {
   ASHBLAZING_ATK_STACK,
   baseComputedStatsObject,
-  ComputedStatsObject
+  ComputedStatsObject,
+  FUA_TYPE
 } from 'lib/conditionals/conditionalConstants.ts'
 import { AbilityEidolon, calculateAshblazingSet, precisionRound } from 'lib/conditionals/utils'
 
@@ -10,6 +11,7 @@ import { Eidolon } from 'types/Character'
 import { CharacterConditional, PrecomputedCharacterConditional } from 'types/CharacterConditional'
 import { Form } from 'types/Form'
 import { ContentItem } from 'types/Conditionals'
+import { buffAbilityDmg } from 'lib/optimizer/calculateBuffs'
 
 export default (e: Eidolon): CharacterConditional => {
   const { basic, skill, ult, talent } = AbilityEidolon.ULT_TALENT_3_SKILL_BASIC_5
@@ -90,7 +92,7 @@ export default (e: Eidolon): CharacterConditional => {
 
       // Boost
       x.ELEMENTAL_DMG += r.enhancedStateActive ? enhancedStateDmgBoost : 0
-      x.FUA_BOOST += 0.20
+      buffAbilityDmg(x, [FUA_TYPE], 0.20)
 
       x.BASIC_TOUGHNESS_DMG += (r.enhancedStateActive) ? 60 : 30
       x.ULT_TOUGHNESS_DMG += 60

--- a/src/lib/conditionals/character/Blade.ts
+++ b/src/lib/conditionals/character/Blade.ts
@@ -92,7 +92,7 @@ export default (e: Eidolon): CharacterConditional => {
 
       // Boost
       x.ELEMENTAL_DMG += r.enhancedStateActive ? enhancedStateDmgBoost : 0
-      buffAbilityDmg(x, [FUA_TYPE], 0.20)
+      buffAbilityDmg(x, FUA_TYPE, 0.20)
 
       x.BASIC_TOUGHNESS_DMG += (r.enhancedStateActive) ? 60 : 30
       x.ULT_TOUGHNESS_DMG += 60

--- a/src/lib/conditionals/character/Bronya.ts
+++ b/src/lib/conditionals/character/Bronya.ts
@@ -114,7 +114,7 @@ export default (e: Eidolon): CharacterConditional => {
       const x = Object.assign({}, baseComputedStatsObject)
 
       // Stats
-      buffAbilityCr(x, [BASIC_TYPE], 1.00)
+      buffAbilityCr(x, BASIC_TYPE, 1.00)
 
       // Scaling
       x.BASIC_SCALING += basicScaling

--- a/src/lib/conditionals/character/Bronya.ts
+++ b/src/lib/conditionals/character/Bronya.ts
@@ -2,6 +2,7 @@ import { Stats } from 'lib/constants'
 import {
   ASHBLAZING_ATK_STACK,
   baseComputedStatsObject,
+  BASIC_TYPE,
   ComputedStatsObject
 } from 'lib/conditionals/conditionalConstants.ts'
 import { AbilityEidolon, calculateAshblazingSet, findContentId, precisionRound } from 'lib/conditionals/utils'
@@ -10,6 +11,7 @@ import { Eidolon } from 'types/Character'
 import { CharacterConditional, PrecomputedCharacterConditional } from 'types/CharacterConditional'
 import { Form } from 'types/Form'
 import { ContentItem } from 'types/Conditionals'
+import { buffDmgTypeCrBoost } from 'lib/optimizer/calculateBuffs'
 
 export default (e: Eidolon): CharacterConditional => {
   const {basic, skill, ult} = AbilityEidolon.ULT_TALENT_3_SKILL_BASIC_5
@@ -112,7 +114,7 @@ export default (e: Eidolon): CharacterConditional => {
       const x = Object.assign({}, baseComputedStatsObject)
 
       // Stats
-      x.BASIC_CR_BOOST += 1.00
+      buffDmgTypeCrBoost(x, [BASIC_TYPE], 1.00)
 
       // Scaling
       x.BASIC_SCALING += basicScaling

--- a/src/lib/conditionals/character/Bronya.ts
+++ b/src/lib/conditionals/character/Bronya.ts
@@ -11,7 +11,7 @@ import { Eidolon } from 'types/Character'
 import { CharacterConditional, PrecomputedCharacterConditional } from 'types/CharacterConditional'
 import { Form } from 'types/Form'
 import { ContentItem } from 'types/Conditionals'
-import { buffDmgTypeCrBoost } from 'lib/optimizer/calculateBuffs'
+import { buffAbilityCr } from 'lib/optimizer/calculateBuffs'
 
 export default (e: Eidolon): CharacterConditional => {
   const {basic, skill, ult} = AbilityEidolon.ULT_TALENT_3_SKILL_BASIC_5
@@ -114,7 +114,7 @@ export default (e: Eidolon): CharacterConditional => {
       const x = Object.assign({}, baseComputedStatsObject)
 
       // Stats
-      buffDmgTypeCrBoost(x, [BASIC_TYPE], 1.00)
+      buffAbilityCr(x, [BASIC_TYPE], 1.00)
 
       // Scaling
       x.BASIC_SCALING += basicScaling

--- a/src/lib/conditionals/character/Clara.ts
+++ b/src/lib/conditionals/character/Clara.ts
@@ -93,7 +93,7 @@ export default (e: Eidolon): CharacterConditional => {
       x.DMG_RED_MULTI *= (1 - 0.10)
       x.DMG_RED_MULTI *= r.ultBuff ? (1 - ultDmgReductionValue) : 1
       x.DMG_RED_MULTI *= (e >= 4 && r.e4DmgReductionBuff) ? (1 - 0.30) : 1
-      buffAbilityDmg(x, [FUA_TYPE], 0.30)
+      buffAbilityDmg(x, FUA_TYPE, 0.30)
 
       x.BASIC_TOUGHNESS_DMG += 30
       x.SKILL_TOUGHNESS_DMG += 30

--- a/src/lib/conditionals/character/Clara.ts
+++ b/src/lib/conditionals/character/Clara.ts
@@ -2,7 +2,8 @@ import { Stats } from 'lib/constants'
 import {
   ASHBLAZING_ATK_STACK,
   baseComputedStatsObject,
-  ComputedStatsObject
+  ComputedStatsObject,
+  FUA_TYPE
 } from 'lib/conditionals/conditionalConstants.ts'
 import { AbilityEidolon, calculateAshblazingSet, precisionRound } from 'lib/conditionals/utils'
 
@@ -10,6 +11,7 @@ import { Eidolon } from 'types/Character'
 import { CharacterConditional, PrecomputedCharacterConditional } from 'types/CharacterConditional'
 import { Form } from 'types/Form'
 import { ContentItem } from 'types/Conditionals'
+import { buffAbilityDmg } from 'lib/optimizer/calculateBuffs'
 
 export default (e: Eidolon): CharacterConditional => {
   const { basic, skill, ult, talent } = AbilityEidolon.SKILL_BASIC_3_ULT_TALENT_5
@@ -91,7 +93,7 @@ export default (e: Eidolon): CharacterConditional => {
       x.DMG_RED_MULTI *= (1 - 0.10)
       x.DMG_RED_MULTI *= r.ultBuff ? (1 - ultDmgReductionValue) : 1
       x.DMG_RED_MULTI *= (e >= 4 && r.e4DmgReductionBuff) ? (1 - 0.30) : 1
-      x.FUA_BOOST += 0.30
+      buffAbilityDmg(x, [FUA_TYPE], 0.30)
 
       x.BASIC_TOUGHNESS_DMG += 30
       x.SKILL_TOUGHNESS_DMG += 30

--- a/src/lib/conditionals/character/DanHeng.ts
+++ b/src/lib/conditionals/character/DanHeng.ts
@@ -72,7 +72,7 @@ export default (e: Eidolon): CharacterConditional => {
 
       // Boost
       x.RES_PEN += (r.talentPenBuff) ? extraPenValue : 0
-      r.enemySlowed && buffAbilityDmg(x, [BASIC_TYPE], 0.40)
+      buffAbilityDmg(x, [BASIC_TYPE], 0.40, (r.enemySlowed))
 
       x.BASIC_TOUGHNESS_DMG += 30
       x.SKILL_TOUGHNESS_DMG += 60

--- a/src/lib/conditionals/character/DanHeng.ts
+++ b/src/lib/conditionals/character/DanHeng.ts
@@ -1,11 +1,12 @@
 import { Stats } from 'lib/constants'
-import { baseComputedStatsObject, ComputedStatsObject } from 'lib/conditionals/conditionalConstants.ts'
+import { baseComputedStatsObject, BASIC_TYPE, ComputedStatsObject } from 'lib/conditionals/conditionalConstants.ts'
 import { AbilityEidolon, precisionRound } from 'lib/conditionals/utils'
 
 import { Eidolon } from 'types/Character'
 import { CharacterConditional, PrecomputedCharacterConditional } from 'types/CharacterConditional'
 import { Form } from 'types/Form'
 import { ContentItem } from 'types/Conditionals'
+import { buffAbilityDmg } from 'lib/optimizer/calculateBuffs'
 
 // TODO: missing A4 SPD buff
 export default (e: Eidolon): CharacterConditional => {
@@ -70,8 +71,8 @@ export default (e: Eidolon): CharacterConditional => {
       x.ULT_SCALING += (r.enemySlowed) ? ultExtraScaling : 0
 
       // Boost
-      x.BASIC_BOOST += (r.enemySlowed) ? 0.40 : 0
       x.RES_PEN += (r.talentPenBuff) ? extraPenValue : 0
+      r.enemySlowed && buffAbilityDmg(x, [BASIC_TYPE], 0.40)
 
       x.BASIC_TOUGHNESS_DMG += 30
       x.SKILL_TOUGHNESS_DMG += 60

--- a/src/lib/conditionals/character/DanHeng.ts
+++ b/src/lib/conditionals/character/DanHeng.ts
@@ -72,7 +72,7 @@ export default (e: Eidolon): CharacterConditional => {
 
       // Boost
       x.RES_PEN += (r.talentPenBuff) ? extraPenValue : 0
-      buffAbilityDmg(x, [BASIC_TYPE], 0.40, (r.enemySlowed))
+      buffAbilityDmg(x, BASIC_TYPE, 0.40, (r.enemySlowed))
 
       x.BASIC_TOUGHNESS_DMG += 30
       x.SKILL_TOUGHNESS_DMG += 60

--- a/src/lib/conditionals/character/DrRatio.ts
+++ b/src/lib/conditionals/character/DrRatio.ts
@@ -3,13 +3,15 @@ import { AbilityEidolon, calculateAshblazingSet, precisionRound } from 'lib/cond
 import {
   ASHBLAZING_ATK_STACK,
   baseComputedStatsObject,
-  ComputedStatsObject
+  ComputedStatsObject,
+  FUA_TYPE
 } from 'lib/conditionals/conditionalConstants.ts'
 
 import { Eidolon } from 'types/Character'
 import { CharacterConditional, PrecomputedCharacterConditional } from 'types/CharacterConditional'
 import { ContentItem } from 'types/Conditionals'
 import { Form } from 'types/Form'
+import { buffAbilityDmg } from 'lib/optimizer/calculateBuffs'
 
 const DrRatio = (e: Eidolon): CharacterConditional => {
   const { basic, skill, ult, talent } = AbilityEidolon.ULT_BASIC_3_SKILL_TALENT_5
@@ -97,7 +99,7 @@ const DrRatio = (e: Eidolon): CharacterConditional => {
 
       // Boost
       x.ELEMENTAL_DMG += (r.enemyDebuffStacks >= 3) ? Math.min(0.50, r.enemyDebuffStacks * 0.10) : 0
-      x.FUA_BOOST += (e >= 6) ? 0.50 : 0
+      buffAbilityDmg(x, [FUA_TYPE], 0.50, (e >= 6))
 
       x.BASIC_TOUGHNESS_DMG += 30
       x.SKILL_TOUGHNESS_DMG += 60

--- a/src/lib/conditionals/character/DrRatio.ts
+++ b/src/lib/conditionals/character/DrRatio.ts
@@ -99,7 +99,7 @@ const DrRatio = (e: Eidolon): CharacterConditional => {
 
       // Boost
       x.ELEMENTAL_DMG += (r.enemyDebuffStacks >= 3) ? Math.min(0.50, r.enemyDebuffStacks * 0.10) : 0
-      buffAbilityDmg(x, [FUA_TYPE], 0.50, (e >= 6))
+      buffAbilityDmg(x, FUA_TYPE, 0.50, (e >= 6))
 
       x.BASIC_TOUGHNESS_DMG += 30
       x.SKILL_TOUGHNESS_DMG += 60

--- a/src/lib/conditionals/character/Firefly.ts
+++ b/src/lib/conditionals/character/Firefly.ts
@@ -152,7 +152,7 @@ export default (e: Eidolon): CharacterConditional => {
       const r = request.characterConditionals
       const x: ComputedStatsObject = c.x
 
-      buffAbilityVulnerability(x, [BREAK_TYPE], ultWeaknessBrokenBreakVulnerability, (r.enhancedStateActive && x.ENEMY_WEAKNESS_BROKEN))
+      buffAbilityVulnerability(x, BREAK_TYPE, ultWeaknessBrokenBreakVulnerability, (r.enhancedStateActive && x.ENEMY_WEAKNESS_BROKEN))
 
       const trueAtk = x[Stats.ATK] - x.RATIO_BASED_ATK_BUFF - (x.RATIO_BASED_ATK_P_BUFF * request.baseAtk)
       x[Stats.BE] += (r.atkToBeConversion && (trueAtk > 1800)) ? 0.008 * Math.floor((trueAtk - 1800) / 10) : 0

--- a/src/lib/conditionals/character/Firefly.ts
+++ b/src/lib/conditionals/character/Firefly.ts
@@ -152,7 +152,7 @@ export default (e: Eidolon): CharacterConditional => {
       const r = request.characterConditionals
       const x: ComputedStatsObject = c.x
 
-      r.enhancedStateActive && x.ENEMY_WEAKNESS_BROKEN && buffAbilityVulnerability(x, [BREAK_TYPE], ultWeaknessBrokenBreakVulnerability)
+      buffAbilityVulnerability(x, [BREAK_TYPE], ultWeaknessBrokenBreakVulnerability, (r.enhancedStateActive && x.ENEMY_WEAKNESS_BROKEN))
 
       const trueAtk = x[Stats.ATK] - x.RATIO_BASED_ATK_BUFF - (x.RATIO_BASED_ATK_P_BUFF * request.baseAtk)
       x[Stats.BE] += (r.atkToBeConversion && (trueAtk > 1800)) ? 0.008 * Math.floor((trueAtk - 1800) / 10) : 0

--- a/src/lib/conditionals/character/Firefly.ts
+++ b/src/lib/conditionals/character/Firefly.ts
@@ -1,4 +1,4 @@
-import { baseComputedStatsObject, ComputedStatsObject } from 'lib/conditionals/conditionalConstants'
+import { baseComputedStatsObject, BREAK_TYPE, ComputedStatsObject } from 'lib/conditionals/conditionalConstants'
 import { AbilityEidolon, precisionRound } from 'lib/conditionals/utils'
 
 import { Eidolon } from 'types/Character'
@@ -6,6 +6,7 @@ import { CharacterConditional, PrecomputedCharacterConditional } from 'types/Cha
 import { Form } from 'types/Form'
 import { ContentItem } from 'types/Conditionals'
 import { Stats } from 'lib/constants'
+import { buffDmgTypeVulnerability } from 'lib/optimizer/calculateBuffs'
 
 export default (e: Eidolon): CharacterConditional => {
   const { basic, skill, ult, talent } = AbilityEidolon.SKILL_BASIC_3_ULT_TALENT_5
@@ -151,7 +152,7 @@ export default (e: Eidolon): CharacterConditional => {
       const r = request.characterConditionals
       const x: ComputedStatsObject = c.x
 
-      x.BREAK_VULNERABILITY += (r.enhancedStateActive && x.ENEMY_WEAKNESS_BROKEN) ? ultWeaknessBrokenBreakVulnerability : 0
+      r.enhancedStateActive && x.ENEMY_WEAKNESS_BROKEN && buffDmgTypeVulnerability(x, [BREAK_TYPE], ultWeaknessBrokenBreakVulnerability)
 
       const trueAtk = x[Stats.ATK] - x.RATIO_BASED_ATK_BUFF - (x.RATIO_BASED_ATK_P_BUFF * request.baseAtk)
       x[Stats.BE] += (r.atkToBeConversion && (trueAtk > 1800)) ? 0.008 * Math.floor((trueAtk - 1800) / 10) : 0

--- a/src/lib/conditionals/character/Firefly.ts
+++ b/src/lib/conditionals/character/Firefly.ts
@@ -6,7 +6,7 @@ import { CharacterConditional, PrecomputedCharacterConditional } from 'types/Cha
 import { Form } from 'types/Form'
 import { ContentItem } from 'types/Conditionals'
 import { Stats } from 'lib/constants'
-import { buffDmgTypeVulnerability } from 'lib/optimizer/calculateBuffs'
+import { buffAbilityVulnerability } from 'lib/optimizer/calculateBuffs'
 
 export default (e: Eidolon): CharacterConditional => {
   const { basic, skill, ult, talent } = AbilityEidolon.SKILL_BASIC_3_ULT_TALENT_5
@@ -152,7 +152,7 @@ export default (e: Eidolon): CharacterConditional => {
       const r = request.characterConditionals
       const x: ComputedStatsObject = c.x
 
-      r.enhancedStateActive && x.ENEMY_WEAKNESS_BROKEN && buffDmgTypeVulnerability(x, [BREAK_TYPE], ultWeaknessBrokenBreakVulnerability)
+      r.enhancedStateActive && x.ENEMY_WEAKNESS_BROKEN && buffAbilityVulnerability(x, [BREAK_TYPE], ultWeaknessBrokenBreakVulnerability)
 
       const trueAtk = x[Stats.ATK] - x.RATIO_BASED_ATK_BUFF - (x.RATIO_BASED_ATK_P_BUFF * request.baseAtk)
       x[Stats.BE] += (r.atkToBeConversion && (trueAtk > 1800)) ? 0.008 * Math.floor((trueAtk - 1800) / 10) : 0

--- a/src/lib/conditionals/character/Gallagher.ts
+++ b/src/lib/conditionals/character/Gallagher.ts
@@ -108,7 +108,7 @@ const Gallagher = (e: Eidolon): CharacterConditional => {
     precomputeMutualEffects: (x: ComputedStatsObject, request: Form) => {
       const m = request.characterConditionals
 
-      m.targetBesotted && buffAbilityVulnerability(x, [BREAK_TYPE], talentBesottedScaling)
+      buffAbilityVulnerability(x, [BREAK_TYPE], talentBesottedScaling, m.targetBesotted)
     },
     calculateBaseMultis: (c: PrecomputedCharacterConditional) => {
       const x = c.x

--- a/src/lib/conditionals/character/Gallagher.ts
+++ b/src/lib/conditionals/character/Gallagher.ts
@@ -1,10 +1,11 @@
 import { AbilityEidolon, findContentId, precisionRound } from 'lib/conditionals/utils'
-import { baseComputedStatsObject, ComputedStatsObject } from 'lib/conditionals/conditionalConstants.ts'
+import { baseComputedStatsObject, BREAK_TYPE, ComputedStatsObject } from 'lib/conditionals/conditionalConstants.ts'
 import { Eidolon } from 'types/Character'
 import { ContentItem } from 'types/Conditionals'
 import { CharacterConditional, PrecomputedCharacterConditional } from 'types/CharacterConditional'
 import { Form } from 'types/Form'
 import { Stats } from 'lib/constants.ts'
+import { buffDmgTypeVulnerability } from 'lib/optimizer/calculateBuffs'
 
 const Gallagher = (e: Eidolon): CharacterConditional => {
   const { basic, talent } = AbilityEidolon.SKILL_BASIC_3_ULT_TALENT_5
@@ -107,7 +108,7 @@ const Gallagher = (e: Eidolon): CharacterConditional => {
     precomputeMutualEffects: (x: ComputedStatsObject, request: Form) => {
       const m = request.characterConditionals
 
-      x.BREAK_VULNERABILITY += (m.targetBesotted) ? talentBesottedScaling : 0
+      m.targetBesotted && buffDmgTypeVulnerability(x, [BREAK_TYPE], talentBesottedScaling)
     },
     calculateBaseMultis: (c: PrecomputedCharacterConditional) => {
       const x = c.x

--- a/src/lib/conditionals/character/Gallagher.ts
+++ b/src/lib/conditionals/character/Gallagher.ts
@@ -5,7 +5,7 @@ import { ContentItem } from 'types/Conditionals'
 import { CharacterConditional, PrecomputedCharacterConditional } from 'types/CharacterConditional'
 import { Form } from 'types/Form'
 import { Stats } from 'lib/constants.ts'
-import { buffDmgTypeVulnerability } from 'lib/optimizer/calculateBuffs'
+import { buffAbilityVulnerability } from 'lib/optimizer/calculateBuffs'
 
 const Gallagher = (e: Eidolon): CharacterConditional => {
   const { basic, talent } = AbilityEidolon.SKILL_BASIC_3_ULT_TALENT_5
@@ -108,7 +108,7 @@ const Gallagher = (e: Eidolon): CharacterConditional => {
     precomputeMutualEffects: (x: ComputedStatsObject, request: Form) => {
       const m = request.characterConditionals
 
-      m.targetBesotted && buffDmgTypeVulnerability(x, [BREAK_TYPE], talentBesottedScaling)
+      m.targetBesotted && buffAbilityVulnerability(x, [BREAK_TYPE], talentBesottedScaling)
     },
     calculateBaseMultis: (c: PrecomputedCharacterConditional) => {
       const x = c.x

--- a/src/lib/conditionals/character/Gallagher.ts
+++ b/src/lib/conditionals/character/Gallagher.ts
@@ -108,7 +108,7 @@ const Gallagher = (e: Eidolon): CharacterConditional => {
     precomputeMutualEffects: (x: ComputedStatsObject, request: Form) => {
       const m = request.characterConditionals
 
-      buffAbilityVulnerability(x, [BREAK_TYPE], talentBesottedScaling, (m.targetBesotted))
+      buffAbilityVulnerability(x, BREAK_TYPE, talentBesottedScaling, (m.targetBesotted))
     },
     calculateBaseMultis: (c: PrecomputedCharacterConditional) => {
       const x = c.x

--- a/src/lib/conditionals/character/Gallagher.ts
+++ b/src/lib/conditionals/character/Gallagher.ts
@@ -108,7 +108,7 @@ const Gallagher = (e: Eidolon): CharacterConditional => {
     precomputeMutualEffects: (x: ComputedStatsObject, request: Form) => {
       const m = request.characterConditionals
 
-      buffAbilityVulnerability(x, [BREAK_TYPE], talentBesottedScaling, m.targetBesotted)
+      buffAbilityVulnerability(x, [BREAK_TYPE], talentBesottedScaling, (m.targetBesotted))
     },
     calculateBaseMultis: (c: PrecomputedCharacterConditional) => {
       const x = c.x

--- a/src/lib/conditionals/character/Herta.ts
+++ b/src/lib/conditionals/character/Herta.ts
@@ -154,11 +154,11 @@ export default (e: Eidolon): CharacterConditional => {
       x.ULT_SCALING += ultScaling
       x.FUA_SCALING += fuaScaling
 
-      buffAbilityDmg(x, [SKILL_TYPE], 0.20, (r.enemyHpGte50))
+      buffAbilityDmg(x, SKILL_TYPE, 0.20, (r.enemyHpGte50))
 
       // Boost
-      buffAbilityDmg(x, [ULT_TYPE], 0.20, (r.targetFrozen))
-      buffAbilityDmg(x, [FUA_TYPE], 0.10, (e >= 4))
+      buffAbilityDmg(x, ULT_TYPE, 0.20, (r.targetFrozen))
+      buffAbilityDmg(x, FUA_TYPE, 0.10, (e >= 4))
 
       x.BASIC_TOUGHNESS_DMG += 30
       x.SKILL_TOUGHNESS_DMG += 30

--- a/src/lib/conditionals/character/Herta.ts
+++ b/src/lib/conditionals/character/Herta.ts
@@ -3,7 +3,9 @@ import {
   ASHBLAZING_ATK_STACK,
   baseComputedStatsObject,
   ComputedStatsObject,
-  SKILL_TYPE
+  FUA_TYPE,
+  SKILL_TYPE,
+  ULT_TYPE
 } from 'lib/conditionals/conditionalConstants.ts'
 import { AbilityEidolon, calculateAshblazingSet, precisionRound } from 'lib/conditionals/utils'
 
@@ -155,8 +157,8 @@ export default (e: Eidolon): CharacterConditional => {
       r.enemyHpGte50 && buffAbilityDmg(x, [SKILL_TYPE], 0.20)
 
       // Boost
-      x.ULT_BOOST += (r.targetFrozen) ? 0.20 : 0
-      x.FUA_BOOST += (e >= 4) ? 0.10 : 0
+      r.targetFrozen && buffAbilityDmg(x, [ULT_TYPE], 0.20)
+      e >= 4 && buffAbilityDmg(x, [FUA_TYPE], 0.10)
 
       x.BASIC_TOUGHNESS_DMG += 30
       x.SKILL_TOUGHNESS_DMG += 30

--- a/src/lib/conditionals/character/Herta.ts
+++ b/src/lib/conditionals/character/Herta.ts
@@ -1,11 +1,17 @@
 import { Stats } from 'lib/constants'
-import { ASHBLAZING_ATK_STACK, baseComputedStatsObject, ComputedStatsObject } from 'lib/conditionals/conditionalConstants.ts'
+import {
+  ASHBLAZING_ATK_STACK,
+  baseComputedStatsObject,
+  ComputedStatsObject,
+  SKILL_TYPE
+} from 'lib/conditionals/conditionalConstants.ts'
 import { AbilityEidolon, calculateAshblazingSet, precisionRound } from 'lib/conditionals/utils'
 
 import { Eidolon } from 'types/Character'
 import { CharacterConditional, PrecomputedCharacterConditional } from 'types/CharacterConditional'
 import { Form } from 'types/Form'
 import { ContentItem } from 'types/Conditionals'
+import { buffAbilityDmg } from 'lib/optimizer/calculateBuffs'
 
 export default (e: Eidolon): CharacterConditional => {
   const { basic, skill, ult, talent } = AbilityEidolon.SKILL_BASIC_3_ULT_TALENT_5
@@ -146,7 +152,7 @@ export default (e: Eidolon): CharacterConditional => {
       x.ULT_SCALING += ultScaling
       x.FUA_SCALING += fuaScaling
 
-      x.SKILL_BOOST += (r.enemyHpGte50) ? 0.45 : 0
+      r.enemyHpGte50 && buffAbilityDmg(x, [SKILL_TYPE], 0.20)
 
       // Boost
       x.ULT_BOOST += (r.targetFrozen) ? 0.20 : 0

--- a/src/lib/conditionals/character/Herta.ts
+++ b/src/lib/conditionals/character/Herta.ts
@@ -154,11 +154,11 @@ export default (e: Eidolon): CharacterConditional => {
       x.ULT_SCALING += ultScaling
       x.FUA_SCALING += fuaScaling
 
-      r.enemyHpGte50 && buffAbilityDmg(x, [SKILL_TYPE], 0.20)
+      buffAbilityDmg(x, [SKILL_TYPE], 0.20, (r.enemyHpGte50))
 
       // Boost
-      r.targetFrozen && buffAbilityDmg(x, [ULT_TYPE], 0.20)
-      e >= 4 && buffAbilityDmg(x, [FUA_TYPE], 0.10)
+      buffAbilityDmg(x, [ULT_TYPE], 0.20, (r.targetFrozen))
+      buffAbilityDmg(x, [FUA_TYPE], 0.10, (e >= 4))
 
       x.BASIC_TOUGHNESS_DMG += 30
       x.SKILL_TOUGHNESS_DMG += 30

--- a/src/lib/conditionals/character/Himeko.ts
+++ b/src/lib/conditionals/character/Himeko.ts
@@ -103,7 +103,7 @@ export default (e: Eidolon): CharacterConditional => {
       x.DOT_SCALING += dotScaling
 
       // Boost
-      r.targetBurned && buffAbilityDmg(x, [SKILL_TYPE], 0.20)
+      buffAbilityDmg(x, [SKILL_TYPE], 0.20, (r.targetBurned))
       x.ELEMENTAL_DMG += (e >= 2 && r.e2EnemyHp50DmgBoost) ? 0.15 : 0
 
       x.BASIC_TOUGHNESS_DMG += 30

--- a/src/lib/conditionals/character/Himeko.ts
+++ b/src/lib/conditionals/character/Himeko.ts
@@ -103,7 +103,7 @@ export default (e: Eidolon): CharacterConditional => {
       x.DOT_SCALING += dotScaling
 
       // Boost
-      buffAbilityDmg(x, [SKILL_TYPE], 0.20, (r.targetBurned))
+      buffAbilityDmg(x, SKILL_TYPE, 0.20, (r.targetBurned))
       x.ELEMENTAL_DMG += (e >= 2 && r.e2EnemyHp50DmgBoost) ? 0.15 : 0
 
       x.BASIC_TOUGHNESS_DMG += 30

--- a/src/lib/conditionals/character/Himeko.ts
+++ b/src/lib/conditionals/character/Himeko.ts
@@ -2,7 +2,8 @@ import { Stats } from 'lib/constants'
 import {
   ASHBLAZING_ATK_STACK,
   baseComputedStatsObject,
-  ComputedStatsObject
+  ComputedStatsObject,
+  SKILL_TYPE
 } from 'lib/conditionals/conditionalConstants.ts'
 import { AbilityEidolon, calculateAshblazingSet, precisionRound } from 'lib/conditionals/utils'
 
@@ -10,6 +11,7 @@ import { Eidolon } from 'types/Character'
 import { CharacterConditional, PrecomputedCharacterConditional } from 'types/CharacterConditional'
 import { Form } from 'types/Form'
 import { ContentItem } from 'types/Conditionals'
+import { buffAbilityDmg } from 'lib/optimizer/calculateBuffs'
 
 export default (e: Eidolon): CharacterConditional => {
   const {basic, skill, ult, talent} = AbilityEidolon.SKILL_BASIC_3_ULT_TALENT_5
@@ -101,7 +103,7 @@ export default (e: Eidolon): CharacterConditional => {
       x.DOT_SCALING += dotScaling
 
       // Boost
-      x.SKILL_BOOST += (r.targetBurned) ? 0.20 : 0
+      r.targetBurned && buffAbilityDmg(x, [SKILL_TYPE], 0.20)
       x.ELEMENTAL_DMG += (e >= 2 && r.e2EnemyHp50DmgBoost) ? 0.15 : 0
 
       x.BASIC_TOUGHNESS_DMG += 30

--- a/src/lib/conditionals/character/Hook.ts
+++ b/src/lib/conditionals/character/Hook.ts
@@ -62,7 +62,7 @@ export default (e: Eidolon): CharacterConditional => {
       x.DOT_SCALING += dotScaling
 
       // Boost
-      buffAbilityDmg(x, [SKILL_TYPE], 0.20, (e >= 1 && r.enhancedSkill))
+      buffAbilityDmg(x, SKILL_TYPE, 0.20, (e >= 1 && r.enhancedSkill))
       x.ELEMENTAL_DMG += (e >= 6 && r.targetBurned) ? 0.20 : 0
 
       x.BASIC_TOUGHNESS_DMG += 30

--- a/src/lib/conditionals/character/Hook.ts
+++ b/src/lib/conditionals/character/Hook.ts
@@ -1,11 +1,12 @@
 import { Stats } from 'lib/constants'
-import { baseComputedStatsObject, ComputedStatsObject } from 'lib/conditionals/conditionalConstants.ts'
+import { baseComputedStatsObject, ComputedStatsObject, SKILL_TYPE } from 'lib/conditionals/conditionalConstants.ts'
 import { AbilityEidolon, precisionRound } from 'lib/conditionals/utils'
 
 import { Eidolon } from 'types/Character'
 import { CharacterConditional, PrecomputedCharacterConditional } from 'types/CharacterConditional'
 import { Form } from 'types/Form'
 import { ContentItem } from 'types/Conditionals'
+import { buffAbilityDmg } from 'lib/optimizer/calculateBuffs'
 
 export default (e: Eidolon): CharacterConditional => {
   const {basic, skill, ult, talent} = AbilityEidolon.SKILL_BASIC_3_ULT_TALENT_5
@@ -61,7 +62,7 @@ export default (e: Eidolon): CharacterConditional => {
       x.DOT_SCALING += dotScaling
 
       // Boost
-      x.SKILL_BOOST += (e >= 1 && r.enhancedSkill) ? 0.20 : 0
+      e >= 1 && r.enhancedSkill && buffAbilityDmg(x, [SKILL_TYPE], 0.20)
       x.ELEMENTAL_DMG += (e >= 6 && r.targetBurned) ? 0.20 : 0
 
       x.BASIC_TOUGHNESS_DMG += 30

--- a/src/lib/conditionals/character/Hook.ts
+++ b/src/lib/conditionals/character/Hook.ts
@@ -62,7 +62,7 @@ export default (e: Eidolon): CharacterConditional => {
       x.DOT_SCALING += dotScaling
 
       // Boost
-      e >= 1 && r.enhancedSkill && buffAbilityDmg(x, [SKILL_TYPE], 0.20)
+      buffAbilityDmg(x, [SKILL_TYPE], 0.20, (e >= 1 && r.enhancedSkill))
       x.ELEMENTAL_DMG += (e >= 6 && r.targetBurned) ? 0.20 : 0
 
       x.BASIC_TOUGHNESS_DMG += 30

--- a/src/lib/conditionals/character/ImbibitorLunae.ts
+++ b/src/lib/conditionals/character/ImbibitorLunae.ts
@@ -96,7 +96,7 @@ export default (e: Eidolon): CharacterConditional => {
 
       // Boost
       x.ELEMENTAL_DMG += r.talentRighteousHeartStacks * righteousHeartDmgValue
-      e >= 6 && r.basicEnhanced == 3 && buffAbilityResShred(x, [BASIC_TYPE], 0.20 * r.e6ResPenStacks)
+      buffAbilityResShred(x, [BASIC_TYPE], 0.20 * r.e6ResPenStacks, (e >= 6 && r.basicEnhanced == 3))
 
       x.BASIC_TOUGHNESS_DMG += 30 + 30 * r.basicEnhanced
       x.ULT_TOUGHNESS_DMG += 60

--- a/src/lib/conditionals/character/ImbibitorLunae.ts
+++ b/src/lib/conditionals/character/ImbibitorLunae.ts
@@ -1,11 +1,12 @@
 import { Stats } from 'lib/constants'
-import { baseComputedStatsObject, ComputedStatsObject } from 'lib/conditionals/conditionalConstants.ts'
+import { baseComputedStatsObject, BASIC_TYPE, ComputedStatsObject } from 'lib/conditionals/conditionalConstants.ts'
 import { AbilityEidolon, precisionRound } from 'lib/conditionals/utils'
 
 import { Eidolon } from 'types/Character'
 import { CharacterConditional, PrecomputedCharacterConditional } from 'types/CharacterConditional'
 import { Form } from 'types/Form'
 import { ContentItem } from 'types/Conditionals'
+import { buffDmgTypeResShred } from 'lib/optimizer/calculateBuffs'
 
 export default (e: Eidolon): CharacterConditional => {
   const { basic, skill, ult, talent } = AbilityEidolon.SKILL_BASIC_3_ULT_TALENT_5
@@ -95,7 +96,7 @@ export default (e: Eidolon): CharacterConditional => {
 
       // Boost
       x.ELEMENTAL_DMG += r.talentRighteousHeartStacks * righteousHeartDmgValue
-      x.BASIC_RES_PEN += (e >= 6 && r.basicEnhanced == 3) ? 0.20 * r.e6ResPenStacks : 0
+      e >= 6 && r.basicEnhanced == 3 && buffDmgTypeResShred(x, [BASIC_TYPE], 0.20 * r.e6ResPenStacks)
 
       x.BASIC_TOUGHNESS_DMG += 30 + 30 * r.basicEnhanced
       x.ULT_TOUGHNESS_DMG += 60

--- a/src/lib/conditionals/character/ImbibitorLunae.ts
+++ b/src/lib/conditionals/character/ImbibitorLunae.ts
@@ -6,7 +6,7 @@ import { Eidolon } from 'types/Character'
 import { CharacterConditional, PrecomputedCharacterConditional } from 'types/CharacterConditional'
 import { Form } from 'types/Form'
 import { ContentItem } from 'types/Conditionals'
-import { buffDmgTypeResShred } from 'lib/optimizer/calculateBuffs'
+import { buffAbilityResShred } from 'lib/optimizer/calculateBuffs'
 
 export default (e: Eidolon): CharacterConditional => {
   const { basic, skill, ult, talent } = AbilityEidolon.SKILL_BASIC_3_ULT_TALENT_5
@@ -96,7 +96,7 @@ export default (e: Eidolon): CharacterConditional => {
 
       // Boost
       x.ELEMENTAL_DMG += r.talentRighteousHeartStacks * righteousHeartDmgValue
-      e >= 6 && r.basicEnhanced == 3 && buffDmgTypeResShred(x, [BASIC_TYPE], 0.20 * r.e6ResPenStacks)
+      e >= 6 && r.basicEnhanced == 3 && buffAbilityResShred(x, [BASIC_TYPE], 0.20 * r.e6ResPenStacks)
 
       x.BASIC_TOUGHNESS_DMG += 30 + 30 * r.basicEnhanced
       x.ULT_TOUGHNESS_DMG += 60

--- a/src/lib/conditionals/character/ImbibitorLunae.ts
+++ b/src/lib/conditionals/character/ImbibitorLunae.ts
@@ -96,7 +96,7 @@ export default (e: Eidolon): CharacterConditional => {
 
       // Boost
       x.ELEMENTAL_DMG += r.talentRighteousHeartStacks * righteousHeartDmgValue
-      buffAbilityResShred(x, [BASIC_TYPE], 0.20 * r.e6ResPenStacks, (e >= 6 && r.basicEnhanced == 3))
+      buffAbilityResShred(x, BASIC_TYPE, 0.20 * r.e6ResPenStacks, (e >= 6 && r.basicEnhanced == 3))
 
       x.BASIC_TOUGHNESS_DMG += 30 + 30 * r.basicEnhanced
       x.ULT_TOUGHNESS_DMG += 60

--- a/src/lib/conditionals/character/Jade.ts
+++ b/src/lib/conditionals/character/Jade.ts
@@ -1,7 +1,8 @@
 import {
   ASHBLAZING_ATK_STACK,
   baseComputedStatsObject,
-  ComputedStatsObject
+  ComputedStatsObject,
+  FUA_TYPE
 } from 'lib/conditionals/conditionalConstants.ts'
 import { AbilityEidolon, calculateAshblazingSet, precisionRound } from 'lib/conditionals/utils'
 
@@ -10,6 +11,7 @@ import { CharacterConditional, PrecomputedCharacterConditional } from 'types/Cha
 import { Form } from 'types/Form'
 import { ContentItem } from 'types/Conditionals'
 import { Stats } from 'lib/constants'
+import { buffAbilityDmg } from 'lib/optimizer/calculateBuffs'
 
 export default (e: Eidolon): CharacterConditional => {
   const { basic, skill, ult, talent } = AbilityEidolon.SKILL_TALENT_3_ULT_BASIC_5
@@ -143,7 +145,7 @@ export default (e: Eidolon): CharacterConditional => {
       x.FUA_SCALING += fuaScaling
       x.FUA_SCALING += (r.enhancedFollowUp) ? ultFuaScalingBuff : 0
 
-      x.FUA_BOOST += (e >= 1 && r.e1FuaDmgBoost) ? 0.32 : 0
+      buffAbilityDmg(x, [FUA_TYPE], 0.32, (e >= 1 && r.e1FuaDmgBoost))
       x.DEF_SHRED += (e >= 4 && r.e4DefShredBuff) ? 0.12 : 0
       x.QUANTUM_RES_PEN += (e >= 6 && r.e6ResShredBuff) ? 0.20 : 0
 

--- a/src/lib/conditionals/character/Jade.ts
+++ b/src/lib/conditionals/character/Jade.ts
@@ -145,7 +145,7 @@ export default (e: Eidolon): CharacterConditional => {
       x.FUA_SCALING += fuaScaling
       x.FUA_SCALING += (r.enhancedFollowUp) ? ultFuaScalingBuff : 0
 
-      buffAbilityDmg(x, [FUA_TYPE], 0.32, (e >= 1 && r.e1FuaDmgBoost))
+      buffAbilityDmg(x, FUA_TYPE, 0.32, (e >= 1 && r.e1FuaDmgBoost))
       x.DEF_SHRED += (e >= 4 && r.e4DefShredBuff) ? 0.12 : 0
       x.QUANTUM_RES_PEN += (e >= 6 && r.e6ResShredBuff) ? 0.20 : 0
 

--- a/src/lib/conditionals/character/Jiaoqiu.ts
+++ b/src/lib/conditionals/character/Jiaoqiu.ts
@@ -6,7 +6,7 @@ import { CharacterConditional, PrecomputedCharacterConditional } from 'types/Cha
 import { Form } from 'types/Form'
 import { ContentItem } from 'types/Conditionals'
 import { BETA_UPDATE, Stats } from 'lib/constants'
-import { buffDmgTypeVulnerability } from 'lib/optimizer/calculateBuffs'
+import { buffAbilityVulnerability } from 'lib/optimizer/calculateBuffs'
 
 export default (e: Eidolon): CharacterConditional => {
   const { basic, skill, ult, talent } = AbilityEidolon.SKILL_BASIC_3_ULT_TALENT_5
@@ -125,7 +125,7 @@ export default (e: Eidolon): CharacterConditional => {
     precomputeMutualEffects: (x: ComputedStatsObject, request: Form) => {
       const m = request.characterConditionals
 
-      m.ultFieldActive && buffDmgTypeVulnerability(x, [ULT_TYPE], ultVulnerabilityScaling)
+      m.ultFieldActive && buffAbilityVulnerability(x, [ULT_TYPE], ultVulnerabilityScaling)
 
       x.DMG_TAKEN_MULTI += (m.ashenRoastStacks > 0) ? talentVulnerabilityBase : 0
       x.DMG_TAKEN_MULTI += Math.max(0, m.ashenRoastStacks - 1) * talentVulnerabilityScaling

--- a/src/lib/conditionals/character/Jiaoqiu.ts
+++ b/src/lib/conditionals/character/Jiaoqiu.ts
@@ -125,7 +125,7 @@ export default (e: Eidolon): CharacterConditional => {
     precomputeMutualEffects: (x: ComputedStatsObject, request: Form) => {
       const m = request.characterConditionals
 
-      buffAbilityVulnerability(x, [ULT_TYPE], ultVulnerabilityScaling, (m.ultFieldActive))
+      buffAbilityVulnerability(x, ULT_TYPE, ultVulnerabilityScaling, (m.ultFieldActive))
 
       x.DMG_TAKEN_MULTI += (m.ashenRoastStacks > 0) ? talentVulnerabilityBase : 0
       x.DMG_TAKEN_MULTI += Math.max(0, m.ashenRoastStacks - 1) * talentVulnerabilityScaling

--- a/src/lib/conditionals/character/Jiaoqiu.ts
+++ b/src/lib/conditionals/character/Jiaoqiu.ts
@@ -1,4 +1,4 @@
-import { baseComputedStatsObject, ComputedStatsObject } from 'lib/conditionals/conditionalConstants'
+import { baseComputedStatsObject, ComputedStatsObject, ULT_TYPE } from 'lib/conditionals/conditionalConstants'
 import { AbilityEidolon, findContentId } from 'lib/conditionals/utils'
 
 import { Eidolon } from 'types/Character'
@@ -6,6 +6,7 @@ import { CharacterConditional, PrecomputedCharacterConditional } from 'types/Cha
 import { Form } from 'types/Form'
 import { ContentItem } from 'types/Conditionals'
 import { BETA_UPDATE, Stats } from 'lib/constants'
+import { buffDmgTypeVulnerability } from 'lib/optimizer/calculateBuffs'
 
 export default (e: Eidolon): CharacterConditional => {
   const { basic, skill, ult, talent } = AbilityEidolon.SKILL_BASIC_3_ULT_TALENT_5
@@ -124,7 +125,8 @@ export default (e: Eidolon): CharacterConditional => {
     precomputeMutualEffects: (x: ComputedStatsObject, request: Form) => {
       const m = request.characterConditionals
 
-      x.ULT_VULNERABILITY += (m.ultFieldActive) ? ultVulnerabilityScaling : 0
+      m.ultFieldActive && buffDmgTypeVulnerability(x, [ULT_TYPE], ultVulnerabilityScaling)
+
       x.DMG_TAKEN_MULTI += (m.ashenRoastStacks > 0) ? talentVulnerabilityBase : 0
       x.DMG_TAKEN_MULTI += Math.max(0, m.ashenRoastStacks - 1) * talentVulnerabilityScaling
 

--- a/src/lib/conditionals/character/Jiaoqiu.ts
+++ b/src/lib/conditionals/character/Jiaoqiu.ts
@@ -125,7 +125,7 @@ export default (e: Eidolon): CharacterConditional => {
     precomputeMutualEffects: (x: ComputedStatsObject, request: Form) => {
       const m = request.characterConditionals
 
-      m.ultFieldActive && buffAbilityVulnerability(x, [ULT_TYPE], ultVulnerabilityScaling)
+      buffAbilityVulnerability(x, [ULT_TYPE], ultVulnerabilityScaling, (m.ultFieldActive))
 
       x.DMG_TAKEN_MULTI += (m.ashenRoastStacks > 0) ? talentVulnerabilityBase : 0
       x.DMG_TAKEN_MULTI += Math.max(0, m.ashenRoastStacks - 1) * talentVulnerabilityScaling

--- a/src/lib/conditionals/character/JingYuan.ts
+++ b/src/lib/conditionals/character/JingYuan.ts
@@ -13,7 +13,7 @@ import { Eidolon } from 'types/Character'
 import { CharacterConditional, PrecomputedCharacterConditional } from 'types/CharacterConditional'
 import { ContentItem } from 'types/Conditionals'
 import { Form } from 'types/Form'
-import { buffDmgTypeBoost, buffDmgTypeCdBoost, buffDmgTypeVulnerability } from 'lib/optimizer/calculateBuffs'
+import { buffAbilityCd, buffAbilityDmg, buffAbilityVulnerability } from 'lib/optimizer/calculateBuffs'
 
 export default (e: Eidolon): CharacterConditional => {
   const { basic, skill, ult, talent } = AbilityEidolon.ULT_BASIC_3_SKILL_TALENT_5
@@ -98,9 +98,9 @@ export default (e: Eidolon): CharacterConditional => {
       x.FUA_SCALING += fuaScaling
 
       // Boost
-      r.talentHitsPerAction >= 6 && buffDmgTypeCdBoost(x, [FUA_TYPE], 0.25)
-      e >= 2 && r.e2DmgBuff && buffDmgTypeBoost(x, [BASIC_TYPE, SKILL_TYPE, ULT_TYPE], 0.20)
-      e >= 6 && buffDmgTypeVulnerability(x, [FUA_TYPE], r.e6FuaVulnerabilityStacks * 0.12)
+      r.talentHitsPerAction >= 6 && buffAbilityCd(x, [FUA_TYPE], 0.25)
+      e >= 2 && r.e2DmgBuff && buffAbilityDmg(x, [BASIC_TYPE, SKILL_TYPE, ULT_TYPE], 0.20)
+      e >= 6 && buffAbilityVulnerability(x, [FUA_TYPE], r.e6FuaVulnerabilityStacks * 0.12)
 
       // Lightning lord calcs
       const stacks = r.talentHitsPerAction

--- a/src/lib/conditionals/character/JingYuan.ts
+++ b/src/lib/conditionals/character/JingYuan.ts
@@ -1,11 +1,19 @@
 import { Stats } from 'lib/constants'
-import { baseComputedStatsObject, ComputedStatsObject } from 'lib/conditionals/conditionalConstants.ts'
+import {
+  baseComputedStatsObject,
+  BASIC_TYPE,
+  ComputedStatsObject,
+  FUA_TYPE,
+  SKILL_TYPE,
+  ULT_TYPE
+} from 'lib/conditionals/conditionalConstants.ts'
 import { AbilityEidolon, calculateAshblazingSet } from 'lib/conditionals/utils'
 
 import { Eidolon } from 'types/Character'
 import { CharacterConditional, PrecomputedCharacterConditional } from 'types/CharacterConditional'
 import { ContentItem } from 'types/Conditionals'
 import { Form } from 'types/Form'
+import { buffDmgTypeBoost, buffDmgTypeCdBoost, buffDmgTypeVulnerability } from 'lib/optimizer/calculateBuffs'
 
 export default (e: Eidolon): CharacterConditional => {
   const { basic, skill, ult, talent } = AbilityEidolon.ULT_BASIC_3_SKILL_TALENT_5
@@ -90,12 +98,9 @@ export default (e: Eidolon): CharacterConditional => {
       x.FUA_SCALING += fuaScaling
 
       // Boost
-      x.FUA_CD_BOOST += (r.talentHitsPerAction >= 6) ? 0.25 : 0
-      x.BASIC_BOOST += (e >= 2 && r.e2DmgBuff) ? 0.20 : 0
-      x.SKILL_BOOST += (e >= 2 && r.e2DmgBuff) ? 0.20 : 0
-      x.ULT_BOOST += (e >= 2 && r.e2DmgBuff) ? 0.20 : 0
-
-      x.FUA_VULNERABILITY += (e >= 6) ? r.e6FuaVulnerabilityStacks * 0.12 : 0
+      r.talentHitsPerAction >= 6 && buffDmgTypeCdBoost(x, [FUA_TYPE], 0.25)
+      e >= 2 && r.e2DmgBuff && buffDmgTypeBoost(x, [BASIC_TYPE, SKILL_TYPE, ULT_TYPE], 0.20)
+      e >= 6 && buffDmgTypeVulnerability(x, [FUA_TYPE], r.e6FuaVulnerabilityStacks * 0.12)
 
       // Lightning lord calcs
       const stacks = r.talentHitsPerAction

--- a/src/lib/conditionals/character/JingYuan.ts
+++ b/src/lib/conditionals/character/JingYuan.ts
@@ -98,9 +98,9 @@ export default (e: Eidolon): CharacterConditional => {
       x.FUA_SCALING += fuaScaling
 
       // Boost
-      buffAbilityCd(x, [FUA_TYPE], 0.25, (r.talentHitsPerAction >= 6))
-      buffAbilityDmg(x, [BASIC_TYPE, SKILL_TYPE, ULT_TYPE], 0.20, (e >= 2 && r.e2DmgBuff))
-      buffAbilityVulnerability(x, [FUA_TYPE], r.e6FuaVulnerabilityStacks * 0.12, (e >= 6))
+      buffAbilityCd(x, FUA_TYPE, 0.25, (r.talentHitsPerAction >= 6))
+      buffAbilityDmg(x, BASIC_TYPE | SKILL_TYPE | ULT_TYPE, 0.20, (e >= 2 && r.e2DmgBuff))
+      buffAbilityVulnerability(x, FUA_TYPE, r.e6FuaVulnerabilityStacks * 0.12, (e >= 6))
 
       // Lightning lord calcs
       const stacks = r.talentHitsPerAction

--- a/src/lib/conditionals/character/JingYuan.ts
+++ b/src/lib/conditionals/character/JingYuan.ts
@@ -98,9 +98,9 @@ export default (e: Eidolon): CharacterConditional => {
       x.FUA_SCALING += fuaScaling
 
       // Boost
-      r.talentHitsPerAction >= 6 && buffAbilityCd(x, [FUA_TYPE], 0.25)
-      e >= 2 && r.e2DmgBuff && buffAbilityDmg(x, [BASIC_TYPE, SKILL_TYPE, ULT_TYPE], 0.20)
-      e >= 6 && buffAbilityVulnerability(x, [FUA_TYPE], r.e6FuaVulnerabilityStacks * 0.12)
+      buffAbilityCd(x, [FUA_TYPE], 0.25, (r.talentHitsPerAction >= 6))
+      buffAbilityDmg(x, [BASIC_TYPE, SKILL_TYPE, ULT_TYPE], 0.20, (e >= 2 && r.e2DmgBuff))
+      buffAbilityVulnerability(x, [FUA_TYPE], r.e6FuaVulnerabilityStacks * 0.12, (e >= 6))
 
       // Lightning lord calcs
       const stacks = r.talentHitsPerAction

--- a/src/lib/conditionals/character/Jingliu.ts
+++ b/src/lib/conditionals/character/Jingliu.ts
@@ -1,6 +1,11 @@
 import { Stats } from 'lib/constants'
 import { AbilityEidolon, precisionRound } from 'lib/conditionals/utils'
-import { baseComputedStatsObject, ComputedStatsObject, SKILL_TYPE } from 'lib/conditionals/conditionalConstants.ts'
+import {
+  baseComputedStatsObject,
+  ComputedStatsObject,
+  SKILL_TYPE,
+  ULT_TYPE
+} from 'lib/conditionals/conditionalConstants.ts'
 import { Eidolon } from 'types/Character'
 import { ConditionalMap, ContentItem } from 'types/Conditionals'
 import { CharacterConditional, PrecomputedCharacterConditional } from 'types/CharacterConditional'
@@ -81,7 +86,7 @@ const Jingliu = (e: Eidolon): CharacterConditional => {
 
       // Traces
       x[Stats.RES] += (r.talentEnhancedState) ? 0.35 : 0
-      x.ULT_BOOST += (r.talentEnhancedState) ? 0.20 : 0
+      r.talentEnhancedState && buffAbilityDmg(x, [ULT_TYPE], 0.20)
 
       // Eidolons
       x[Stats.CD] += (e >= 1 && r.e1CdBuff) ? 0.24 : 0

--- a/src/lib/conditionals/character/Jingliu.ts
+++ b/src/lib/conditionals/character/Jingliu.ts
@@ -1,10 +1,11 @@
 import { Stats } from 'lib/constants'
 import { AbilityEidolon, precisionRound } from 'lib/conditionals/utils'
-import { baseComputedStatsObject, ComputedStatsObject } from 'lib/conditionals/conditionalConstants.ts'
+import { baseComputedStatsObject, ComputedStatsObject, SKILL_TYPE } from 'lib/conditionals/conditionalConstants.ts'
 import { Eidolon } from 'types/Character'
 import { ConditionalMap, ContentItem } from 'types/Conditionals'
 import { CharacterConditional, PrecomputedCharacterConditional } from 'types/CharacterConditional'
 import { Form } from 'types/Form'
+import { buffAbilityDmg } from 'lib/optimizer/calculateBuffs'
 
 const Jingliu = (e: Eidolon): CharacterConditional => {
   const { basic, skill, ult, talent } = AbilityEidolon.ULT_TALENT_3_SKILL_BASIC_5
@@ -98,7 +99,7 @@ const Jingliu = (e: Eidolon): CharacterConditional => {
       x.FUA_SCALING += 0
 
       // BOOST
-      x.SKILL_BOOST += (e >= 2 && r.talentEnhancedState && r.e2SkillDmgBuff) ? 0.80 : 0
+      e >= 2 && r.talentEnhancedState && r.e2SkillDmgBuff && buffAbilityDmg(x, [SKILL_TYPE], 0.80)
 
       x.BASIC_TOUGHNESS_DMG += 30
       x.SKILL_TOUGHNESS_DMG += 60

--- a/src/lib/conditionals/character/Jingliu.ts
+++ b/src/lib/conditionals/character/Jingliu.ts
@@ -7,8 +7,12 @@ import {
   ULT_TYPE
 } from 'lib/conditionals/conditionalConstants.ts'
 import { Eidolon } from 'types/Character'
-import { ConditionalMap, ContentItem } from 'types/Conditionals'
-import { CharacterConditional, PrecomputedCharacterConditional } from 'types/CharacterConditional'
+import { ContentItem } from 'types/Conditionals'
+import {
+  CharacterConditional,
+  CharacterConditionalMap,
+  PrecomputedCharacterConditional
+} from 'types/CharacterConditional'
 import { Form } from 'types/Form'
 import { buffAbilityDmg } from 'lib/optimizer/calculateBuffs'
 
@@ -77,7 +81,7 @@ const Jingliu = (e: Eidolon): CharacterConditional => {
     teammateDefaults: () => ({
     }),
     precomputeEffects: (request: Form) => {
-      const r: ConditionalMap = request.characterConditionals
+      const r: CharacterConditionalMap = request.characterConditionals
       const x = Object.assign({}, baseComputedStatsObject)
 
       // Skills
@@ -86,7 +90,7 @@ const Jingliu = (e: Eidolon): CharacterConditional => {
 
       // Traces
       x[Stats.RES] += (r.talentEnhancedState) ? 0.35 : 0
-      r.talentEnhancedState && buffAbilityDmg(x, [ULT_TYPE], 0.20)
+      buffAbilityDmg(x, [ULT_TYPE], 0.20, (r.talentEnhancedState))
 
       // Eidolons
       x[Stats.CD] += (e >= 1 && r.e1CdBuff) ? 0.24 : 0
@@ -104,7 +108,7 @@ const Jingliu = (e: Eidolon): CharacterConditional => {
       x.FUA_SCALING += 0
 
       // BOOST
-      e >= 2 && r.talentEnhancedState && r.e2SkillDmgBuff && buffAbilityDmg(x, [SKILL_TYPE], 0.80)
+      buffAbilityDmg(x, [SKILL_TYPE], 0.80, (e >= 2 && r.talentEnhancedState && r.e2SkillDmgBuff))
 
       x.BASIC_TOUGHNESS_DMG += 30
       x.SKILL_TOUGHNESS_DMG += 60

--- a/src/lib/conditionals/character/Jingliu.ts
+++ b/src/lib/conditionals/character/Jingliu.ts
@@ -90,7 +90,7 @@ const Jingliu = (e: Eidolon): CharacterConditional => {
 
       // Traces
       x[Stats.RES] += (r.talentEnhancedState) ? 0.35 : 0
-      buffAbilityDmg(x, [ULT_TYPE], 0.20, (r.talentEnhancedState))
+      buffAbilityDmg(x, ULT_TYPE, 0.20, (r.talentEnhancedState))
 
       // Eidolons
       x[Stats.CD] += (e >= 1 && r.e1CdBuff) ? 0.24 : 0
@@ -108,7 +108,7 @@ const Jingliu = (e: Eidolon): CharacterConditional => {
       x.FUA_SCALING += 0
 
       // BOOST
-      buffAbilityDmg(x, [SKILL_TYPE], 0.80, (e >= 2 && r.talentEnhancedState && r.e2SkillDmgBuff))
+      buffAbilityDmg(x, SKILL_TYPE, 0.80, (e >= 2 && r.talentEnhancedState && r.e2SkillDmgBuff))
 
       x.BASIC_TOUGHNESS_DMG += 30
       x.SKILL_TOUGHNESS_DMG += 60

--- a/src/lib/conditionals/character/Kafka.ts
+++ b/src/lib/conditionals/character/Kafka.ts
@@ -11,7 +11,7 @@ import { Eidolon } from 'types/Character'
 import { CharacterConditional, PrecomputedCharacterConditional } from 'types/CharacterConditional'
 import { ContentItem } from 'types/Conditionals'
 import { Form } from 'types/Form'
-import { buffDmgTypeVulnerability } from 'lib/optimizer/calculateBuffs'
+import { buffAbilityVulnerability } from 'lib/optimizer/calculateBuffs'
 
 export default (e: Eidolon): CharacterConditional => {
   const {basic, skill, ult, talent} = AbilityEidolon.SKILL_BASIC_3_ULT_TALENT_5
@@ -87,7 +87,7 @@ export default (e: Eidolon): CharacterConditional => {
     precomputeMutualEffects: (x: ComputedStatsObject, request: Form) => {
       const m = request.characterConditionals
 
-      e >= 1 && m.e1DotDmgReceivedDebuff && buffDmgTypeVulnerability(x, [DOT_TYPE], 0.30)
+      e >= 1 && m.e1DotDmgReceivedDebuff && buffAbilityVulnerability(x, [DOT_TYPE], 0.30)
       x.DOT_BOOST += (e >= 2 && m.e2TeamDotBoost) ? 0.25 : 0
     },
     calculateBaseMultis: (c: PrecomputedCharacterConditional, request: Form) => {

--- a/src/lib/conditionals/character/Kafka.ts
+++ b/src/lib/conditionals/character/Kafka.ts
@@ -87,8 +87,8 @@ export default (e: Eidolon): CharacterConditional => {
     precomputeMutualEffects: (x: ComputedStatsObject, request: Form) => {
       const m = request.characterConditionals
 
-      buffAbilityVulnerability(x, [DOT_TYPE], 0.30, (e >= 1 && m.e1DotDmgReceivedDebuff))
-      buffAbilityDmg(x, [DOT_TYPE], 0.25, (e >= 2 && m.e2TeamDotBoost))
+      buffAbilityVulnerability(x, DOT_TYPE, 0.30, (e >= 1 && m.e1DotDmgReceivedDebuff))
+      buffAbilityDmg(x, DOT_TYPE, 0.25, (e >= 2 && m.e2TeamDotBoost))
     },
     calculateBaseMultis: (c: PrecomputedCharacterConditional, request: Form) => {
       const x = c.x

--- a/src/lib/conditionals/character/Kafka.ts
+++ b/src/lib/conditionals/character/Kafka.ts
@@ -2,7 +2,8 @@ import { Stats } from 'lib/constants'
 import {
   ASHBLAZING_ATK_STACK,
   baseComputedStatsObject,
-  ComputedStatsObject
+  ComputedStatsObject,
+  DOT_TYPE
 } from 'lib/conditionals/conditionalConstants.ts'
 import { AbilityEidolon, calculateAshblazingSet, findContentId } from 'lib/conditionals/utils'
 
@@ -10,6 +11,7 @@ import { Eidolon } from 'types/Character'
 import { CharacterConditional, PrecomputedCharacterConditional } from 'types/CharacterConditional'
 import { ContentItem } from 'types/Conditionals'
 import { Form } from 'types/Form'
+import { buffDmgTypeVulnerability } from 'lib/optimizer/calculateBuffs'
 
 export default (e: Eidolon): CharacterConditional => {
   const {basic, skill, ult, talent} = AbilityEidolon.SKILL_BASIC_3_ULT_TALENT_5
@@ -85,7 +87,7 @@ export default (e: Eidolon): CharacterConditional => {
     precomputeMutualEffects: (x: ComputedStatsObject, request: Form) => {
       const m = request.characterConditionals
 
-      x.DOT_VULNERABILITY += (e >= 1 && m.e1DotDmgReceivedDebuff) ? 0.30 : 0
+      e >= 1 && m.e1DotDmgReceivedDebuff && buffDmgTypeVulnerability(x, [DOT_TYPE], 0.30)
       x.DOT_BOOST += (e >= 2 && m.e2TeamDotBoost) ? 0.25 : 0
     },
     calculateBaseMultis: (c: PrecomputedCharacterConditional, request: Form) => {

--- a/src/lib/conditionals/character/Kafka.ts
+++ b/src/lib/conditionals/character/Kafka.ts
@@ -11,7 +11,7 @@ import { Eidolon } from 'types/Character'
 import { CharacterConditional, PrecomputedCharacterConditional } from 'types/CharacterConditional'
 import { ContentItem } from 'types/Conditionals'
 import { Form } from 'types/Form'
-import { buffAbilityVulnerability } from 'lib/optimizer/calculateBuffs'
+import { buffAbilityDmg, buffAbilityVulnerability } from 'lib/optimizer/calculateBuffs'
 
 export default (e: Eidolon): CharacterConditional => {
   const {basic, skill, ult, talent} = AbilityEidolon.SKILL_BASIC_3_ULT_TALENT_5
@@ -87,8 +87,8 @@ export default (e: Eidolon): CharacterConditional => {
     precomputeMutualEffects: (x: ComputedStatsObject, request: Form) => {
       const m = request.characterConditionals
 
-      e >= 1 && m.e1DotDmgReceivedDebuff && buffAbilityVulnerability(x, [DOT_TYPE], 0.30)
-      x.DOT_BOOST += (e >= 2 && m.e2TeamDotBoost) ? 0.25 : 0
+      buffAbilityVulnerability(x, [DOT_TYPE], 0.30, (e >= 1 && m.e1DotDmgReceivedDebuff))
+      buffAbilityDmg(x, [DOT_TYPE], 0.25, (e >= 2 && m.e2TeamDotBoost))
     },
     calculateBaseMultis: (c: PrecomputedCharacterConditional, request: Form) => {
       const x = c.x

--- a/src/lib/conditionals/character/March7thImaginary.ts
+++ b/src/lib/conditionals/character/March7thImaginary.ts
@@ -1,4 +1,4 @@
-import { baseComputedStatsObject, ComputedStatsObject } from 'lib/conditionals/conditionalConstants'
+import { baseComputedStatsObject, BASIC_TYPE, ComputedStatsObject } from 'lib/conditionals/conditionalConstants'
 import { AbilityEidolon } from 'lib/conditionals/utils'
 
 import { Eidolon } from 'types/Character'
@@ -6,6 +6,7 @@ import { CharacterConditional, PrecomputedCharacterConditional } from 'types/Cha
 import { Form } from 'types/Form'
 import { ContentItem } from 'types/Conditionals'
 import { BETA_UPDATE, Stats } from 'lib/constants'
+import { buffDmgTypeCdBoost } from 'lib/optimizer/calculateBuffs'
 
 export default (e: Eidolon): CharacterConditional => {
   const { basic, skill, ult, talent } = AbilityEidolon.SKILL_BASIC_3_ULT_TALENT_5
@@ -126,7 +127,7 @@ export default (e: Eidolon): CharacterConditional => {
       x[Stats.SPD_P] += (r.selfSpdBuff) ? 0.10 : 0
       x.BASIC_BOOST += (r.talentDmgBuff) ? talentDmgBuff : 0
 
-      x.BASIC_CD_BOOST += (e >= 1 && r.e1EnhancedBasicCdBuff && r.enhancedBasic) ? 0.36 : 0
+      e >= 1 && r.e1EnhancedBasicCdBuff && r.enhancedBasic && buffDmgTypeCdBoost(x, [BASIC_TYPE], 0.36)
 
       const additionalMasterBuffScaling = (r.masterAdditionalDmgBuff) ? basicExtraScalingMasterBuff * r.basicAttackHits : 0
       x.BASIC_SCALING += (r.enhancedBasic) ? basicEnhancedScaling * r.basicAttackHits : basicScaling

--- a/src/lib/conditionals/character/March7thImaginary.ts
+++ b/src/lib/conditionals/character/March7thImaginary.ts
@@ -125,9 +125,9 @@ export default (e: Eidolon): CharacterConditional => {
       const x = Object.assign({}, baseComputedStatsObject)
 
       x[Stats.SPD_P] += (r.selfSpdBuff) ? 0.10 : 0
-      buffAbilityDmg(x, [BASIC_TYPE], talentDmgBuff, (r.talentDmgBuff))
+      buffAbilityDmg(x, BASIC_TYPE, talentDmgBuff, (r.talentDmgBuff))
 
-      buffAbilityCd(x, [BASIC_TYPE], 0.36, (e >= 1 && r.e1EnhancedBasicCdBuff && r.enhancedBasic))
+      buffAbilityCd(x, BASIC_TYPE, 0.36, (e >= 1 && r.e1EnhancedBasicCdBuff && r.enhancedBasic))
 
       const additionalMasterBuffScaling = (r.masterAdditionalDmgBuff) ? basicExtraScalingMasterBuff * r.basicAttackHits : 0
       x.BASIC_SCALING += (r.enhancedBasic) ? basicEnhancedScaling * r.basicAttackHits : basicScaling

--- a/src/lib/conditionals/character/March7thImaginary.ts
+++ b/src/lib/conditionals/character/March7thImaginary.ts
@@ -125,9 +125,9 @@ export default (e: Eidolon): CharacterConditional => {
       const x = Object.assign({}, baseComputedStatsObject)
 
       x[Stats.SPD_P] += (r.selfSpdBuff) ? 0.10 : 0
-      r.talentDmgBuff && buffAbilityDmg(x, [BASIC_TYPE], talentDmgBuff)
+      buffAbilityDmg(x, [BASIC_TYPE], talentDmgBuff, (r.talentDmgBuff))
 
-      e >= 1 && r.e1EnhancedBasicCdBuff && r.enhancedBasic && buffAbilityCd(x, [BASIC_TYPE], 0.36)
+      buffAbilityCd(x, [BASIC_TYPE], 0.36, (e >= 1 && r.e1EnhancedBasicCdBuff && r.enhancedBasic))
 
       const additionalMasterBuffScaling = (r.masterAdditionalDmgBuff) ? basicExtraScalingMasterBuff * r.basicAttackHits : 0
       x.BASIC_SCALING += (r.enhancedBasic) ? basicEnhancedScaling * r.basicAttackHits : basicScaling

--- a/src/lib/conditionals/character/March7thImaginary.ts
+++ b/src/lib/conditionals/character/March7thImaginary.ts
@@ -6,7 +6,7 @@ import { CharacterConditional, PrecomputedCharacterConditional } from 'types/Cha
 import { Form } from 'types/Form'
 import { ContentItem } from 'types/Conditionals'
 import { BETA_UPDATE, Stats } from 'lib/constants'
-import { buffDmgTypeCdBoost } from 'lib/optimizer/calculateBuffs'
+import { buffAbilityCd, buffAbilityDmg } from 'lib/optimizer/calculateBuffs'
 
 export default (e: Eidolon): CharacterConditional => {
   const { basic, skill, ult, talent } = AbilityEidolon.SKILL_BASIC_3_ULT_TALENT_5
@@ -125,9 +125,9 @@ export default (e: Eidolon): CharacterConditional => {
       const x = Object.assign({}, baseComputedStatsObject)
 
       x[Stats.SPD_P] += (r.selfSpdBuff) ? 0.10 : 0
-      x.BASIC_BOOST += (r.talentDmgBuff) ? talentDmgBuff : 0
+      r.talentDmgBuff && buffAbilityDmg(x, [BASIC_TYPE], talentDmgBuff)
 
-      e >= 1 && r.e1EnhancedBasicCdBuff && r.enhancedBasic && buffDmgTypeCdBoost(x, [BASIC_TYPE], 0.36)
+      e >= 1 && r.e1EnhancedBasicCdBuff && r.enhancedBasic && buffAbilityCd(x, [BASIC_TYPE], 0.36)
 
       const additionalMasterBuffScaling = (r.masterAdditionalDmgBuff) ? basicExtraScalingMasterBuff * r.basicAttackHits : 0
       x.BASIC_SCALING += (r.enhancedBasic) ? basicEnhancedScaling * r.basicAttackHits : basicScaling

--- a/src/lib/conditionals/character/Pela.ts
+++ b/src/lib/conditionals/character/Pela.ts
@@ -96,7 +96,7 @@ export default (e: Eidolon): CharacterConditional => {
       x.SKILL_SCALING += skillScaling
       x.ULT_SCALING += ultScaling
 
-      buffAbilityDmg(x, [BASIC_TYPE, SKILL_TYPE, ULT_TYPE], 0.20, (r.skillRemovedBuff))
+      buffAbilityDmg(x, BASIC_TYPE | SKILL_TYPE | ULT_TYPE, 0.20, (r.skillRemovedBuff))
       x.ELEMENTAL_DMG += (r.enemyDebuffed) ? 0.20 : 0
 
       x.BASIC_TOUGHNESS_DMG += 30

--- a/src/lib/conditionals/character/Pela.ts
+++ b/src/lib/conditionals/character/Pela.ts
@@ -1,11 +1,18 @@
 import { Stats } from 'lib/constants'
-import { baseComputedStatsObject, ComputedStatsObject } from 'lib/conditionals/conditionalConstants.ts'
+import {
+  baseComputedStatsObject,
+  BASIC_TYPE,
+  ComputedStatsObject,
+  SKILL_TYPE,
+  ULT_TYPE
+} from 'lib/conditionals/conditionalConstants.ts'
 import { AbilityEidolon, findContentId, precisionRound } from 'lib/conditionals/utils'
 
 import { Eidolon } from 'types/Character'
 import { CharacterConditional, PrecomputedCharacterConditional } from 'types/CharacterConditional'
 import { ContentItem } from 'types/Conditionals'
 import { Form } from 'types/Form'
+import { buffAbilityDmg } from 'lib/optimizer/calculateBuffs'
 
 export default (e: Eidolon): CharacterConditional => {
   const { basic, skill, ult } = AbilityEidolon.SKILL_BASIC_3_ULT_TALENT_5
@@ -89,11 +96,7 @@ export default (e: Eidolon): CharacterConditional => {
       x.SKILL_SCALING += skillScaling
       x.ULT_SCALING += ultScaling
 
-      // Boost
-      x.BASIC_BOOST += (r.skillRemovedBuff) ? 0.20 : 0
-      x.SKILL_BOOST += (r.skillRemovedBuff) ? 0.20 : 0
-      x.ULT_BOOST += (r.skillRemovedBuff) ? 0.20 : 0
-
+      r.skillRemovedBuff && buffAbilityDmg(x, [BASIC_TYPE, SKILL_TYPE, ULT_TYPE], 0.20)
       x.ELEMENTAL_DMG += (r.enemyDebuffed) ? 0.20 : 0
 
       x.BASIC_TOUGHNESS_DMG += 30

--- a/src/lib/conditionals/character/Pela.ts
+++ b/src/lib/conditionals/character/Pela.ts
@@ -96,7 +96,7 @@ export default (e: Eidolon): CharacterConditional => {
       x.SKILL_SCALING += skillScaling
       x.ULT_SCALING += ultScaling
 
-      r.skillRemovedBuff && buffAbilityDmg(x, [BASIC_TYPE, SKILL_TYPE, ULT_TYPE], 0.20)
+      buffAbilityDmg(x, [BASIC_TYPE, SKILL_TYPE, ULT_TYPE], 0.20, (r.skillRemovedBuff))
       x.ELEMENTAL_DMG += (r.enemyDebuffed) ? 0.20 : 0
 
       x.BASIC_TOUGHNESS_DMG += 30

--- a/src/lib/conditionals/character/Qingque.ts
+++ b/src/lib/conditionals/character/Qingque.ts
@@ -83,7 +83,7 @@ export default (e: Eidolon): CharacterConditional => {
 
       // Boost
       x.ELEMENTAL_DMG += r.skillDmgIncreaseStacks * skillStackDmg
-      e >= 1 && buffAbilityDmg(x, [ULT_TYPE], 0.10)
+      buffAbilityDmg(x, [ULT_TYPE], 0.10, (e >= 1))
 
       x.BASIC_TOUGHNESS_DMG += (r.basicEnhanced) ? 60 : 30
       x.ULT_TOUGHNESS_DMG += 60

--- a/src/lib/conditionals/character/Qingque.ts
+++ b/src/lib/conditionals/character/Qingque.ts
@@ -83,7 +83,7 @@ export default (e: Eidolon): CharacterConditional => {
 
       // Boost
       x.ELEMENTAL_DMG += r.skillDmgIncreaseStacks * skillStackDmg
-      buffAbilityDmg(x, [ULT_TYPE], 0.10, (e >= 1))
+      buffAbilityDmg(x, ULT_TYPE, 0.10, (e >= 1))
 
       x.BASIC_TOUGHNESS_DMG += (r.basicEnhanced) ? 60 : 30
       x.ULT_TOUGHNESS_DMG += 60

--- a/src/lib/conditionals/character/Qingque.ts
+++ b/src/lib/conditionals/character/Qingque.ts
@@ -2,7 +2,8 @@ import { Stats } from 'lib/constants'
 import {
   ASHBLAZING_ATK_STACK,
   baseComputedStatsObject,
-  ComputedStatsObject
+  ComputedStatsObject,
+  ULT_TYPE
 } from 'lib/conditionals/conditionalConstants.ts'
 import { AbilityEidolon, calculateAshblazingSet, precisionRound } from 'lib/conditionals/utils'
 
@@ -10,6 +11,7 @@ import { Eidolon } from 'types/Character'
 import { CharacterConditional, PrecomputedCharacterConditional } from 'types/CharacterConditional'
 import { Form } from 'types/Form'
 import { ContentItem } from 'types/Conditionals'
+import { buffAbilityDmg } from 'lib/optimizer/calculateBuffs'
 
 export default (e: Eidolon): CharacterConditional => {
   const { basic, skill, ult, talent } = AbilityEidolon.ULT_TALENT_3_SKILL_BASIC_5
@@ -81,7 +83,7 @@ export default (e: Eidolon): CharacterConditional => {
 
       // Boost
       x.ELEMENTAL_DMG += r.skillDmgIncreaseStacks * skillStackDmg
-      x.ULT_BOOST += (e >= 1) ? 0.10 : 0
+      e >= 1 && buffAbilityDmg(x, [ULT_TYPE], 0.10)
 
       x.BASIC_TOUGHNESS_DMG += (r.basicEnhanced) ? 60 : 30
       x.ULT_TOUGHNESS_DMG += 60

--- a/src/lib/conditionals/character/Robin.ts
+++ b/src/lib/conditionals/character/Robin.ts
@@ -158,7 +158,7 @@ export default (e: Eidolon): CharacterConditional => {
       x.RATIO_BASED_ATK_BUFF += (t.concertoActive) ? t.teammateATKValue * ultAtkBuffScalingValue : 0
 
       x[Stats.SPD_P] += (e >= 2 && t.concertoActive && t.e2UltSpdBuff) ? 0.16 : 0
-      buffAbilityCd(x, [FUA_TYPE], 0.25, (t.traceFuaCdBoost && t.concertoActive))
+      buffAbilityCd(x, FUA_TYPE, 0.25, (t.traceFuaCdBoost && t.concertoActive))
     },
     calculateBaseMultis: (c: PrecomputedCharacterConditional, request: Form) => {
       const r = request.characterConditionals
@@ -166,7 +166,7 @@ export default (e: Eidolon): CharacterConditional => {
 
       x[Stats.ATK] += (r.concertoActive) ? x[Stats.ATK] * ultAtkBuffScalingValue + ultAtkBuffFlatValue : 0
 
-      buffAbilityCr(x, [ULT_TYPE], 1.00)
+      buffAbilityCr(x, ULT_TYPE, 1.00)
       x.ULT_CD_OVERRIDE = (e >= 6 && r.concertoActive && r.e6UltCDBoost) ? 6.00 : 1.50
 
       x.BASIC_DMG += x.BASIC_SCALING * x[Stats.ATK]

--- a/src/lib/conditionals/character/Robin.ts
+++ b/src/lib/conditionals/character/Robin.ts
@@ -1,11 +1,12 @@
 import { Stats } from 'lib/constants'
-import { baseComputedStatsObject, ComputedStatsObject } from 'lib/conditionals/conditionalConstants'
+import { baseComputedStatsObject, ComputedStatsObject, FUA_TYPE, ULT_TYPE } from 'lib/conditionals/conditionalConstants'
 import { AbilityEidolon, findContentId, precisionRound } from 'lib/conditionals/utils'
 
 import { Eidolon } from 'types/Character'
 import { CharacterConditional, PrecomputedCharacterConditional } from 'types/CharacterConditional'
 import { Form } from 'types/Form'
 import { ContentItem } from 'types/Conditionals'
+import { buffDmgTypeCdBoost, buffDmgTypeCrBoost } from 'lib/optimizer/calculateBuffs'
 
 export default (e: Eidolon): CharacterConditional => {
   const { basic, skill, ult, talent } = AbilityEidolon.SKILL_ULT_3_BASIC_TALENT_5
@@ -157,7 +158,7 @@ export default (e: Eidolon): CharacterConditional => {
       x.RATIO_BASED_ATK_BUFF += (t.concertoActive) ? t.teammateATKValue * ultAtkBuffScalingValue : 0
 
       x[Stats.SPD_P] += (e >= 2 && t.concertoActive && t.e2UltSpdBuff) ? 0.16 : 0
-      x.FUA_CD_BOOST += (t.traceFuaCdBoost && t.concertoActive) ? 0.25 : 0
+      t.traceFuaCdBoost && t.concertoActive && buffDmgTypeCdBoost(x, [FUA_TYPE], 0.25)
     },
     calculateBaseMultis: (c: PrecomputedCharacterConditional, request: Form) => {
       const r = request.characterConditionals
@@ -165,7 +166,7 @@ export default (e: Eidolon): CharacterConditional => {
 
       x[Stats.ATK] += (r.concertoActive) ? x[Stats.ATK] * ultAtkBuffScalingValue + ultAtkBuffFlatValue : 0
 
-      x.ULT_CR_BOOST += 1.00
+      buffDmgTypeCrBoost(x, [ULT_TYPE], 1.00)
       x.ULT_CD_OVERRIDE = (e >= 6 && r.concertoActive && r.e6UltCDBoost) ? 6.00 : 1.50
 
       x.BASIC_DMG += x.BASIC_SCALING * x[Stats.ATK]

--- a/src/lib/conditionals/character/Robin.ts
+++ b/src/lib/conditionals/character/Robin.ts
@@ -158,7 +158,7 @@ export default (e: Eidolon): CharacterConditional => {
       x.RATIO_BASED_ATK_BUFF += (t.concertoActive) ? t.teammateATKValue * ultAtkBuffScalingValue : 0
 
       x[Stats.SPD_P] += (e >= 2 && t.concertoActive && t.e2UltSpdBuff) ? 0.16 : 0
-      t.traceFuaCdBoost && t.concertoActive && buffAbilityCd(x, [FUA_TYPE], 0.25)
+      buffAbilityCd(x, [FUA_TYPE], 0.25, (t.traceFuaCdBoost && t.concertoActive))
     },
     calculateBaseMultis: (c: PrecomputedCharacterConditional, request: Form) => {
       const r = request.characterConditionals

--- a/src/lib/conditionals/character/Robin.ts
+++ b/src/lib/conditionals/character/Robin.ts
@@ -6,7 +6,7 @@ import { Eidolon } from 'types/Character'
 import { CharacterConditional, PrecomputedCharacterConditional } from 'types/CharacterConditional'
 import { Form } from 'types/Form'
 import { ContentItem } from 'types/Conditionals'
-import { buffDmgTypeCdBoost, buffDmgTypeCrBoost } from 'lib/optimizer/calculateBuffs'
+import { buffAbilityCd, buffAbilityCr } from 'lib/optimizer/calculateBuffs'
 
 export default (e: Eidolon): CharacterConditional => {
   const { basic, skill, ult, talent } = AbilityEidolon.SKILL_ULT_3_BASIC_TALENT_5
@@ -158,7 +158,7 @@ export default (e: Eidolon): CharacterConditional => {
       x.RATIO_BASED_ATK_BUFF += (t.concertoActive) ? t.teammateATKValue * ultAtkBuffScalingValue : 0
 
       x[Stats.SPD_P] += (e >= 2 && t.concertoActive && t.e2UltSpdBuff) ? 0.16 : 0
-      t.traceFuaCdBoost && t.concertoActive && buffDmgTypeCdBoost(x, [FUA_TYPE], 0.25)
+      t.traceFuaCdBoost && t.concertoActive && buffAbilityCd(x, [FUA_TYPE], 0.25)
     },
     calculateBaseMultis: (c: PrecomputedCharacterConditional, request: Form) => {
       const r = request.characterConditionals
@@ -166,7 +166,7 @@ export default (e: Eidolon): CharacterConditional => {
 
       x[Stats.ATK] += (r.concertoActive) ? x[Stats.ATK] * ultAtkBuffScalingValue + ultAtkBuffFlatValue : 0
 
-      buffDmgTypeCrBoost(x, [ULT_TYPE], 1.00)
+      buffAbilityCr(x, [ULT_TYPE], 1.00)
       x.ULT_CD_OVERRIDE = (e >= 6 && r.concertoActive && r.e6UltCDBoost) ? 6.00 : 1.50
 
       x.BASIC_DMG += x.BASIC_SCALING * x[Stats.ATK]

--- a/src/lib/conditionals/character/Sampo.ts
+++ b/src/lib/conditionals/character/Sampo.ts
@@ -6,7 +6,7 @@ import { Eidolon } from 'types/Character'
 import { CharacterConditional, PrecomputedCharacterConditional } from 'types/CharacterConditional'
 import { Form } from 'types/Form'
 import { ContentItem } from 'types/Conditionals'
-import { buffDmgTypeVulnerability } from 'lib/optimizer/calculateBuffs'
+import { buffAbilityVulnerability } from 'lib/optimizer/calculateBuffs'
 
 export default (e: Eidolon): CharacterConditional => {
   const {basic, skill, ult, talent} = AbilityEidolon.SKILL_BASIC_3_ULT_TALENT_5
@@ -92,7 +92,7 @@ export default (e: Eidolon): CharacterConditional => {
     precomputeMutualEffects: (x: ComputedStatsObject, request: Form) => {
       const m = request.characterConditionals
 
-      m.targetDotTakenDebuff && buffDmgTypeVulnerability(x, [DOT_TYPE], dotVulnerabilityValue)
+      m.targetDotTakenDebuff && buffAbilityVulnerability(x, [DOT_TYPE], dotVulnerabilityValue)
     },
     calculateBaseMultis: (c: PrecomputedCharacterConditional) => {
       const x = c.x

--- a/src/lib/conditionals/character/Sampo.ts
+++ b/src/lib/conditionals/character/Sampo.ts
@@ -1,11 +1,12 @@
 import { Stats } from 'lib/constants'
-import { baseComputedStatsObject, ComputedStatsObject } from 'lib/conditionals/conditionalConstants.ts'
+import { baseComputedStatsObject, ComputedStatsObject, DOT_TYPE } from 'lib/conditionals/conditionalConstants.ts'
 import { AbilityEidolon, findContentId, precisionRound } from 'lib/conditionals/utils'
 
 import { Eidolon } from 'types/Character'
 import { CharacterConditional, PrecomputedCharacterConditional } from 'types/CharacterConditional'
 import { Form } from 'types/Form'
 import { ContentItem } from 'types/Conditionals'
+import { buffDmgTypeVulnerability } from 'lib/optimizer/calculateBuffs'
 
 export default (e: Eidolon): CharacterConditional => {
   const {basic, skill, ult, talent} = AbilityEidolon.SKILL_BASIC_3_ULT_TALENT_5
@@ -91,7 +92,7 @@ export default (e: Eidolon): CharacterConditional => {
     precomputeMutualEffects: (x: ComputedStatsObject, request: Form) => {
       const m = request.characterConditionals
 
-      x.DOT_VULNERABILITY += (m.targetDotTakenDebuff) ? dotVulnerabilityValue : 0
+      m.targetDotTakenDebuff && buffDmgTypeVulnerability(x, [DOT_TYPE], dotVulnerabilityValue)
     },
     calculateBaseMultis: (c: PrecomputedCharacterConditional) => {
       const x = c.x

--- a/src/lib/conditionals/character/Sampo.ts
+++ b/src/lib/conditionals/character/Sampo.ts
@@ -92,7 +92,7 @@ export default (e: Eidolon): CharacterConditional => {
     precomputeMutualEffects: (x: ComputedStatsObject, request: Form) => {
       const m = request.characterConditionals
 
-      buffAbilityVulnerability(x, [DOT_TYPE], dotVulnerabilityValue, (m.targetDotTakenDebuff))
+      buffAbilityVulnerability(x, DOT_TYPE, dotVulnerabilityValue, (m.targetDotTakenDebuff))
     },
     calculateBaseMultis: (c: PrecomputedCharacterConditional) => {
       const x = c.x

--- a/src/lib/conditionals/character/Sampo.ts
+++ b/src/lib/conditionals/character/Sampo.ts
@@ -92,7 +92,7 @@ export default (e: Eidolon): CharacterConditional => {
     precomputeMutualEffects: (x: ComputedStatsObject, request: Form) => {
       const m = request.characterConditionals
 
-      m.targetDotTakenDebuff && buffAbilityVulnerability(x, [DOT_TYPE], dotVulnerabilityValue)
+      buffAbilityVulnerability(x, [DOT_TYPE], dotVulnerabilityValue, (m.targetDotTakenDebuff))
     },
     calculateBaseMultis: (c: PrecomputedCharacterConditional) => {
       const x = c.x

--- a/src/lib/conditionals/character/Sushang.ts
+++ b/src/lib/conditionals/character/Sushang.ts
@@ -1,11 +1,12 @@
 import { Stats } from 'lib/constants'
-import { baseComputedStatsObject, ComputedStatsObject } from 'lib/conditionals/conditionalConstants.ts'
+import { baseComputedStatsObject, ComputedStatsObject, SKILL_TYPE } from 'lib/conditionals/conditionalConstants.ts'
 import { AbilityEidolon, precisionRound } from 'lib/conditionals/utils'
 
 import { Eidolon } from 'types/Character'
 import { ContentItem } from 'types/Conditionals'
 import { CharacterConditional, PrecomputedCharacterConditional } from 'types/CharacterConditional'
 import { Form } from 'types/Form'
+import { buffAbilityDmg } from 'lib/optimizer/calculateBuffs'
 
 export default (e: Eidolon): CharacterConditional => {
   const { basic, skill, ult, talent } = AbilityEidolon.ULT_TALENT_3_SKILL_BASIC_5
@@ -105,7 +106,7 @@ export default (e: Eidolon): CharacterConditional => {
       x.ULT_SCALING += ultScaling
 
       // Boost
-      x.SKILL_BOOST += r.skillTriggerStacks * 0.025 * stanceScalingProportion
+      buffAbilityDmg(x, [SKILL_TYPE], r.skillTriggerStacks * 0.02 * stanceScalingProportion)
       x.DMG_RED_MULTI *= (e >= 2 && r.e2DmgReductionBuff) ? (1 - 0.20) : 1
 
       x.BASIC_TOUGHNESS_DMG += 30

--- a/src/lib/conditionals/character/Sushang.ts
+++ b/src/lib/conditionals/character/Sushang.ts
@@ -106,7 +106,7 @@ export default (e: Eidolon): CharacterConditional => {
       x.ULT_SCALING += ultScaling
 
       // Boost
-      buffAbilityDmg(x, SKILL_TYPE, r.skillTriggerStacks * 0.02 * stanceScalingProportion)
+      buffAbilityDmg(x, SKILL_TYPE, r.skillTriggerStacks * 0.025 * stanceScalingProportion)
       x.DMG_RED_MULTI *= (e >= 2 && r.e2DmgReductionBuff) ? (1 - 0.20) : 1
 
       x.BASIC_TOUGHNESS_DMG += 30

--- a/src/lib/conditionals/character/Sushang.ts
+++ b/src/lib/conditionals/character/Sushang.ts
@@ -106,7 +106,7 @@ export default (e: Eidolon): CharacterConditional => {
       x.ULT_SCALING += ultScaling
 
       // Boost
-      buffAbilityDmg(x, [SKILL_TYPE], r.skillTriggerStacks * 0.02 * stanceScalingProportion)
+      buffAbilityDmg(x, SKILL_TYPE, r.skillTriggerStacks * 0.02 * stanceScalingProportion)
       x.DMG_RED_MULTI *= (e >= 2 && r.e2DmgReductionBuff) ? (1 - 0.20) : 1
 
       x.BASIC_TOUGHNESS_DMG += 30

--- a/src/lib/conditionals/character/Tingyun.ts
+++ b/src/lib/conditionals/character/Tingyun.ts
@@ -97,7 +97,7 @@ export default (e: Eidolon): CharacterConditional => {
       x.ULT_SCALING += ultScaling
 
       // Boost
-      buffAbilityDmg(x, [BASIC_TYPE], 0.40)
+      buffAbilityDmg(x, BASIC_TYPE, 0.40)
       x.BENEDICTION_LIGHTNING_DMG = (r.benedictionBuff) ? skillLightningDmgBoostScaling + talentScaling : 0
 
       x.BASIC_TOUGHNESS_DMG += 30

--- a/src/lib/conditionals/character/Tingyun.ts
+++ b/src/lib/conditionals/character/Tingyun.ts
@@ -1,11 +1,12 @@
 import { Stats } from 'lib/constants'
-import { baseComputedStatsObject, ComputedStatsObject } from 'lib/conditionals/conditionalConstants.ts'
+import { baseComputedStatsObject, BASIC_TYPE, ComputedStatsObject } from 'lib/conditionals/conditionalConstants.ts'
 import { AbilityEidolon, findContentId, precisionRound } from 'lib/conditionals/utils'
 import { Eidolon } from 'types/Character'
 
 import { Form } from 'types/Form'
 import { CharacterConditional, PrecomputedCharacterConditional } from 'types/CharacterConditional'
 import { ContentItem } from 'types/Conditionals'
+import { buffAbilityDmg } from 'lib/optimizer/calculateBuffs'
 
 export default (e: Eidolon): CharacterConditional => {
   const { basic, skill, ult, talent } = AbilityEidolon.ULT_BASIC_3_SKILL_TALENT_5
@@ -96,7 +97,7 @@ export default (e: Eidolon): CharacterConditional => {
       x.ULT_SCALING += ultScaling
 
       // Boost
-      x.BASIC_BOOST += 0.40
+      buffAbilityDmg(x, [BASIC_TYPE], 0.40)
       x.BENEDICTION_LIGHTNING_DMG = (r.benedictionBuff) ? skillLightningDmgBoostScaling + talentScaling : 0
 
       x.BASIC_TOUGHNESS_DMG += 30

--- a/src/lib/conditionals/character/Topaz.ts
+++ b/src/lib/conditionals/character/Topaz.ts
@@ -88,9 +88,12 @@ export default (e: Eidolon): CharacterConditional => {
       x.BASIC_DMG_TYPE = BASIC_TYPE | FUA_TYPE
       x.SKILL_DMG_TYPE = SKILL_TYPE | FUA_TYPE
 
-      // Numby buffs only applies to the skill/fua not basic
-      buffAbilityCd(x, [SKILL_TYPE, FUA_TYPE], enhancedStateFuaCdBoost, (r.numbyEnhancedState))
-      buffAbilityResShred(x, [SKILL_TYPE, FUA_TYPE], 0.10, (e >= 6))
+      buffAbilityCd(x, SKILL_TYPE | FUA_TYPE, enhancedStateFuaCdBoost, (r.numbyEnhancedState))
+      buffAbilityResShred(x, SKILL_TYPE | FUA_TYPE, 0.10, (e >= 6))
+
+      // Numby buffs only applies to the skill/fua not basic, we deduct it from basic
+      buffAbilityCd(x, BASIC_TYPE, -enhancedStateFuaCdBoost, (r.numbyEnhancedState))
+      buffAbilityResShred(x, BASIC_TYPE, -0.10, (e >= 6))
 
       // Scaling
       x.BASIC_SCALING += basicScaling
@@ -111,8 +114,8 @@ export default (e: Eidolon): CharacterConditional => {
     precomputeMutualEffects: (x: ComputedStatsObject, request: Form) => {
       const m = request.characterConditionals
 
-      buffAbilityVulnerability(x, [FUA_TYPE], proofOfDebtFuaVulnerability, (m.enemyProofOfDebtDebuff))
-      buffAbilityCd(x, [FUA_TYPE], 0.25 * m.e1DebtorStacks, (e >= 1 && m.enemyProofOfDebtDebuff))
+      buffAbilityVulnerability(x, FUA_TYPE, proofOfDebtFuaVulnerability, (m.enemyProofOfDebtDebuff))
+      buffAbilityCd(x, FUA_TYPE, 0.25 * m.e1DebtorStacks, (e >= 1 && m.enemyProofOfDebtDebuff))
     },
     calculateBaseMultis: (c: PrecomputedCharacterConditional, request: Form) => {
       const r = request.characterConditionals

--- a/src/lib/conditionals/character/Topaz.ts
+++ b/src/lib/conditionals/character/Topaz.ts
@@ -89,8 +89,8 @@ export default (e: Eidolon): CharacterConditional => {
       x.SKILL_DMG_TYPE = SKILL_TYPE | FUA_TYPE
 
       // Numby buffs only applies to the skill/fua not basic
-      r.numbyEnhancedState && buffAbilityCd(x, [SKILL_TYPE, FUA_TYPE], enhancedStateFuaCdBoost)
-      e >= 6 && buffAbilityResShred(x, [SKILL_TYPE, FUA_TYPE], 0.10)
+      buffAbilityCd(x, [SKILL_TYPE, FUA_TYPE], enhancedStateFuaCdBoost, (r.numbyEnhancedState))
+      buffAbilityResShred(x, [SKILL_TYPE, FUA_TYPE], 0.10, (e >= 6))
 
       // Scaling
       x.BASIC_SCALING += basicScaling
@@ -111,8 +111,8 @@ export default (e: Eidolon): CharacterConditional => {
     precomputeMutualEffects: (x: ComputedStatsObject, request: Form) => {
       const m = request.characterConditionals
 
-      m.enemyProofOfDebtDebuff && buffAbilityVulnerability(x, [FUA_TYPE], proofOfDebtFuaVulnerability)
-      e >= 1 && m.enemyProofOfDebtDebuff && buffAbilityCd(x, [FUA_TYPE], 0.25 * m.e1DebtorStacks)
+      buffAbilityVulnerability(x, [FUA_TYPE], proofOfDebtFuaVulnerability, (m.enemyProofOfDebtDebuff))
+      buffAbilityCd(x, [FUA_TYPE], 0.25 * m.e1DebtorStacks, (e >= 1 && m.enemyProofOfDebtDebuff))
     },
     calculateBaseMultis: (c: PrecomputedCharacterConditional, request: Form) => {
       const r = request.characterConditionals

--- a/src/lib/conditionals/character/Topaz.ts
+++ b/src/lib/conditionals/character/Topaz.ts
@@ -2,7 +2,10 @@ import { Stats } from 'lib/constants'
 import {
   ASHBLAZING_ATK_STACK,
   baseComputedStatsObject,
-  ComputedStatsObject
+  BASIC_TYPE,
+  ComputedStatsObject,
+  FUA_TYPE,
+  SKILL_TYPE
 } from 'lib/conditionals/conditionalConstants.ts'
 import { AbilityEidolon, calculateAshblazingSet, findContentId, precisionRound } from 'lib/conditionals/utils'
 
@@ -10,6 +13,7 @@ import { Eidolon } from 'types/Character'
 import { CharacterConditional, PrecomputedCharacterConditional } from 'types/CharacterConditional'
 import { Form } from 'types/Form'
 import { ContentItem } from 'types/Conditionals'
+import { buffDmgTypeCdBoost, buffDmgTypeResShred, buffDmgTypeVulnerability } from 'lib/optimizer/calculateBuffs'
 
 export default (e: Eidolon): CharacterConditional => {
   const { basic, skill, ult, talent } = AbilityEidolon.SKILL_BASIC_3_ULT_TALENT_5
@@ -81,7 +85,12 @@ export default (e: Eidolon): CharacterConditional => {
       const r = request.characterConditionals
       const x = Object.assign({}, baseComputedStatsObject)
 
-      // Stats
+      x.BASIC_DMG_TYPE = BASIC_TYPE | FUA_TYPE
+      x.SKILL_DMG_TYPE = SKILL_TYPE | FUA_TYPE
+
+      // Numby buffs only applies to the skill/fua not basic
+      r.numbyEnhancedState && buffDmgTypeCdBoost(x, [SKILL_TYPE, FUA_TYPE], enhancedStateFuaCdBoost)
+      e >= 6 && buffDmgTypeResShred(x, [SKILL_TYPE, FUA_TYPE], 0.10)
 
       // Scaling
       x.BASIC_SCALING += basicScaling
@@ -102,8 +111,8 @@ export default (e: Eidolon): CharacterConditional => {
     precomputeMutualEffects: (x: ComputedStatsObject, request: Form) => {
       const m = request.characterConditionals
 
-      x.FUA_VULNERABILITY += (m.enemyProofOfDebtDebuff) ? proofOfDebtFuaVulnerability : 0
-      x.FUA_CD_BOOST += (e >= 1 && m.enemyProofOfDebtDebuff) ? 0.25 * m.e1DebtorStacks : 0
+      m.enemyProofOfDebtDebuff && buffDmgTypeVulnerability(x, [FUA_TYPE], proofOfDebtFuaVulnerability)
+      e >= 1 && m.enemyProofOfDebtDebuff && buffDmgTypeCdBoost(x, [FUA_TYPE], 0.25 * m.e1DebtorStacks)
     },
     calculateBaseMultis: (c: PrecomputedCharacterConditional, request: Form) => {
       const r = request.characterConditionals
@@ -116,32 +125,6 @@ export default (e: Eidolon): CharacterConditional => {
       x.BASIC_DMG += x.BASIC_SCALING * (x[Stats.ATK] - ashblazingBasicData.ashblazingAtk + ashblazingBasicData.ashblazingMulti)
       x.FUA_DMG += x.FUA_SCALING * (x[Stats.ATK] - ashblazingFuaData.ashblazingAtk + ashblazingFuaData.ashblazingMulti)
       x.SKILL_DMG = x.FUA_DMG
-
-      /*
-       * Copy fua boosts to skill/basic
-       * BOOSTS get added, while vulnerability / def pen gets replaced (?)
-       */
-      x.SKILL_BOOST += x.FUA_BOOST
-      x.SKILL_CD_BOOST += x.FUA_CD_BOOST
-      x.SKILL_CR_BOOST += x.FUA_CR_BOOST
-      x.SKILL_VULNERABILITY = x.FUA_VULNERABILITY
-      x.SKILL_DEF_PEN = x.FUA_DEF_PEN
-      x.SKILL_RES_PEN = x.FUA_RES_PEN
-
-      x.BASIC_BOOST += x.FUA_BOOST
-      x.BASIC_CD_BOOST += x.FUA_CD_BOOST
-      x.BASIC_CR_BOOST += x.FUA_CR_BOOST
-      x.BASIC_VULNERABILITY = x.FUA_VULNERABILITY
-      x.BASIC_DEF_PEN = x.FUA_DEF_PEN
-      x.BASIC_RES_PEN = x.FUA_RES_PEN
-
-      // Her ult buff only applies to the skill/fua not basic
-      x.FUA_CD_BOOST += (r.numbyEnhancedState) ? enhancedStateFuaCdBoost : 0
-      x.SKILL_CD_BOOST += (r.numbyEnhancedState) ? enhancedStateFuaCdBoost : 0
-
-      // Her e6 only applies to skill/fua not basic
-      x.SKILL_RES_PEN += (e >= 6) ? 0.10 : 0
-      x.FUA_RES_PEN += (e >= 6) ? 0.10 : 0
     },
   }
 }

--- a/src/lib/conditionals/character/Topaz.ts
+++ b/src/lib/conditionals/character/Topaz.ts
@@ -13,7 +13,7 @@ import { Eidolon } from 'types/Character'
 import { CharacterConditional, PrecomputedCharacterConditional } from 'types/CharacterConditional'
 import { Form } from 'types/Form'
 import { ContentItem } from 'types/Conditionals'
-import { buffDmgTypeCdBoost, buffDmgTypeResShred, buffDmgTypeVulnerability } from 'lib/optimizer/calculateBuffs'
+import { buffAbilityCd, buffAbilityResShred, buffAbilityVulnerability } from 'lib/optimizer/calculateBuffs'
 
 export default (e: Eidolon): CharacterConditional => {
   const { basic, skill, ult, talent } = AbilityEidolon.SKILL_BASIC_3_ULT_TALENT_5
@@ -89,8 +89,8 @@ export default (e: Eidolon): CharacterConditional => {
       x.SKILL_DMG_TYPE = SKILL_TYPE | FUA_TYPE
 
       // Numby buffs only applies to the skill/fua not basic
-      r.numbyEnhancedState && buffDmgTypeCdBoost(x, [SKILL_TYPE, FUA_TYPE], enhancedStateFuaCdBoost)
-      e >= 6 && buffDmgTypeResShred(x, [SKILL_TYPE, FUA_TYPE], 0.10)
+      r.numbyEnhancedState && buffAbilityCd(x, [SKILL_TYPE, FUA_TYPE], enhancedStateFuaCdBoost)
+      e >= 6 && buffAbilityResShred(x, [SKILL_TYPE, FUA_TYPE], 0.10)
 
       // Scaling
       x.BASIC_SCALING += basicScaling
@@ -111,8 +111,8 @@ export default (e: Eidolon): CharacterConditional => {
     precomputeMutualEffects: (x: ComputedStatsObject, request: Form) => {
       const m = request.characterConditionals
 
-      m.enemyProofOfDebtDebuff && buffDmgTypeVulnerability(x, [FUA_TYPE], proofOfDebtFuaVulnerability)
-      e >= 1 && m.enemyProofOfDebtDebuff && buffDmgTypeCdBoost(x, [FUA_TYPE], 0.25 * m.e1DebtorStacks)
+      m.enemyProofOfDebtDebuff && buffAbilityVulnerability(x, [FUA_TYPE], proofOfDebtFuaVulnerability)
+      e >= 1 && m.enemyProofOfDebtDebuff && buffAbilityCd(x, [FUA_TYPE], 0.25 * m.e1DebtorStacks)
     },
     calculateBaseMultis: (c: PrecomputedCharacterConditional, request: Form) => {
       const r = request.characterConditionals

--- a/src/lib/conditionals/character/TrailblazerDestruction.ts
+++ b/src/lib/conditionals/character/TrailblazerDestruction.ts
@@ -1,10 +1,16 @@
 import { Stats } from 'lib/constants'
-import { baseComputedStatsObject, ComputedStatsObject } from 'lib/conditionals/conditionalConstants.ts'
+import {
+  baseComputedStatsObject,
+  ComputedStatsObject,
+  SKILL_TYPE,
+  ULT_TYPE
+} from 'lib/conditionals/conditionalConstants.ts'
 import { AbilityEidolon, precisionRound } from 'lib/conditionals/utils'
 import { Eidolon } from 'types/Character'
 import { ContentItem } from 'types/Conditionals'
 import { CharacterConditional, PrecomputedCharacterConditional } from 'types/CharacterConditional'
 import { Form } from 'types/Form'
+import { buffAbilityDmg } from 'lib/optimizer/calculateBuffs'
 
 export default (e: Eidolon): CharacterConditional => {
   const {basic, skill, ult, talent} = AbilityEidolon.SKILL_TALENT_3_ULT_BASIC_5
@@ -58,8 +64,8 @@ export default (e: Eidolon): CharacterConditional => {
       x.ULT_SCALING += (r.enhancedUlt) ? ultEnhancedScaling : ultScaling
 
       // Boost
-      x.SKILL_BOOST += 0.25
-      x.ULT_BOOST += (r.enhancedUlt) ? 0.25 : 0
+      buffAbilityDmg(x, [SKILL_TYPE], 0.25)
+      r.enhancedUlt && buffAbilityDmg(x, [ULT_TYPE], 0.25)
 
       x.BASIC_TOUGHNESS_DMG += 30
       x.SKILL_TOUGHNESS_DMG += 60

--- a/src/lib/conditionals/character/TrailblazerDestruction.ts
+++ b/src/lib/conditionals/character/TrailblazerDestruction.ts
@@ -65,7 +65,7 @@ export default (e: Eidolon): CharacterConditional => {
 
       // Boost
       buffAbilityDmg(x, [SKILL_TYPE], 0.25)
-      r.enhancedUlt && buffAbilityDmg(x, [ULT_TYPE], 0.25)
+      buffAbilityDmg(x, [ULT_TYPE], 0.25, (r.enhancedUlt))
 
       x.BASIC_TOUGHNESS_DMG += 30
       x.SKILL_TOUGHNESS_DMG += 60

--- a/src/lib/conditionals/character/TrailblazerDestruction.ts
+++ b/src/lib/conditionals/character/TrailblazerDestruction.ts
@@ -64,8 +64,8 @@ export default (e: Eidolon): CharacterConditional => {
       x.ULT_SCALING += (r.enhancedUlt) ? ultEnhancedScaling : ultScaling
 
       // Boost
-      buffAbilityDmg(x, [SKILL_TYPE], 0.25)
-      buffAbilityDmg(x, [ULT_TYPE], 0.25, (r.enhancedUlt))
+      buffAbilityDmg(x, SKILL_TYPE, 0.25)
+      buffAbilityDmg(x, ULT_TYPE, 0.25, (r.enhancedUlt))
 
       x.BASIC_TOUGHNESS_DMG += 30
       x.SKILL_TOUGHNESS_DMG += 60

--- a/src/lib/conditionals/character/Xueyi.ts
+++ b/src/lib/conditionals/character/Xueyi.ts
@@ -107,9 +107,9 @@ export default (e: Eidolon): CharacterConditional => {
       x.FUA_SCALING += fuaScaling * (r.fuaHits as number)
 
       // Boost
-      buffAbilityDmg(x, [ULT_TYPE], r.toughnessReductionDmgBoost)
-      buffAbilityDmg(x, [ULT_TYPE], 0.10, (r.enemyToughness50))
-      buffAbilityDmg(x, [FUA_TYPE], 0.40, (e >= 1))
+      buffAbilityDmg(x, ULT_TYPE, r.toughnessReductionDmgBoost)
+      buffAbilityDmg(x, ULT_TYPE, 0.10, (r.enemyToughness50))
+      buffAbilityDmg(x, FUA_TYPE, 0.40, (e >= 1))
 
       x.BASIC_TOUGHNESS_DMG += 30
       x.SKILL_TOUGHNESS_DMG += 60

--- a/src/lib/conditionals/character/Xueyi.ts
+++ b/src/lib/conditionals/character/Xueyi.ts
@@ -3,14 +3,17 @@ import { AbilityEidolon, calculateAshblazingSet, precisionRound } from 'lib/cond
 import {
   ASHBLAZING_ATK_STACK,
   baseComputedStatsObject,
-  ComputedStatsObject
+  ComputedStatsObject,
+  FUA_TYPE,
+  ULT_TYPE
 } from 'lib/conditionals/conditionalConstants.ts'
 
-import { ConditionalMap, ContentItem } from 'types/Conditionals'
+import { ContentItem } from 'types/Conditionals'
 import { CharacterConditional, PrecomputedCharacterConditional } from 'types/CharacterConditional'
 import { Form } from 'types/Form'
 
 import { Eidolon } from 'types/Character'
+import { buffAbilityDmg } from 'lib/optimizer/calculateBuffs'
 
 export default (e: Eidolon): CharacterConditional => {
   const { basic, skill, ult, talent } = AbilityEidolon.SKILL_BASIC_3_ULT_TALENT_5
@@ -91,7 +94,7 @@ export default (e: Eidolon): CharacterConditional => {
     teammateDefaults: () => ({
     }),
     precomputeEffects: (request: Form) => {
-      const r: ConditionalMap = request.characterConditionals
+      const r = request.characterConditionals
       const x = Object.assign({}, baseComputedStatsObject)
 
       // Stats
@@ -104,14 +107,14 @@ export default (e: Eidolon): CharacterConditional => {
       x.FUA_SCALING += fuaScaling * (r.fuaHits as number)
 
       // Boost
-      x.ULT_BOOST += (r.enemyToughness50) ? 0.10 : 0
-      x.ULT_BOOST += r.toughnessReductionDmgBoost as number
-      x.FUA_BOOST += (e >= 1) ? 0.40 : 0
+      buffAbilityDmg(x, [ULT_TYPE], r.toughnessReductionDmgBoost)
+      buffAbilityDmg(x, [ULT_TYPE], 0.10, (r.enemyToughness50))
+      buffAbilityDmg(x, [FUA_TYPE], 0.40, (e >= 1))
 
       x.BASIC_TOUGHNESS_DMG += 30
       x.SKILL_TOUGHNESS_DMG += 60
       x.ULT_TOUGHNESS_DMG += 120
-      x.FUA_TOUGHNESS_DMG += 15 * (r.fuaHits as number)
+      x.FUA_TOUGHNESS_DMG += 15 * (r.fuaHits)
 
       return x
     },

--- a/src/lib/conditionals/character/Yunli.ts
+++ b/src/lib/conditionals/character/Yunli.ts
@@ -6,7 +6,7 @@ import { CharacterConditional, PrecomputedCharacterConditional } from 'types/Cha
 import { Form } from 'types/Form'
 import { ContentItem } from 'types/Conditionals'
 import { BETA_UPDATE, Stats } from 'lib/constants'
-import { buffAbilityDefShred } from 'lib/optimizer/calculateBuffs'
+import { buffAbilityDefShred, buffAbilityDmg } from 'lib/optimizer/calculateBuffs'
 
 export default (e: Eidolon): CharacterConditional => {
   const { basic, skill, ult, talent } = AbilityEidolon.SKILL_BASIC_3_ULT_TALENT_5
@@ -125,7 +125,7 @@ export default (e: Eidolon): CharacterConditional => {
       x.DMG_RED_MULTI *= (r.blockActive) ? 1 - 0.20 : 1
 
       x[Stats.CR] += (e >= 2 && r.e2CrBuff) ? 0.18 : 0
-      e >= 4 && r.e4DefShred && buffAbilityDefShred(x, [FUA_TYPE], 0.20)
+      buffAbilityDefShred(x, [FUA_TYPE], 0.20, (e >= 4 && r.e4DefShred))
 
       x.BASIC_TOUGHNESS_DMG += 30
       x.BASIC_TOUGHNESS_DMG += 60
@@ -143,7 +143,8 @@ export default (e: Eidolon): CharacterConditional => {
     calculateBaseMultis: (c: PrecomputedCharacterConditional, request: Form) => {
       const r = request.characterConditionals
       const x: ComputedStatsObject = c.x
-      x.FUA_BOOST += (e >= 1 && r.e1UltBuff) ? 0.20 : 0
+
+      buffAbilityDmg(x, [FUA_TYPE], 0.20, (e >= 1 && r.e1UltBuff))
 
       x.BASIC_DMG += x.BASIC_SCALING * x[Stats.ATK]
       x.SKILL_DMG += x.SKILL_SCALING * x[Stats.ATK]

--- a/src/lib/conditionals/character/Yunli.ts
+++ b/src/lib/conditionals/character/Yunli.ts
@@ -6,7 +6,7 @@ import { CharacterConditional, PrecomputedCharacterConditional } from 'types/Cha
 import { Form } from 'types/Form'
 import { ContentItem } from 'types/Conditionals'
 import { BETA_UPDATE, Stats } from 'lib/constants'
-import { buffDmgTypeDefShred } from 'lib/optimizer/calculateBuffs'
+import { buffAbilityDefShred } from 'lib/optimizer/calculateBuffs'
 
 export default (e: Eidolon): CharacterConditional => {
   const { basic, skill, ult, talent } = AbilityEidolon.SKILL_BASIC_3_ULT_TALENT_5
@@ -125,7 +125,7 @@ export default (e: Eidolon): CharacterConditional => {
       x.DMG_RED_MULTI *= (r.blockActive) ? 1 - 0.20 : 1
 
       x[Stats.CR] += (e >= 2 && r.e2CrBuff) ? 0.18 : 0
-      e >= 4 && r.e4DefShred && buffDmgTypeDefShred(x, [FUA_TYPE], 0.20)
+      e >= 4 && r.e4DefShred && buffAbilityDefShred(x, [FUA_TYPE], 0.20)
 
       x.BASIC_TOUGHNESS_DMG += 30
       x.BASIC_TOUGHNESS_DMG += 60

--- a/src/lib/conditionals/character/Yunli.ts
+++ b/src/lib/conditionals/character/Yunli.ts
@@ -1,4 +1,4 @@
-import { baseComputedStatsObject, ComputedStatsObject } from 'lib/conditionals/conditionalConstants'
+import { baseComputedStatsObject, ComputedStatsObject, FUA_TYPE, ULT_TYPE } from 'lib/conditionals/conditionalConstants'
 import { AbilityEidolon } from 'lib/conditionals/utils'
 
 import { Eidolon } from 'types/Character'
@@ -6,6 +6,7 @@ import { CharacterConditional, PrecomputedCharacterConditional } from 'types/Cha
 import { Form } from 'types/Form'
 import { ContentItem } from 'types/Conditionals'
 import { BETA_UPDATE, Stats } from 'lib/constants'
+import { buffDmgTypeDefShred } from 'lib/optimizer/calculateBuffs'
 
 export default (e: Eidolon): CharacterConditional => {
   const { basic, skill, ult, talent } = AbilityEidolon.SKILL_BASIC_3_ULT_TALENT_5
@@ -107,20 +108,9 @@ export default (e: Eidolon): CharacterConditional => {
       const r = request.characterConditionals
       const x = Object.assign({}, baseComputedStatsObject)
 
-      x[Stats.CD] += (r.blockActive) ? blockCdBuff : 0
-      x[Stats.ATK_P] += (r.counterAtkBuff) ? 0.30 : 0
-      x.DMG_RED_MULTI *= (r.blockActive) ? 1 - 0.20 : 1
-
-      x[Stats.CR] += (e >= 2 && r.e2CrBuff) ? 0.18 : 0
-
-      x.BASIC_TOUGHNESS_DMG += 30
-      x.BASIC_TOUGHNESS_DMG += 60
-      x.FUA_TOUGHNESS_DMG += (r.blockActive) ? 60 : 30
-
-      x.BASIC_SCALING += basicScaling
-      x.SKILL_SCALING += skillScaling
       if (r.blockActive) {
         if (r.ultCull) {
+          x.FUA_DMG_TYPE = ULT_TYPE | FUA_TYPE
           x.FUA_SCALING += ultCullScaling + r.ultCullHits * ultCullHitsScaling
         } else {
           x.FUA_SCALING += ultSlashScaling
@@ -128,6 +118,21 @@ export default (e: Eidolon): CharacterConditional => {
       } else {
         x.FUA_SCALING += talentCounterScaling
       }
+
+      x[Stats.CD] += (r.blockActive) ? blockCdBuff : 0
+      x[Stats.ATK_P] += (r.counterAtkBuff) ? 0.30 : 0
+
+      x.DMG_RED_MULTI *= (r.blockActive) ? 1 - 0.20 : 1
+
+      x[Stats.CR] += (e >= 2 && r.e2CrBuff) ? 0.18 : 0
+      e >= 4 && r.e4DefShred && buffDmgTypeDefShred(x, [FUA_TYPE], 0.20)
+
+      x.BASIC_TOUGHNESS_DMG += 30
+      x.BASIC_TOUGHNESS_DMG += 60
+      x.FUA_TOUGHNESS_DMG += (r.blockActive) ? 60 : 30
+
+      x.BASIC_SCALING += basicScaling
+      x.SKILL_SCALING += skillScaling
 
       return x
     },
@@ -138,17 +143,6 @@ export default (e: Eidolon): CharacterConditional => {
     calculateBaseMultis: (c: PrecomputedCharacterConditional, request: Form) => {
       const r = request.characterConditionals
       const x: ComputedStatsObject = c.x
-
-      if (r.blockActive && r.ultCull) {
-        x.FUA_BOOST += x.ULT_BOOST
-        x.FUA_CD_BOOST += x.ULT_CD_BOOST
-        x.FUA_CR_BOOST += x.ULT_CR_BOOST
-        x.FUA_VULNERABILITY = x.ULT_VULNERABILITY
-        x.FUA_DEF_PEN = x.ULT_DEF_PEN
-        x.FUA_RES_PEN = x.ULT_RES_PEN
-      }
-
-      x.FUA_DEF_PEN += (e >= 4 && r.e4DefShred) ? 0.20 : 0
       x.FUA_BOOST += (e >= 1 && r.e1UltBuff) ? 0.20 : 0
 
       x.BASIC_DMG += x.BASIC_SCALING * x[Stats.ATK]

--- a/src/lib/conditionals/character/Yunli.ts
+++ b/src/lib/conditionals/character/Yunli.ts
@@ -124,8 +124,10 @@ export default (e: Eidolon): CharacterConditional => {
 
       x.DMG_RED_MULTI *= (r.blockActive) ? 1 - 0.20 : 1
 
+
+      buffAbilityDmg(x, FUA_TYPE, 0.20, (e >= 1 && r.e1UltBuff))
       x[Stats.CR] += (e >= 2 && r.e2CrBuff) ? 0.18 : 0
-      buffAbilityDefShred(x, [FUA_TYPE], 0.20, (e >= 4 && r.e4DefShred))
+      buffAbilityDefShred(x, FUA_TYPE, 0.20, (e >= 4 && r.e4DefShred))
 
       x.BASIC_TOUGHNESS_DMG += 30
       x.BASIC_TOUGHNESS_DMG += 60
@@ -143,8 +145,6 @@ export default (e: Eidolon): CharacterConditional => {
     calculateBaseMultis: (c: PrecomputedCharacterConditional, request: Form) => {
       const r = request.characterConditionals
       const x: ComputedStatsObject = c.x
-
-      buffAbilityDmg(x, [FUA_TYPE], 0.20, (e >= 1 && r.e1UltBuff))
 
       x.BASIC_DMG += x.BASIC_SCALING * x[Stats.ATK]
       x.SKILL_DMG += x.SKILL_SCALING * x[Stats.ATK]

--- a/src/lib/conditionals/conditionalConstants.ts
+++ b/src/lib/conditionals/conditionalConstants.ts
@@ -4,8 +4,35 @@ const Stats = Constants.Stats
 
 export const ASHBLAZING_ATK_STACK = 0.06
 
+// Ability types
+export const BASIC_TYPE = 1
+export const SKILL_TYPE = 2
+export const ULT_TYPE = 4
+export const FUA_TYPE = 8
+export const DOT_TYPE = 16
+export const BREAK_TYPE = 32
+export const SUPER_BREAK_TYPE = 64
+
+export const ABILITY_TYPE_TO_DMG_TYPE_VARIABLE = {
+  [BASIC_TYPE]: 'BASIC_DMG_TYPE',
+  [SKILL_TYPE]: 'SKILL_DMG_TYPE',
+  [ULT_TYPE]: 'ULT_DMG_TYPE',
+  [FUA_TYPE]: 'FUA_DMG_TYPE',
+  [DOT_TYPE]: 'DOT_DMG_TYPE',
+  [BREAK_TYPE]: 'BREAK_DMG_TYPE',
+  [SUPER_BREAK_TYPE]: 'SUPER_BREAK_TYPE',
+}
+
 // TODO profile & convert to array for performance?
 export const baseComputedStatsObject = {
+  BASIC_DMG_TYPE: BASIC_TYPE,
+  SKILL_DMG_TYPE: SKILL_TYPE,
+  ULT_DMG_TYPE: ULT_TYPE,
+  FUA_DMG_TYPE: FUA_TYPE,
+  DOT_DMG_TYPE: DOT_TYPE,
+  BREAK_DMG_TYPE: BREAK_TYPE,
+  SUPER_BREAK_TYPE: SUPER_BREAK_TYPE,
+
   [Stats.HP_P]: 0,
   [Stats.ATK_P]: 0,
   [Stats.DEF_P]: 0,
@@ -47,6 +74,7 @@ export const baseComputedStatsObject = {
   ULT_BOOST: 0,
   FUA_BOOST: 0,
   DOT_BOOST: 0,
+  BREAK_BOOST: 0,
 
   DMG_TAKEN_MULTI: 0, // TODO: Rename to VULNERABILITY
   BASIC_VULNERABILITY: 0,
@@ -133,3 +161,4 @@ export const baseComputedStatsObject = {
   DMG_RED_MULTI: 1, // Dmg reduction multiplier for EHP calcs - this should be multiplied by (1 - multi)
 }
 export type ComputedStatsObject = typeof baseComputedStatsObject
+

--- a/src/lib/conditionals/conditionalConstants.ts
+++ b/src/lib/conditionals/conditionalConstants.ts
@@ -74,7 +74,6 @@ export const baseComputedStatsObject = {
   ULT_BOOST: 0,
   FUA_BOOST: 0,
   DOT_BOOST: 0,
-  BREAK_BOOST: 0,
 
   DMG_TAKEN_MULTI: 0, // TODO: Rename to VULNERABILITY
   BASIC_VULNERABILITY: 0,

--- a/src/lib/conditionals/lightcone/3star/CollapsingSky.ts
+++ b/src/lib/conditionals/lightcone/3star/CollapsingSky.ts
@@ -42,7 +42,7 @@ export default (s: SuperImpositionLevel): LightConeConditional => {
     precomputeEffects: (x: ComputedStatsObject, request: Form) => {
       const r = request.lightConeConditionals
 
-      buffAbilityDmg(x, [BASIC_TYPE, SKILL_TYPE], sValues[s], (r.basicSkillDmgBuff))
+      buffAbilityDmg(x, BASIC_TYPE | SKILL_TYPE, sValues[s], (r.basicSkillDmgBuff))
     },
     calculatePassives: (/* c, request */) => { },
     calculateBaseMultis: (/* c, request */) => { },

--- a/src/lib/conditionals/lightcone/3star/CollapsingSky.ts
+++ b/src/lib/conditionals/lightcone/3star/CollapsingSky.ts
@@ -4,6 +4,8 @@ import { Form } from 'types/Form'
 import { LightConeConditional } from 'types/LightConeConditionals'
 import getContentFromLCRanks from '../getContentFromLCRank'
 import { ContentItem } from 'types/Conditionals'
+import { buffAbilityDmg } from 'lib/optimizer/calculateBuffs'
+import { BASIC_TYPE, SKILL_TYPE } from 'lib/conditionals/conditionalConstants'
 
 export default (s: SuperImpositionLevel): LightConeConditional => {
   const sValues = [0.20, 0.25, 0.30, 0.35, 0.40]
@@ -41,8 +43,7 @@ export default (s: SuperImpositionLevel): LightConeConditional => {
     precomputeEffects: (x: PrecomputedCharacterConditional, request: Form) => {
       const r = request.lightConeConditionals
 
-      x.BASIC_BOOST += (r.basicSkillDmgBuff) ? sValues[s] : 0
-      x.SKILL_BOOST += (r.basicSkillDmgBuff) ? sValues[s] : 0
+      r.basicSkillDmgBuff && buffAbilityDmg(x, [BASIC_TYPE, SKILL_TYPE], sValues[s])
     },
     calculatePassives: (/* c, request */) => { },
     calculateBaseMultis: (/* c, request */) => { },

--- a/src/lib/conditionals/lightcone/3star/CollapsingSky.ts
+++ b/src/lib/conditionals/lightcone/3star/CollapsingSky.ts
@@ -1,11 +1,10 @@
 import { SuperImpositionLevel } from 'types/LightCone'
-import { PrecomputedCharacterConditional } from 'types/CharacterConditional'
 import { Form } from 'types/Form'
 import { LightConeConditional } from 'types/LightConeConditionals'
 import getContentFromLCRanks from '../getContentFromLCRank'
 import { ContentItem } from 'types/Conditionals'
 import { buffAbilityDmg } from 'lib/optimizer/calculateBuffs'
-import { BASIC_TYPE, SKILL_TYPE } from 'lib/conditionals/conditionalConstants'
+import { BASIC_TYPE, ComputedStatsObject, SKILL_TYPE } from 'lib/conditionals/conditionalConstants'
 
 export default (s: SuperImpositionLevel): LightConeConditional => {
   const sValues = [0.20, 0.25, 0.30, 0.35, 0.40]
@@ -40,10 +39,10 @@ export default (s: SuperImpositionLevel): LightConeConditional => {
     defaults: () => ({
       basicSkillDmgBuff: true,
     }),
-    precomputeEffects: (x: PrecomputedCharacterConditional, request: Form) => {
+    precomputeEffects: (x: ComputedStatsObject, request: Form) => {
       const r = request.lightConeConditionals
 
-      r.basicSkillDmgBuff && buffAbilityDmg(x, [BASIC_TYPE, SKILL_TYPE], sValues[s])
+      buffAbilityDmg(x, [BASIC_TYPE, SKILL_TYPE], sValues[s], (r.basicSkillDmgBuff))
     },
     calculatePassives: (/* c, request */) => { },
     calculateBaseMultis: (/* c, request */) => { },

--- a/src/lib/conditionals/lightcone/3star/DataBank.ts
+++ b/src/lib/conditionals/lightcone/3star/DataBank.ts
@@ -1,9 +1,10 @@
 import { SuperImpositionLevel } from 'types/LightCone'
-import { PrecomputedCharacterConditional } from 'types/CharacterConditional'
 import { Form } from 'types/Form'
 import { LightConeConditional } from 'types/LightConeConditionals'
 import getContentFromLCRanks from '../getContentFromLCRank'
 import { ContentItem } from 'types/Conditionals'
+import { buffAbilityDmg } from 'lib/optimizer/calculateBuffs'
+import { ComputedStatsObject, ULT_TYPE } from 'lib/conditionals/conditionalConstants'
 
 export default (s: SuperImpositionLevel): LightConeConditional => {
   const sValues = [0.28, 0.35, 0.42, 0.49, 0.56]
@@ -38,10 +39,10 @@ export default (s: SuperImpositionLevel): LightConeConditional => {
     defaults: () => ({
       ultDmgBuff: true,
     }),
-    precomputeEffects: (x: PrecomputedCharacterConditional, request: Form) => {
+    precomputeEffects: (x: ComputedStatsObject, request: Form) => {
       const r = request.lightConeConditionals
 
-      x.ULT_BOOST += (r.ultDmgBuff) ? sValues[s] : 0
+      r.ultDmgBuff && buffAbilityDmg(x, [ULT_TYPE], sValues[s])
     },
     calculatePassives: (/* c, request */) => { },
     calculateBaseMultis: (/* c, request */) => { },

--- a/src/lib/conditionals/lightcone/3star/DataBank.ts
+++ b/src/lib/conditionals/lightcone/3star/DataBank.ts
@@ -42,7 +42,7 @@ export default (s: SuperImpositionLevel): LightConeConditional => {
     precomputeEffects: (x: ComputedStatsObject, request: Form) => {
       const r = request.lightConeConditionals
 
-      r.ultDmgBuff && buffAbilityDmg(x, [ULT_TYPE], sValues[s])
+      buffAbilityDmg(x, [ULT_TYPE], sValues[s], (r.ultDmgBuff))
     },
     calculatePassives: (/* c, request */) => { },
     calculateBaseMultis: (/* c, request */) => { },

--- a/src/lib/conditionals/lightcone/3star/DataBank.ts
+++ b/src/lib/conditionals/lightcone/3star/DataBank.ts
@@ -42,7 +42,7 @@ export default (s: SuperImpositionLevel): LightConeConditional => {
     precomputeEffects: (x: ComputedStatsObject, request: Form) => {
       const r = request.lightConeConditionals
 
-      buffAbilityDmg(x, [ULT_TYPE], sValues[s], (r.ultDmgBuff))
+      buffAbilityDmg(x, ULT_TYPE, sValues[s], (r.ultDmgBuff))
     },
     calculatePassives: (/* c, request */) => { },
     calculateBaseMultis: (/* c, request */) => { },

--- a/src/lib/conditionals/lightcone/4star/DreamvilleAdventure.ts
+++ b/src/lib/conditionals/lightcone/4star/DreamvilleAdventure.ts
@@ -71,9 +71,9 @@ export default (s: SuperImpositionLevel): LightConeConditional => {
     precomputeMutualEffects: (x: ComputedStatsObject, request: Form) => {
       const m = request.lightConeConditionals
 
-      m.basicDmgBuff && buffAbilityDmg(x, [BASIC_TYPE], sValues[s])
-      m.skillDmgBuff && buffAbilityDmg(x, [SKILL_TYPE], sValues[s])
-      m.ultDmgBuff && buffAbilityDmg(x, [ULT_TYPE], sValues[s])
+      buffAbilityDmg(x, [BASIC_TYPE], sValues[s], (m.basicDmgBuff))
+      buffAbilityDmg(x, [SKILL_TYPE], sValues[s], (m.skillDmgBuff))
+      buffAbilityDmg(x, [ULT_TYPE], sValues[s], (m.ultDmgBuff))
     },
     calculatePassives: (/* c, request */) => { },
     calculateBaseMultis: (/* c, request */) => { },

--- a/src/lib/conditionals/lightcone/4star/DreamvilleAdventure.ts
+++ b/src/lib/conditionals/lightcone/4star/DreamvilleAdventure.ts
@@ -71,9 +71,9 @@ export default (s: SuperImpositionLevel): LightConeConditional => {
     precomputeMutualEffects: (x: ComputedStatsObject, request: Form) => {
       const m = request.lightConeConditionals
 
-      buffAbilityDmg(x, [BASIC_TYPE], sValues[s], (m.basicDmgBuff))
-      buffAbilityDmg(x, [SKILL_TYPE], sValues[s], (m.skillDmgBuff))
-      buffAbilityDmg(x, [ULT_TYPE], sValues[s], (m.ultDmgBuff))
+      buffAbilityDmg(x, BASIC_TYPE, sValues[s], (m.basicDmgBuff))
+      buffAbilityDmg(x, SKILL_TYPE, sValues[s], (m.skillDmgBuff))
+      buffAbilityDmg(x, ULT_TYPE, sValues[s], (m.ultDmgBuff))
     },
     calculatePassives: (/* c, request */) => { },
     calculateBaseMultis: (/* c, request */) => { },

--- a/src/lib/conditionals/lightcone/4star/DreamvilleAdventure.ts
+++ b/src/lib/conditionals/lightcone/4star/DreamvilleAdventure.ts
@@ -4,7 +4,8 @@ import { PrecomputedCharacterConditional } from 'types/CharacterConditional'
 import { Form } from 'types/Form'
 import { LightConeConditional } from 'types/LightConeConditionals'
 import getContentFromLCRanks from '../getContentFromLCRank'
-import { ComputedStatsObject } from 'lib/conditionals/conditionalConstants.ts'
+import { BASIC_TYPE, ComputedStatsObject, SKILL_TYPE, ULT_TYPE } from 'lib/conditionals/conditionalConstants.ts'
+import { buffAbilityDmg } from 'lib/optimizer/calculateBuffs'
 
 export default (s: SuperImpositionLevel): LightConeConditional => {
   const sValues = [0.12, 0.14, 0.16, 0.18, 0.20]
@@ -70,9 +71,9 @@ export default (s: SuperImpositionLevel): LightConeConditional => {
     precomputeMutualEffects: (x: ComputedStatsObject, request: Form) => {
       const m = request.lightConeConditionals
 
-      x.BASIC_BOOST += (m.basicDmgBuff) ? sValues[s] : 0
-      x.SKILL_BOOST += (m.skillDmgBuff) ? sValues[s] : 0
-      x.ULT_BOOST += (m.ultDmgBuff) ? sValues[s] : 0
+      m.basicDmgBuff && buffAbilityDmg(x, [BASIC_TYPE], sValues[s])
+      m.skillDmgBuff && buffAbilityDmg(x, [SKILL_TYPE], sValues[s])
+      m.ultDmgBuff && buffAbilityDmg(x, [ULT_TYPE], sValues[s])
     },
     calculatePassives: (/* c, request */) => { },
     calculateBaseMultis: (/* c, request */) => { },

--- a/src/lib/conditionals/lightcone/4star/EyesOfThePrey.ts
+++ b/src/lib/conditionals/lightcone/4star/EyesOfThePrey.ts
@@ -1,6 +1,7 @@
-import { PrecomputedCharacterConditional } from 'types/CharacterConditional'
 import { SuperImpositionLevel } from 'types/LightCone'
 import { LightConeConditional } from 'types/LightConeConditionals'
+import { buffAbilityDmg } from 'lib/optimizer/calculateBuffs'
+import { ComputedStatsObject, DOT_TYPE } from 'lib/conditionals/conditionalConstants'
 
 export default (s: SuperImpositionLevel): LightConeConditional => {
   const sValues = [0.24, 0.30, 0.36, 0.42, 0.48]
@@ -10,8 +11,8 @@ export default (s: SuperImpositionLevel): LightConeConditional => {
     teammateContent: () => [],
     defaults: () => ({
     }),
-    precomputeEffects: (x: PrecomputedCharacterConditional/* , request: Form */) => {
-      x.DOT_BOOST += sValues[s]
+    precomputeEffects: (x: ComputedStatsObject/* , request: Form */) => {
+      buffAbilityDmg(x, [DOT_TYPE], sValues[s])
     },
     calculatePassives: (/* c, request */) => { },
     calculateBaseMultis: (/* c, request */) => { },

--- a/src/lib/conditionals/lightcone/4star/EyesOfThePrey.ts
+++ b/src/lib/conditionals/lightcone/4star/EyesOfThePrey.ts
@@ -12,7 +12,7 @@ export default (s: SuperImpositionLevel): LightConeConditional => {
     defaults: () => ({
     }),
     precomputeEffects: (x: ComputedStatsObject/* , request: Form */) => {
-      buffAbilityDmg(x, [DOT_TYPE], sValues[s])
+      buffAbilityDmg(x, DOT_TYPE, sValues[s])
     },
     calculatePassives: (/* c, request */) => { },
     calculateBaseMultis: (/* c, request */) => { },

--- a/src/lib/conditionals/lightcone/4star/MakeTheWorldClamor.ts
+++ b/src/lib/conditionals/lightcone/4star/MakeTheWorldClamor.ts
@@ -1,9 +1,10 @@
 import { ContentItem } from 'types/Conditionals'
 import { SuperImpositionLevel } from 'types/LightCone'
-import { PrecomputedCharacterConditional } from 'types/CharacterConditional'
 import { Form } from 'types/Form'
 import { LightConeConditional } from 'types/LightConeConditionals'
 import getContentFromLCRanks from '../getContentFromLCRank'
+import { buffAbilityDmg } from 'lib/optimizer/calculateBuffs'
+import { ComputedStatsObject, ULT_TYPE } from 'lib/conditionals/conditionalConstants'
 
 export default (s: SuperImpositionLevel): LightConeConditional => {
   const sValues = [0.32, 0.40, 0.48, 0.56, 0.64]
@@ -39,10 +40,10 @@ export default (s: SuperImpositionLevel): LightConeConditional => {
     defaults: () => ({
       ultDmgBuff: true,
     }),
-    precomputeEffects: (x: PrecomputedCharacterConditional, request: Form) => {
+    precomputeEffects: (x: ComputedStatsObject, request: Form) => {
       const r = request.lightConeConditionals
 
-      x.ULT_BOOST += (r.ultDmgBuff) ? sValues[s] : 0
+      buffAbilityDmg(x, [ULT_TYPE], sValues[s], (r.ultDmgBuff))
     },
     calculatePassives: (/* c, request */) => { },
     calculateBaseMultis: (/* c, request */) => { },

--- a/src/lib/conditionals/lightcone/4star/MakeTheWorldClamor.ts
+++ b/src/lib/conditionals/lightcone/4star/MakeTheWorldClamor.ts
@@ -43,7 +43,7 @@ export default (s: SuperImpositionLevel): LightConeConditional => {
     precomputeEffects: (x: ComputedStatsObject, request: Form) => {
       const r = request.lightConeConditionals
 
-      buffAbilityDmg(x, [ULT_TYPE], sValues[s], (r.ultDmgBuff))
+      buffAbilityDmg(x, ULT_TYPE, sValues[s], (r.ultDmgBuff))
     },
     calculatePassives: (/* c, request */) => { },
     calculateBaseMultis: (/* c, request */) => { },

--- a/src/lib/conditionals/lightcone/4star/SubscribeForMore.ts
+++ b/src/lib/conditionals/lightcone/4star/SubscribeForMore.ts
@@ -1,9 +1,10 @@
 import { ContentItem } from 'types/Conditionals'
 import { SuperImpositionLevel } from 'types/LightCone'
-import { PrecomputedCharacterConditional } from 'types/CharacterConditional'
 import { Form } from 'types/Form'
 import { LightConeConditional } from 'types/LightConeConditionals'
 import getContentFromLCRanks from '../getContentFromLCRank'
+import { buffAbilityDmg } from 'lib/optimizer/calculateBuffs'
+import { BASIC_TYPE, ComputedStatsObject, SKILL_TYPE } from 'lib/conditionals/conditionalConstants'
 
 export default (s: SuperImpositionLevel): LightConeConditional => {
   const sValues = [0.24, 0.30, 0.36, 0.42, 0.48]
@@ -38,13 +39,11 @@ export default (s: SuperImpositionLevel): LightConeConditional => {
     defaults: () => ({
       maxEnergyDmgBoost: true,
     }),
-    precomputeEffects: (x: PrecomputedCharacterConditional, request: Form) => {
+    precomputeEffects: (x: ComputedStatsObject, request: Form) => {
       const r = request.lightConeConditionals
 
-      x.BASIC_BOOST += sValues[s]
-      x.SKILL_BOOST += sValues[s]
-      x.BASIC_BOOST += (r.maxEnergyDmgBoost) ? sValues[s] : 0
-      x.SKILL_BOOST += (r.maxEnergyDmgBoost) ? sValues[s] : 0
+      buffAbilityDmg(x, [BASIC_TYPE, SKILL_TYPE], sValues[s])
+      r.maxEnergyDmgBoost && buffAbilityDmg(x, [BASIC_TYPE, SKILL_TYPE], sValues[s])
     },
     calculatePassives: (/* c, request */) => { },
     calculateBaseMultis: (/* c, request */) => { },

--- a/src/lib/conditionals/lightcone/4star/SubscribeForMore.ts
+++ b/src/lib/conditionals/lightcone/4star/SubscribeForMore.ts
@@ -42,8 +42,8 @@ export default (s: SuperImpositionLevel): LightConeConditional => {
     precomputeEffects: (x: ComputedStatsObject, request: Form) => {
       const r = request.lightConeConditionals
 
-      buffAbilityDmg(x, [BASIC_TYPE, SKILL_TYPE], sValues[s])
-      buffAbilityDmg(x, [BASIC_TYPE, SKILL_TYPE], sValues[s], (r.maxEnergyDmgBoost))
+      buffAbilityDmg(x, BASIC_TYPE | SKILL_TYPE, sValues[s])
+      buffAbilityDmg(x, BASIC_TYPE | SKILL_TYPE, sValues[s], (r.maxEnergyDmgBoost))
     },
     calculatePassives: (/* c, request */) => { },
     calculateBaseMultis: (/* c, request */) => { },

--- a/src/lib/conditionals/lightcone/4star/SubscribeForMore.ts
+++ b/src/lib/conditionals/lightcone/4star/SubscribeForMore.ts
@@ -43,7 +43,7 @@ export default (s: SuperImpositionLevel): LightConeConditional => {
       const r = request.lightConeConditionals
 
       buffAbilityDmg(x, [BASIC_TYPE, SKILL_TYPE], sValues[s])
-      r.maxEnergyDmgBoost && buffAbilityDmg(x, [BASIC_TYPE, SKILL_TYPE], sValues[s])
+      buffAbilityDmg(x, [BASIC_TYPE, SKILL_TYPE], sValues[s], (r.maxEnergyDmgBoost))
     },
     calculatePassives: (/* c, request */) => { },
     calculateBaseMultis: (/* c, request */) => { },

--- a/src/lib/conditionals/lightcone/4star/TheBirthOfTheSelf.ts
+++ b/src/lib/conditionals/lightcone/4star/TheBirthOfTheSelf.ts
@@ -43,8 +43,8 @@ export default (s: SuperImpositionLevel): LightConeConditional => {
     precomputeEffects: (x: ComputedStatsObject, request: Form) => {
       const r = request.lightConeConditionals
 
-      buffAbilityDmg(x, [FUA_TYPE], sValues[s])
-      buffAbilityDmg(x, [FUA_TYPE], sValues[s], (r.enemyHp50FuaBuff))
+      buffAbilityDmg(x, FUA_TYPE, sValues[s])
+      buffAbilityDmg(x, FUA_TYPE, sValues[s], (r.enemyHp50FuaBuff))
     },
     calculatePassives: (/* c, request */) => { },
     calculateBaseMultis: (/* c, request */) => { },

--- a/src/lib/conditionals/lightcone/4star/TheBirthOfTheSelf.ts
+++ b/src/lib/conditionals/lightcone/4star/TheBirthOfTheSelf.ts
@@ -1,9 +1,10 @@
 import { ContentItem } from 'types/Conditionals'
 import { SuperImpositionLevel } from 'types/LightCone'
-import { PrecomputedCharacterConditional } from 'types/CharacterConditional'
 import { Form } from 'types/Form'
 import { LightConeConditional } from 'types/LightConeConditionals'
 import getContentFromLCRanks from '../getContentFromLCRank'
+import { buffAbilityDmg } from 'lib/optimizer/calculateBuffs'
+import { ComputedStatsObject, FUA_TYPE } from 'lib/conditionals/conditionalConstants'
 
 export default (s: SuperImpositionLevel): LightConeConditional => {
   const sValues = [0.24, 0.30, 0.36, 0.42, 0.48]
@@ -39,11 +40,11 @@ export default (s: SuperImpositionLevel): LightConeConditional => {
     defaults: () => ({
       enemyHp50FuaBuff: true,
     }),
-    precomputeEffects: (x: PrecomputedCharacterConditional, request: Form) => {
+    precomputeEffects: (x: ComputedStatsObject, request: Form) => {
       const r = request.lightConeConditionals
 
-      x.FUA_BOOST += sValues[s]
-      x.FUA_BOOST += (r.enemyHp50FuaBuff) ? sValues[s] : 0
+      buffAbilityDmg(x, [FUA_TYPE], sValues[s])
+      buffAbilityDmg(x, [FUA_TYPE], sValues[s], (r.enemyHp50FuaBuff))
     },
     calculatePassives: (/* c, request */) => { },
     calculateBaseMultis: (/* c, request */) => { },

--- a/src/lib/conditionals/lightcone/5star/AlongThePassingShore.ts
+++ b/src/lib/conditionals/lightcone/5star/AlongThePassingShore.ts
@@ -32,7 +32,7 @@ export default (s: SuperImpositionLevel): LightConeConditional => {
       const r = request.lightConeConditionals
 
       x.ELEMENTAL_DMG += (r.emptyBubblesDebuff) ? sValuesDmgBoost[s] : 0
-      buffAbilityDmg(x, [ULT_TYPE], sValuesUltDmgBoost[s], (r.emptyBubblesDebuff))
+      buffAbilityDmg(x, ULT_TYPE, sValuesUltDmgBoost[s], (r.emptyBubblesDebuff))
     },
     calculatePassives: (/* c, request */) => { },
     calculateBaseMultis: (/* c, request */) => { },

--- a/src/lib/conditionals/lightcone/5star/AlongThePassingShore.ts
+++ b/src/lib/conditionals/lightcone/5star/AlongThePassingShore.ts
@@ -1,9 +1,10 @@
 import { ContentItem } from 'types/Conditionals'
-import { PrecomputedCharacterConditional } from 'types/CharacterConditional'
 import { Form } from 'types/Form'
 import { SuperImpositionLevel } from 'types/LightCone'
 import { LightConeConditional } from 'types/LightConeConditionals'
 import { precisionRound } from 'lib/conditionals/utils.ts'
+import { buffAbilityDmg } from 'lib/optimizer/calculateBuffs'
+import { ComputedStatsObject, ULT_TYPE } from 'lib/conditionals/conditionalConstants'
 
 export default (s: SuperImpositionLevel): LightConeConditional => {
   const sValuesDmgBoost = [0.24, 0.28, 0.32, 0.36, 0.40]
@@ -27,11 +28,11 @@ export default (s: SuperImpositionLevel): LightConeConditional => {
     defaults: () => ({
       emptyBubblesDebuff: true,
     }),
-    precomputeEffects: (x: PrecomputedCharacterConditional, request: Form) => {
+    precomputeEffects: (x: ComputedStatsObject, request: Form) => {
       const r = request.lightConeConditionals
 
       x.ELEMENTAL_DMG += (r.emptyBubblesDebuff) ? sValuesDmgBoost[s] : 0
-      x.ULT_BOOST += (r.emptyBubblesDebuff) ? sValuesUltDmgBoost[s] : 0
+      buffAbilityDmg(x, [ULT_TYPE], sValuesUltDmgBoost[s], (r.emptyBubblesDebuff))
     },
     calculatePassives: (/* c, request */) => { },
     calculateBaseMultis: (/* c, request */) => { },

--- a/src/lib/conditionals/lightcone/5star/AnInstantBeforeAGaze.ts
+++ b/src/lib/conditionals/lightcone/5star/AnInstantBeforeAGaze.ts
@@ -50,7 +50,7 @@ export default (s: SuperImpositionLevel): LightConeConditional => {
     precomputeEffects: (x: ComputedStatsObject, request: Form) => {
       const r = request.lightConeConditionals
 
-      buffAbilityDmg(x, [ULT_TYPE], r.maxEnergyUltDmgStacks * sValues[s])
+      buffAbilityDmg(x, ULT_TYPE, r.maxEnergyUltDmgStacks * sValues[s])
     },
     calculatePassives: (/* c, request */) => { },
     calculateBaseMultis: (/* c, request */) => { },

--- a/src/lib/conditionals/lightcone/5star/AnInstantBeforeAGaze.ts
+++ b/src/lib/conditionals/lightcone/5star/AnInstantBeforeAGaze.ts
@@ -1,9 +1,10 @@
-import { PrecomputedCharacterConditional } from 'types/CharacterConditional'
 import { ContentItem } from 'types/Conditionals'
 import { Form } from 'types/Form'
 import getContentFromLCRanks from '../getContentFromLCRank'
 import { SuperImpositionLevel } from 'types/LightCone'
 import { LightConeConditional, LightConeRawRank } from 'types/LightConeConditionals'
+import { buffAbilityDmg } from 'lib/optimizer/calculateBuffs'
+import { ComputedStatsObject, ULT_TYPE } from 'lib/conditionals/conditionalConstants'
 
 export default (s: SuperImpositionLevel): LightConeConditional => {
   const sValues = [0.0036, 0.0042, 0.0048, 0.0054, 0.006]
@@ -46,10 +47,10 @@ export default (s: SuperImpositionLevel): LightConeConditional => {
     defaults: () => ({
       maxEnergyUltDmgStacks: 180,
     }),
-    precomputeEffects: (x: PrecomputedCharacterConditional, request: Form) => {
+    precomputeEffects: (x: ComputedStatsObject, request: Form) => {
       const r = request.lightConeConditionals
 
-      x.ULT_BOOST += r.maxEnergyUltDmgStacks * sValues[s]
+      buffAbilityDmg(x, [ULT_TYPE], r.maxEnergyUltDmgStacks * sValues[s])
     },
     calculatePassives: (/* c, request */) => { },
     calculateBaseMultis: (/* c, request */) => { },

--- a/src/lib/conditionals/lightcone/5star/BaptismOfPureThought.ts
+++ b/src/lib/conditionals/lightcone/5star/BaptismOfPureThought.ts
@@ -5,7 +5,7 @@ import getContentFromLCRanks from '../getContentFromLCRank'
 import { ContentItem } from 'types/Conditionals'
 import { ComputedStatsObject, FUA_TYPE } from 'lib/conditionals/conditionalConstants.ts'
 import { Stats } from 'lib/constants'
-import { buffDmgTypeDefShred } from 'lib/optimizer/calculateBuffs'
+import { buffAbilityDefShred } from 'lib/optimizer/calculateBuffs'
 
 const lcRank = {
   id: '23020',
@@ -69,7 +69,7 @@ const BaptismOfPureThought = (s: SuperImpositionLevel): LightConeConditional => 
       x[Stats.CD] += r.debuffCdStacks * sValuesCd[s]
       x.ELEMENTAL_DMG += r.postUltBuff ? sValuesDmg[s] : 0
 
-      r.postUltBuff && buffDmgTypeDefShred(x, [FUA_TYPE], sValuesFuaPen[s])
+      r.postUltBuff && buffAbilityDefShred(x, [FUA_TYPE], sValuesFuaPen[s])
     },
     calculatePassives: (/* c, request */) => { },
     calculateBaseMultis: (/* c, request */) => { },

--- a/src/lib/conditionals/lightcone/5star/BaptismOfPureThought.ts
+++ b/src/lib/conditionals/lightcone/5star/BaptismOfPureThought.ts
@@ -69,7 +69,7 @@ const BaptismOfPureThought = (s: SuperImpositionLevel): LightConeConditional => 
       x[Stats.CD] += r.debuffCdStacks * sValuesCd[s]
       x.ELEMENTAL_DMG += r.postUltBuff ? sValuesDmg[s] : 0
 
-      r.postUltBuff && buffAbilityDefShred(x, [FUA_TYPE], sValuesFuaPen[s])
+      buffAbilityDefShred(x, [FUA_TYPE], sValuesFuaPen[s], (r.postUltBuff))
     },
     calculatePassives: (/* c, request */) => { },
     calculateBaseMultis: (/* c, request */) => { },

--- a/src/lib/conditionals/lightcone/5star/BaptismOfPureThought.ts
+++ b/src/lib/conditionals/lightcone/5star/BaptismOfPureThought.ts
@@ -69,7 +69,7 @@ const BaptismOfPureThought = (s: SuperImpositionLevel): LightConeConditional => 
       x[Stats.CD] += r.debuffCdStacks * sValuesCd[s]
       x.ELEMENTAL_DMG += r.postUltBuff ? sValuesDmg[s] : 0
 
-      buffAbilityDefShred(x, [FUA_TYPE], sValuesFuaPen[s], (r.postUltBuff))
+      buffAbilityDefShred(x, FUA_TYPE, sValuesFuaPen[s], (r.postUltBuff))
     },
     calculatePassives: (/* c, request */) => { },
     calculateBaseMultis: (/* c, request */) => { },

--- a/src/lib/conditionals/lightcone/5star/BaptismOfPureThought.ts
+++ b/src/lib/conditionals/lightcone/5star/BaptismOfPureThought.ts
@@ -3,8 +3,9 @@ import { Form } from 'types/Form'
 import { LightConeConditional } from 'types/LightConeConditionals'
 import getContentFromLCRanks from '../getContentFromLCRank'
 import { ContentItem } from 'types/Conditionals'
-import { ComputedStatsObject } from 'lib/conditionals/conditionalConstants.ts'
+import { ComputedStatsObject, FUA_TYPE } from 'lib/conditionals/conditionalConstants.ts'
 import { Stats } from 'lib/constants'
+import { buffDmgTypeDefShred } from 'lib/optimizer/calculateBuffs'
 
 const lcRank = {
   id: '23020',
@@ -67,7 +68,8 @@ const BaptismOfPureThought = (s: SuperImpositionLevel): LightConeConditional => 
 
       x[Stats.CD] += r.debuffCdStacks * sValuesCd[s]
       x.ELEMENTAL_DMG += r.postUltBuff ? sValuesDmg[s] : 0
-      x.FUA_DEF_PEN += r.postUltBuff ? sValuesFuaPen[s] : 0
+
+      r.postUltBuff && buffDmgTypeDefShred(x, [FUA_TYPE], sValuesFuaPen[s])
     },
     calculatePassives: (/* c, request */) => { },
     calculateBaseMultis: (/* c, request */) => { },

--- a/src/lib/conditionals/lightcone/5star/BeforeDawn.ts
+++ b/src/lib/conditionals/lightcone/5star/BeforeDawn.ts
@@ -53,8 +53,8 @@ export default (s: SuperImpositionLevel): LightConeConditional => {
     precomputeEffects: (x: ComputedStatsObject, request: Form) => {
       const r = request.lightConeConditionals
 
-      buffAbilityDmg(x, [SKILL_TYPE, ULT_TYPE], sValuesSkillUltDmg[s])
-      buffAbilityDmg(x, [FUA_TYPE], sValuesFuaDmg[s], (r.fuaDmgBoost))
+      buffAbilityDmg(x, SKILL_TYPE | ULT_TYPE, sValuesSkillUltDmg[s])
+      buffAbilityDmg(x, FUA_TYPE, sValuesFuaDmg[s], (r.fuaDmgBoost))
     },
     calculatePassives: (/* c, request */) => { },
     calculateBaseMultis: (/* c, request */) => { },

--- a/src/lib/conditionals/lightcone/5star/BeforeDawn.ts
+++ b/src/lib/conditionals/lightcone/5star/BeforeDawn.ts
@@ -54,7 +54,7 @@ export default (s: SuperImpositionLevel): LightConeConditional => {
       const r = request.lightConeConditionals
 
       buffAbilityDmg(x, [SKILL_TYPE, ULT_TYPE], sValuesSkillUltDmg[s])
-      r.fuaDmgBoost && buffAbilityDmg(x, [FUA_TYPE], sValuesFuaDmg[s])
+      buffAbilityDmg(x, [FUA_TYPE], sValuesFuaDmg[s], (r.fuaDmgBoost))
     },
     calculatePassives: (/* c, request */) => { },
     calculateBaseMultis: (/* c, request */) => { },

--- a/src/lib/conditionals/lightcone/5star/BeforeDawn.ts
+++ b/src/lib/conditionals/lightcone/5star/BeforeDawn.ts
@@ -1,9 +1,10 @@
 import { ContentItem } from 'types/Conditionals'
-import { PrecomputedCharacterConditional } from 'types/CharacterConditional'
 import { Form } from 'types/Form'
 import getContentFromLCRanks from '../getContentFromLCRank'
 import { SuperImpositionLevel } from 'types/LightCone'
 import { LightConeConditional, LightConeRawRank } from 'types/LightConeConditionals'
+import { buffAbilityDmg } from 'lib/optimizer/calculateBuffs'
+import { ComputedStatsObject, FUA_TYPE, SKILL_TYPE, ULT_TYPE } from 'lib/conditionals/conditionalConstants'
 
 export default (s: SuperImpositionLevel): LightConeConditional => {
   const sValuesSkillUltDmg = [0.18, 0.21, 0.24, 0.27, 0.30]
@@ -49,12 +50,11 @@ export default (s: SuperImpositionLevel): LightConeConditional => {
     defaults: () => ({
       fuaDmgBoost: true,
     }),
-    precomputeEffects: (x: PrecomputedCharacterConditional, request: Form) => {
+    precomputeEffects: (x: ComputedStatsObject, request: Form) => {
       const r = request.lightConeConditionals
 
-      x.SKILL_BOOST += sValuesSkillUltDmg[s]
-      x.ULT_BOOST += sValuesSkillUltDmg[s]
-      x.FUA_BOOST += (r.fuaDmgBoost) ? sValuesFuaDmg[s] : 0
+      buffAbilityDmg(x, [SKILL_TYPE, ULT_TYPE], sValuesSkillUltDmg[s])
+      r.fuaDmgBoost && buffAbilityDmg(x, [FUA_TYPE], sValuesFuaDmg[s])
     },
     calculatePassives: (/* c, request */) => { },
     calculateBaseMultis: (/* c, request */) => { },

--- a/src/lib/conditionals/lightcone/5star/DanceAtSunset.ts
+++ b/src/lib/conditionals/lightcone/5star/DanceAtSunset.ts
@@ -33,7 +33,7 @@ export default (s: SuperImpositionLevel): LightConeConditional => {
     precomputeEffects: (x: ComputedStatsObject, request: Form) => {
       const r = request.lightConeConditionals
 
-      buffAbilityDmg(x, [FUA_TYPE], r.fuaDmgStacks * sValuesFuaDmg[s])
+      buffAbilityDmg(x, FUA_TYPE, r.fuaDmgStacks * sValuesFuaDmg[s])
     },
     calculatePassives: (/* c, request */) => {
     },

--- a/src/lib/conditionals/lightcone/5star/DanceAtSunset.ts
+++ b/src/lib/conditionals/lightcone/5star/DanceAtSunset.ts
@@ -2,9 +2,10 @@ import { ContentItem } from 'types/Conditionals'
 import { Form } from 'types/Form'
 import { SuperImpositionLevel } from 'types/LightCone'
 import { LightConeConditional } from 'types/LightConeConditionals'
-import { ComputedStatsObject } from 'lib/conditionals/conditionalConstants'
+import { ComputedStatsObject, FUA_TYPE } from 'lib/conditionals/conditionalConstants'
 import { PrecomputedCharacterConditional } from 'types/CharacterConditional'
 import { BETA_UPDATE } from 'lib/constants'
+import { buffAbilityDmg } from 'lib/optimizer/calculateBuffs'
 
 export default (s: SuperImpositionLevel): LightConeConditional => {
   const sValuesFuaDmg = [0.36, 0.42, 0.48, 0.54, 0.60]
@@ -32,7 +33,7 @@ export default (s: SuperImpositionLevel): LightConeConditional => {
     precomputeEffects: (x: ComputedStatsObject, request: Form) => {
       const r = request.lightConeConditionals
 
-      x.FUA_BOOST += r.fuaDmgStacks * sValuesFuaDmg[s]
+      buffAbilityDmg(x, [FUA_TYPE], r.fuaDmgStacks * sValuesFuaDmg[s])
     },
     calculatePassives: (/* c, request */) => {
     },

--- a/src/lib/conditionals/lightcone/5star/InTheNight.ts
+++ b/src/lib/conditionals/lightcone/5star/InTheNight.ts
@@ -5,7 +5,7 @@ import getContentFromLCRanks from '../getContentFromLCRank'
 import { SuperImpositionLevel } from 'types/LightCone'
 import { LightConeConditional, LightConeRawRank } from 'types/LightConeConditionals'
 import { Stats } from 'lib/constants'
-import { buffDmgTypeBoost, buffDmgTypeCdBoost } from 'lib/optimizer/calculateBuffs'
+import { buffAbilityCd, buffAbilityDmg } from 'lib/optimizer/calculateBuffs'
 import { BASIC_TYPE, SKILL_TYPE, ULT_TYPE } from 'lib/conditionals/conditionalConstants'
 
 export default (s: SuperImpositionLevel): LightConeConditional => {
@@ -58,8 +58,8 @@ export default (s: SuperImpositionLevel): LightConeConditional => {
 
       const stacks = Math.max(0, Math.min(6, Math.floor((x[Stats.SPD] - 100) / 10)))
 
-      r.spdScalingBuffs && buffDmgTypeBoost(x, [BASIC_TYPE, SKILL_TYPE], stacks * sValuesDmg[s])
-      r.spdScalingBuffs && buffDmgTypeCdBoost(x, [ULT_TYPE], stacks * sValuesCd[s])
+      r.spdScalingBuffs && buffAbilityDmg(x, [BASIC_TYPE, SKILL_TYPE], stacks * sValuesDmg[s])
+      r.spdScalingBuffs && buffAbilityCd(x, [ULT_TYPE], stacks * sValuesCd[s])
     },
   }
 }

--- a/src/lib/conditionals/lightcone/5star/InTheNight.ts
+++ b/src/lib/conditionals/lightcone/5star/InTheNight.ts
@@ -58,8 +58,8 @@ export default (s: SuperImpositionLevel): LightConeConditional => {
 
       const stacks = Math.max(0, Math.min(6, Math.floor((x[Stats.SPD] - 100) / 10)))
 
-      buffAbilityDmg(x, [BASIC_TYPE, SKILL_TYPE], stacks * sValuesDmg[s], (r.spdScalingBuffs))
-      buffAbilityCd(x, [ULT_TYPE], stacks * sValuesCd[s], (r.spdScalingBuffs))
+      buffAbilityDmg(x, BASIC_TYPE | SKILL_TYPE, stacks * sValuesDmg[s], (r.spdScalingBuffs))
+      buffAbilityCd(x, ULT_TYPE, stacks * sValuesCd[s], (r.spdScalingBuffs))
     },
   }
 }

--- a/src/lib/conditionals/lightcone/5star/InTheNight.ts
+++ b/src/lib/conditionals/lightcone/5star/InTheNight.ts
@@ -5,6 +5,8 @@ import getContentFromLCRanks from '../getContentFromLCRank'
 import { SuperImpositionLevel } from 'types/LightCone'
 import { LightConeConditional, LightConeRawRank } from 'types/LightConeConditionals'
 import { Stats } from 'lib/constants'
+import { buffDmgTypeBoost, buffDmgTypeCdBoost } from 'lib/optimizer/calculateBuffs'
+import { BASIC_TYPE, SKILL_TYPE, ULT_TYPE } from 'lib/conditionals/conditionalConstants'
 
 export default (s: SuperImpositionLevel): LightConeConditional => {
   const sValuesDmg = [0.06, 0.07, 0.08, 0.09, 0.10]
@@ -56,9 +58,8 @@ export default (s: SuperImpositionLevel): LightConeConditional => {
 
       const stacks = Math.max(0, Math.min(6, Math.floor((x[Stats.SPD] - 100) / 10)))
 
-      x.BASIC_BOOST += (r.spdScalingBuffs) ? stacks * sValuesDmg[s] : 0
-      x.SKILL_BOOST += (r.spdScalingBuffs) ? stacks * sValuesDmg[s] : 0
-      x.ULT_CD_BOOST += (r.spdScalingBuffs) ? stacks * sValuesCd[s] : 0
+      r.spdScalingBuffs && buffDmgTypeBoost(x, [BASIC_TYPE, SKILL_TYPE], stacks * sValuesDmg[s])
+      r.spdScalingBuffs && buffDmgTypeCdBoost(x, [ULT_TYPE], stacks * sValuesCd[s])
     },
   }
 }

--- a/src/lib/conditionals/lightcone/5star/InTheNight.ts
+++ b/src/lib/conditionals/lightcone/5star/InTheNight.ts
@@ -58,8 +58,8 @@ export default (s: SuperImpositionLevel): LightConeConditional => {
 
       const stacks = Math.max(0, Math.min(6, Math.floor((x[Stats.SPD] - 100) / 10)))
 
-      r.spdScalingBuffs && buffAbilityDmg(x, [BASIC_TYPE, SKILL_TYPE], stacks * sValuesDmg[s])
-      r.spdScalingBuffs && buffAbilityCd(x, [ULT_TYPE], stacks * sValuesCd[s])
+      buffAbilityDmg(x, [BASIC_TYPE, SKILL_TYPE], stacks * sValuesDmg[s], (r.spdScalingBuffs))
+      buffAbilityCd(x, [ULT_TYPE], stacks * sValuesCd[s], (r.spdScalingBuffs))
     },
   }
 }

--- a/src/lib/conditionals/lightcone/5star/ReforgedRemembrance.ts
+++ b/src/lib/conditionals/lightcone/5star/ReforgedRemembrance.ts
@@ -4,7 +4,7 @@ import { Form } from 'types/Form'
 import { LightConeConditional } from 'types/LightConeConditionals'
 import getContentFromLCRanks from '../getContentFromLCRank'
 import { ContentItem } from 'types/Conditionals'
-import { buffDmgTypeDefShred } from 'lib/optimizer/calculateBuffs'
+import { buffAbilityDefShred } from 'lib/optimizer/calculateBuffs'
 import { ComputedStatsObject, DOT_TYPE } from 'lib/conditionals/conditionalConstants'
 
 export default (s: SuperImpositionLevel): LightConeConditional => {
@@ -52,7 +52,7 @@ export default (s: SuperImpositionLevel): LightConeConditional => {
 
       x[Stats.ATK_P] += r.prophetStacks * sValuesAtk[s]
 
-      buffDmgTypeDefShred(x, [DOT_TYPE], r.prophetStacks * sValuesDotPen[s])
+      buffAbilityDefShred(x, [DOT_TYPE], r.prophetStacks * sValuesDotPen[s])
     },
     calculatePassives: (/* c, request */) => { },
     calculateBaseMultis: (/* c, request */) => { },

--- a/src/lib/conditionals/lightcone/5star/ReforgedRemembrance.ts
+++ b/src/lib/conditionals/lightcone/5star/ReforgedRemembrance.ts
@@ -1,10 +1,11 @@
 import { Stats } from 'lib/constants'
 import { SuperImpositionLevel } from 'types/LightCone'
-import { PrecomputedCharacterConditional } from 'types/CharacterConditional'
 import { Form } from 'types/Form'
 import { LightConeConditional } from 'types/LightConeConditionals'
 import getContentFromLCRanks from '../getContentFromLCRank'
 import { ContentItem } from 'types/Conditionals'
+import { buffDmgTypeDefShred } from 'lib/optimizer/calculateBuffs'
+import { ComputedStatsObject, DOT_TYPE } from 'lib/conditionals/conditionalConstants'
 
 export default (s: SuperImpositionLevel): LightConeConditional => {
   const sValuesAtk = [0.05, 0.06, 0.07, 0.08, 0.09]
@@ -46,11 +47,12 @@ export default (s: SuperImpositionLevel): LightConeConditional => {
     defaults: () => ({
       prophetStacks: 4,
     }),
-    precomputeEffects: (x: PrecomputedCharacterConditional, request: Form) => {
+    precomputeEffects: (x: ComputedStatsObject, request: Form) => {
       const r = request.lightConeConditionals
 
       x[Stats.ATK_P] += r.prophetStacks * sValuesAtk[s]
-      x.DOT_DEF_PEN += r.prophetStacks * sValuesDotPen[s]
+
+      buffDmgTypeDefShred(x, [DOT_TYPE], r.prophetStacks * sValuesDotPen[s])
     },
     calculatePassives: (/* c, request */) => { },
     calculateBaseMultis: (/* c, request */) => { },

--- a/src/lib/conditionals/lightcone/5star/ReforgedRemembrance.ts
+++ b/src/lib/conditionals/lightcone/5star/ReforgedRemembrance.ts
@@ -52,7 +52,7 @@ export default (s: SuperImpositionLevel): LightConeConditional => {
 
       x[Stats.ATK_P] += r.prophetStacks * sValuesAtk[s]
 
-      buffAbilityDefShred(x, [DOT_TYPE], r.prophetStacks * sValuesDotPen[s])
+      buffAbilityDefShred(x, DOT_TYPE, r.prophetStacks * sValuesDotPen[s])
     },
     calculatePassives: (/* c, request */) => { },
     calculateBaseMultis: (/* c, request */) => { },

--- a/src/lib/conditionals/lightcone/5star/SailingTowardsASecondLife.ts
+++ b/src/lib/conditionals/lightcone/5star/SailingTowardsASecondLife.ts
@@ -49,7 +49,7 @@ export default (s: SuperImpositionLevel): LightConeConditional => {
 
       x[Stats.SPD] += (r.spdBuffConditional && x[Stats.BE] >= 1.50) ? sValuesSpdBuff[s] * request.baseSpd : 0
 
-      buffAbilityDefShred(x, [BREAK_TYPE], sValuesDefShred[s], (r.breakDmgDefShred))
+      buffAbilityDefShred(x, BREAK_TYPE, sValuesDefShred[s], (r.breakDmgDefShred))
     },
   }
 }

--- a/src/lib/conditionals/lightcone/5star/SailingTowardsASecondLife.ts
+++ b/src/lib/conditionals/lightcone/5star/SailingTowardsASecondLife.ts
@@ -2,10 +2,11 @@ import { ContentItem } from 'types/Conditionals'
 import { Form } from 'types/Form'
 import { SuperImpositionLevel } from 'types/LightCone'
 import { LightConeConditional } from 'types/LightConeConditionals'
-import { ComputedStatsObject } from 'lib/conditionals/conditionalConstants.ts'
+import { BREAK_TYPE, ComputedStatsObject } from 'lib/conditionals/conditionalConstants.ts'
 import { Stats } from 'lib/constants.ts'
 import { PrecomputedCharacterConditional } from 'types/CharacterConditional'
 import { precisionRound } from 'lib/conditionals/utils'
+import { buffDmgTypeDefShred } from 'lib/optimizer/calculateBuffs'
 
 export default (s: SuperImpositionLevel): LightConeConditional => {
   const sValuesSpdBuff = [0.12, 0.14, 0.16, 0.18, 0.20]
@@ -46,8 +47,9 @@ export default (s: SuperImpositionLevel): LightConeConditional => {
       const r = request.lightConeConditionals
       const x: ComputedStatsObject = c.x
 
-      x.BREAK_DEF_PEN += (r.breakDmgDefShred) ? sValuesDefShred[s] : 0
       x[Stats.SPD] += (r.spdBuffConditional && x[Stats.BE] >= 1.50) ? sValuesSpdBuff[s] * request.baseSpd : 0
+
+      r.breakDmgDefShred && buffDmgTypeDefShred(x, [BREAK_TYPE], sValuesDefShred[s])
     },
   }
 }

--- a/src/lib/conditionals/lightcone/5star/SailingTowardsASecondLife.ts
+++ b/src/lib/conditionals/lightcone/5star/SailingTowardsASecondLife.ts
@@ -49,7 +49,7 @@ export default (s: SuperImpositionLevel): LightConeConditional => {
 
       x[Stats.SPD] += (r.spdBuffConditional && x[Stats.BE] >= 1.50) ? sValuesSpdBuff[s] * request.baseSpd : 0
 
-      r.breakDmgDefShred && buffAbilityDefShred(x, [BREAK_TYPE], sValuesDefShred[s])
+      buffAbilityDefShred(x, [BREAK_TYPE], sValuesDefShred[s], (r.breakDmgDefShred))
     },
   }
 }

--- a/src/lib/conditionals/lightcone/5star/SailingTowardsASecondLife.ts
+++ b/src/lib/conditionals/lightcone/5star/SailingTowardsASecondLife.ts
@@ -6,7 +6,7 @@ import { BREAK_TYPE, ComputedStatsObject } from 'lib/conditionals/conditionalCon
 import { Stats } from 'lib/constants.ts'
 import { PrecomputedCharacterConditional } from 'types/CharacterConditional'
 import { precisionRound } from 'lib/conditionals/utils'
-import { buffDmgTypeDefShred } from 'lib/optimizer/calculateBuffs'
+import { buffAbilityDefShred } from 'lib/optimizer/calculateBuffs'
 
 export default (s: SuperImpositionLevel): LightConeConditional => {
   const sValuesSpdBuff = [0.12, 0.14, 0.16, 0.18, 0.20]
@@ -49,7 +49,7 @@ export default (s: SuperImpositionLevel): LightConeConditional => {
 
       x[Stats.SPD] += (r.spdBuffConditional && x[Stats.BE] >= 1.50) ? sValuesSpdBuff[s] * request.baseSpd : 0
 
-      r.breakDmgDefShred && buffDmgTypeDefShred(x, [BREAK_TYPE], sValuesDefShred[s])
+      r.breakDmgDefShred && buffAbilityDefShred(x, [BREAK_TYPE], sValuesDefShred[s])
     },
   }
 }

--- a/src/lib/conditionals/lightcone/5star/SolitaryHealing.ts
+++ b/src/lib/conditionals/lightcone/5star/SolitaryHealing.ts
@@ -48,7 +48,7 @@ export default (s: SuperImpositionLevel): LightConeConditional => {
     precomputeEffects: (x: ComputedStatsObject, request: Form) => {
       const r = request.lightConeConditionals
 
-      buffAbilityDmg(x, [DOT_TYPE], sValues[s], (r.postUltDotDmgBuff))
+      buffAbilityDmg(x, DOT_TYPE, sValues[s], (r.postUltDotDmgBuff))
     },
     calculatePassives: (/* c, request */) => { },
     calculateBaseMultis: (/* c, request */) => { },

--- a/src/lib/conditionals/lightcone/5star/SolitaryHealing.ts
+++ b/src/lib/conditionals/lightcone/5star/SolitaryHealing.ts
@@ -1,9 +1,10 @@
 import { ContentItem } from 'types/Conditionals'
-import { PrecomputedCharacterConditional } from 'types/CharacterConditional'
 import { Form } from 'types/Form'
 import getContentFromLCRanks from '../getContentFromLCRank'
 import { SuperImpositionLevel } from 'types/LightCone'
 import { LightConeConditional, LightConeRawRank } from 'types/LightConeConditionals'
+import { buffAbilityDmg } from 'lib/optimizer/calculateBuffs'
+import { ComputedStatsObject, DOT_TYPE } from 'lib/conditionals/conditionalConstants'
 
 export default (s: SuperImpositionLevel): LightConeConditional => {
   const sValues = [0.24, 0.30, 0.36, 0.42, 0.48]
@@ -44,10 +45,10 @@ export default (s: SuperImpositionLevel): LightConeConditional => {
     defaults: () => ({
       postUltDotDmgBuff: true,
     }),
-    precomputeEffects: (x: PrecomputedCharacterConditional, request: Form) => {
+    precomputeEffects: (x: ComputedStatsObject, request: Form) => {
       const r = request.lightConeConditionals
 
-      x.DOT_BOOST += r.postUltDotDmgBuff ? sValues[s] : 0
+      buffAbilityDmg(x, [DOT_TYPE], sValues[s], (r.postUltDotDmgBuff))
     },
     calculatePassives: (/* c, request */) => { },
     calculateBaseMultis: (/* c, request */) => { },

--- a/src/lib/conditionals/lightcone/5star/WorrisomeBlissful.ts
+++ b/src/lib/conditionals/lightcone/5star/WorrisomeBlissful.ts
@@ -4,8 +4,9 @@ import { Form } from 'types/Form'
 import getContentFromLCRanks from '../getContentFromLCRank'
 import { SuperImpositionLevel } from 'types/LightCone'
 import { LightConeConditional, LightConeRawRank } from 'types/LightConeConditionals'
-import { ComputedStatsObject } from 'lib/conditionals/conditionalConstants.ts'
+import { ComputedStatsObject, FUA_TYPE } from 'lib/conditionals/conditionalConstants.ts'
 import { Stats } from 'lib/constants'
+import { buffAbilityDmg } from 'lib/optimizer/calculateBuffs'
 
 export default (s: SuperImpositionLevel): LightConeConditional => {
   const sValuesFuaDmg = [0.30, 0.35, 0.40, 0.45, 0.50]
@@ -55,7 +56,7 @@ export default (s: SuperImpositionLevel): LightConeConditional => {
       targetTameStacks: 2,
     }),
     precomputeEffects: (x: PrecomputedCharacterConditional, _request: Form) => {
-      x.FUA_BOOST += sValuesFuaDmg[s]
+      buffAbilityDmg(x, [FUA_TYPE], sValuesFuaDmg[s])
     },
     precomputeMutualEffects: (x: ComputedStatsObject, request: Form) => {
       const m = request.lightConeConditionals

--- a/src/lib/conditionals/lightcone/5star/WorrisomeBlissful.ts
+++ b/src/lib/conditionals/lightcone/5star/WorrisomeBlissful.ts
@@ -1,5 +1,4 @@
 import { ContentItem } from 'types/Conditionals'
-import { PrecomputedCharacterConditional } from 'types/CharacterConditional'
 import { Form } from 'types/Form'
 import getContentFromLCRanks from '../getContentFromLCRank'
 import { SuperImpositionLevel } from 'types/LightCone'
@@ -55,8 +54,8 @@ export default (s: SuperImpositionLevel): LightConeConditional => {
     teammateDefaults: () => ({
       targetTameStacks: 2,
     }),
-    precomputeEffects: (x: PrecomputedCharacterConditional, _request: Form) => {
-      buffAbilityDmg(x, [FUA_TYPE], sValuesFuaDmg[s])
+    precomputeEffects: (x: ComputedStatsObject, _request: Form) => {
+      buffAbilityDmg(x, FUA_TYPE, sValuesFuaDmg[s])
     },
     precomputeMutualEffects: (x: ComputedStatsObject, request: Form) => {
       const m = request.lightConeConditionals

--- a/src/lib/conditionals/lightcone/5star/YetHopeIsPriceless.ts
+++ b/src/lib/conditionals/lightcone/5star/YetHopeIsPriceless.ts
@@ -6,7 +6,7 @@ import { ComputedStatsObject, FUA_TYPE, ULT_TYPE } from 'lib/conditionals/condit
 import { PrecomputedCharacterConditional } from 'types/CharacterConditional'
 import { Stats } from 'lib/constants'
 import { precisionRound } from 'lib/conditionals/utils'
-import { buffDmgTypeDefShred } from 'lib/optimizer/calculateBuffs'
+import { buffAbilityDefShred } from 'lib/optimizer/calculateBuffs'
 
 export default (s: SuperImpositionLevel): LightConeConditional => {
   const sValuesFuaDmg = [0.12, 0.14, 0.16, 0.18, 0.20]
@@ -45,7 +45,7 @@ export default (s: SuperImpositionLevel): LightConeConditional => {
     precomputeEffects: (x: ComputedStatsObject, request: Form) => {
       const r = request.lightConeConditionals
 
-      r.ultFuaDefShred && buffDmgTypeDefShred(x, [ULT_TYPE, FUA_TYPE], sValuesUltFuaDefShred[s])
+      r.ultFuaDefShred && buffAbilityDefShred(x, [ULT_TYPE, FUA_TYPE], sValuesUltFuaDefShred[s])
     },
     calculatePassives: (/* c, request */) => {
     },

--- a/src/lib/conditionals/lightcone/5star/YetHopeIsPriceless.ts
+++ b/src/lib/conditionals/lightcone/5star/YetHopeIsPriceless.ts
@@ -2,10 +2,11 @@ import { ContentItem } from 'types/Conditionals'
 import { Form } from 'types/Form'
 import { SuperImpositionLevel } from 'types/LightCone'
 import { LightConeConditional } from 'types/LightConeConditionals'
-import { ComputedStatsObject } from 'lib/conditionals/conditionalConstants'
+import { ComputedStatsObject, FUA_TYPE, ULT_TYPE } from 'lib/conditionals/conditionalConstants'
 import { PrecomputedCharacterConditional } from 'types/CharacterConditional'
 import { Stats } from 'lib/constants'
 import { precisionRound } from 'lib/conditionals/utils'
+import { buffDmgTypeDefShred } from 'lib/optimizer/calculateBuffs'
 
 export default (s: SuperImpositionLevel): LightConeConditional => {
   const sValuesFuaDmg = [0.12, 0.14, 0.16, 0.18, 0.20]
@@ -44,8 +45,7 @@ export default (s: SuperImpositionLevel): LightConeConditional => {
     precomputeEffects: (x: ComputedStatsObject, request: Form) => {
       const r = request.lightConeConditionals
 
-      x.ULT_DEF_PEN += (r.ultFuaDefShred) ? sValuesUltFuaDefShred[s] : 0
-      x.FUA_DEF_PEN += (r.ultFuaDefShred) ? sValuesUltFuaDefShred[s] : 0
+      r.ultFuaDefShred && buffDmgTypeDefShred(x, [ULT_TYPE, FUA_TYPE], sValuesUltFuaDefShred[s])
     },
     calculatePassives: (/* c, request */) => {
     },

--- a/src/lib/conditionals/lightcone/5star/YetHopeIsPriceless.ts
+++ b/src/lib/conditionals/lightcone/5star/YetHopeIsPriceless.ts
@@ -45,7 +45,7 @@ export default (s: SuperImpositionLevel): LightConeConditional => {
     precomputeEffects: (x: ComputedStatsObject, request: Form) => {
       const r = request.lightConeConditionals
 
-      buffAbilityDefShred(x, [ULT_TYPE, FUA_TYPE], sValuesUltFuaDefShred[s], (r.ultFuaDefShred))
+      buffAbilityDefShred(x, ULT_TYPE | FUA_TYPE, sValuesUltFuaDefShred[s], (r.ultFuaDefShred))
     },
     calculatePassives: (/* c, request */) => {
     },
@@ -53,7 +53,7 @@ export default (s: SuperImpositionLevel): LightConeConditional => {
       const r = request.lightConeConditionals
       const x: ComputedStatsObject = c.x
 
-      buffAbilityDmg(x, [FUA_TYPE], sValuesFuaDmg[s] * Math.min(4, Math.floor(x[Stats.CD] - 1.20) / 0.20), (r.fuaDmgBoost))
+      buffAbilityDmg(x, FUA_TYPE, sValuesFuaDmg[s] * Math.min(4, Math.floor(x[Stats.CD] - 1.20) / 0.20), (r.fuaDmgBoost))
     },
   }
 }

--- a/src/lib/conditionals/lightcone/5star/YetHopeIsPriceless.ts
+++ b/src/lib/conditionals/lightcone/5star/YetHopeIsPriceless.ts
@@ -6,7 +6,7 @@ import { ComputedStatsObject, FUA_TYPE, ULT_TYPE } from 'lib/conditionals/condit
 import { PrecomputedCharacterConditional } from 'types/CharacterConditional'
 import { Stats } from 'lib/constants'
 import { precisionRound } from 'lib/conditionals/utils'
-import { buffAbilityDefShred } from 'lib/optimizer/calculateBuffs'
+import { buffAbilityDefShred, buffAbilityDmg } from 'lib/optimizer/calculateBuffs'
 
 export default (s: SuperImpositionLevel): LightConeConditional => {
   const sValuesFuaDmg = [0.12, 0.14, 0.16, 0.18, 0.20]
@@ -45,7 +45,7 @@ export default (s: SuperImpositionLevel): LightConeConditional => {
     precomputeEffects: (x: ComputedStatsObject, request: Form) => {
       const r = request.lightConeConditionals
 
-      r.ultFuaDefShred && buffAbilityDefShred(x, [ULT_TYPE, FUA_TYPE], sValuesUltFuaDefShred[s])
+      buffAbilityDefShred(x, [ULT_TYPE, FUA_TYPE], sValuesUltFuaDefShred[s], (r.ultFuaDefShred))
     },
     calculatePassives: (/* c, request */) => {
     },
@@ -53,7 +53,7 @@ export default (s: SuperImpositionLevel): LightConeConditional => {
       const r = request.lightConeConditionals
       const x: ComputedStatsObject = c.x
 
-      x.FUA_BOOST += (r.fuaDmgBoost) ? sValuesFuaDmg[s] * Math.min(4, Math.floor(x[Stats.CD] - 1.20) / 0.20) : 0
+      buffAbilityDmg(x, [FUA_TYPE], sValuesFuaDmg[s] * Math.min(4, Math.floor(x[Stats.CD] - 1.20) / 0.20), (r.fuaDmgBoost))
     },
   }
 }

--- a/src/lib/optimizer/calculateBuffs.ts
+++ b/src/lib/optimizer/calculateBuffs.ts
@@ -1,14 +1,4 @@
-import {
-  ABILITY_TYPE_TO_DMG_TYPE_VARIABLE,
-  BASIC_TYPE,
-  BREAK_TYPE,
-  ComputedStatsObject,
-  DOT_TYPE,
-  FUA_TYPE,
-  SKILL_TYPE,
-  SUPER_BREAK_TYPE,
-  ULT_TYPE
-} from 'lib/conditionals/conditionalConstants'
+import { ABILITY_TYPE_TO_DMG_TYPE_VARIABLE, ComputedStatsObject } from 'lib/conditionals/conditionalConstants'
 
 /*
  * These methods handle buffing damage types for characters who have dynamic ability types. For example Yunli's FUA
@@ -27,80 +17,68 @@ function extractAbilityTypeFlags(x: ComputedStatsObject, abilityTypeBitFlags: nu
   return activeAbilityTypes
 }
 
-export function buffAbilityDmg(x: ComputedStatsObject, dmgTypeBitFlags: number[], value: number, condition?: Condition) {
+export function buffAbilityDmg(x: ComputedStatsObject, abilityTypeFlags: number, value: number, condition?: Condition) {
   if (condition === false) return
 
-  const activeAbilityTypes = extractAbilityTypeFlags(x, dmgTypeBitFlags)
-
-  if (activeAbilityTypes & BASIC_TYPE) x.BASIC_BOOST += value
-  if (activeAbilityTypes & SKILL_TYPE) x.SKILL_BOOST += value
-  if (activeAbilityTypes & ULT_TYPE) x.ULT_BOOST += value
-  if (activeAbilityTypes & FUA_TYPE) x.FUA_BOOST += value
-  if (activeAbilityTypes & DOT_TYPE) x.DOT_BOOST += value
+  if (abilityTypeFlags & x.BASIC_DMG_TYPE) x.BASIC_BOOST += value
+  if (abilityTypeFlags & x.SKILL_DMG_TYPE) x.SKILL_BOOST += value
+  if (abilityTypeFlags & x.ULT_DMG_TYPE)   x.ULT_BOOST += value
+  if (abilityTypeFlags & x.FUA_DMG_TYPE)   x.FUA_BOOST += value
+  if (abilityTypeFlags & x.DOT_DMG_TYPE)   x.DOT_BOOST += value
   // No break
 }
 
-export function buffAbilityVulnerability(x: ComputedStatsObject, dmgTypeBitFlags: number[], value: number, condition?: Condition) {
+export function buffAbilityVulnerability(x: ComputedStatsObject, abilityTypeFlags: number, value: number, condition?: Condition) {
   if (condition === false) return
 
-  const activeAbilityTypes = extractAbilityTypeFlags(x, dmgTypeBitFlags)
-
-  if (activeAbilityTypes & BASIC_TYPE) x.BASIC_VULNERABILITY += value
-  if (activeAbilityTypes & SKILL_TYPE) x.SKILL_VULNERABILITY += value
-  if (activeAbilityTypes & ULT_TYPE) x.ULT_VULNERABILITY += value
-  if (activeAbilityTypes & FUA_TYPE) x.FUA_VULNERABILITY += value
-  if (activeAbilityTypes & DOT_TYPE) x.DOT_VULNERABILITY += value
-  if (activeAbilityTypes & BREAK_TYPE) x.BREAK_VULNERABILITY += value
+  if (abilityTypeFlags & x.BASIC_DMG_TYPE) x.BASIC_VULNERABILITY += value
+  if (abilityTypeFlags & x.SKILL_DMG_TYPE) x.SKILL_VULNERABILITY += value
+  if (abilityTypeFlags & x.ULT_DMG_TYPE)   x.ULT_VULNERABILITY += value
+  if (abilityTypeFlags & x.FUA_DMG_TYPE)   x.FUA_VULNERABILITY += value
+  if (abilityTypeFlags & x.DOT_DMG_TYPE)   x.DOT_VULNERABILITY += value
+  if (abilityTypeFlags & x.BREAK_DMG_TYPE) x.BREAK_VULNERABILITY += value
   // No super break
 }
 
-export function buffAbilityResShred(x: ComputedStatsObject, dmgTypeBitFlags: number[], value: number, condition?: Condition) {
+export function buffAbilityResShred(x: ComputedStatsObject, abilityTypeFlags: number, value: number, condition?: Condition) {
   if (condition === false) return
 
-  const activeAbilityTypes = extractAbilityTypeFlags(x, dmgTypeBitFlags)
-
-  if (activeAbilityTypes & BASIC_TYPE) x.BASIC_RES_PEN += value
-  if (activeAbilityTypes & SKILL_TYPE) x.SKILL_RES_PEN += value
-  if (activeAbilityTypes & ULT_TYPE) x.ULT_RES_PEN += value
-  if (activeAbilityTypes & FUA_TYPE) x.FUA_RES_PEN += value
-  if (activeAbilityTypes & DOT_TYPE) x.DOT_RES_PEN += value
+  if (abilityTypeFlags & x.BASIC_DMG_TYPE) x.BASIC_RES_PEN += value
+  if (abilityTypeFlags & x.SKILL_DMG_TYPE) x.SKILL_RES_PEN += value
+  if (abilityTypeFlags & x.ULT_DMG_TYPE)   x.ULT_RES_PEN += value
+  if (abilityTypeFlags & x.FUA_DMG_TYPE)   x.FUA_RES_PEN += value
+  if (abilityTypeFlags & x.DOT_DMG_TYPE)   x.DOT_RES_PEN += value
   // No break
 }
 
-export function buffAbilityDefShred(x: ComputedStatsObject, dmgTypeBitFlags: number[], value: number, condition?: Condition) {
+export function buffAbilityDefShred(x: ComputedStatsObject, abilityTypeFlags: number, value: number, condition?: Condition) {
   if (condition === false) return
 
-  const activeAbilityTypes = extractAbilityTypeFlags(x, dmgTypeBitFlags)
-
-  if (activeAbilityTypes & BASIC_TYPE) x.BASIC_DEF_PEN += value
-  if (activeAbilityTypes & SKILL_TYPE) x.SKILL_DEF_PEN += value
-  if (activeAbilityTypes & ULT_TYPE) x.ULT_DEF_PEN += value
-  if (activeAbilityTypes & FUA_TYPE) x.FUA_DEF_PEN += value
-  if (activeAbilityTypes & DOT_TYPE) x.DOT_DEF_PEN += value
-  if (activeAbilityTypes & BREAK_TYPE) x.BREAK_DEF_PEN += value
-  if (activeAbilityTypes & SUPER_BREAK_TYPE) x.SUPER_BREAK_DEF_PEN += value
+  if (abilityTypeFlags & x.BASIC_DMG_TYPE)   x.BASIC_DEF_PEN += value
+  if (abilityTypeFlags & x.SKILL_DMG_TYPE)   x.SKILL_DEF_PEN += value
+  if (abilityTypeFlags & x.ULT_DMG_TYPE)     x.ULT_DEF_PEN += value
+  if (abilityTypeFlags & x.FUA_DMG_TYPE)     x.FUA_DEF_PEN += value
+  if (abilityTypeFlags & x.DOT_DMG_TYPE)     x.DOT_DEF_PEN += value
+  if (abilityTypeFlags & x.BREAK_DMG_TYPE)   x.BREAK_DEF_PEN += value
+  if (abilityTypeFlags & x.SUPER_BREAK_TYPE) x.SUPER_BREAK_DEF_PEN += value
 }
 
-export function buffAbilityCr(x: ComputedStatsObject, dmgTypeBitFlags: number[], value: number, condition?: Condition) {
+export function buffAbilityCr(x: ComputedStatsObject, abilityTypeFlags: number, value: number, condition?: Condition) {
   if (condition === false) return
 
-  const activeAbilityTypes = extractAbilityTypeFlags(x, dmgTypeBitFlags)
-
-  if (activeAbilityTypes & BASIC_TYPE) x.BASIC_CR_BOOST += value
-  if (activeAbilityTypes & SKILL_TYPE) x.SKILL_CR_BOOST += value
-  if (activeAbilityTypes & ULT_TYPE) x.ULT_CR_BOOST += value
-  if (activeAbilityTypes & FUA_TYPE) x.FUA_CR_BOOST += value
+  if (abilityTypeFlags & x.BASIC_DMG_TYPE) x.BASIC_CR_BOOST += value
+  if (abilityTypeFlags & x.SKILL_DMG_TYPE) x.SKILL_CR_BOOST += value
+  if (abilityTypeFlags & x.ULT_DMG_TYPE)   x.ULT_CR_BOOST += value
+  if (abilityTypeFlags & x.FUA_DMG_TYPE)   x.FUA_CR_BOOST += value
   // No fua break
 }
 
-export function buffAbilityCd(x: ComputedStatsObject, dmgTypeBitFlags: number[], value: number, condition?: Condition) {
+export function buffAbilityCd(x: ComputedStatsObject, abilityTypeFlags: number, value: number, condition?: Condition) {
   if (condition === false) return
 
-  const activeAbilityTypes = extractAbilityTypeFlags(x, dmgTypeBitFlags)
-
-  if (activeAbilityTypes & BASIC_TYPE) x.BASIC_CD_BOOST += value
-  if (activeAbilityTypes & SKILL_TYPE) x.SKILL_CD_BOOST += value
-  if (activeAbilityTypes & ULT_TYPE) x.ULT_CD_BOOST += value
-  if (activeAbilityTypes & FUA_TYPE) x.FUA_CD_BOOST += value
+  if (abilityTypeFlags & x.BASIC_DMG_TYPE) x.BASIC_CD_BOOST += value
+  if (abilityTypeFlags & x.SKILL_DMG_TYPE) x.SKILL_CD_BOOST += value
+  if (abilityTypeFlags & x.ULT_DMG_TYPE)   x.ULT_CD_BOOST += value
+  if (abilityTypeFlags & x.FUA_DMG_TYPE)   x.FUA_CD_BOOST += value
   // No fua break
 }

--- a/src/lib/optimizer/calculateBuffs.ts
+++ b/src/lib/optimizer/calculateBuffs.ts
@@ -15,6 +15,7 @@ import {
  * can be both ULT and FUA dmg so buffs must be applied to both without overlapping.
  */
 
+type Condition = boolean | number | undefined
 
 function extractAbilityTypeFlags(x: ComputedStatsObject, abilityTypeBitFlags: number[]) {
   let activeAbilityTypes = 0
@@ -26,7 +27,9 @@ function extractAbilityTypeFlags(x: ComputedStatsObject, abilityTypeBitFlags: nu
   return activeAbilityTypes
 }
 
-export function buffAbilityDmg(x: ComputedStatsObject, dmgTypeBitFlags: number[], value: number) {
+export function buffAbilityDmg(x: ComputedStatsObject, dmgTypeBitFlags: number[], value: number, condition?: Condition) {
+  if (condition === false) return
+
   const activeAbilityTypes = extractAbilityTypeFlags(x, dmgTypeBitFlags)
 
   if (activeAbilityTypes & BASIC_TYPE) x.BASIC_BOOST += value
@@ -37,7 +40,9 @@ export function buffAbilityDmg(x: ComputedStatsObject, dmgTypeBitFlags: number[]
   // No break
 }
 
-export function buffAbilityVulnerability(x: ComputedStatsObject, dmgTypeBitFlags: number[], value: number) {
+export function buffAbilityVulnerability(x: ComputedStatsObject, dmgTypeBitFlags: number[], value: number, condition?: Condition) {
+  if (condition === false) return
+
   const activeAbilityTypes = extractAbilityTypeFlags(x, dmgTypeBitFlags)
 
   if (activeAbilityTypes & BASIC_TYPE) x.BASIC_VULNERABILITY += value
@@ -49,7 +54,9 @@ export function buffAbilityVulnerability(x: ComputedStatsObject, dmgTypeBitFlags
   // No super break
 }
 
-export function buffAbilityResShred(x: ComputedStatsObject, dmgTypeBitFlags: number[], value: number) {
+export function buffAbilityResShred(x: ComputedStatsObject, dmgTypeBitFlags: number[], value: number, condition?: Condition) {
+  if (condition === false) return
+
   const activeAbilityTypes = extractAbilityTypeFlags(x, dmgTypeBitFlags)
 
   if (activeAbilityTypes & BASIC_TYPE) x.BASIC_RES_PEN += value
@@ -60,7 +67,9 @@ export function buffAbilityResShred(x: ComputedStatsObject, dmgTypeBitFlags: num
   // No break
 }
 
-export function buffAbilityDefShred(x: ComputedStatsObject, dmgTypeBitFlags: number[], value: number) {
+export function buffAbilityDefShred(x: ComputedStatsObject, dmgTypeBitFlags: number[], value: number, condition?: Condition) {
+  if (condition === false) return
+
   const activeAbilityTypes = extractAbilityTypeFlags(x, dmgTypeBitFlags)
 
   if (activeAbilityTypes & BASIC_TYPE) x.BASIC_DEF_PEN += value
@@ -72,7 +81,9 @@ export function buffAbilityDefShred(x: ComputedStatsObject, dmgTypeBitFlags: num
   if (activeAbilityTypes & SUPER_BREAK_TYPE) x.SUPER_BREAK_DEF_PEN += value
 }
 
-export function buffAbilityCr(x: ComputedStatsObject, dmgTypeBitFlags: number[], value: number) {
+export function buffAbilityCr(x: ComputedStatsObject, dmgTypeBitFlags: number[], value: number, condition?: Condition) {
+  if (condition === false) return
+
   const activeAbilityTypes = extractAbilityTypeFlags(x, dmgTypeBitFlags)
 
   if (activeAbilityTypes & BASIC_TYPE) x.BASIC_CR_BOOST += value
@@ -82,7 +93,9 @@ export function buffAbilityCr(x: ComputedStatsObject, dmgTypeBitFlags: number[],
   // No fua break
 }
 
-export function buffAbilityCd(x: ComputedStatsObject, dmgTypeBitFlags: number[], value: number) {
+export function buffAbilityCd(x: ComputedStatsObject, dmgTypeBitFlags: number[], value: number, condition?: Condition) {
+  if (condition === false) return
+
   const activeAbilityTypes = extractAbilityTypeFlags(x, dmgTypeBitFlags)
 
   if (activeAbilityTypes & BASIC_TYPE) x.BASIC_CD_BOOST += value

--- a/src/lib/optimizer/calculateBuffs.ts
+++ b/src/lib/optimizer/calculateBuffs.ts
@@ -26,7 +26,7 @@ function extractAbilityTypeFlags(x: ComputedStatsObject, abilityTypeBitFlags: nu
   return activeAbilityTypes
 }
 
-export function buffDmgTypeBoost(x: ComputedStatsObject, dmgTypeBitFlags: number[], value: number) {
+export function buffAbilityDmg(x: ComputedStatsObject, dmgTypeBitFlags: number[], value: number) {
   const activeAbilityTypes = extractAbilityTypeFlags(x, dmgTypeBitFlags)
 
   if (activeAbilityTypes & BASIC_TYPE) x.BASIC_BOOST += value
@@ -37,7 +37,7 @@ export function buffDmgTypeBoost(x: ComputedStatsObject, dmgTypeBitFlags: number
   // No break
 }
 
-export function buffDmgTypeVulnerability(x: ComputedStatsObject, dmgTypeBitFlags: number[], value: number) {
+export function buffAbilityVulnerability(x: ComputedStatsObject, dmgTypeBitFlags: number[], value: number) {
   const activeAbilityTypes = extractAbilityTypeFlags(x, dmgTypeBitFlags)
 
   if (activeAbilityTypes & BASIC_TYPE) x.BASIC_VULNERABILITY += value
@@ -49,7 +49,7 @@ export function buffDmgTypeVulnerability(x: ComputedStatsObject, dmgTypeBitFlags
   // No super break
 }
 
-export function buffDmgTypeResShred(x: ComputedStatsObject, dmgTypeBitFlags: number[], value: number) {
+export function buffAbilityResShred(x: ComputedStatsObject, dmgTypeBitFlags: number[], value: number) {
   const activeAbilityTypes = extractAbilityTypeFlags(x, dmgTypeBitFlags)
 
   if (activeAbilityTypes & BASIC_TYPE) x.BASIC_RES_PEN += value
@@ -60,7 +60,7 @@ export function buffDmgTypeResShred(x: ComputedStatsObject, dmgTypeBitFlags: num
   // No break
 }
 
-export function buffDmgTypeDefShred(x: ComputedStatsObject, dmgTypeBitFlags: number[], value: number) {
+export function buffAbilityDefShred(x: ComputedStatsObject, dmgTypeBitFlags: number[], value: number) {
   const activeAbilityTypes = extractAbilityTypeFlags(x, dmgTypeBitFlags)
 
   if (activeAbilityTypes & BASIC_TYPE) x.BASIC_DEF_PEN += value
@@ -72,7 +72,7 @@ export function buffDmgTypeDefShred(x: ComputedStatsObject, dmgTypeBitFlags: num
   if (activeAbilityTypes & SUPER_BREAK_TYPE) x.SUPER_BREAK_DEF_PEN += value
 }
 
-export function buffDmgTypeCrBoost(x: ComputedStatsObject, dmgTypeBitFlags: number[], value: number) {
+export function buffAbilityCr(x: ComputedStatsObject, dmgTypeBitFlags: number[], value: number) {
   const activeAbilityTypes = extractAbilityTypeFlags(x, dmgTypeBitFlags)
 
   if (activeAbilityTypes & BASIC_TYPE) x.BASIC_CR_BOOST += value
@@ -82,7 +82,7 @@ export function buffDmgTypeCrBoost(x: ComputedStatsObject, dmgTypeBitFlags: numb
   // No fua break
 }
 
-export function buffDmgTypeCdBoost(x: ComputedStatsObject, dmgTypeBitFlags: number[], value: number) {
+export function buffAbilityCd(x: ComputedStatsObject, dmgTypeBitFlags: number[], value: number) {
   const activeAbilityTypes = extractAbilityTypeFlags(x, dmgTypeBitFlags)
 
   if (activeAbilityTypes & BASIC_TYPE) x.BASIC_CD_BOOST += value

--- a/src/lib/optimizer/calculateBuffs.ts
+++ b/src/lib/optimizer/calculateBuffs.ts
@@ -1,21 +1,17 @@
-import { ABILITY_TYPE_TO_DMG_TYPE_VARIABLE, ComputedStatsObject } from 'lib/conditionals/conditionalConstants'
+import { ComputedStatsObject } from 'lib/conditionals/conditionalConstants'
 
 /*
  * These methods handle buffing damage types for characters who have dynamic ability types. For example Yunli's FUA
  * can be both ULT and FUA dmg so buffs must be applied to both without overlapping.
+ *
+ * The flags are bitwise, so the usage should be:
+ * buffAbilityDmg(x, BASIC_TYPE | SKILL_TYPE, 1.00, condition)
+ *
+ * And changing characters ability type should be:
+ * x.BASIC_DMG_TYPE = BASIC_TYPE | FUA_TYPE
  */
 
 type Condition = boolean | number | undefined
-
-function extractAbilityTypeFlags(x: ComputedStatsObject, abilityTypeBitFlags: number[]) {
-  let activeAbilityTypes = 0
-  for (const abilityTypeBitFlag of abilityTypeBitFlags) {
-    const dmgTypeVarName = ABILITY_TYPE_TO_DMG_TYPE_VARIABLE[abilityTypeBitFlag]
-    activeAbilityTypes |= x[dmgTypeVarName]
-  }
-
-  return activeAbilityTypes
-}
 
 export function buffAbilityDmg(x: ComputedStatsObject, abilityTypeFlags: number, value: number, condition?: Condition) {
   if (condition === false) return
@@ -70,7 +66,7 @@ export function buffAbilityCr(x: ComputedStatsObject, abilityTypeFlags: number, 
   if (abilityTypeFlags & x.SKILL_DMG_TYPE) x.SKILL_CR_BOOST += value
   if (abilityTypeFlags & x.ULT_DMG_TYPE)   x.ULT_CR_BOOST += value
   if (abilityTypeFlags & x.FUA_DMG_TYPE)   x.FUA_CR_BOOST += value
-  // No fua break
+  // No dot, break
 }
 
 export function buffAbilityCd(x: ComputedStatsObject, abilityTypeFlags: number, value: number, condition?: Condition) {
@@ -80,5 +76,5 @@ export function buffAbilityCd(x: ComputedStatsObject, abilityTypeFlags: number, 
   if (abilityTypeFlags & x.SKILL_DMG_TYPE) x.SKILL_CD_BOOST += value
   if (abilityTypeFlags & x.ULT_DMG_TYPE)   x.ULT_CD_BOOST += value
   if (abilityTypeFlags & x.FUA_DMG_TYPE)   x.FUA_CD_BOOST += value
-  // No fua break
+  // No dot, break
 }

--- a/src/lib/optimizer/calculateBuffs.ts
+++ b/src/lib/optimizer/calculateBuffs.ts
@@ -1,0 +1,93 @@
+import {
+  ABILITY_TYPE_TO_DMG_TYPE_VARIABLE,
+  BASIC_TYPE,
+  BREAK_TYPE,
+  ComputedStatsObject,
+  DOT_TYPE,
+  FUA_TYPE,
+  SKILL_TYPE,
+  SUPER_BREAK_TYPE,
+  ULT_TYPE
+} from 'lib/conditionals/conditionalConstants'
+
+/*
+ * These methods handle buffing damage types for characters who have dynamic ability types. For example Yunli's FUA
+ * can be both ULT and FUA dmg so buffs must be applied to both without overlapping.
+ */
+
+
+function extractAbilityTypeFlags(x: ComputedStatsObject, abilityTypeBitFlags: number[]) {
+  let activeAbilityTypes = 0
+  for (const abilityTypeBitFlag of abilityTypeBitFlags) {
+    const dmgTypeVarName = ABILITY_TYPE_TO_DMG_TYPE_VARIABLE[abilityTypeBitFlag]
+    activeAbilityTypes |= x[dmgTypeVarName]
+  }
+
+  return activeAbilityTypes
+}
+
+export function buffDmgTypeBoost(x: ComputedStatsObject, dmgTypeBitFlags: number[], value: number) {
+  const activeAbilityTypes = extractAbilityTypeFlags(x, dmgTypeBitFlags)
+
+  if (activeAbilityTypes & BASIC_TYPE) x.BASIC_BOOST += value
+  if (activeAbilityTypes & SKILL_TYPE) x.SKILL_BOOST += value
+  if (activeAbilityTypes & ULT_TYPE) x.ULT_BOOST += value
+  if (activeAbilityTypes & FUA_TYPE) x.FUA_BOOST += value
+  if (activeAbilityTypes & DOT_TYPE) x.DOT_BOOST += value
+  // No break
+}
+
+export function buffDmgTypeVulnerability(x: ComputedStatsObject, dmgTypeBitFlags: number[], value: number) {
+  const activeAbilityTypes = extractAbilityTypeFlags(x, dmgTypeBitFlags)
+
+  if (activeAbilityTypes & BASIC_TYPE) x.BASIC_VULNERABILITY += value
+  if (activeAbilityTypes & SKILL_TYPE) x.SKILL_VULNERABILITY += value
+  if (activeAbilityTypes & ULT_TYPE) x.ULT_VULNERABILITY += value
+  if (activeAbilityTypes & FUA_TYPE) x.FUA_VULNERABILITY += value
+  if (activeAbilityTypes & DOT_TYPE) x.DOT_VULNERABILITY += value
+  if (activeAbilityTypes & BREAK_TYPE) x.BREAK_VULNERABILITY += value
+  // No super break
+}
+
+export function buffDmgTypeResShred(x: ComputedStatsObject, dmgTypeBitFlags: number[], value: number) {
+  const activeAbilityTypes = extractAbilityTypeFlags(x, dmgTypeBitFlags)
+
+  if (activeAbilityTypes & BASIC_TYPE) x.BASIC_RES_PEN += value
+  if (activeAbilityTypes & SKILL_TYPE) x.SKILL_RES_PEN += value
+  if (activeAbilityTypes & ULT_TYPE) x.ULT_RES_PEN += value
+  if (activeAbilityTypes & FUA_TYPE) x.FUA_RES_PEN += value
+  if (activeAbilityTypes & DOT_TYPE) x.DOT_RES_PEN += value
+  // No break
+}
+
+export function buffDmgTypeDefShred(x: ComputedStatsObject, dmgTypeBitFlags: number[], value: number) {
+  const activeAbilityTypes = extractAbilityTypeFlags(x, dmgTypeBitFlags)
+
+  if (activeAbilityTypes & BASIC_TYPE) x.BASIC_DEF_PEN += value
+  if (activeAbilityTypes & SKILL_TYPE) x.SKILL_DEF_PEN += value
+  if (activeAbilityTypes & ULT_TYPE) x.ULT_DEF_PEN += value
+  if (activeAbilityTypes & FUA_TYPE) x.FUA_DEF_PEN += value
+  if (activeAbilityTypes & DOT_TYPE) x.DOT_DEF_PEN += value
+  if (activeAbilityTypes & BREAK_TYPE) x.BREAK_DEF_PEN += value
+  if (activeAbilityTypes & SUPER_BREAK_TYPE) x.SUPER_BREAK_DEF_PEN += value
+}
+
+export function buffDmgTypeCrBoost(x: ComputedStatsObject, dmgTypeBitFlags: number[], value: number) {
+  const activeAbilityTypes = extractAbilityTypeFlags(x, dmgTypeBitFlags)
+
+  if (activeAbilityTypes & BASIC_TYPE) x.BASIC_CR_BOOST += value
+  if (activeAbilityTypes & SKILL_TYPE) x.SKILL_CR_BOOST += value
+  if (activeAbilityTypes & ULT_TYPE) x.ULT_CR_BOOST += value
+  if (activeAbilityTypes & FUA_TYPE) x.FUA_CR_BOOST += value
+  // No fua break
+}
+
+export function buffDmgTypeCdBoost(x: ComputedStatsObject, dmgTypeBitFlags: number[], value: number) {
+  const activeAbilityTypes = extractAbilityTypeFlags(x, dmgTypeBitFlags)
+
+  if (activeAbilityTypes & BASIC_TYPE) x.BASIC_CD_BOOST += value
+  if (activeAbilityTypes & SKILL_TYPE) x.SKILL_CD_BOOST += value
+  if (activeAbilityTypes & ULT_TYPE) x.ULT_CD_BOOST += value
+  if (activeAbilityTypes & FUA_TYPE) x.FUA_CD_BOOST += value
+  // No fua break
+}

--- a/src/lib/optimizer/calculateStats.js
+++ b/src/lib/optimizer/calculateStats.js
@@ -1,7 +1,7 @@
 import { Stats } from 'lib/constants.ts'
 import { p2, p4 } from 'lib/optimizer/optimizerUtils'
 import { calculatePassiveStatConversions } from 'lib/optimizer/calculateDamage.js'
-import { buffDmgTypeBoost } from 'lib/optimizer/calculateBuffs'
+import { buffAbilityDmg } from 'lib/optimizer/calculateBuffs'
 import { BASIC_TYPE, FUA_TYPE, SKILL_TYPE, ULT_TYPE } from 'lib/conditionals/conditionalConstants'
 
 export function calculateSetCounts(c, setH, setG, setB, setF, setP, setL) {
@@ -225,21 +225,21 @@ export function calculateComputedStats(c, request, params) {
 
 
   // Basic boost
-  p4(sets.MusketeerOfWildWheat) && buffDmgTypeBoost(x, [BASIC_TYPE], 0.10)
+  p4(sets.MusketeerOfWildWheat) && buffAbilityDmg(x, [BASIC_TYPE], 0.10)
 
   // Skill boost
-  p4(sets.FiresmithOfLavaForging) && buffDmgTypeBoost(x, [SKILL_TYPE], 0.12)
+  p4(sets.FiresmithOfLavaForging) && buffAbilityDmg(x, [SKILL_TYPE], 0.12)
 
   // Fua boost
-  p2(sets.TheAshblazingGrandDuke) && buffDmgTypeBoost(x, [FUA_TYPE], 0.20)
-  p2(sets.DuranDynastyOfRunningWolves) && buffDmgTypeBoost(x, [FUA_TYPE], 0.05 * params.valueDuranDynastyOfRunningWolves)
+  p2(sets.TheAshblazingGrandDuke) && buffAbilityDmg(x, [FUA_TYPE], 0.20)
+  p2(sets.DuranDynastyOfRunningWolves) && buffAbilityDmg(x, [FUA_TYPE], 0.05 * params.valueDuranDynastyOfRunningWolves)
 
   // Ult boost
-  p4(sets.TheWindSoaringValorous) && buffDmgTypeBoost(x, [ULT_TYPE], 0.36 * params.enabledTheWindSoaringValorous)
+  p4(sets.TheWindSoaringValorous) && buffAbilityDmg(x, [ULT_TYPE], 0.36 * params.enabledTheWindSoaringValorous)
 
   // Multiple boost
-  p2(sets.RutilantArena) && (x[Stats.CR] >= 0.70) && buffDmgTypeBoost(x, [BASIC_TYPE, SKILL_TYPE], 0.20)
-  p2(sets.InertSalsotto) && (x[Stats.CR] >= 0.50) && buffDmgTypeBoost(x, [ULT_TYPE, FUA_TYPE], 0.15)
+  p2(sets.RutilantArena) && (x[Stats.CR] >= 0.70) && buffAbilityDmg(x, [BASIC_TYPE, SKILL_TYPE], 0.20)
+  p2(sets.InertSalsotto) && (x[Stats.CR] >= 0.50) && buffAbilityDmg(x, [ULT_TYPE, FUA_TYPE], 0.15)
 
   x.DEF_SHRED
     += p4(sets.GeniusOfBrilliantStars) ? (params.enabledGeniusOfBrilliantStars ? 0.20 : 0.10) : 0

--- a/src/lib/optimizer/calculateStats.js
+++ b/src/lib/optimizer/calculateStats.js
@@ -1,6 +1,8 @@
 import { Stats } from 'lib/constants.ts'
 import { p2, p4 } from 'lib/optimizer/optimizerUtils'
 import { calculatePassiveStatConversions } from 'lib/optimizer/calculateDamage.js'
+import { buffDmgTypeBoost } from 'lib/optimizer/calculateBuffs'
+import { BASIC_TYPE, FUA_TYPE, SKILL_TYPE, ULT_TYPE } from 'lib/conditionals/conditionalConstants'
 
 export function calculateSetCounts(c, setH, setG, setB, setF, setP, setL) {
   c.sets = {
@@ -221,22 +223,23 @@ export function calculateComputedStats(c, request, params) {
     + 0.30 * params.enabledWatchmakerMasterOfDreamMachinations * p4(sets.WatchmakerMasterOfDreamMachinations)
     + 0.40 * params.enabledForgeOfTheKalpagniLantern * p2(sets.ForgeOfTheKalpagniLantern)
 
-  x.BASIC_BOOST
-    += 0.10 * p4(sets.MusketeerOfWildWheat)
-    + 0.20 * (x[Stats.CR] >= 0.70 ? 1 : 0) * p2(sets.RutilantArena)
 
-  x.SKILL_BOOST
-    += 0.12 * p4(sets.FiresmithOfLavaForging)
-    + 0.20 * (x[Stats.CR] >= 0.70 ? 1 : 0) * p2(sets.RutilantArena)
+  // Basic boost
+  p4(sets.MusketeerOfWildWheat) && buffDmgTypeBoost(x, [BASIC_TYPE], 0.10)
 
-  x.ULT_BOOST
-    += 0.15 * (x[Stats.CR] >= 0.50 ? 1 : 0) * p2(sets.InertSalsotto)
+  // Skill boost
+  p4(sets.FiresmithOfLavaForging) && buffDmgTypeBoost(x, [SKILL_TYPE], 0.12)
 
-  x.FUA_BOOST
-    += 0.15 * (x[Stats.CR] >= 0.50 ? 1 : 0) * p2(sets.InertSalsotto)
+  // Fua boost
+  p2(sets.TheAshblazingGrandDuke) && buffDmgTypeBoost(x, [FUA_TYPE], 0.20)
+  p2(sets.DuranDynastyOfRunningWolves) && buffDmgTypeBoost(x, [FUA_TYPE], 0.05 * params.valueDuranDynastyOfRunningWolves)
 
-  x.FUA_BOOST
-    += 0.20 * p2(sets.TheAshblazingGrandDuke)
+  // Ult boost
+  p4(sets.TheWindSoaringValorous) && buffDmgTypeBoost(x, [ULT_TYPE], 0.36 * params.enabledTheWindSoaringValorous)
+
+  // Multiple boost
+  p2(sets.RutilantArena) && (x[Stats.CR] >= 0.70) && buffDmgTypeBoost(x, [BASIC_TYPE, SKILL_TYPE], 0.20)
+  p2(sets.InertSalsotto) && (x[Stats.CR] >= 0.50) && buffDmgTypeBoost(x, [ULT_TYPE, FUA_TYPE], 0.15)
 
   x.DEF_SHRED
     += p4(sets.GeniusOfBrilliantStars) ? (params.enabledGeniusOfBrilliantStars ? 0.20 : 0.10) : 0
@@ -254,12 +257,6 @@ export function calculateComputedStats(c, request, params) {
     += 0.12 * (x[Stats.SPD] >= 135 ? 1 : 0) * p2(sets.FirmamentFrontlineGlamoth)
     + 0.06 * (x[Stats.SPD] >= 160 ? 1 : 0) * p2(sets.FirmamentFrontlineGlamoth)
     + 0.12 * p2(sets.PioneerDiverOfDeadWaters) * (params.valuePioneerDiverOfDeadWaters > -1 ? 1 : 0)
-
-  x.FUA_BOOST
-    += 0.05 * params.valueDuranDynastyOfRunningWolves * p2(sets.DuranDynastyOfRunningWolves)
-
-  x.ULT_BOOST
-    += 0.36 * params.enabledTheWindSoaringValorous * p4(sets.TheWindSoaringValorous)
 
   return x
 }

--- a/src/lib/optimizer/calculateStats.js
+++ b/src/lib/optimizer/calculateStats.js
@@ -225,21 +225,21 @@ export function calculateComputedStats(c, request, params) {
 
 
   // Basic boost
-  p4(sets.MusketeerOfWildWheat) && buffAbilityDmg(x, [BASIC_TYPE], 0.10)
+  p4(sets.MusketeerOfWildWheat) && buffAbilityDmg(x, BASIC_TYPE, 0.10)
 
   // Skill boost
-  p4(sets.FiresmithOfLavaForging) && buffAbilityDmg(x, [SKILL_TYPE], 0.12)
+  p4(sets.FiresmithOfLavaForging) && buffAbilityDmg(x, SKILL_TYPE, 0.12)
 
   // Fua boost
-  p2(sets.TheAshblazingGrandDuke) && buffAbilityDmg(x, [FUA_TYPE], 0.20)
-  p2(sets.DuranDynastyOfRunningWolves) && buffAbilityDmg(x, [FUA_TYPE], 0.05 * params.valueDuranDynastyOfRunningWolves)
+  p2(sets.TheAshblazingGrandDuke) && buffAbilityDmg(x, FUA_TYPE, 0.20)
+  p2(sets.DuranDynastyOfRunningWolves) && buffAbilityDmg(x, FUA_TYPE, 0.05 * params.valueDuranDynastyOfRunningWolves)
 
   // Ult boost
-  p4(sets.TheWindSoaringValorous) && buffAbilityDmg(x, [ULT_TYPE], 0.36 * params.enabledTheWindSoaringValorous)
+  p4(sets.TheWindSoaringValorous) && buffAbilityDmg(x, ULT_TYPE, 0.36 * params.enabledTheWindSoaringValorous)
 
   // Multiple boost
-  p2(sets.RutilantArena) && (x[Stats.CR] >= 0.70) && buffAbilityDmg(x, [BASIC_TYPE, SKILL_TYPE], 0.20)
-  p2(sets.InertSalsotto) && (x[Stats.CR] >= 0.50) && buffAbilityDmg(x, [ULT_TYPE, FUA_TYPE], 0.15)
+  p2(sets.RutilantArena) && (x[Stats.CR] >= 0.70) && buffAbilityDmg(x, BASIC_TYPE | SKILL_TYPE, 0.20)
+  p2(sets.InertSalsotto) && (x[Stats.CR] >= 0.50) && buffAbilityDmg(x, ULT_TYPE | FUA_TYPE, 0.15)
 
   x.DEF_SHRED
     += p4(sets.GeniusOfBrilliantStars) ? (params.enabledGeniusOfBrilliantStars ? 0.20 : 0.10) : 0

--- a/src/style/style.css
+++ b/src/style/style.css
@@ -223,8 +223,8 @@ body,
 }
 
 .ag-header-cell {
-    padding-left: 2px !important;
-    padding-right: 2px !important;
+    padding-left: 0px !important;
+    padding-right: 0px !important;
 }
 
 .ant-layout {

--- a/src/types/Form.d.ts
+++ b/src/types/Form.d.ts
@@ -22,14 +22,12 @@ export type Form = {
   characterEidolon: Eidolon
   characterId: CharacterId | undefined
   characterLevel: number
-  enemyOptions: {
-    enemyCount: number
-    enemyElementalWeak: number
-    enemyLevel: number
-    enemyMaxToughness: number
-    enemyResistance: number
-    enemyWeaknessBroken: boolean
-  }
+  enemyCount: number
+  enemyElementalWeak: number
+  enemyLevel: number
+  enemyMaxToughness: number
+  enemyResistance: number
+  enemyWeaknessBroken: boolean
   enhance: RelicEnhance | number
   grade: RelicGrade | number
   keepCurrentRelics: boolean


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Moved buff logic to calculateBuffs
* Rewrote the buff logic to handle ability dmg type switching: Yunli, Topaz, Acheron

```
/*
 * These methods handle buffing damage types for characters who have dynamic ability types. For example Yunli's FUA
 * can be both ULT and FUA dmg so buffs must be applied to both without overlapping.
 *
 * The flags are bitwise, so the usage should be:
 * buffAbilityDmg(x, BASIC_TYPE | SKILL_TYPE, 1.00, condition)
 *
 * And changing characters ability type should be:
 * x.BASIC_DMG_TYPE = BASIC_TYPE | FUA_TYPE
 */
```

* Refactored all conditionals to use the new logic
* Fixed a few bugs along the way
  * Yunli no longer gets double buffed by salsotto
  * Yunli now correctly benefits from FUA vulnerability
  * Herta skill 50% hp buff is now correctly 20%


## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

