### PR TITLE
feat: pevent edit relic when relic not selected & only show relic delete confirm when relic selected

### DIFF
--- a/src/components/RelicsTab.jsx
+++ b/src/components/RelicsTab.jsx
@@ -49,6 +49,7 @@ export default function RelicsTab() {
   const [selectedRelic, setSelectedRelic] = useState()
   const [editModalOpen, setEditModalOpen] = useState(false)
   const [addModalOpen, setAddModalOpen] = useState(false)
+  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false)
   const [plottedCharacterType, setPlottedCharacterType] = useState(PLOT_CUSTOM)
   const [relicInsight, setRelicInsight] = useState('buckets')
 
@@ -312,9 +313,18 @@ export default function RelicsTab() {
     setAddModalOpen(true)
   }
 
-  function deleteClicked() {
+  function deleteClicked(isOpen) {
     console.log('delete clicked')
 
+    if (!selectedRelic) {
+      setDeleteConfirmOpen(false)
+      return Message.error('No relic selected')
+    }
+
+    setDeleteConfirmOpen(isOpen)
+  }
+
+  function deletePerform() {
     if (!selectedRelic) return Message.error('No relic selected')
 
     DB.deleteRelic(selectedRelic.id)
@@ -413,7 +423,9 @@ export default function RelicsTab() {
           <Popconfirm
             title="Confirm"
             description="Delete this relic?"
-            onConfirm={deleteClicked}
+            open={deleteConfirmOpen}
+            onOpenChange={deleteClicked}
+            onConfirm={deletePerform}
             placement="bottom"
             okText="Yes"
             cancelText="Cancel"

--- a/src/components/RelicsTab.jsx
+++ b/src/components/RelicsTab.jsx
@@ -303,6 +303,7 @@ export default function RelicsTab() {
 
   function editClicked() {
     console.log('edit clicked')
+    if (!selectedRelic) return Message.error('No relic selected')
     setEditModalOpen(true)
   }
 


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* On the RelicsTab
  * Prevent edit relic when relic not selected, display a 'relic not selected' user message.
  * Prevent delete confirmation popup from showing if no relic is selected.

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* None

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

