### PR TITLE
feat: rescoring WIP

### DIFF
--- a/src/lib/dataParser.js
+++ b/src/lib/dataParser.js
@@ -2230,7 +2230,7 @@ function getScoringMetadata() {
         ],
         teammates: [
           {
-            characterId: '1006', // SW
+            characterId: '1006', // Silver Wolf
             lightCone: '23007', // Rain
             characterEidolon: 0,
             lightConeSuperimposition: 1,


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->


Rules:
* SPD -> 1
* Crit DPS should be 0.75 / 1 / 1 / 1 unless they have special scaling

HP / DEF weighting
Support characters have 2.0 weight to split between HP / DEF
For every other (0.75 | 1) stat weight that they scale with (EHR, ATK, BE, etc), remove 0.5, to minimum of 1
If 2.0 remain and one of the stats is worth more than the other (Huohuo and HP% for example), assign 1 / 0.75

  - [ ] DPS
    - [ ] Not changing
      - [ ] Crit 0.75 / 1 / 1 / 1 
        - [x] Acheron
        - [x] Argenti
        - [x] Arlan
        - [x] Clara
        - [x] Dan Heng
        - [x] Dan Heng • Imbibitor Lunae
        - [x] Feixiao
        - [x] Herta
        - [x] Dr. Ratio
        - [x] Hook
        - [x] Jade
        - [x] Jing Yuan
        - [x] Jingliu
        - [x] March 7th Hunt
        - [x] Misha
        - [x] Moze
        - [x] Qingque
        - [x] Seele
        - [x] Serval
        - [x] Topaz & Numby
        - [x] Yanqing
        - [x] Yunli
      - [ ] Crit other
        - [x] Blade 0.25 / 1 / 1 / 1 / 1
        - [x] Xueyi 0.75 / 1 / 1 / 1 / 1
    - [ ] Changing
      - [x] Black Swan 
        * Before: 1 ATK / 1 SPD / 1 EHR / 0.5 BE
        * After: 1 ATK / 1 SPD / 1 EHR
      - [x] Kafka 
        * Before: 1 ATK / 1 SPD / 0.5 CR / 0.5 CD / 0.5 EHR 
        * After1 ATK / 1 SPD / 0.5 EHR
      - [x] Firefly 
        * Before: 1 ATK / 1 SPD / 1 BE
        * After: 0.75 ATK / 1 SPD / 1 BE
      - [x] Sampo
        * Before: 1 ATK / 1 SPD / 1 EHR / 1 BE 
        * After: 1 ATK / 1 SPD / 1 EHR
  - [ ] (Rebalance TBD)
      - [x] Himeko 
        * Unchanged: 0.75 ATK / 1 SPD / 1 CR / 1 CD / 0.5 BE
      - [x] Sushang 
        * Unchanged: 0.75 ATK / 1 SPD / 1 CR / 1 CD / 0.5 BE
      - [x] Trailblazer 
        * Unchanged: Physical  0.75 ATK / 1 SPD / 1 CR / 1 CD / 0.5 BE
      - [x] Welt 
        * Unchanged: 0.75 ATK / 1 SPD / 1 CR / 1 CD / 1 EHR 
      - [x] Luka 
        * Unchanged: 1 ATK / 1 SPD / 1 EHR / 0.75 BE
  - [ ] Supports
    - [ ] Sustains
      - [ ] Aventurine 2.0 - CR - CD = 1.0
        * Before: 0.5 HP / 1 DEF / 1 SPD / 1 CR / 1 CD 
        * After: 0 HP / 1 DEF / 1 SPD / 1 CR / 1 CD
      - [ ] Bailu 2.0 - 0 = 2.0
        * Before: 1 HP / 0.75 DEF / 1 SPD / 0.75 RES 
        * After: 1 HP / 0.5 DEF / 1 SPD / 0.5 RES
      - [ ] FuXuan 2.0 - 0 = 2.0
        * Before: 1 HP / 0.75 DEF / 1 SPD / 0.75 RES 
        * After: 1 HP / 1 DEF / 1 SPD / 0.5 RES
      - [ ] Gallagher 2.0 - BE = 1.5
        * Before: 0.75 HP / 0.75 DEF / 1 SPD / 0.75 RES / 1 BE 
        * After: 0.75 HP / 0.75 HP / 1 SPD / 0.5 RES / 1 BE
      - [ ] Gepard 2.0 - EHR = 1.5
        * Before: 0.5 HP / 1 DEF / 1 SPD / 0.75 EHR / 0.75 RES 
        * After: 0.5 HP / 1 DEF / 1 SPD / 0.75 EHR / 0.5 RES
      - [ ] Huohuo 2 - 0 = 2
        * Before: 1 HP / 0.75 DEF / 1 SPD / 0.75 RES 
        * After: 1 HP / 0.75 DEF / 1 SPD / 0.5 RES
      - [ ] Lingsha 2 - BE - ATK = 1.0
        * Before: 0.75 ATK / 0.5 HP / 0.5 DEF / 1 SPD / 0.75 RES / 1 BE
        * After: 0.75 ATK / 0.5 HP / 0.5 DEF / 1 SPD / 0.5 RES / 1 BE
      - [ ] Luocha 2 - ATK = 1.5
        * Before: 1 ATK / 0.75 HP / 0.75 HP / 1 SPD / 0.75 RES
        * After: 1 ATK / 0.75 HP / 0.75 HP / 1 SPD / 0.5 RES
      - [ ] Lynx
        * Before: 1 HP / 0.75 DEF / 1 SPD / 0.75 RES
        * After: 1 HP / 0.75 DEF / 1 SPD / 0.5 RES 
      - [ ] March 7th Preservation 2 - EHR = 1.5
        * Before: 0.5 HP / 1 DEF / 1 SPD / 1 EHR / 0.75 RES 
        * After: 0.5 HP / 1 DEF / 1 SPD / 1 EHR / 0.5 RES
      - [ ] Natasha 2 - 0 = 2
        * Before: 1 HP / 0.75 DEF / 1 SPD / 0.75 RES  
        * After: 1 HP / 0.75 DEF / 1 SPD / 0.5 RES 
      - [ ] Trailblazer Fire 2 - EHR = 1.5
        * Before: 0.5 HP / 1 DEF / 1 SPD / 0.75 EHR / 0.75 RES
        * After: 0.5 HP / 1 DEF / 1 SPD / 0.75 EHR / 0.5 RES
    - [ ] Offensive
      - [ ] Asta 2 - ATK = 1.5
        * Before: 0.75 ATK / 0.75 HP / 0.75 DEF / 1 SPD / 0.75 RES / 0.5 BE 
        * After: 0.75 ATK / 0.75 HP / 0.75 DEF / 1 SPD / 0.5 RES / 0.5 BE 
      - [ ] Boothill
        * Before: 0.25 ATK / 1 SPD / 0.5 CR / 0.5 CD / 1 BE 
        * After: / / / / 
      - [ ] Bronya
        * Before: 0.75 HP / 0.75 DEF / 1 SPD / 1 CD / 0.75 RES 
        * After: / / / / 
      - [ ] Guinaifen
        * Before: 1 ATK / 1 SPD / 1 EHR / 0.75 BE 
        * After: / / / / 
      - [ ] Hanya
        * Before: 0.75 HP / 0.75 DEF / 1 SPD / 1 RES 
        * After: / / / / 
      - [ ] Jiaoqiu
        * Before: 0.5 ATK / 0.5 HP / 0.5 DEF / 1 SPD / 1 EHR 
        * After: / / / / 
      - [ ] Pela
        * Before: 0.75 HP / 0.75 DEF / 1 SPD / 1 EHR / 0.75 RES 
        * After: / / / / 
      - [ ] Robin
        * Before: 1 ATK / 0.75 HP / 0.75 DEF / 1 SPD / 0.75 RES
        * After: / / / / 
      - [ ] Ruan Mei
        * Before: 0.75 HP / 0.75 DEF / 1 SPD / 0.75 RES / 1 BE
        * After: / / / / 
      - [ ] Silver Wolf
        * Before: 0.5 ATK / 0.25 HP / 0.25 DEF / 1 SPD / 0.75 CR / 0.75 CD / 1 EHR / 0.75 BE 
        * After: / / / / 
      - [ ] Sparkle
        * Before: 0.75 HP / 0.75 DEF / 1 SPD / 1 CD / 0.75 RES 
        * After: / / / / 
      - [ ] Tingyun
        * Before: 1 ATK / 0.75 HP / 0.75 DEF / 1 SPD / 0.75 RES 
        * After: / / / / 
      - [ ] Trailblazer Imaginary 
        * Before: 0.75 HP / 0.75 DEF / 1 SPD / 0.75 RES / 1 BE 
        * After: / / / / 
      - [ ] Yukong
        * Before: 0.75 ATK / 1 SPD / 1 CR / 1 CD 
        * After: / / / / 


## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR---->

* 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. ---->
- [ ] I have added commit messages that are descriptive and meaningful.
- [ ] I have tested the changes locally.
- [ ] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. ---->


