### PR TITLE
hotfix: smarter stat display rules, flex the card center section 

### DIFF
--- a/src/components/CharacterPreview.jsx
+++ b/src/components/CharacterPreview.jsx
@@ -161,15 +161,15 @@ export function CharacterPreview(props) {
           </Flex>
 
           <Flex vertical gap={defaultGap}>
-            <RelicPreview setSelectedRelic={setSelectedRelic} />
-            <RelicPreview setSelectedRelic={setSelectedRelic} />
-            <RelicPreview setSelectedRelic={setSelectedRelic} />
+            <RelicPreview setSelectedRelic={setSelectedRelic}/>
+            <RelicPreview setSelectedRelic={setSelectedRelic}/>
+            <RelicPreview setSelectedRelic={setSelectedRelic}/>
           </Flex>
 
           <Flex vertical gap={defaultGap}>
-            <RelicPreview setSelectedRelic={setSelectedRelic} />
-            <RelicPreview setSelectedRelic={setSelectedRelic} />
-            <RelicPreview setSelectedRelic={setSelectedRelic} />
+            <RelicPreview setSelectedRelic={setSelectedRelic}/>
+            <RelicPreview setSelectedRelic={setSelectedRelic}/>
+            <RelicPreview setSelectedRelic={setSelectedRelic}/>
           </Flex>
         </Flex>
       </Flex>
@@ -310,7 +310,7 @@ export function CharacterPreview(props) {
                   <Flex vertical gap={10}>
                     <HeaderText>Combat sim scoring settings</HeaderText>
                     <Button
-                      icon={<SyncOutlined />}
+                      icon={<SyncOutlined/>}
                       onClick={() => {
                         const characterMetadata = Utils.clone(DB.getMetadata().characters[character.id])
                         const simulation = characterMetadata.scoringMetadata.simulation
@@ -326,7 +326,7 @@ export function CharacterPreview(props) {
                       Reset custom team to default
                     </Button>
                     <Button
-                      icon={<SwapOutlined />}
+                      icon={<SwapOutlined/>}
                       onClick={() => {
                         const characterMetadata = Utils.clone(DB.getScoringMetadata(character.id))
                         const simulation = characterMetadata.simulation
@@ -365,7 +365,7 @@ export function CharacterPreview(props) {
           DEFAULT_TEAM,
           {
             label: (
-              <SettingOutlined />
+              <SettingOutlined/>
             ),
             value: SETTINGS_TEAM,
             className: 'short-segmented',
@@ -416,9 +416,9 @@ export function CharacterPreview(props) {
               outline: '1px solid rgba(255, 255, 255, 0.3)',
             }}
           />
-          <OverlayText text={`E${teammate.characterEidolon}`} top={-12} />
-          <img src={Assets.getLightConeIconById(teammate.lightCone)} style={{ height: iconSize, marginTop: 2 }} />
-          <OverlayText text={`S${teammate.lightConeSuperimposition}`} top={-16} />
+          <OverlayText text={`E${teammate.characterEidolon}`} top={-12}/>
+          <img src={Assets.getLightConeIconById(teammate.lightCone)} style={{ height: iconSize, marginTop: 2 }}/>
+          <OverlayText text={`S${teammate.lightConeSuperimposition}`} top={-16}/>
         </Flex>
       </Card.Grid>
     )
@@ -494,7 +494,7 @@ export function CharacterPreview(props) {
                         top: 46,
                       }}
                       className="character-build-portrait-button"
-                      icon={<EditOutlined />}
+                      icon={<EditOutlined/>}
                       onClick={() => {
                         setCharacterModalAdd(false)
                         setOriginalCharacterModalInitialCharacter(character)
@@ -511,7 +511,7 @@ export function CharacterPreview(props) {
                       top: 7,
                     }}
                     className="character-build-portrait-button"
-                    icon={<EditOutlined />}
+                    icon={<EditOutlined/>}
                     onClick={() => setEditPortraitModalOpen(true)}
                     type="primary"
                   >
@@ -638,7 +638,7 @@ export function CharacterPreview(props) {
                       width={36}
                       src={Assets.getElement(characterElement)}
                     />
-                    <Rarity rarity={characterMetadata.rarity} />
+                    <Rarity rarity={characterMetadata.rarity}/>
                     <Image
                       preview={false}
                       width={36}
@@ -662,18 +662,8 @@ export function CharacterPreview(props) {
                   simScore={simScoringResult ? simScoringResult.originalSimResult.simScore : undefined}
                 />
                 {
-                  !simScoringResult
-                  && (
-                    <Flex vertical>
-                      <StatText style={{ fontSize: 17, marginBottom: 10, fontWeight: 600, textAlign: 'center', color: '#e1a564' }}>
-                        {`Character Score: ${scoringResults.totalScore.toFixed(0)} ${scoringResults.totalScore == 0 ? '' : '(' + scoringResults.totalRating + ')'}`}
-                      </StatText>
-                    </Flex>
-                  )
-                }
-                {
                   simScoringResult
-                  && <ScoreHeader result={simScoringResult} />
+                  && <ScoreHeader result={simScoringResult}/>
                 }
                 {
                   simScoringResult
@@ -716,55 +706,66 @@ export function CharacterPreview(props) {
                           />
                         </Flex>
                       </Card>
-                      <ScoreFooter result={simScoringResult} />
+                      <ScoreFooter result={simScoringResult}/>
                     </Flex>
                   )
                 }
                 {
                   simScoringResult && (
                     <Flex vertical gap={defaultGap}>
-                      <CharacterCardScoringStatUpgrades result={simScoringResult} />
+                      <CharacterCardScoringStatUpgrades result={simScoringResult}/>
+                    </Flex>
+                  )
+                }
+
+                {
+                  !simScoringResult
+                  && (
+                    <Flex vertical>
+                      <StatText style={{ fontSize: 17, fontWeight: 600, textAlign: 'center', color: '#e1a564' }}>
+                        {`Character Score: ${scoringResults.totalScore.toFixed(0)} ${scoringResults.totalScore == 0 ? '' : '(' + scoringResults.totalRating + ')'}`}
+                      </StatText>
+                    </Flex>
+                  )
+                }
+                {
+                  !simScoringResult
+                  && (
+                    <Flex vertical style={{ width: middleColumnWidth }}>
+
+                      <Flex vertical>
+                        <StatText
+                          style={{ fontSize: 18, fontWeight: 400, marginLeft: 10, marginRight: 10, textAlign: 'center' }}
+                          ellipsis={true}
+                        >
+                          {`${lightConeName}`}
+                          &nbsp;
+                        </StatText>
+                        <StatText style={{ fontSize: 18, fontWeight: 400, textAlign: 'center' }}>
+                          {`Lv${lightConeLevel} S${lightConeSuperimposition}`}
+                        </StatText>
+                      </Flex>
+                      <div style={{
+                        width: `${tempLcParentW}px`,
+                        height: `${tempLcParentH}px`,
+                        overflow: 'hidden',
+                        borderRadius: '8px',
+                        outline: outline,
+                        filter: filter,
+                      }}
+                      >
+                        <LoadingBlurredImage
+                          src={lightConeSrc}
+                          style={{
+                            width: tempLcInnerW,
+                            transform: `translate(${(tempLcInnerW - tempLcParentW) / 2 / tempLcInnerW * -100}%, ${(tempLcInnerH - tempLcParentH) / 2 / tempLcInnerH * -100 + 8}%)`, // Magic # 8 to fit certain LCs
+                          }}
+                        />
+                      </div>
                     </Flex>
                   )
                 }
               </Flex>
-              {
-                !simScoringResult
-                && (
-                  <Flex vertical style={{ width: middleColumnWidth }}>
-
-                    <Flex vertical>
-                      <StatText
-                        style={{ fontSize: 18, fontWeight: 400, marginLeft: 10, marginRight: 10, textAlign: 'center' }}
-                        ellipsis={true}
-                      >
-                        {`${lightConeName}`}
-                        &nbsp;
-                      </StatText>
-                      <StatText style={{ fontSize: 18, fontWeight: 400, textAlign: 'center' }}>
-                        {`Lv${lightConeLevel} S${lightConeSuperimposition}`}
-                      </StatText>
-                    </Flex>
-                    <div style={{
-                      width: `${tempLcParentW}px`,
-                      height: `${tempLcParentH}px`,
-                      overflow: 'hidden',
-                      borderRadius: '8px',
-                      outline: outline,
-                      filter: filter,
-                    }}
-                    >
-                      <LoadingBlurredImage
-                        src={lightConeSrc}
-                        style={{
-                          width: tempLcInnerW,
-                          transform: `translate(${(tempLcInnerW - tempLcParentW) / 2 / tempLcInnerW * -100}%, ${(tempLcInnerH - tempLcParentH) / 2 / tempLcInnerH * -100 + 8}%)`, // Magic # 8 to fit certain LCs
-                        }}
-                      />
-                    </div>
-                  </Flex>
-                )
-              }
             </Flex>
 
             <Flex vertical gap={defaultGap}>
@@ -861,7 +862,7 @@ export function CharacterPreview(props) {
               />
             </Flex>
           </Flex>
-          <CharacterScoringSummary simScoringResult={simScoringResult} />
+          <CharacterScoringSummary simScoringResult={simScoringResult}/>
         </Flex>
       )}
     </Flex>

--- a/src/components/characterPreview/CharacterStatSummary.tsx
+++ b/src/components/characterPreview/CharacterStatSummary.tsx
@@ -1,6 +1,6 @@
 import { Flex } from 'antd'
 import StatRow from 'components/characterPreview/StatRow.tsx'
-import { Constants } from 'lib/constants.ts'
+import { Constants, Stats } from 'lib/constants.ts'
 
 export const CharacterStatSummary = (props: {
   finalStats: any
@@ -10,19 +10,20 @@ export const CharacterStatSummary = (props: {
 }) => {
   return (
     <Flex vertical style={{ paddingLeft: 6, paddingRight: 8 }} gap={3}>
-      <StatRow finalStats={props.finalStats} stat={Constants.Stats.HP} />
-      <StatRow finalStats={props.finalStats} stat={Constants.Stats.ATK} />
-      <StatRow finalStats={props.finalStats} stat={Constants.Stats.DEF} />
-      <StatRow finalStats={props.finalStats} stat={Constants.Stats.SPD} />
-      <StatRow finalStats={props.finalStats} stat={Constants.Stats.CR} />
-      <StatRow finalStats={props.finalStats} stat={Constants.Stats.CD} />
-      <StatRow finalStats={props.finalStats} stat={Constants.Stats.EHR} />
-      <StatRow finalStats={props.finalStats} stat={Constants.Stats.RES} />
-      <StatRow finalStats={props.finalStats} stat={Constants.Stats.BE} />
-      {!props.simScore && <StatRow finalStats={props.finalStats} stat={Constants.Stats.OHB} />}
-      <StatRow finalStats={props.finalStats} stat={Constants.Stats.ERR} />
-      <StatRow finalStats={props.finalStats} stat={props.elementalDmgValue} />
-      {props.simScore != null && <StatRow finalStats={props.finalStats} stat="simScore" value={props.simScore} />}
+      <StatRow finalStats={props.finalStats} stat={Constants.Stats.HP}/>
+      <StatRow finalStats={props.finalStats} stat={Constants.Stats.ATK}/>
+      <StatRow finalStats={props.finalStats} stat={Constants.Stats.DEF}/>
+      <StatRow finalStats={props.finalStats} stat={Constants.Stats.SPD}/>
+      <StatRow finalStats={props.finalStats} stat={Constants.Stats.CR}/>
+      <StatRow finalStats={props.finalStats} stat={Constants.Stats.CD}/>
+      <StatRow finalStats={props.finalStats} stat={Constants.Stats.EHR}/>
+      <StatRow finalStats={props.finalStats} stat={Constants.Stats.RES}/>
+      <StatRow finalStats={props.finalStats} stat={Constants.Stats.BE}/>
+      {!props.simScore && !!props.finalStats[Stats.OHB] && <StatRow finalStats={props.finalStats} stat={Stats.OHB}/>}
+      <StatRow finalStats={props.finalStats} stat={Constants.Stats.ERR}/>
+      <StatRow finalStats={props.finalStats} stat={props.elementalDmgValue}/>
+      {props.cv != null && props.cv > 64.8 && <StatRow finalStats={props.finalStats} stat="CV" value={props.cv}/>}
+      {props.simScore != null && <StatRow finalStats={props.finalStats} stat="simScore" value={props.simScore}/>}
     </Flex>
   )
 }


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Added CV back
* Added some rules for showing stats, hiding < 64.8 CV, hiding 0% healing boost
* Adjusting the flex display in the center

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

![image](https://github.com/user-attachments/assets/ac53216b-d27e-4b00-a2b9-03c234dc1c8f)

![image](https://github.com/user-attachments/assets/36d41b54-a871-4b40-9625-5238a38c456f)


