### PR TITLE
hotfix: set min missing crit rate to 0 for sim stat roll limits

### DIFF
--- a/src/lib/characterScorer.ts
+++ b/src/lib/characterScorer.ts
@@ -906,24 +906,24 @@ function calculateMaxSubstatRollCounts(
   // Assumes maximum 100 CR is needed ever
   const critValue = StatCalculator.getMaxedSubstatValue(Stats.CR, scoringParams.quality)
   const missingCrit = Math.max(0, 100 - baselineSimResult.x[Stats.CR] * 100)
-  maxCounts[Stats.CR] = Math.min(
+  maxCounts[Stats.CR] = Math.max(scoringParams.baselineFreeRolls, Math.min(
     request.simBody == Stats.CR
       ? Math.ceil((missingCrit - 32.4) / critValue)
       : Math.ceil(missingCrit / critValue),
     maxCounts[Stats.CR],
-  )
+  ))
 
   // Simplify EHR so the sim is not wasting permutations
   // Assumes 20 enemy effect RES
   // Assumes maximum 120 EHR is needed ever
   const ehrValue = StatCalculator.getMaxedSubstatValue(Stats.EHR, scoringParams.quality)
-  const missingEhr = 120 - baselineSimResult.x[Stats.EHR] * 100
-  maxCounts[Stats.EHR] = Math.min(
+  const missingEhr = Math.max(0, 120 - baselineSimResult.x[Stats.EHR] * 100)
+  maxCounts[Stats.EHR] = Math.max(scoringParams.baselineFreeRolls, Math.min(
     request.simBody == Stats.EHR
       ? Math.ceil((missingEhr - 43.2) / ehrValue)
       : Math.ceil(missingEhr / ehrValue),
     maxCounts[Stats.EHR],
-  )
+  ))
 
   return maxCounts
 }

--- a/src/lib/characterScorer.ts
+++ b/src/lib/characterScorer.ts
@@ -396,10 +396,9 @@ export function scoreCharacterSimulation(
   const baselineSimScore = baselineSimResult.simScore
   const maximumSimScore = maximumSimResult.simScore
 
-  const percent
-    = originalSimScore >= benchmarkSimScore
-      ? 1 + (originalSimScore - benchmarkSimScore) / (maximumSimScore - benchmarkSimScore)
-      : (originalSimScore - baselineSimScore) / (benchmarkSimScore - baselineSimScore)
+  const percent = originalSimScore >= benchmarkSimScore
+    ? 1 + (originalSimScore - benchmarkSimScore) / (maximumSimScore - benchmarkSimScore)
+    : (originalSimScore - baselineSimScore) / (benchmarkSimScore - baselineSimScore)
 
   // ===== Calculate upgrades =====
 
@@ -551,6 +550,7 @@ function generateStatImprovements(
 
   // Upgrade mains
   const mainUpgradeResults: SimulationStatUpgrade[] = []
+
   function upgradeMain(part: string) {
     const originalSimClone: Simulation = TsUtils.clone(originalSim)
     for (const upgradeMainStat of metadata.parts[part]) {
@@ -576,6 +576,7 @@ function generateStatImprovements(
       })
     }
   }
+
   upgradeMain(Parts.Body)
   upgradeMain(Parts.Feet)
   upgradeMain(Parts.PlanarSphere)
@@ -904,7 +905,7 @@ function calculateMaxSubstatRollCounts(
   // Main stat  20 * 3.24 + 32.4 + 5 = 102.2% crit
   // Assumes maximum 100 CR is needed ever
   const critValue = StatCalculator.getMaxedSubstatValue(Stats.CR, scoringParams.quality)
-  const missingCrit = 100 - baselineSimResult.x[Stats.CR] * 100
+  const missingCrit = Math.max(0, 100 - baselineSimResult.x[Stats.CR] * 100)
   maxCounts[Stats.CR] = Math.min(
     request.simBody == Stats.CR
       ? Math.ceil((missingCrit - 32.4) / critValue)


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* There was a bug where Yanqing's crit passive overflowed the crit rate roll cap here. We should make the min missing crit 0 when that happens

![image](https://github.com/user-attachments/assets/c5c0f3eb-acec-4bc0-a78d-046e860af60f)

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

