### PR TITLE
feat: add top-n results selector for gpu optimizer

### DIFF
--- a/src/components/optimizerTab/Sidebar.jsx
+++ b/src/components/optimizerTab/Sidebar.jsx
@@ -122,6 +122,7 @@ function ComputeEngineSelect() {
       }}
       style={{ width: '100%', flex: 1 }}
       className='custom-dropdown-button'
+      trigger={['click']}
     >
       <Button style={{ padding: 3 }}>
         <Flex justify='space-around' align='center' style={{ width: '100%' }}>

--- a/src/components/optimizerTab/optimizerForm/CharacterSelectorDisplay.tsx
+++ b/src/components/optimizerTab/optimizerForm/CharacterSelectorDisplay.tsx
@@ -22,11 +22,24 @@ const Text = styled(Typography)`
 const resultLimitString = (limit: number) => `Find top ${limit.toLocaleString()} results`
 const resultLimitOptions = (() => {
   return [
-    { value: 100, label: resultLimitString(100) },
-    { value: 1000, label: resultLimitString(1000) },
-    { value: 10000, label: resultLimitString(10000) },
-    { value: 100000, label: resultLimitString(100000) },
-    { value: 1000000, label: resultLimitString(1000000) },
+    // { value: 1, label: resultLimitString(1) },
+    // { value: 2, label: resultLimitString(2) },
+    // { value: 4, label: resultLimitString(4) },
+    // { value: 8, label: resultLimitString(8) },
+    // { value: 16, label: resultLimitString(16) },
+    // { value: 32, label: resultLimitString(32) },
+    { value: 64, label: resultLimitString(64) },
+    { value: 128, label: resultLimitString(128) },
+    { value: 256, label: resultLimitString(256) },
+    { value: 512, label: resultLimitString(512) },
+    { value: 1024, label: resultLimitString(1024) },
+    { value: 2048, label: resultLimitString(2048) },
+    { value: 4096, label: resultLimitString(4096) },
+    { value: 8192, label: resultLimitString(8192) },
+    { value: 16384, label: resultLimitString(16384) },
+    { value: 32768, label: resultLimitString(32768) },
+    { value: 65536, label: resultLimitString(65536) },
+    // { value: 131072, label: resultLimitString(131072) },
   ]
 })()
 
@@ -143,12 +156,13 @@ export default function CharacterSelectorDisplay(_props: CharacterSelectorDispla
         <HeaderText>Optimization target</HeaderText>
       </Flex>
 
-      <Form.Item name='resultLimit'>
+      <Form.Item name='resultsLimit'>
         <Select
           showSearch
           style={{ width: panelWidth }}
           options={resultLimitOptions}
           placeholder='Find top results'
+          listHeight={800}
         />
       </Form.Item>
 

--- a/src/lib/defaultForm.js
+++ b/src/lib/defaultForm.js
@@ -69,7 +69,7 @@ export function getDefaultForm(initialCharacter) {
     teammate1: defaultTeammate(),
     teammate2: defaultTeammate(),
     resultSort: scoringMetadata?.sortOption.key,
-    resultLimit: 100000,
+    resultsLimit: 1024,
     combatBuffs: combatBuffs,
     combo: {
       BASIC: 0,

--- a/src/lib/gpu/webgpuInternals.ts
+++ b/src/lib/gpu/webgpuInternals.ts
@@ -171,7 +171,7 @@ export function initializeGpuPipeline(
   const WORKGROUP_SIZE = 256
   const BLOCK_SIZE = 65536
   const CYCLES_PER_INVOCATION = 512
-  const RESULTS_LIMIT = 1024
+  const RESULTS_LIMIT = request.resultsLimit || 1024
   const DEBUG = debug
 
   const wgsl = generateWgsl(params, request, {

--- a/src/lib/gpu/webgpuOptimizer.ts
+++ b/src/lib/gpu/webgpuOptimizer.ts
@@ -183,14 +183,19 @@ function outputResults(gpuContext: GpuExecutionContext) {
     const g = (((index - b * fSize * pSize * lSize - f * pSize * lSize - p * lSize - l) / (lSize * pSize * fSize * bSize)) % gSize)
     const h = (((index - g * bSize * fSize * pSize * lSize - b * fSize * pSize * lSize - f * pSize * lSize - p * lSize - l) / (lSize * pSize * fSize * bSize * gSize)) % hSize)
 
-    const c = calculateBuild(gpuContext.request, {
-      Head: relics.Head[h],
-      Hands: relics.Hands[g],
-      Body: relics.Body[b],
-      Feet: relics.Feet[f],
-      PlanarSphere: relics.PlanarSphere[p],
-      LinkRope: relics.LinkRope[l],
-    })
+    const cachedParams = gpuContext.params
+    const c = calculateBuild(
+      gpuContext.request,
+      {
+        Head: relics.Head[h],
+        Hands: relics.Hands[g],
+        Body: relics.Body[b],
+        Feet: relics.Feet[f],
+        PlanarSphere: relics.PlanarSphere[p],
+        LinkRope: relics.LinkRope[l],
+      },
+      cachedParams,
+    )
 
     c.id = index
     renameFields(c)

--- a/src/lib/optimizer/optimizer.ts
+++ b/src/lib/optimizer/optimizer.ts
@@ -127,8 +127,8 @@ export const Optimizer = {
     let results = []
     const sortOption = SortOption[request.resultSort]
     const gridSortColumn = request.statDisplay == 'combat' ? sortOption.combatGridColumn : sortOption.basicGridColumn
-    const resultLimit = request.resultLimit || 100000
-    const queueResults = new FixedSizePriorityQueue(resultLimit, (a, b) => a[gridSortColumn] - b[gridSortColumn])
+    const resultsLimit = request.resultsLimit || 1024
+    const queueResults = new FixedSizePriorityQueue(resultsLimit, (a, b) => a[gridSortColumn] - b[gridSortColumn])
 
     // Incrementally increase the optimization run sizes instead of having a fixed size, so it doesnt lag for 2 seconds on Start
     const increment = 20000

--- a/src/lib/optimizerTabController.js
+++ b/src/lib/optimizerTabController.js
@@ -501,8 +501,8 @@ export const OptimizerTabController = {
       }
     }
 
-    if (!newForm.resultLimit) {
-      newForm.resultLimit = 100000
+    if (!newForm.resultsLimit) {
+      newForm.resultsLimit = 1024
     }
 
     if (!newForm.mainStatUpscaleLevel) {
@@ -550,7 +550,7 @@ export const OptimizerTabController = {
       return false
     }
 
-    if (!x.resultLimit || !x.resultSort) {
+    if (!x.resultsLimit || !x.resultSort) {
       Message.error('Missing optimization target fields')
       console.log('Missing optimization target fields')
       return false


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Added results limit selector, defaults to 1024

![image](https://github.com/user-attachments/assets/37d5c604-e61d-4175-a35e-0294fb9c2f2c)

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

