### PR TITLE
feat: combat stats panel for scoring card

### DIFF
--- a/src/components/CharacterModal.jsx
+++ b/src/components/CharacterModal.jsx
@@ -10,7 +10,7 @@ export default function CharacterModal(props) {
   const [characterForm] = Form.useForm()
   window.characterForm = characterForm
 
-  const [characterId, setCharacterId] = useState('')
+  const [characterId, setCharacterId] = useState(props.initialCharacter?.form.characterId || '')
   const [eidolon, setEidolon] = useState(props.initialCharacter?.form.characterEidolon || 0)
   const [superimposition, setSuperimposition] = useState(props.initialCharacter?.form.lightConeSuperimposition || 1)
   const characterMetadata = useMemo(() => DB.getMetadata().characters, [])

--- a/src/components/CharacterPreview.jsx
+++ b/src/components/CharacterPreview.jsx
@@ -859,7 +859,7 @@ export function CharacterPreview(props) {
       {!isBuilds && (
         <Flex vertical>
           <Flex justify="center" gap={25}>
-            <Flex justify="center" style={{ paddingLeft: 20, paddingRight: 5, borderRadius: 7, height: 40, marginTop: 10, backgroundColor: 'rgba(255, 255, 255, 0.05)' }} align="center">
+            <Flex justify="center" style={{ paddingLeft: 20, paddingRight: 5, borderRadius: 7, height: 40, marginTop: 10, backgroundColor: token.colorBgContainer + '85' }} align="center">
               <Text style={{ width: 150 }}>
                 Scoring algorithm:
               </Text>
@@ -887,7 +887,7 @@ export function CharacterPreview(props) {
               />
             </Flex>
 
-            <Flex justify="center" style={{ paddingLeft: 20, paddingRight: 5, borderRadius: 7, height: 40, marginTop: 10, backgroundColor: 'rgba(255, 255, 255, 0.05)' }} align="center">
+            <Flex justify="center" style={{ paddingLeft: 20, paddingRight: 5, borderRadius: 7, height: 40, marginTop: 10, backgroundColor: token.colorBgContainer + '85' }} align="center">
               <Text style={{ width: 150 }}>
                 Combat score details:
               </Text>

--- a/src/components/CharacterPreview.jsx
+++ b/src/components/CharacterPreview.jsx
@@ -904,12 +904,12 @@ export function CharacterPreview(props) {
                   {
                     label: 'Combat Stats',
                     value: COMBAT_STATS,
-                    disabled: characterMetadata.scoringMetadata.simulation == null,
+                    disabled: characterMetadata.scoringMetadata.simulation == null || scoringType == CHARACTER_SCORE,
                   },
                   {
                     label: `Damage Upgrades`,
                     value: DAMAGE_UPGRADES,
-                    disabled: characterMetadata.scoringMetadata.simulation == null,
+                    disabled: characterMetadata.scoringMetadata.simulation == null || scoringType == CHARACTER_SCORE,
                   },
                 ]}
               />

--- a/src/components/CharacterPreview.jsx
+++ b/src/components/CharacterPreview.jsx
@@ -5,7 +5,7 @@ import { RelicScorer } from 'lib/relicScorer.ts'
 import { StatCalculator } from 'lib/statCalculator'
 import { DB } from 'lib/db'
 import { Assets } from 'lib/assets'
-import { CHARACTER_SCORE, Constants, CUSTOM_TEAM, DEFAULT_TEAM, ElementToDamage, SETTINGS_TEAM, SIMULATION_SCORE } from 'lib/constants.ts'
+import { CHARACTER_SCORE, COMBAT_STATS, Constants, CUSTOM_TEAM, DAMAGE_UPGRADES, DEFAULT_TEAM, ElementToDamage, SETTINGS_TEAM, SIMULATION_SCORE } from 'lib/constants.ts'
 import { defaultGap, innerW, lcInnerH, lcInnerW, lcParentH, lcParentW, middleColumnWidth, parentH, parentW } from 'lib/constantsUi'
 
 import Rarity from 'components/characterPreview/Rarity'
@@ -21,7 +21,7 @@ import CharacterCustomPortrait from './CharacterCustomPortrait'
 import { SaveState } from 'lib/saveState'
 import { getSimScoreGrade, scoreCharacterSimulation } from 'lib/characterScorer'
 import { Utils } from 'lib/utils'
-import { CharacterCardScoringStatUpgrades, CharacterScoringSummary } from 'components/characterPreview/CharacterScoringSummary'
+import { CharacterCardCombatStats, CharacterCardScoringStatUpgrades, CharacterScoringSummary } from 'components/characterPreview/CharacterScoringSummary'
 import CharacterModal from 'components/CharacterModal'
 import { LoadingBlurredImage } from 'components/LoadingBlurredImage'
 import { SavedSessionKeys } from 'lib/constantsSession'
@@ -64,6 +64,7 @@ export function CharacterPreview(props) {
   const [customPortrait, setCustomPortrait] = useState(null) // <null | CustomImageConfig>
   const [teamSelection, setTeamSelection] = useState(CUSTOM_TEAM)
   const [scoringType, setScoringType] = useState(SIMULATION_SCORE)
+  const [combatScoreDetails, setCombatScoreDetails] = useState(COMBAT_STATS)
   const [isCharacterModalOpen, setCharacterModalOpen] = useState(false)
   const [characterModalInitialCharacter, setCharacterModalInitialCharacter] = useState()
   const [selectedTeammateIndex, setSelectedTeammateIndex] = useState()
@@ -278,7 +279,7 @@ export function CharacterPreview(props) {
     }
 
     const textDisplay = (
-      <Flex align="center" vertical style={{ marginBottom: 4, paddingTop: 5, paddingBottom: 5 }}>
+      <Flex align="center" vertical style={{ marginBottom: 4, paddingTop: 3, paddingBottom: 3 }}>
         <StatText style={textStyle}>
           Combat Sim
         </StatText>
@@ -298,7 +299,7 @@ export function CharacterPreview(props) {
   function ScoreFooter(props) {
     const tabsDisplay = (
       <Segmented
-        style={{ marginLeft: 10, marginRight: 10, marginTop: 4, marginBottom: 2, alignItems: 'center' }}
+        style={{ marginLeft: 10, marginRight: 10, marginTop: 1, marginBottom: 2, alignItems: 'center' }}
         onChange={(selection) => {
           if (selection == SETTINGS_TEAM) {
             window.modalApi.info({
@@ -648,7 +649,7 @@ export function CharacterPreview(props) {
                 justify="space-between"
               >
                 <Flex vertical>
-                  <Flex justify="space-around" style={{ height: 26, marginBottom: 8 }} align="center">
+                  <Flex justify="space-around" style={{ height: 26, marginBottom: 6 }} align="center">
                     <Image
                       preview={false}
                       width={36}
@@ -727,9 +728,17 @@ export function CharacterPreview(props) {
                   )
                 }
                 {
-                  simScoringResult && (
+                  simScoringResult && combatScoreDetails == DAMAGE_UPGRADES && (
                     <Flex vertical gap={defaultGap}>
                       <CharacterCardScoringStatUpgrades result={simScoringResult}/>
+                    </Flex>
+                  )
+                }
+
+                {
+                  simScoringResult && combatScoreDetails == COMBAT_STATS && (
+                    <Flex vertical gap={defaultGap}>
+                      <CharacterCardCombatStats result={simScoringResult}/>
                     </Flex>
                   )
                 }
@@ -849,13 +858,13 @@ export function CharacterPreview(props) {
 
       {!isBuilds && (
         <Flex vertical>
-          <Flex justify="center">
+          <Flex justify="center" gap={25}>
             <Flex justify="center" style={{ paddingLeft: 20, paddingRight: 5, borderRadius: 7, height: 40, marginTop: 10, backgroundColor: 'rgba(255, 255, 255, 0.05)' }} align="center">
-              <Text style={{ width: 220 }}>
-                Character scoring algorithm:
+              <Text style={{ width: 150 }}>
+                Scoring algorithm:
               </Text>
               <Segmented
-                style={{ width: 480, height: 30 }}
+                style={{ width: 300, height: 30 }}
                 onChange={(selection) => {
                   setScoringType(selection)
                   window.store.getState().setSavedSessionKey(SavedSessionKeys.scoringType, selection)
@@ -865,14 +874,42 @@ export function CharacterPreview(props) {
                 block
                 options={[
                   {
-                    label: `${SIMULATION_SCORE}${characterMetadata.scoringMetadata.simulation == null ? ' (TBD)' : ''}`,
+                    label: `Combat Score${characterMetadata.scoringMetadata.simulation == null ? ' (TBD)' : ''}`,
                     value: SIMULATION_SCORE,
                     disabled: false,
                   },
                   {
-                    label: CHARACTER_SCORE,
+                    label: 'Stat Score',
                     value: CHARACTER_SCORE,
                     disabled: false,
+                  },
+                ]}
+              />
+            </Flex>
+
+            <Flex justify="center" style={{ paddingLeft: 20, paddingRight: 5, borderRadius: 7, height: 40, marginTop: 10, backgroundColor: 'rgba(255, 255, 255, 0.05)' }} align="center">
+              <Text style={{ width: 150 }}>
+                Combat score details:
+              </Text>
+              <Segmented
+                style={{ width: 300, height: 30 }}
+                onChange={(selection) => {
+                  setCombatScoreDetails(selection)
+                  window.store.getState().setSavedSessionKey(SavedSessionKeys.combatScoreDetails, selection)
+                  setTimeout(() => SaveState.save(), 1000)
+                }}
+                value={combatScoreDetails}
+                block
+                options={[
+                  {
+                    label: 'Combat Stats',
+                    value: COMBAT_STATS,
+                    disabled: characterMetadata.scoringMetadata.simulation == null,
+                  },
+                  {
+                    label: `Damage Upgrades`,
+                    value: DAMAGE_UPGRADES,
+                    disabled: characterMetadata.scoringMetadata.simulation == null,
                   },
                 ]}
               />

--- a/src/components/characterPreview/CharacterScoringSummary.tsx
+++ b/src/components/characterPreview/CharacterScoringSummary.tsx
@@ -647,7 +647,7 @@ export function CharacterCardCombatStats(props: { result: SimulationScore }) {
   const elementalDmgValue = ElementToDamage[result.characterMetadata.element]
   let substats = Utils.clone(simulationMetadata.substats)
   substats = Utils.filterUnique(substats)
-  substats.push(Stats.SPD)
+  if (substats.length < 6) substats.push(Stats.SPD)
   substats.sort((a, b) => SubStats.indexOf(a) - SubStats.indexOf(b))
   substats.push(elementalDmgValue)
 

--- a/src/components/characterPreview/CharacterScoringSummary.tsx
+++ b/src/components/characterPreview/CharacterScoringSummary.tsx
@@ -412,17 +412,41 @@ export const CharacterScoringSummary = (props: { simScoringResult: SimulationSco
     combatStats[elementalDmgValue] = combatStats.ELEMENTAL_DMG
 
     return (
-      <Flex vertical gap={50}>
+      <Flex vertical gap={25}>
         <Flex vertical gap={defaultGap}>
           <Flex justify="space-around">
             <pre style={{ fontSize: 20, fontWeight: 'bold', color: highlight ? color : '' }}>
               <u>{`${props.nameText} build (${Utils.truncate10ths(Utils.precisionRound(props.percent * 100))}%)`}</u>
             </pre>
           </Flex>
+        </Flex>
 
-          <pre style={{ margin: '10px auto' }}>
-            {props.subText}
+        <Flex vertical gap={defaultGap} style={{ width: statPreviewWidth }}>
+          <pre style={{ margin: 'auto', color: highlight ? color : '' }}>
+            {props.basicText}
           </pre>
+          <CharacterStatSummary
+            finalStats={basicStats}
+            elementalDmgValue={elementalDmgValue}
+            simScore={simResult.simScore}
+          />
+        </Flex>
+
+        <Flex vertical gap={defaultGap} style={{ width: statPreviewWidth }}>
+          <pre style={{ margin: 'auto', color: highlight ? color : '' }}>
+            {props.statText} <u>combat stats</u>
+          </pre>
+          <CharacterStatSummary
+            finalStats={combatStats}
+            elementalDmgValue={elementalDmgValue}
+            simScore={simResult.simScore}
+          />
+        </Flex>
+
+        <Flex vertical gap={defaultGap}>
+        <pre style={{ margin: '10px auto', color: highlight ? color : '' }}>
+          {props.subText}
+        </pre>
           <Flex gap={5} justify="space-around">
             <Flex vertical gap={defaultGap} style={{ width: 120 }}>
               <ScoringNumber label="ATK%: " number={request.stats[Stats.ATK_P]} precision={props.precision}/>
@@ -444,7 +468,7 @@ export const CharacterScoringSummary = (props: { simScoringResult: SimulationSco
         </Flex>
 
         <Flex vertical gap={defaultGap}>
-          <pre style={{ margin: '0 auto' }}>
+          <pre style={{ margin: '0 auto', color: highlight ? color : '' }}>
             {props.mainText}
           </pre>
           <Flex gap={defaultGap} justify="space-around">
@@ -457,30 +481,8 @@ export const CharacterScoringSummary = (props: { simScoringResult: SimulationSco
           </Flex>
         </Flex>
 
-        <Flex vertical gap={defaultGap} style={{ width: statPreviewWidth }}>
-          <pre style={{ margin: 'auto' }}>
-            {props.basicText}
-          </pre>
-          <CharacterStatSummary
-            finalStats={basicStats}
-            elementalDmgValue={elementalDmgValue}
-            simScore={simResult.simScore}
-          />
-        </Flex>
-
-        <Flex vertical gap={defaultGap} style={{ width: statPreviewWidth }}>
-          <pre style={{ margin: 'auto' }}>
-            {props.statText} <u>combat stats</u>
-          </pre>
-          <CharacterStatSummary
-            finalStats={combatStats}
-            elementalDmgValue={elementalDmgValue}
-            simScore={simResult.simScore}
-          />
-        </Flex>
-
-        <Flex vertical gap={defaultGap}>
-          <pre style={{ margin: '0 auto' }}>
+        <Flex vertical gap={20}>
+          <pre style={{ margin: '0 auto', color: highlight ? color : '' }}>
             {props.damageText}
           </pre>
           <Flex gap={defaultGap} justify="space-around">

--- a/src/components/characterPreview/CharacterScoringSummary.tsx
+++ b/src/components/characterPreview/CharacterScoringSummary.tsx
@@ -13,7 +13,7 @@ import { StatTextSm } from 'components/characterPreview/StatText'
 import { HeaderText } from 'components/HeaderText'
 import { TsUtils } from 'lib/TsUtils'
 import { Simulation } from 'lib/statSimulationController'
-import { displayTextMap } from "components/characterPreview/StatRow";
+import { damageStats, displayTextMap } from "components/characterPreview/StatRow";
 
 const { Text } = Typography
 
@@ -647,9 +647,7 @@ export function CharacterCardCombatStats(props: { result: SimulationScore }) {
   const elementalDmgValue = ElementToDamage[result.characterMetadata.element]
   let substats = Utils.clone(simulationMetadata.substats)
   substats = Utils.filterUnique(substats)
-  // if (substats.length < 4) {
   substats.push(Stats.SPD)
-  // }
   substats.sort((a, b) => SubStats.indexOf(a) - SubStats.indexOf(b))
   substats.push(elementalDmgValue)
 
@@ -658,7 +656,7 @@ export function CharacterCardCombatStats(props: { result: SimulationScore }) {
   for (const stat of substats) {
     if (stat == Stats.ATK_P || stat == Stats.DEF_P || stat == Stats.HP_P) continue
 
-    const value = result.originalSimResult.x[stat]
+    const value = damageStats[stat] ? result.originalSimResult.x.ELEMENTAL_DMG : result.originalSimResult.x[stat]
     const flat = Utils.isFlat(stat)
 
     let display = Math.floor(value)

--- a/src/components/characterPreview/CharacterScoringSummary.tsx
+++ b/src/components/characterPreview/CharacterScoringSummary.tsx
@@ -9,7 +9,7 @@ import { VerticalDivider } from 'components/Dividers'
 import DB from 'lib/db'
 import React, { ReactElement } from 'react'
 import { StatCalculator } from 'lib/statCalculator'
-import StatText, { StatTextSm } from 'components/characterPreview/StatText'
+import { StatTextSm } from 'components/characterPreview/StatText'
 import { HeaderText } from 'components/HeaderText'
 import { TsUtils } from 'lib/TsUtils'
 import { Simulation } from 'lib/statSimulationController'
@@ -702,9 +702,9 @@ export function CharacterCardScoringStatUpgrades(props: { result: SimulationScor
     rows.push(
       <Flex key={Utils.randomId()} justify="space-between" align="center" style={{ width: '100%' }}>
         <img src={Assets.getStatIcon(stat)} style={{ width: iconSize, height: iconSize, marginRight: 3 }}/>
-        <StatText>{`+1x ${StatsToShortSpaced[stat]}`}</StatText>
+        <StatTextSm>{`+1x ${StatsToShortSpaced[stat]}`}</StatTextSm>
         <Divider style={{ margin: 'auto 10px', flexGrow: 1, width: 'unset', minWidth: 'unset' }} dashed/>
-        <StatText>{`+ ${(upgradeDmg * 100).toFixed(2)}%`}</StatText>
+        <StatTextSm>{`+ ${(upgradeDmg * 100).toFixed(2)}%`}</StatTextSm>
       </Flex>,
     )
   }
@@ -720,9 +720,9 @@ export function CharacterCardScoringStatUpgrades(props: { result: SimulationScor
     extraRows.push(
       <Flex gap={3} key={Utils.randomId()} justify="space-between" align="center" style={{ width: '100%', paddingLeft: 1 }}>
         <img src={Assets.getPart(part)} style={{ width: iconSize, height: iconSize, marginRight: 3 }}/>
-        <StatText>{`➔ ${StatsToShortSpaced[stat]}`}</StatText>
+        <StatTextSm>{`➔ ${StatsToShortSpaced[stat]}`}</StatTextSm>
         <Divider style={{ margin: 'auto 10px', flexGrow: 1, width: 'unset', minWidth: 'unset' }} dashed/>
-        <StatText>{`+ ${(upgradeDmg * 100).toFixed(2)}%`}</StatText>
+        <StatTextSm>{`+ ${(upgradeDmg * 100).toFixed(2)}%`}</StatTextSm>
       </Flex>,
     )
   }
@@ -737,7 +737,7 @@ export function CharacterCardScoringStatUpgrades(props: { result: SimulationScor
         <img src={Assets.getSetImage(setUpgrade.simulation.request.simRelicSet2)} style={{ width: iconSize, height: iconSize, marginRight: 5 }}/>
         <img src={Assets.getSetImage(setUpgrade.simulation.request.simOrnamentSet)} style={{ width: iconSize, height: iconSize, marginRight: 3 }}/>
         <Divider style={{ margin: 'auto 10px', flexGrow: 1, width: 'unset', minWidth: 'unset' }} dashed/>
-        <StatText>{`+ ${(upgradeDmg * 100).toFixed(2)}%`}</StatText>
+        <StatTextSm>{`+ ${(upgradeDmg * 100).toFixed(2)}%`}</StatTextSm>
       </Flex>,
     )
   }

--- a/src/components/characterPreview/StatRow.tsx
+++ b/src/components/characterPreview/StatRow.tsx
@@ -24,11 +24,27 @@ const checkSpeedInBreakpoint = (speedValue: number): boolean => {
   })
 }
 
+export const displayTextMap = {
+  'simScore': 'Sim Damage',
+  'Fire DMG Boost': 'Fire DMG',
+  'Ice DMG Boost': 'Ice DMG',
+  'Imaginary DMG Boost': 'Imaginary DMG',
+  'Lightning DMG Boost': 'Lightning DMG',
+  'Physical DMG Boost': 'Physical DMG',
+  'Quantum DMG Boost': 'Quantum DMG',
+  'Wind DMG Boost': 'Wind DMG',
+  'Outgoing Healing Boost': 'Healing Boost',
+  'Energy Regeneration Rate': 'Energy Regen',
+  'BASIC': 'Basic Damage',
+  'ULT': 'Ult Damage',
+  'SKILL': 'Skill Damage',
+  'FUA': 'FUA Damage',
+  'DOT': 'DoT Damage',
+}
+
 const StatRow = (props: { stat: string; finalStats: any; value?: number }): JSX.Element => {
   const { stat, finalStats } = props
-  const readableStat = stat == 'simScore'
-    ? 'Sim Damage'
-    : stat.replace('DMG Boost', 'DMG').replace('Outgoing Healing Boost', 'Healing Boost').replace('Energy Regeneration Rate', 'Energy Regen')
+  const readableStat = displayTextMap[stat] || stat
   const value = Utils.precisionRound(finalStats[stat])
 
   let valueDisplay

--- a/src/components/characterPreview/StatRow.tsx
+++ b/src/components/characterPreview/StatRow.tsx
@@ -24,6 +24,16 @@ const checkSpeedInBreakpoint = (speedValue: number): boolean => {
   })
 }
 
+export const damageStats = {
+  'Fire DMG Boost': 'Fire DMG',
+  'Ice DMG Boost': 'Ice DMG',
+  'Imaginary DMG Boost': 'Imaginary DMG',
+  'Lightning DMG Boost': 'Lightning DMG',
+  'Physical DMG Boost': 'Physical DMG',
+  'Quantum DMG Boost': 'Quantum DMG',
+  'Wind DMG Boost': 'Wind DMG',
+}
+
 export const displayTextMap = {
   'simScore': 'Sim Damage',
   'Fire DMG Boost': 'Fire DMG',

--- a/src/components/characterPreview/StatText.tsx
+++ b/src/components/characterPreview/StatText.tsx
@@ -4,10 +4,16 @@ import styled from 'styled-components'
 const { Text } = Typography
 
 const StatText = styled(Text)`
-  font-family: Segoe UI,Frutiger,Frutiger Linotype,Dejavu Sans,Helvetica Neue,Arial,sans-serif;
-  font-size: 17px;
-  font-weight: 400;
-  white-space: nowrap;
+    font-family: Segoe UI, Frutiger, Frutiger Linotype, Dejavu Sans, Helvetica Neue, Arial, sans-serif;
+    font-size: 17px;
+    font-weight: 400;
+    white-space: nowrap;
+`
+export const StatTextSm = styled(Text)`
+    font-family: Segoe UI, Frutiger, Frutiger Linotype, Dejavu Sans, Helvetica Neue, Arial, sans-serif;
+    font-size: 16px;
+    font-weight: 400;
+    white-space: nowrap;
 `
 
 export default StatText

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -749,3 +749,6 @@ export const SETTINGS_TEAM = 'Settings'
 export const SIMULATION_SCORE = 'Combat Simulation Score'
 export const CHARACTER_SCORE = 'Character Score'
 
+export const DAMAGE_UPGRADES = 'Damage Upgrades'
+export const COMBAT_STATS = 'Combat Stats'
+

--- a/src/lib/constantsSession.ts
+++ b/src/lib/constantsSession.ts
@@ -2,4 +2,5 @@ export enum SavedSessionKeys {
   optimizerCharacterId = 'optimizerCharacterId',
   relicScorerSidebarOpen = 'relicScorerSidebarOpen',
   scoringType = 'scoringType',
+  combatScoreDetails = 'combatScoreDetails',
 }

--- a/src/lib/dataParser.js
+++ b/src/lib/dataParser.js
@@ -1769,7 +1769,7 @@ function getScoringMetadata() {
           SKILL: 2,
           ULT: 1,
           FUA: 2,
-          DOT: 20,
+          DOT: 16,
           BREAK: 0,
         },
         relicSets: [
@@ -5360,7 +5360,7 @@ function getScoringMetadata() {
           SKILL: 1,
           ULT: 1,
           FUA: 0,
-          DOT: 8,
+          DOT: 16,
           BREAK: 0,
         },
         relicSets: [

--- a/src/lib/dataParser.js
+++ b/src/lib/dataParser.js
@@ -1769,7 +1769,7 @@ function getScoringMetadata() {
           SKILL: 2,
           ULT: 1,
           FUA: 2,
-          DOT: 8,
+          DOT: 20,
           BREAK: 0,
         },
         relicSets: [

--- a/src/lib/db.js
+++ b/src/lib/db.js
@@ -2,7 +2,7 @@ import { create } from 'zustand'
 import objectHash from 'object-hash'
 import { OptimizerTabController } from 'lib/optimizerTabController'
 import { RelicAugmenter } from 'lib/relicAugmenter'
-import { Constants, CURRENT_OPTIMIZER_VERSION, DEFAULT_STAT_DISPLAY, RelicSetFilterOptions, Sets, SIMULATION_SCORE } from 'lib/constants.ts'
+import { COMBAT_STATS, Constants, CURRENT_OPTIMIZER_VERSION, DEFAULT_STAT_DISPLAY, RelicSetFilterOptions, Sets, SIMULATION_SCORE } from 'lib/constants.ts'
 import { SavedSessionKeys } from 'lib/constantsSession'
 import { getDefaultForm } from 'lib/defaultForm'
 import { Utils } from 'lib/utils'
@@ -143,6 +143,7 @@ window.store = create((set) => ({
     [SavedSessionKeys.optimizerCharacterId]: null,
     [SavedSessionKeys.relicScorerSidebarOpen]: true,
     [SavedSessionKeys.scoringType]: SIMULATION_SCORE,
+    [SavedSessionKeys.combatScoreDetails]: COMBAT_STATS,
   },
 
   settings: DefaultSettingOptions,

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -328,4 +328,8 @@ export const Utils = {
 
     return `${minutesS}:${secondsS}`
   },
+
+  filterUnique: (arr) => {
+    return arr.filter((value, index, array) => array.indexOf(value) === index)
+  }
 }


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Update teammate character modal's LC initial character so it preloads the path
* Update kafka / swan to lean towards DOT over crit in sims
* Add combat stats panel / selector for sim scoring card


![image](https://github.com/user-attachments/assets/29577a81-f7d4-453c-b171-4f5231e74084)


## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

