### PR TITLE
feat: select and delete multiple relics

### DIFF
--- a/src/components/RelicsTab.jsx
+++ b/src/components/RelicsTab.jsx
@@ -18,6 +18,7 @@ import { SaveState } from 'lib/saveState'
 import { Hint } from 'lib/hint'
 import PropTypes from 'prop-types'
 import { RelicModalController } from 'lib/relicModalController'
+import { arrowKeyGridNavigation } from 'lib/arrowKeyGridNavigation'
 import { getGridTheme } from 'lib/theme'
 
 const { useToken } = theme
@@ -271,11 +272,16 @@ export default function RelicsTab() {
   }), [])
 
   const onSelectionChanged = useCallback((event) => {
+    console.log('selectionChanged', event)
     setselectedRelics(event.api.getSelectedRows())
   }, [])
 
   const rowClickedListener = useCallback((event) => {
     console.log('rowClicked', event)
+    if (!event.type) {
+      const node = gridRef.current.api.getRowNode(event.id)
+      node.setSelected(true, true)
+    }
     setSelectedRelic(event.data)
   }, [])
 
@@ -283,6 +289,10 @@ export default function RelicsTab() {
     console.log('rowDblClicked', e)
     setSelectedRelic(e.data)
     setEditModalOpen(true)
+  }, [])
+
+  const navigateToNextCell = useCallback((params) => {
+    return arrowKeyGridNavigation(params, gridRef, (selectedNode) => rowClickedListener(selectedNode))
   }, [])
 
   function onAddOk(relic) {
@@ -382,14 +392,14 @@ export default function RelicsTab() {
 
   return (
     <Flex style={{ width: 1350, marginBottom: 100 }}>
-      <RelicModal selectedRelic={selectedRelic} type="add" onOk={onAddOk} setOpen={setAddModalOpen} open={addModalOpen}/>
-      <RelicModal selectedRelic={selectedRelic} type="edit" onOk={onEditOk} setOpen={setEditModalOpen} open={editModalOpen}/>
+      <RelicModal selectedRelic={selectedRelic} type='add' onOk={onAddOk} setOpen={setAddModalOpen} open={addModalOpen}/>
+      <RelicModal selectedRelic={selectedRelic} type='edit' onOk={onEditOk} setOpen={setEditModalOpen} open={editModalOpen}/>
       <Flex vertical gap={10}>
 
         <RelicFilterBar setValueColumns={setValueColumns} valueColumns={valueColumns} valueColumnOptions={valueColumnOptions}/>
 
         <div
-          id="relicGrid" className="ag-theme-balham-dark" style={{
+          id='relicGrid' className='ag-theme-balham-dark' style={{
             ...{ width: 1350, height: 500, resize: 'vertical', overflow: 'hidden' },
             ...getGridTheme(token),
           }}
@@ -406,7 +416,7 @@ export default function RelicsTab() {
 
             animateRows={true}
             headerHeight={24}
-            rowSelection="multiple"
+            rowSelection='multiple'
 
             pagination={true}
             paginationPageSizeSelector={false}
@@ -415,31 +425,32 @@ export default function RelicsTab() {
             onSelectionChanged={onSelectionChanged}
             onRowClicked={rowClickedListener}
             onRowDoubleClicked={onRowDoubleClickedListener}
+            navigateToNextCell={navigateToNextCell}
           />
         </div>
         <Flex gap={10}>
           <Button
-            type="primary"
+            type='primary'
             onClick={editClicked}
             style={{ width: '150px' }}
             disabled={selectedRelics.length === 0 || selectedRelics.length > 1}
           >
             Edit Relic
           </Button>
-          <Button type="primary" onClick={addClicked} style={{ width: '150px' }}>
+          <Button type='primary' onClick={addClicked} style={{ width: '150px' }}>
             Add New Relic
           </Button>
           <Popconfirm
-            title="Confirm"
+            title='Confirm'
             description={selectedRelics.length > 1 ? `Delete the selected ${selectedRelics.length} relics?` : 'Delete the selected relic?'}
             open={deleteConfirmOpen}
             onOpenChange={deleteClicked}
             onConfirm={deletePerform}
-            placement="bottom"
-            okText="Yes"
-            cancelText="Cancel"
+            placement='bottom'
+            okText='Yes'
+            cancelText='Cancel'
           >
-            <Button type="primary" style={{ width: '150px' }} disabled={selectedRelics.length === 0}>
+            <Button type='primary' style={{ width: '150px' }} disabled={selectedRelics.length === 0}>
               Delete Relic
             </Button>
           </Popconfirm>
@@ -559,7 +570,7 @@ export default function RelicsTab() {
                         return (
                           <Flex key={x.cid} gap={4}>
                             <li style={x.owned ? { fontWeight: 'bold' } : undefined}>
-                              <Flex align="center" gap={8}>
+                              <Flex align='center' gap={8}>
                                 {rect}
                                 <a style={{ height: '19px' }}> {/* 20 px is too big and pushes the characters below the lower edge of the plot */}
                                   <img


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

Motivation to be able to select and delete all the ropes I just salvaged.

* Enabled ability to select multiple relics on the relicsTab page using CTRL and SHIFT.
  * Added a selectedRelics var to hold selected relics.
  * Changed Edit/Delete Relic buttons to enable/disable depending on number of relics selected.
  * Changed the Delete button Popconfirm message to show number of relics selected.
  * Changed the deletePerform function to delete multiple selected relics.
* ~~Removed feature, arrowKeyGridNavigation. It was conflicting with multiple select by selecting rows instead of navigating.~~

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* None

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

