### PR TITLE
hotfix: update reliquary to v4, still 0.1.8 output for now

### DIFF
--- a/src/components/importerTab/ReliquaryDescription.tsx
+++ b/src/components/importerTab/ReliquaryDescription.tsx
@@ -12,8 +12,8 @@ export function ReliquaryDescription(): ReactElement {
           )
           <ul>
             {/*<li><b style={{ color: '#ffaa4f' }}>***** Status: Down for maintenance after 2.4 patch *****</b></li>*/}
-            <li><b style={{ color: '#82e192' }}>Status: Updated for patch 2.4, new download required</b></li>
-            <li><b style={{ color: '#ffaa4f' }}>Note: March and Trailblazer imports do not work currently, new version with fix coming soon</b></li>
+            {/*<li><b style={{ color: '#ffaa4f' }}>Note: March and Trailblazer imports do not work currently, new version with fix coming soon</b></li>*/}
+            <li><b style={{ color: '#82e192' }}>Status: Updated for patch 2.4, new download required for March 7th support</b></li>
             <li>Accurate speed decimals, instant scan</li>
             <li>Imports full inventory and character roster</li>
           </ul>

--- a/src/lib/importer/importConfig.js
+++ b/src/lib/importer/importConfig.js
@@ -20,7 +20,7 @@ export const ReliquaryArchiverConfig = {
   defaultFileName: 'archiver_output.json',
   sourceString: 'reliquary_archiver',
   latestBuildVersion: 'v0.1.8',
-  latestOutputVersion: 3,
+  latestOutputVersion: 4,
   speedVerified: true,
 }
 


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Update reliquary output to v4, scanner version still stuck at 0.1.8 scanner

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

