### PR TITLE
feat: rescore relic on modification

### DIFF
--- a/src/components/RelicFilterBar.jsx
+++ b/src/components/RelicFilterBar.jsx
@@ -144,8 +144,8 @@ export default function RelicFilterBar(props) {
     characterSelectorChange(currentlySelectedCharacterId)
   }, [])
 
-  function characterSelectorChange(id) {
-    const relics = Object.values(DB.getRelicsById())
+  function characterSelectorChange(id, singleRelic) {
+    const relics = singleRelic ? [singleRelic] : Object.values(DB.getRelicsById())
     console.log('idChange', id)
 
     setRelicsTabFocusCharacter(id)
@@ -180,6 +180,8 @@ export default function RelicFilterBar(props) {
         }
       }
     }
+
+    if (singleRelic) return
 
     // Clone the relics to refresh the sort
     DB.setRelics(Utils.clone(relics))
@@ -218,6 +220,12 @@ export default function RelicFilterBar(props) {
   function rescoreClicked() {
     characterSelectorChange(currentlySelectedCharacterId)
   }
+
+  function rescoreSingleRelic(singleRelic) {
+    characterSelectorChange(currentlySelectedCharacterId, singleRelic)
+  }
+
+  window.rescoreSingleRelic = rescoreSingleRelic
 
   return (
     <Flex vertical gap={2}>

--- a/src/components/RelicModal.tsx
+++ b/src/components/RelicModal.tsx
@@ -431,7 +431,7 @@ function SubstatInput(props: { index: number; upgrades: RelicUpgradeValues[]; re
             controls={false}
             onChange={props.resetUpgradeValues}
             formatter={(value) => {
-              return Utils.isFlat(field) ? value : Utils.precisionRound(parseFloat(value)).toFixed(1)
+              return Utils.isFlat(field) ? value : (value ? Utils.precisionRound(parseFloat(value)).toFixed(1) : '')
             }}
             tabIndex={0}
           />

--- a/src/lib/relicModalController.ts
+++ b/src/lib/relicModalController.ts
@@ -14,6 +14,7 @@ export const RelicModalController = {
 
     const updatedRelic = { ...selectedRelic, ...relic }
 
+    window.rescoreSingleRelic(updatedRelic)
     DB.setRelic(updatedRelic)
     window.setRelicRows(DB.getRelics())
     SaveState.save()


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* When relics are modified, they now rescore themselves and updates the grid
* Fixed bug with NaN relic substat value inputs

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* Closes https://github.com/fribbels/hsr-optimizer/issues/462

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

