### PR TITLE
hotfix: import relics no longer overwrites equippedBy, bump kelz scanner version

### DIFF
--- a/src/lib/db.js
+++ b/src/lib/db.js
@@ -723,7 +723,7 @@ export const DB = {
           found.augmentedStats = newRelic.augmentedStats
         }
 
-        if (newRelic.equippedBy && newCharacters) {
+        if (newRelic.equippedBy && newCharacters.length) {
           // Update the owner of the existing relic with the newly imported owner
           found.equippedBy = newRelic.equippedBy
           newRelic = found
@@ -740,7 +740,7 @@ export const DB = {
       }
 
       // Update the character's equipped inventory
-      if (newRelic.equippedBy && newCharacters) {
+      if (newRelic.equippedBy && newCharacters.length) {
         const character = characters.find((x) => x.id == newRelic.equippedBy)
         if (character) {
           character.equipped[newRelic.part] = stableRelicId

--- a/src/lib/importer/importConfig.js
+++ b/src/lib/importer/importConfig.js
@@ -7,8 +7,8 @@ export const KelzScannerConfig = {
   releases: 'https://github.com/kel-z/HSR-Scanner/releases/latest',
   defaultFileName: 'HSRScanData.json',
   sourceString: 'HSR-Scanner',
-  latestBuildVersion: 'v1.1.0',
-  latestOutputVersion: 3,
+  latestBuildVersion: 'v1.2.0',
+  latestOutputVersion: 4,
   speedVerified: false,
 }
 


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

- hotfix: bug where importing relics overwrites equippedby
- feat: bump kelz scanner version


## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* Closes https://github.com/fribbels/hsr-optimizer/issues/464

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

