### PR TITLE
hotfix: lingsha break override and feixiao spd boots scoring

### DIFF
--- a/src/lib/characterScorer.ts
+++ b/src/lib/characterScorer.ts
@@ -924,11 +924,11 @@ function calculateMaxSubstatRollCounts(
   return maxCounts
 }
 
-function getBaseSpeed(character: Character) {
+function calculateCharacterSpdStat(character: Character) {
   const statMetadata = DB.getMetadata().characters[character.id]
-  const baseSpd = statMetadata.stats.SPD + (statMetadata.traces.SPD || 0)
+  const baseSpdStat = statMetadata.stats.SPD + (statMetadata.traces.SPD || 0)
 
-  return baseSpd
+  return baseSpdStat
 }
 
 // Generate all main stat possibilities
@@ -938,7 +938,7 @@ function generatePartialSimulations(
   relicsByPart: RelicBuild,
   originalBaseSpeed: number,
 ) {
-  const characterSpdStat = getBaseSpeed(character)
+  const characterSpdStat = calculateCharacterSpdStat(character)
   const forceSpdBoots = originalBaseSpeed - characterSpdStat > 25
   const feetParts: string[] = forceSpdBoots ? [Stats.SPD] : metadata.parts[Parts.Feet]
 

--- a/src/lib/characterScorer.ts
+++ b/src/lib/characterScorer.ts
@@ -1,15 +1,7 @@
 import { Character } from 'types/Character'
 import { StatSimTypes } from 'components/optimizerTab/optimizerForm/StatSimulationDisplay'
 import { CUSTOM_TEAM, Parts, Sets, Stats, SubStats } from 'lib/constants'
-import {
-  calculateOrnamentSets,
-  calculateRelicSets,
-  convertRelicsToSimulation,
-  runSimulations,
-  Simulation,
-  SimulationRequest,
-  SimulationStats
-} from 'lib/statSimulationController'
+import { calculateOrnamentSets, calculateRelicSets, convertRelicsToSimulation, runSimulations, Simulation, SimulationRequest, SimulationStats } from 'lib/statSimulationController'
 import { getDefaultForm } from 'lib/defaultForm'
 import { CharacterConditionals } from 'lib/characterConditionals'
 import { Utils } from 'lib/utils'
@@ -335,7 +327,7 @@ export function scoreCharacterSimulation(
   applyScoringFunction(baselineSimResult)
 
   // Generate partials to calculate speed rolls
-  const partialSimulationWrappers = generatePartialSimulations(metadata, relicsByPart, originalBaseSpeed)
+  const partialSimulationWrappers = generatePartialSimulations(character, metadata, relicsByPart, originalBaseSpeed)
   const candidateBenchmarkSims: Simulation[] = []
 
   // Run sims
@@ -932,13 +924,22 @@ function calculateMaxSubstatRollCounts(
   return maxCounts
 }
 
+function getBaseSpeed(character: Character) {
+  const statMetadata = DB.getMetadata().characters[character.id]
+  const baseSpd = statMetadata.stats.SPD + (statMetadata.traces.SPD || 0)
+
+  return baseSpd
+}
+
 // Generate all main stat possibilities
 function generatePartialSimulations(
+  character: Character,
   metadata: SimulationMetadata,
   relicsByPart: RelicBuild,
   originalBaseSpeed: number,
 ) {
-  const forceSpdBoots = originalBaseSpeed > 140
+  const characterSpdStat = getBaseSpeed(character)
+  const forceSpdBoots = originalBaseSpeed - characterSpdStat > 25
   const feetParts: string[] = forceSpdBoots ? [Stats.SPD] : metadata.parts[Parts.Feet]
 
   // Allow equivalent sets

--- a/src/lib/conditionals/character/Lingsha.ts
+++ b/src/lib/conditionals/character/Lingsha.ts
@@ -117,12 +117,15 @@ export default (e: Eidolon): CharacterConditional => {
 
       buffAbilityVulnerability(x, BREAK_TYPE, ultBreakVulnerability, (m.befogState))
 
+      x[Stats.BE] += (e >= 2 && m.e2BeBuff) ? 0.40 : 0
+      x.RES_PEN += (e >= 6 && m.e6ResShred) ? 0.20 : 0
+    },
+    postPreComputeMutualEffects: (x: ComputedStatsObject, request: Form) => {
+      const m = request.characterConditionals
+
       if (x.ENEMY_WEAKNESS_BROKEN) {
         x.DEF_SHRED += (e >= 1 && m.e1DefShred) ? 0.20 : 0
       }
-
-      x[Stats.BE] += (e >= 2 && m.e2BeBuff) ? 0.40 : 0
-      x.RES_PEN += (e >= 6 && m.e6ResShred) ? 0.20 : 0
     },
     precomputeTeammateEffects: (_x: ComputedStatsObject, _request: Form) => {
     },

--- a/src/lib/conditionals/character/TrailblazerHarmony.ts
+++ b/src/lib/conditionals/character/TrailblazerHarmony.ts
@@ -111,16 +111,13 @@ export default (e: Eidolon): CharacterConditional => {
 
       return x
     },
-    prePrecomputeMutualEffects: (x: ComputedStatsObject, request: Form) => {
+    precomputeMutualEffects: (x: ComputedStatsObject, request: Form) => {
       const m = request.characterConditionals
 
       // Special case where we force the weakness break on if the option is enabled
       if (m.superBreakDmg) {
         x.ENEMY_WEAKNESS_BROKEN = 1
       }
-    },
-    precomputeMutualEffects: (x: ComputedStatsObject, request: Form) => {
-      const m = request.characterConditionals
 
       x[Stats.BE] += (m.backupDancer) ? ultBeScaling : 0
       x.SUPER_BREAK_HMC_MODIFIER += (m.backupDancer && m.superBreakDmg) ? targetsToSuperBreakMulti[request.enemyCount] : 0

--- a/src/lib/dataParser.js
+++ b/src/lib/dataParser.js
@@ -4399,7 +4399,7 @@ function getScoringMetadata() {
           ],
           [Parts.Feet]: [
             Stats.ATK_P,
-            Constants.Stats.SPD,
+            Stats.SPD,
           ],
           [Parts.PlanarSphere]: [
             Stats.ATK_P,

--- a/src/lib/dataParser.js
+++ b/src/lib/dataParser.js
@@ -4399,7 +4399,7 @@ function getScoringMetadata() {
           ],
           [Parts.Feet]: [
             Stats.ATK_P,
-            Stats.SPD,
+            Constants.Stats.SPD,
           ],
           [Parts.PlanarSphere]: [
             Stats.ATK_P,

--- a/src/lib/optimizer/calculateBuild.js
+++ b/src/lib/optimizer/calculateBuild.js
@@ -1,6 +1,6 @@
 import { generateParams } from 'lib/optimizer/calculateParams'
-import { calculateConditionals } from 'lib/optimizer/calculateConditionals'
-import { calculateTeammates } from 'lib/optimizer/calculateTeammates'
+import { calculateConditionals, calculatePostPrecomputeConditionals } from 'lib/optimizer/calculateConditionals'
+import { calculatePostPrecomputeTeammates, calculateTeammates } from 'lib/optimizer/calculateTeammates'
 import { OrnamentSetCount, OrnamentSetToIndex, RelicSetCount, RelicSetToIndex } from 'lib/constants'
 import { baseCharacterStats, calculateBaseStats, calculateComputedStats, calculateElementalStats, calculateRelicStats, calculateSetCounts } from 'lib/optimizer/calculateStats'
 import { calculateBaseMultis, calculateDamage } from 'lib/optimizer/calculateDamage'
@@ -40,6 +40,10 @@ export function calculateBuild(request, relics) {
   // Precompute
   calculateConditionals(request, params)
   calculateTeammates(request, params)
+
+  // Postcompute
+  calculatePostPrecomputeConditionals(request, params)
+  calculatePostPrecomputeTeammates(request, params)
 
   // Compute
   const { Head, Hands, Body, Feet, PlanarSphere, LinkRope } = extractRelics(relics)

--- a/src/lib/optimizer/calculateConditionals.js
+++ b/src/lib/optimizer/calculateConditionals.js
@@ -16,13 +16,10 @@ export function calculateConditionals(request, params) {
   // If the conditionals forced weakness break, keep it. Otherwise use the request's broken status
   precomputedX.ENEMY_WEAKNESS_BROKEN = precomputedX.ENEMY_WEAKNESS_BROKEN || (request.enemyWeaknessBroken ? 1 : 0)
 
-  if (characterConditionals.prePrecomputeMutualEffects) characterConditionals.prePrecomputeMutualEffects(precomputedX, request)
   if (characterConditionals.precomputeMutualEffects) characterConditionals.precomputeMutualEffects(precomputedX, request)
 
   if (lightConeConditionals) {
     if (lightConeConditionals.precomputeEffects) lightConeConditionals.precomputeEffects(precomputedX, request)
-
-    if (lightConeConditionals.prePrecomputeMutualEffects) lightConeConditionals.prePrecomputeMutualEffects(precomputedX, request)
     if (lightConeConditionals.precomputeMutualEffects) lightConeConditionals.precomputeMutualEffects(precomputedX, request)
   }
 

--- a/src/lib/optimizer/calculateConditionals.js
+++ b/src/lib/optimizer/calculateConditionals.js
@@ -16,14 +16,28 @@ export function calculateConditionals(request, params) {
   // If the conditionals forced weakness break, keep it. Otherwise use the request's broken status
   precomputedX.ENEMY_WEAKNESS_BROKEN = precomputedX.ENEMY_WEAKNESS_BROKEN || (request.enemyWeaknessBroken ? 1 : 0)
 
+  if (characterConditionals.prePrecomputeMutualEffects) characterConditionals.prePrecomputeMutualEffects(precomputedX, request)
   if (characterConditionals.precomputeMutualEffects) characterConditionals.precomputeMutualEffects(precomputedX, request)
 
   if (lightConeConditionals) {
     if (lightConeConditionals.precomputeEffects) lightConeConditionals.precomputeEffects(precomputedX, request)
+
+    if (lightConeConditionals.prePrecomputeMutualEffects) lightConeConditionals.prePrecomputeMutualEffects(precomputedX, request)
     if (lightConeConditionals.precomputeMutualEffects) lightConeConditionals.precomputeMutualEffects(precomputedX, request)
   }
 
   params.precomputedX = precomputedX
   params.characterConditionals = characterConditionals
   params.lightConeConditionals = lightConeConditionals
+}
+
+export function calculatePostPrecomputeConditionals(request, params) {
+  let characterConditionals = params.characterConditionals
+  let lightConeConditionals = params.lightConeConditionals
+
+  if (characterConditionals.postPreComputeMutualEffects) characterConditionals.postPreComputeMutualEffects(params.precomputedX, request)
+
+  if (lightConeConditionals) {
+    if (lightConeConditionals.postPreComputeMutualEffects) lightConeConditionals.postPreComputeMutualEffects(params.precomputedX, request)
+  }
 }

--- a/src/lib/optimizer/calculateTeammates.js
+++ b/src/lib/optimizer/calculateTeammates.js
@@ -12,16 +12,16 @@ export function calculateTeammates(request, params) {
     request.teammate2,
   ].filter((x) => !!x && !!x.characterId)
   for (let i = 0; i < teammates.length; i++) {
+    // This set to null so empty light cones don't get overwritten by the main lc. TODO: There's probably a better place for this
+    teammates[i].lightCone = teammates[i].lightCone || null
     const teammateRequest = Object.assign({}, request, teammates[i])
 
     const teammateCharacterConditionals = CharacterConditionals.get(teammateRequest)
     const teammateLightConeConditionals = LightConeConditionals.get(teammateRequest)
 
-    if (teammateCharacterConditionals.prePrecomputeMutualEffects) teammateCharacterConditionals.prePrecomputeMutualEffects(precomputedX, teammateRequest)
     if (teammateCharacterConditionals.precomputeMutualEffects) teammateCharacterConditionals.precomputeMutualEffects(precomputedX, teammateRequest)
     if (teammateCharacterConditionals.precomputeTeammateEffects) teammateCharacterConditionals.precomputeTeammateEffects(precomputedX, teammateRequest)
 
-    if (teammateLightConeConditionals.prePrecomputeMutualEffects) teammateLightConeConditionals.prePrecomputeMutualEffects(precomputedX, teammateRequest)
     if (teammateLightConeConditionals.precomputeMutualEffects) teammateLightConeConditionals.precomputeMutualEffects(precomputedX, teammateRequest)
     if (teammateLightConeConditionals.precomputeTeammateEffects) teammateLightConeConditionals.precomputeTeammateEffects(precomputedX, teammateRequest)
 
@@ -57,5 +57,26 @@ export function calculateTeammates(request, params) {
     // Track unique buffs
     teammateSetEffects[teammateRequest.teamOrnamentSet] = true
     teammateSetEffects[teammateRequest.teamRelicSet] = true
+  }
+}
+
+export function calculatePostPrecomputeTeammates(request, params) {
+  // Postcompute teammate effects
+  const precomputedX = params.precomputedX
+  const teammates = [
+    request.teammate0,
+    request.teammate1,
+    request.teammate2,
+  ].filter((x) => !!x && !!x.characterId)
+  for (let i = 0; i < teammates.length; i++) {
+    // This set to null so empty light cones don't get overwritten by the main lc. TODO: There's probably a better place for this
+    teammates[i].lightCone = teammates[i].lightCone || null
+    const teammateRequest = Object.assign({}, request, teammates[i])
+
+    const teammateCharacterConditionals = CharacterConditionals.get(teammateRequest)
+    const teammateLightConeConditionals = LightConeConditionals.get(teammateRequest)
+
+    if (teammateCharacterConditionals.postPreComputeMutualEffects) teammateCharacterConditionals.postPreComputeMutualEffects(precomputedX, teammateRequest)
+    if (teammateLightConeConditionals.postPreComputeMutualEffects) teammateLightConeConditionals.postPreComputeMutualEffects(precomputedX, teammateRequest)
   }
 }

--- a/src/lib/optimizer/calculateTeammates.js
+++ b/src/lib/optimizer/calculateTeammates.js
@@ -12,7 +12,7 @@ export function calculateTeammates(request, params) {
     request.teammate2,
   ].filter((x) => !!x && !!x.characterId)
   for (let i = 0; i < teammates.length; i++) {
-    // This set to null so empty light cones don't get overwritten by the main lc. TODO: There's probably a better place for this
+    // This is set to null so empty light cones don't get overwritten by the main lc. TODO: There's probably a better place for this
     teammates[i].lightCone = teammates[i].lightCone || null
     const teammateRequest = Object.assign({}, request, teammates[i])
 
@@ -69,7 +69,7 @@ export function calculatePostPrecomputeTeammates(request, params) {
     request.teammate2,
   ].filter((x) => !!x && !!x.characterId)
   for (let i = 0; i < teammates.length; i++) {
-    // This set to null so empty light cones don't get overwritten by the main lc. TODO: There's probably a better place for this
+    // This is set to null so empty light cones don't get overwritten by the main lc. TODO: There's probably a better place for this
     teammates[i].lightCone = teammates[i].lightCone || null
     const teammateRequest = Object.assign({}, request, teammates[i])
 

--- a/src/lib/worker/optimizerWorker.js
+++ b/src/lib/worker/optimizerWorker.js
@@ -1,16 +1,9 @@
 import { OrnamentSetToIndex, RelicSetToIndex, SetsOrnaments, SetsRelics, Stats } from '../constants.ts'
 import { BufferPacker } from '../bufferPacker.js'
-import {
-  baseCharacterStats,
-  calculateBaseStats,
-  calculateComputedStats,
-  calculateElementalStats,
-  calculateRelicStats,
-  calculateSetCounts
-} from 'lib/optimizer/calculateStats'
+import { baseCharacterStats, calculateBaseStats, calculateComputedStats, calculateElementalStats, calculateRelicStats, calculateSetCounts } from 'lib/optimizer/calculateStats'
 import { calculateBaseMultis, calculateDamage } from 'lib/optimizer/calculateDamage'
-import { calculateTeammates } from 'lib/optimizer/calculateTeammates'
-import { calculateConditionals } from 'lib/optimizer/calculateConditionals'
+import { calculatePostPrecomputeTeammates, calculateTeammates } from 'lib/optimizer/calculateTeammates'
+import { calculateConditionals, calculatePostPrecomputeConditionals } from 'lib/optimizer/calculateConditionals'
 import { SortOption } from 'lib/optimizer/sortOptions'
 
 const relicSetCount = Object.values(SetsRelics).length
@@ -46,6 +39,10 @@ self.onmessage = function(e) {
 
   calculateConditionals(request, params)
   calculateTeammates(request, params)
+
+  // PostPrecompute
+  calculatePostPrecomputeConditionals(request, params)
+  calculatePostPrecomputeTeammates(request, params)
 
   const limit = Math.min(data.permutations, data.WIDTH)
 

--- a/src/types/CharacterConditional.d.ts
+++ b/src/types/CharacterConditional.d.ts
@@ -7,8 +7,8 @@ export interface CharacterConditional extends Conditional {
   precomputeEffects: (request: Form) => ComputedStatsObject
 
   // Shared effects between teammates and main character
-  prePrecomputeMutualEffects?: (x: ComputedStatsObject, request: Form) => void
   precomputeMutualEffects?: (x: ComputedStatsObject, request: Form) => void
+  postPreComputeMutualEffects?: (x: ComputedStatsObject, request: Form) => void
 
   // Effects unique to teammate calculation
   precomputeTeammateEffects?: (x: ComputedStatsObject, request: Form) => void


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Fixing a couple bugs:
  * Lingsha not interacting correctly with weakness break override from teammates. Add a postPrecompute step to handle
  * Teammates without light cones were getting the main character's light cone conditionals
  * Feixiao's 130 base spd messing with sim scoring decision on spd vs atk boots. Change decision to base + trace + 25 spd

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

