### PR TITLE
feat: optimiser relic exclusion filter

### DIFF
--- a/src/components/RelicFilterBar.jsx
+++ b/src/components/RelicFilterBar.jsx
@@ -101,8 +101,18 @@ export default function RelicFilterBar(props) {
     })
   }
 
+  function generateRestrictedTags(arr) {
+    return arr.map((x) => {
+      return {
+        key: x,
+        display: Renderer.renderFilter(x),
+      }
+    })
+  }
+
   const gradeData = generateGradeTags([2, 3, 4, 5])
   const verifiedData = generateVerifiedTags([false, true])
+  const restrictedData = generateRestrictedTags([false, true])
   const setsData = generateImageTags(Object.values(Constants.SetsRelics).concat(Object.values(Constants.SetsOrnaments)).filter((x) => !UnreleasedSets[x]),
     (x) => Assets.getSetImage(x, Constants.Parts.PlanarSphere), true)
   const partsData = generateImageTags(Object.values(Constants.Parts), (x) => Assets.getPart(x), false)
@@ -224,6 +234,10 @@ export default function RelicFilterBar(props) {
         <Flex vertical flex={0.25}>
           <HeaderText>Verified</HeaderText>
           <FilterRow name="verified" tags={verifiedData} flexBasis="15%" />
+        </Flex>
+        <Flex vertical flex={0.25}>
+          <HeaderText>Restricted</HeaderText>
+          <FilterRow name="restricted" tags={restrictedData} flexBasis="15%" />
         </Flex>
         <Flex vertical flex={0.4}>
           <HeaderText>Clear</HeaderText>

--- a/src/components/RelicModal.tsx
+++ b/src/components/RelicModal.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import { Button, Flex, Form, Image, InputNumber, Modal, Radio, Select, theme } from 'antd'
+import { Button, Flex, Form, Image, InputNumber, Modal, Radio, Select, Switch, theme } from 'antd'
 import React, { ReactElement, useEffect, useMemo, useState } from 'react'
 import { Constants } from 'lib/constants'
 import { HeaderText } from './HeaderText'
@@ -15,6 +15,7 @@ import { calculateUpgradeValues, RelicForm, RelicUpgradeValues, validateRelic } 
 import { CaretRightOutlined } from '@ant-design/icons'
 import { FormInstance } from 'antd/es/form/hooks/useForm'
 import { generateCharacterList } from 'lib/displayUtils'
+import CharacterSelect from './optimizerTab/optimizerForm/CharacterSelect'
 
 const { useToken } = theme
 
@@ -92,6 +93,8 @@ export default function RelicModal(props: {
   const equippedBy: string = Form.useWatch('equippedBy', relicForm)
   const [upgradeValues, setUpgradeValues] = useState<RelicUpgradeValues[]>([])
 
+  const [restrictionList, setRestrictionList] = useState<string[]>([])
+
   useEffect(() => {
     let defaultValues = {
       grade: 5,
@@ -121,7 +124,10 @@ export default function RelicModal(props: {
         substatValue2: renderSubstat(relic, 2).value,
         substatType3: renderSubstat(relic, 3).stat,
         substatValue3: renderSubstat(relic, 3).value,
+        restrictionEnabled: relic.restriction.enabled,
+        restrictionList: relic.restriction.list,
       }
+      setRestrictionList(relic.restriction.list)
     }
     onValuesChange(defaultValues)
     relicForm.setFieldsValue(defaultValues)
@@ -361,6 +367,32 @@ export default function RelicModal(props: {
               <SubstatInput index={1} upgrades={upgradeValues} relicForm={relicForm} resetUpgradeValues={resetUpgradeValues} plusThree={plusThree} />
               <SubstatInput index={2} upgrades={upgradeValues} relicForm={relicForm} resetUpgradeValues={resetUpgradeValues} plusThree={plusThree} />
               <SubstatInput index={3} upgrades={upgradeValues} relicForm={relicForm} resetUpgradeValues={resetUpgradeValues} plusThree={plusThree} />
+            </Flex>
+          </Flex>
+          <Flex vertical>
+            <HeaderText>Restrict in Optimiser</HeaderText>
+            <Flex gap={10}>
+              <Form.Item name="restrictionList">
+                <CharacterSelect
+                  selectStyle={{ width: 200 }}
+                  value={restrictionList}
+                  onChange={(x) => {
+                    const excludedCharacterIds = Array.from(x || new Map())
+                      .filter((entry) => entry[1] == true)
+                      .map((entry) => entry[0])
+                    relicForm.setFieldValue('restrictionList', excludedCharacterIds)
+                    setRestrictionList(excludedCharacterIds)
+                  }}
+                  multipleSelect={true}
+                />
+              </Form.Item>
+              <Form.Item name="restrictionEnabled">
+                <Switch
+                  style={{ width: 90 }}
+                  checkedChildren="Restricted"
+                  unCheckedChildren="Free"
+                />
+              </Form.Item>
             </Flex>
           </Flex>
         </Flex>

--- a/src/components/RelicModal.tsx
+++ b/src/components/RelicModal.tsx
@@ -106,6 +106,8 @@ export default function RelicModal(props: {
 
     const relic = props.selectedRelic
     if (!relic || props.type != 'edit') {
+      relicForm.setFieldValue('restrictionEnabled', false)
+      relicForm.setFieldValue('restrictionList', [])
       // Ignore
     } else {
       defaultValues = {

--- a/src/components/RelicPreview.jsx
+++ b/src/components/RelicPreview.jsx
@@ -6,6 +6,7 @@ import { Assets } from 'lib/assets'
 import { iconSize } from 'lib/constantsUi'
 import RelicStatText from 'components/relicPreview/RelicStatText'
 import { GenerateStat } from 'components/relicPreview/GenerateStat'
+import { LockOutlined, UnlockOutlined } from '@ant-design/icons'
 
 const RelicPreview = ({
   relic,
@@ -76,6 +77,9 @@ const RelicPreview = ({
               </Flex>
             </Flex>
           </Flex>
+          {relic.restriction && (
+            relic.restriction.enabled ? <LockOutlined /> : <UnlockOutlined />
+          )}
           <img
             style={{ height: 50, width: 50 }}
             src={equippedBySrc}

--- a/src/components/RelicPreview.jsx
+++ b/src/components/RelicPreview.jsx
@@ -6,7 +6,6 @@ import { Assets } from 'lib/assets'
 import { iconSize } from 'lib/constantsUi'
 import RelicStatText from 'components/relicPreview/RelicStatText'
 import { GenerateStat } from 'components/relicPreview/GenerateStat'
-import { LockOutlined, UnlockOutlined } from '@ant-design/icons'
 
 const RelicPreview = ({
   relic,

--- a/src/components/RelicPreview.jsx
+++ b/src/components/RelicPreview.jsx
@@ -77,9 +77,7 @@ const RelicPreview = ({
               </Flex>
             </Flex>
           </Flex>
-          {relic.restriction && (
-            relic.restriction.enabled ? <LockOutlined /> : <UnlockOutlined />
-          )}
+          {relic.restriction && Renderer.renderFilter(relic.restriction.enabled)}
           <img
             style={{ height: 50, width: 50 }}
             src={equippedBySrc}

--- a/src/components/RelicsTab.jsx
+++ b/src/components/RelicsTab.jsx
@@ -97,7 +97,7 @@ const RestrictedFilter = forwardRef((props, ref) => {
     return {
       doesFilterPass(params) {
         if ([0, 2].includes(model.restricted.length)) return true
-        if ((model.restricted[0] && params.data.restriction.enabled) || (!model.restricted[0] && !params.data.restriction.enabled)) return true
+        if ((model.restricted[0] == params.data.restriction.enabled)) return true
         return false
       },
 

--- a/src/components/RelicsTab.jsx
+++ b/src/components/RelicsTab.jsx
@@ -292,7 +292,7 @@ export default function RelicsTab() {
     },
     {
       field: 'restricted',
-      width: 40,
+      width: 55,
       cellRenderer: Renderer.renderFilterCell,
       filter: RestrictedFilter,
     },

--- a/src/components/optimizerTab/optimizerForm/CharacterSelect.tsx
+++ b/src/components/optimizerTab/optimizerForm/CharacterSelect.tsx
@@ -35,7 +35,6 @@ const CharacterSelect: React.FC<CharacterSelectProps> = ({ value, onChange, sele
   const [currentFilters, setCurrentFilters] = useState(Utils.clone(defaultFilters))
   const characterOptions = useMemo(() => Utils.generateCharacterOptions(), [])
   const [selected, setSelected] = useState<Map<string, boolean>>(new Map())
-  const excludedRelicPotentialCharacters = window.store((s) => s.excludedRelicPotentialCharacters)
 
   const labelledOptions: { value: string; label }[] = []
   for (const option of characterOptions) {
@@ -58,7 +57,7 @@ const CharacterSelect: React.FC<CharacterSelectProps> = ({ value, onChange, sele
       setTimeout(() => inputRef?.current?.focus(), 100)
 
       if (multipleSelect) {
-        const newSelected = new Map<string, boolean>(excludedRelicPotentialCharacters.map((characterId: string) => [characterId, true]))
+        const newSelected = new Map<string, boolean>(value.map((characterId: string) => [characterId, true]))
         setSelected(newSelected)
       }
     }
@@ -114,7 +113,7 @@ const CharacterSelect: React.FC<CharacterSelectProps> = ({ value, onChange, sele
         allowClear
         maxTagCount={0}
         maxTagPlaceholder={() => (
-          <span>{excludedRelicPotentialCharacters.length ? `${excludedRelicPotentialCharacters.length} characters excluded` : 'All characters enabled'}</span>
+          <span>{value.length ? `${value.length} characters excluded` : 'All characters enabled'}</span>
         )}
         onClear={() => {
           if (onChange) onChange(null)

--- a/src/components/optimizerTab/optimizerForm/OptimizerOptionsDisplay.tsx
+++ b/src/components/optimizerTab/optimizerForm/OptimizerOptionsDisplay.tsx
@@ -89,6 +89,17 @@ const OptimizerOptionsDisplay = (): JSX.Element => {
           <Text>Keep current relics</Text>
         </Flex>
 
+        <Flex align="center">
+          <Form.Item name="ignoreRestrictions" valuePropName="checked">
+            <Switch
+              checkedChildren={<CheckOutlined />}
+              unCheckedChildren={<CloseOutlined />}
+              style={{ width: 45, marginRight: 5 }}
+            />
+          </Form.Item>
+          <Text>Ignore wearer restrictions</Text>
+        </Flex>
+
         <Flex gap={optimizerTabDefaultGap} style={{ marginTop: 10 }}>
           <Flex vertical gap={2}>
             <HeaderText>

--- a/src/lib/conditionals/character/Jiaoqiu.ts
+++ b/src/lib/conditionals/character/Jiaoqiu.ts
@@ -133,7 +133,7 @@ export default (e: Eidolon): CharacterConditional => {
       x.DMG_TAKEN_MULTI += (m.ashenRoastStacks > 0) ? talentVulnerabilityBase : 0
       x.DMG_TAKEN_MULTI += Math.max(0, m.ashenRoastStacks - 1) * talentVulnerabilityScaling
 
-      x.ELEMENTAL_DMG += (e >= 1 && m.e1DmgBoost && m.ashenRoastStacks > 0) ? 0.48 : 0
+      x.ELEMENTAL_DMG += (e >= 1 && m.e1DmgBoost && m.ashenRoastStacks > 0) ? 0.40 : 0
 
       x.RES_PEN += (e >= 6 && m.e6ResShred) ? m.ashenRoastStacks * 0.03 : 0
     },

--- a/src/lib/db.js
+++ b/src/lib/db.js
@@ -739,14 +739,17 @@ export const DB = {
           found.equippedBy = newRelic.equippedBy
           newRelic = found
         }
+        // Fix metadata if field not present
+        if (!found.restriction) found.restriction = { enabled: false, list: [] }
 
         // Save the old relic because it may have edited speed values, delete the hash to prevent duplicates
         replacementRelics.push(found)
         stableRelicId = found.id
         delete oldRelicHashes[hash]
       } else {
-        // No match found - save the new relic
+        // No match found - add the restriction field - save the new relic
         stableRelicId = newRelic.id
+        newRelic.restriction = { enabled: false, list: [] }
         replacementRelics.push(newRelic)
       }
 
@@ -890,6 +893,7 @@ export const DB = {
         match.verified = true
         updatedOldRelics.push(match)
       } else {
+        newRelic.restriction = { enabled: false, list: [] }
         oldRelics.push(newRelic)
 
         newRelic.verified = true

--- a/src/lib/db.js
+++ b/src/lib/db.js
@@ -409,6 +409,12 @@ export const DB = {
       } else {
         relic.equippedBy = undefined
       }
+      if (!relic.restriction) {
+        relic.restriction = {
+          enabled: false,
+          list: [],
+        }
+      }
     }
 
     if (x.scoringMetadataOverrides) {

--- a/src/lib/db.js
+++ b/src/lib/db.js
@@ -128,6 +128,7 @@ window.store = create((set) => ({
     subStats: [],
     grade: [],
     verified: [],
+    restricted: [],
   },
   characterTabFilters: {
     name: '',

--- a/src/lib/hint.jsx
+++ b/src/lib/hint.jsx
@@ -128,14 +128,14 @@ export const Hint = {
       content: (
         <Flex vertical gap={10}>
           <p>
+            <strong>Allow equipped relics</strong>
+            {' '}
+            - When enabled, the optimizer will allow using currently equipped by a character for the search. Otherwise equipped relics are excluded
+          </p>
+          <p>
             <strong>Character priority filter</strong>
             {' '}
             - When this option is enabled, the character may only steal relics from lower priority characters. The optimizer will ignore relics equipped by higher priority characters on the list. Change character ranks from the priority selector or by dragging them on the Characters page.
-          </p>
-          <p>
-            <strong>Boost main stat</strong>
-            {' '}
-            - Calculates relic mains stats as if they were this level (or their max if they can't reach this level) if they are currently below it. Substats are not changed accordingly, so builds with lower level relics may be stronger once you level them.
           </p>
           <p>
             <strong>Keep current relics</strong>
@@ -143,9 +143,9 @@ export const Hint = {
             - The character must use its currently equipped items, and the optimizer will try to fill in empty slots
           </p>
           <p>
-            <strong>Include equipped relics</strong>
+            <strong>Ignore wearer restrictions</strong>
             {' '}
-            - When enabled, the optimizer will allow using currently equipped by a character for the search. Otherwise equipped relics are excluded
+            - When this option is enabled, the character will ignore the wearer restrictions of relics
           </p>
           <p>
             <strong>Priority</strong>
@@ -158,9 +158,14 @@ export const Hint = {
             - Select specific characters' equipped relics to exclude for the search. This setting overrides the priority filter
           </p>
           <p>
-            <strong>Enhance / grade</strong>
+            <strong>Enhance / Rarity</strong>
             {' '}
             - Select the minimum enhance to search for and minimum stars for relics to include
+          </p>
+          <p>
+            <strong>Boost main stat</strong>
+            {' '}
+            - Calculates relic mains stats as if they were this level (or their max if they can't reach this level) if they are currently below it. Substats are not changed accordingly, so builds with lower level relics may be stronger once you level them.
           </p>
         </Flex>
       ),

--- a/src/lib/optimizer/optimizer.js
+++ b/src/lib/optimizer/optimizer.js
@@ -46,6 +46,8 @@ export const Optimizer = {
     relics = RelicFilters.applyRankFilter(request, relics)
     relics = RelicFilters.applyExcludeFilter(request, relics)
 
+    relics = RelicFilters.applyRestrictionFilter(request, relics)
+
     // Pre-split filters
     const preFilteredRelicsByPart = RelicFilters.splitRelicsByPart(relics)
 
@@ -62,7 +64,7 @@ export const Optimizer = {
     return [relics, preFilteredRelicsByPart]
   },
 
-  optimize: function(request) {
+  optimize: function (request) {
     CANCEL = false
 
     window.store.getState().setPermutationsSearched(0)

--- a/src/lib/relicFilters.js
+++ b/src/lib/relicFilters.js
@@ -137,7 +137,7 @@ export const RelicFilters = {
 
   applyRestrictionFilter: (request, relics) => {
     if (request.ignoreRestrictions) return relics
-    const ret = relics.filter((x) => (!(x.restriction.list).includes(request.characterId) && x.restriction.enabled) || !x.restriction.enabled)
+    const ret = relics.filter((x) => !(x.restriction.list).includes(request.characterId) || !x.restriction.enabled)
     return ret
   },
 

--- a/src/lib/relicFilters.js
+++ b/src/lib/relicFilters.js
@@ -135,6 +135,12 @@ export const RelicFilters = {
     return ret
   },
 
+  applyRestrictionFilter: (request, relics) => {
+    if (request.ignoreRestrictions) return relics
+    const ret = relics.filter((x) => (!(x.restriction.list).includes(request.characterId) && x.restriction.enabled) || !x.restriction.enabled)
+    return ret
+  },
+
   applyGradeFilter: (request, relics) => {
     return relics.filter((x) => x.grade ? x.grade >= request.grade : true)
   },

--- a/src/lib/relicModalController.ts
+++ b/src/lib/relicModalController.ts
@@ -45,6 +45,8 @@ export type RelicForm = {
   substatValue2: number
   substatValue3: number
   equippedBy: string
+  restrictionEnabled: boolean
+  restrictionList: string[]
 }
 
 export function validateRelic(relicForm: RelicForm): Relic | void {
@@ -170,6 +172,10 @@ export function validateRelic(relicForm: RelicForm): Relic | void {
   }
   relic.substats = substats
   RelicAugmenter.augment(relic)
+  relic.restriction = {
+    enabled: relicForm.restrictionEnabled,
+    list: relicForm.restrictionList,
+  }
 
   return relic
 }

--- a/src/lib/renderer.jsx
+++ b/src/lib/renderer.jsx
@@ -1,5 +1,5 @@
 import { Flex, Image, Tooltip } from 'antd'
-import { CheckCircleFilled, LockOutlined, UnlockOutlined } from '@ant-design/icons'
+import { CheckCircleFilled, FilterTwoTone } from '@ant-design/icons'
 import { Constants, StatsToReadableShort } from './constants.ts'
 import { Assets } from './assets'
 import { Utils } from './utils'
@@ -199,8 +199,8 @@ export const Renderer = {
   renderFilter: (enabled) => {
     return (
       enabled
-        ? <Tooltip mouseEnterDelay={0.4} title="Relic wearers restricted for optimizer"><LockOutlined style={{ width: 14 }} /></Tooltip>
-        : <Tooltip mouseEnterDelay={0.4} title="Relic wearers unrestricted for optimizer"><UnlockOutlined /></Tooltip>
+        ? <Tooltip mouseEnterDelay={0.4} title="Relic wearers restricted for optimizer"><FilterTwoTone twoToneColor="#c72436" style={{ width: 14 }} /></Tooltip>
+        : <Tooltip mouseEnterDelay={0.4} title="Relic wearers unrestricted for optimizer"><FilterTwoTone twoToneColor="#bdbdbd" style={{ width: 14 }} /></Tooltip>
     )
   },
 }

--- a/src/lib/renderer.jsx
+++ b/src/lib/renderer.jsx
@@ -1,5 +1,5 @@
 import { Flex, Image, Tooltip } from 'antd'
-import { CheckCircleFilled } from '@ant-design/icons'
+import { CheckCircleFilled, LockOutlined, UnlockOutlined } from '@ant-design/icons'
 import { Constants, StatsToReadableShort } from './constants.ts'
 import { Assets } from './assets'
 import { Utils } from './utils'
@@ -189,6 +189,18 @@ export const Renderer = {
       relic.verified
         ? <Tooltip mouseEnterDelay={0.4} title="Relic substats verified by relic scorer (speed decimals)"><CheckCircleFilled style={{ fontSize: '14px', color: color }} /></Tooltip>
         : <div style={{ width: 14, height: 14, borderRadius: '50%', background: color }} />
+    )
+  },
+
+  renderFilterCell: (x) => {
+    const enabled = x.data.restriction.enabled
+    return Renderer.renderFilter(enabled)
+  },
+  renderFilter: (enabled) => {
+    return (
+      enabled
+        ? <Tooltip mouseEnterDelay={0.4} title="Relic wearers restricted for optimizer"><LockOutlined style={{ width: 14 }} /></Tooltip>
+        : <Tooltip mouseEnterDelay={0.4} title="Relic wearers unrestricted for optimizer"><UnlockOutlined /></Tooltip>
     )
   },
 }

--- a/src/types/Relic.d.ts
+++ b/src/types/Relic.d.ts
@@ -21,7 +21,7 @@ export type Relic = {
   grade: RelicGrade
   id: GUID
   verified?: boolean
-  restriction?: RelicOptimizerRestriction
+  restriction: RelicOptimizerRestriction
 
   main: {
     stat: MainStats

--- a/src/types/Relic.d.ts
+++ b/src/types/Relic.d.ts
@@ -21,6 +21,7 @@ export type Relic = {
   grade: RelicGrade
   id: GUID
   verified?: boolean
+  restriction?: RelicOptimizerRestriction
 
   main: {
     stat: MainStats
@@ -49,4 +50,9 @@ type StatRolls = {
 export type Stat = {
   stat: string
   value: number
+}
+
+type RelicOptimizerRestriction = {
+  enabled: boolean
+  list: string[]
 }

--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -25,6 +25,7 @@ type RelicTabFilters = {
   subStats: unknown[]
   grade: unknown[]
   verified: unknown[]
+  restricted: unknown[]
 }
 
 export type HsrOptimizerStore = {

--- a/tests/RelicModal/3-edit-from-relics-tab.spec.ts
+++ b/tests/RelicModal/3-edit-from-relics-tab.spec.ts
@@ -10,7 +10,7 @@ test('Open RelicModal in edit mode from the CharacterPreview tab', async ({ page
 
   // got relics tab
   await page.getByRole('menuitem', { name: 'Relics' }).click()
-  await page.getByRole('row', { name: 'Hunter of Glacial Forest unlock Head 15 HP 705 11.0 10.3 3.4 5.1 32.4' }).click()
+  await page.getByRole('row', { name: 'Hunter of Glacial Forest filter Head 15 HP 705 11.0 10.3 3.4 5.1 32.4' }).click()
   await page.getByText('+15HP705CRIT Rate11.0%CRIT').click()
 
   await expect(page.getByRole('dialog')).toContainText('Equipped by')

--- a/tests/RelicModal/3-edit-from-relics-tab.spec.ts
+++ b/tests/RelicModal/3-edit-from-relics-tab.spec.ts
@@ -10,7 +10,7 @@ test('Open RelicModal in edit mode from the CharacterPreview tab', async ({ page
 
   // got relics tab
   await page.getByRole('menuitem', { name: 'Relics' }).click()
-  await page.getByRole('row', { name: 'Hunter of Glacial Forest Head 15 HP 705 11.0 10.3 3.4 5.1 32.4' }).click()
+  await page.getByRole('row', { name: 'Hunter of Glacial Forest unlock Head 15 HP 705 11.0 10.3 3.4 5.1 32.4' }).click()
   await page.getByText('+15HP705CRIT Rate11.0%CRIT').click()
 
   await expect(page.getByRole('dialog')).toContainText('Equipped by')

--- a/tests/RelicsTab/delete-relic.spec.ts
+++ b/tests/RelicsTab/delete-relic.spec.ts
@@ -9,10 +9,10 @@ test('Delete relic from RelicsTab', async ({ page }) => {
 
   // nav to RelicsTab
   await page.getByRole('menuitem', { name: 'Relics' }).click()
-  await page.getByRole('row', { name: 'Hunter of Glacial Forest unlock Head 15 HP 705 11.0 10.3 3.4 5.1 32.4' }).click()
+  await page.getByRole('row', { name: 'Hunter of Glacial Forest filter Head 15 HP 705 11.0 10.3 3.4 5.1 32.4' }).click()
   await page.getByRole('button', { name: 'Delete Relic' }).click()
   await page.getByRole('button', { name: 'Yes' }).click()
 
-  await expect(page.getByRole('row', { name: 'Hunter of Glacial Forest unlock Head 15 HP 705 11.0 10.3 3.4 5.1 32.4' })).toHaveCount(0)
+  await expect(page.getByRole('row', { name: 'Hunter of Glacial Forest filter Head 15 HP 705 11.0 10.3 3.4 5.1 32.4' })).toHaveCount(0)
   await expect(page.locator('body')).toContainText('Successfully deleted relic')
 })

--- a/tests/RelicsTab/delete-relic.spec.ts
+++ b/tests/RelicsTab/delete-relic.spec.ts
@@ -9,10 +9,10 @@ test('Delete relic from RelicsTab', async ({ page }) => {
 
   // nav to RelicsTab
   await page.getByRole('menuitem', { name: 'Relics' }).click()
-  await page.getByRole('row', { name: 'Hunter of Glacial Forest Head 15 HP 705 11.0 10.3 3.4 5.1 32.4' }).click()
+  await page.getByRole('row', { name: 'Hunter of Glacial Forest unlock Head 15 HP 705 11.0 10.3 3.4 5.1 32.4' }).click()
   await page.getByRole('button', { name: 'Delete Relic' }).click()
   await page.getByRole('button', { name: 'Yes' }).click()
 
-  await expect(page.getByRole('row', { name: 'Hunter of Glacial Forest Head 15 HP 705 11.0 10.3 3.4 5.1 32.4' })).toHaveCount(0)
+  await expect(page.getByRole('row', { name: 'Hunter of Glacial Forest unlock Head 15 HP 705 11.0 10.3 3.4 5.1 32.4' })).toHaveCount(0)
   await expect(page.locator('body')).toContainText('Successfully deleted relic')
 })

--- a/tests/RelicsTab/delete-relic.spec.ts
+++ b/tests/RelicsTab/delete-relic.spec.ts
@@ -9,7 +9,7 @@ test('Delete relic from RelicsTab', async ({ page }) => {
 
   // nav to RelicsTab
   await page.getByRole('menuitem', { name: 'Relics' }).click()
-  await page.getByRole('row', { name: 'Hunter of Glacial Forest unlock unlock Head 15 HP 705 11.0 10.3 3.4 5.1 32.4' }).click()
+  await page.getByRole('row', { name: 'Hunter of Glacial Forest unlock Head 15 HP 705 11.0 10.3 3.4 5.1 32.4' }).click()
   await page.getByRole('button', { name: 'Delete Relic' }).click()
   await page.getByRole('button', { name: 'Yes' }).click()
 


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Added a per-relic filter which is toggleable, accessed via the relic modal, which allows the user to restrict which characters can use the relic in the optimiser tab
* Added a display and filter option in the relics tab to filter/see which relics have their filter set to active/inactive
* Added a toggle in the optimiser options to bypass the per-relic wearer restrictions
* Updated the optimizer options tooltip with the description of the new option + made names and order consistent with the display

Not over the world with the icons but I can't think of anything that really fits

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* Closes #19 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->
### Updated relic tab
![firefox_2024-07-15_15-26-08](https://github.com/user-attachments/assets/c07557f2-0fe0-453b-b6b7-11a43615f82d)

### Updated optimizer options panel and tooltip
![firefox_2024-07-12_17-47-16](https://github.com/user-attachments/assets/ff4e613d-f186-444f-91b3-c21b4a0817e9)![firefox_2024-07-12_17-48-19](https://github.com/user-attachments/assets/49cb2c5f-0e95-4957-8240-52465f2e514f)

### Display on relic preview
![firefox_2024-07-15_15-28-38](https://github.com/user-attachments/assets/eb1808cc-4dfe-4df4-8690-e5e0608adc95)

### Selection + Toggle in RelicModal
![firefox_2024-07-22_16-10-03](https://github.com/user-attachments/assets/82b6a253-44b1-44b5-bc33-d6623fa83eec)
![firefox_2024-07-22_16-11-40](https://github.com/user-attachments/assets/7c443bc8-dfa5-4499-b9a5-a129587bb96b)
