### PR TITLE
hotfix: prevent character card overflow

### DIFF
--- a/src/components/characterPreview/CharacterScoringSummary.tsx
+++ b/src/components/characterPreview/CharacterScoringSummary.tsx
@@ -678,7 +678,7 @@ export function CharacterCardCombatStats(props: { result: SimulationScore }) {
   let substats = originalSimulationMetadata.substats
   substats = substats.filter((x) => !nonDisplayStats.includes(x))
   substats = Utils.filterUnique(substats)
-  if (substats.length < 6) substats.push(Stats.SPD)
+  if (substats.length < 5) substats.push(Stats.SPD)
   substats.sort((a, b) => SubStats.indexOf(a) - SubStats.indexOf(b))
   substats.push(elementalDmgValue)
 

--- a/src/components/characterPreview/CharacterScoringSummary.tsx
+++ b/src/components/characterPreview/CharacterScoringSummary.tsx
@@ -666,6 +666,11 @@ function addOnHitStats(simulationScore: SimulationScore) {
   }
 }
 
+const percentFlatStats = {
+  [Stats.ATK_P]: true,
+  [Stats.DEF_P]: true,
+  [Stats.HP_P]: true,
+}
 
 export function CharacterCardCombatStats(props: { result: SimulationScore }) {
   const result = TsUtils.clone(props.result)
@@ -677,7 +682,7 @@ export function CharacterCardCombatStats(props: { result: SimulationScore }) {
   const nonDisplayStats = simulationMetadata.nonDisplayStats || []
   let substats = originalSimulationMetadata.substats
   substats = substats.filter((x) => !nonDisplayStats.includes(x))
-  substats = Utils.filterUnique(substats)
+  substats = Utils.filterUnique(substats).filter((x) => !percentFlatStats[x])
   if (substats.length < 5) substats.push(Stats.SPD)
   substats.sort((a, b) => SubStats.indexOf(a) - SubStats.indexOf(b))
   substats.push(elementalDmgValue)
@@ -685,7 +690,7 @@ export function CharacterCardCombatStats(props: { result: SimulationScore }) {
   const rows: ReactElement[] = []
 
   for (const stat of substats) {
-    if (stat == Stats.ATK_P || stat == Stats.DEF_P || stat == Stats.HP_P) continue
+    if (percentFlatStats[stat]) continue
 
     const value = damageStats[stat] ? result.originalSimResult.x.ELEMENTAL_DMG : result.originalSimResult.x[stat]
     const flat = Utils.isFlat(stat)

--- a/src/components/characterPreview/CharacterStatSummary.tsx
+++ b/src/components/characterPreview/CharacterStatSummary.tsx
@@ -20,7 +20,7 @@ export const CharacterStatSummary = (props: {
       <StatRow finalStats={props.finalStats} stat={Constants.Stats.RES}/>
       <StatRow finalStats={props.finalStats} stat={Constants.Stats.BE}/>
       {!props.simScore && !!props.finalStats[Stats.OHB] && <StatRow finalStats={props.finalStats} stat={Stats.OHB}/>}
-      <StatRow finalStats={props.finalStats} stat={Constants.Stats.ERR}/>
+      {(props.simScore == null || props.cv <= 64.8) && <StatRow finalStats={props.finalStats} stat={Constants.Stats.ERR}/>}
       <StatRow finalStats={props.finalStats} stat={props.elementalDmgValue}/>
       {props.cv != null && props.cv > 64.8 && <StatRow finalStats={props.finalStats} stat="CV" value={props.cv}/>}
       {props.simScore != null && <StatRow finalStats={props.finalStats} stat="simScore" value={props.simScore}/>}


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Fix character cards overflowing from combat stats on break units

Before: 
![image](https://github.com/user-attachments/assets/d6253cc1-105a-4fd7-b9b8-ef1d429f77ae)

After:
![image](https://github.com/user-attachments/assets/1071d236-72e0-45b4-ab3e-fbfdec7a6011)


## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

