### PR TITLE
feat: disable valorous by default and enable on certain characters, fix ashblazing counts, jiaoqiu prisoner

### DIFF
--- a/src/components/RelicScorerTab.jsx
+++ b/src/components/RelicScorerTab.jsx
@@ -477,7 +477,13 @@ function CharacterPreviewSelection(props) {
           </Flex>
         </Flex>
 
-        <Segmented style={{ width: '100%', overflow: 'hidden' }} options={options} block onChange={selectionChange} value={props.selectedCharacter?.id}/>
+        <Segmented
+          style={{ width: '100%', overflow: 'hidden' }}
+          options={options}
+          block
+          onChange={selectionChange}
+          value={props.selectedCharacter?.id}
+        />
         <Flex id='previewWrapper' style={{ padding: '5px', backgroundColor: token.colorBgBase }}>
           <CharacterPreview
             class='relicScorerCharacterPreview'

--- a/src/components/optimizerTab/optimizerForm/RecommendedPresetsButton.tsx
+++ b/src/components/optimizerTab/optimizerForm/RecommendedPresetsButton.tsx
@@ -25,7 +25,7 @@ import { Utils } from 'lib/utils'
 export const SpdValues = {
   SPD0: {
     key: 'SPD0',
-    label: '0 SPD - Action advance support recommended',
+    label: 'No minimum speed',
     value: undefined,
   },
   SPD111: {

--- a/src/components/optimizerTab/optimizerForm/RecommendedPresetsButton.tsx
+++ b/src/components/optimizerTab/optimizerForm/RecommendedPresetsButton.tsx
@@ -107,6 +107,9 @@ export const PresetEffects = {
   WASTELANDER_SET: (form) => {
     form.setConditionals[Sets.PrisonerInDeepConfinement][1] = 2
   },
+  VALOROUS_SET: (form) => {
+    form.setConditionals[Sets.TheWindSoaringValorous][1] = true
+  },
   BANANA_SET: (form) => {
     form.setConditionals[Sets.TheWondrousBananAmusementPark][1] = true
   },
@@ -155,7 +158,7 @@ const RecommendedPresetsButton = () => {
       overlayStyle={{ width: 'max-content' }}
     >
       <a onClick={(e) => e.preventDefault()}>
-        <Button type="primary" style={{ width: '100%' }}>
+        <Button type='primary' style={{ width: '100%' }}>
           Recommended presets
           <DownOutlined/>
         </Button>

--- a/src/lib/dataParser.js
+++ b/src/lib/dataParser.js
@@ -1367,7 +1367,9 @@ function getScoringMetadata() {
           Stats.ERR,
         ],
       },
-      presets: [],
+      presets: [
+        PresetEffects.VALOROUS_SET,
+      ],
       sortOption: SortOption.DEF,
     },
     1002: { // Dan Heng
@@ -1521,6 +1523,7 @@ function getScoringMetadata() {
       },
       presets: [
         PresetEffects.fnAshblazingSet(4),
+        PresetEffects.VALOROUS_SET,
       ],
       sortOption: SortOption.FUA,
       simulation: {
@@ -1741,6 +1744,7 @@ function getScoringMetadata() {
       presets: [
         PresetEffects.PRISONER_SET,
         PresetEffects.fnAshblazingSet(6),
+        PresetEffects.VALOROUS_SET,
       ],
       sortOption: SortOption.DOT,
       simulation: {
@@ -2042,7 +2046,8 @@ function getScoringMetadata() {
         ],
       },
       presets: [
-        PresetEffects.fnAshblazingSet(4),
+        PresetEffects.fnAshblazingSet(8),
+        PresetEffects.VALOROUS_SET,
       ],
       sortOption: SortOption.FUA,
       simulation: {
@@ -3126,7 +3131,9 @@ function getScoringMetadata() {
           Stats.ATK_P,
         ],
       },
-      presets: [],
+      presets: [
+        PresetEffects.VALOROUS_SET,
+      ],
       sortOption: SortOption.BASIC,
       simulation: {
         parts: {
@@ -3328,6 +3335,7 @@ function getScoringMetadata() {
       },
       presets: [
         PresetEffects.fnAshblazingSet(8),
+        PresetEffects.VALOROUS_SET,
         PresetEffects.BANANA_SET,
       ],
       sortOption: SortOption.FUA,
@@ -3437,7 +3445,9 @@ function getScoringMetadata() {
           Stats.HP_P,
         ],
       },
-      presets: [],
+      presets: [
+        PresetEffects.VALOROUS_SET,
+      ],
       sortOption: SortOption.BASIC,
       simulation: {
         parts: {
@@ -3747,7 +3757,10 @@ function getScoringMetadata() {
           Stats.ATK_P,
         ],
       },
-      presets: [],
+      presets: [
+        PresetEffects.VALOROUS_SET,
+        PresetEffects.fnAshblazingSet(2),
+      ],
       sortOption: SortOption.ULT,
       simulation: {
         parts: {
@@ -4159,6 +4172,7 @@ function getScoringMetadata() {
       },
       presets: [
         PresetEffects.fnAshblazingSet(3),
+        PresetEffects.VALOROUS_SET,
       ],
       sortOption: SortOption.SKILL,
       simulation: {
@@ -4343,7 +4357,9 @@ function getScoringMetadata() {
         [Constants.Parts.PlanarSphere]: [],
         [Constants.Parts.LinkRope]: [],
       },
-      presets: [],
+      presets: [
+        PresetEffects.PRISONER_SET,
+      ],
       sortOption: SortOption.EHR,
     },
     1220: { // Feixiao
@@ -4388,7 +4404,8 @@ function getScoringMetadata() {
         ],
       },
       presets: [
-        PresetEffects.fnAshblazingSet(1),
+        PresetEffects.fnAshblazingSet(4),
+        PresetEffects.VALOROUS_SET,
       ],
       sortOption: SortOption.ULT,
       simulation: {
@@ -4497,7 +4514,10 @@ function getScoringMetadata() {
           Constants.Stats.ATK_P,
         ],
       },
-      presets: [],
+      presets: [
+        PresetEffects.VALOROUS_SET,
+        PresetEffects.fnAshblazingSet(8),
+      ],
       sortOption: SortOption.FUA,
       simulation: {
         parts: {
@@ -4610,7 +4630,8 @@ function getScoringMetadata() {
       },
       presets: [
         PresetEffects.BANANA_SET,
-        PresetEffects.fnAshblazingSet(3),
+        PresetEffects.fnAshblazingSet(6),
+        PresetEffects.VALOROUS_SET,
       ],
       sortOption: SortOption.BE,
     },
@@ -4657,6 +4678,7 @@ function getScoringMetadata() {
       },
       presets: [
         PresetEffects.fnAshblazingSet(6),
+        PresetEffects.VALOROUS_SET,
       ],
       sortOption: SortOption.FUA,
       simulation: {
@@ -4767,7 +4789,10 @@ function getScoringMetadata() {
           Constants.Stats.ATK_P,
         ],
       },
-      presets: [],
+      presets: [
+        PresetEffects.fnAshblazingSet(2),
+        PresetEffects.VALOROUS_SET,
+      ],
       sortOption: SortOption.BASIC,
       simulation: {
         parts: {
@@ -5063,7 +5088,7 @@ function getScoringMetadata() {
         ],
       },
       presets: [
-        PresetEffects.fnAshblazingSet(7),
+        PresetEffects.VALOROUS_SET,
       ],
       sortOption: SortOption.FUA,
       simulation: {
@@ -5182,6 +5207,7 @@ function getScoringMetadata() {
       presets: [
         PresetEffects.fnAshblazingSet(1),
         PresetEffects.fnPioneerSet(4),
+        PresetEffects.VALOROUS_SET,
         PresetEffects.WASTELANDER_SET,
       ],
       sortOption: SortOption.FUA,
@@ -5800,7 +5826,10 @@ function getScoringMetadata() {
           Constants.Stats.ATK_P,
         ],
       },
-      presets: [],
+      presets: [
+        PresetEffects.VALOROUS_SET,
+        PresetEffects.fnAshblazingSet(8),
+      ],
       sortOption: SortOption.FUA,
       simulation: {
         parts: {

--- a/src/lib/dataParser.js
+++ b/src/lib/dataParser.js
@@ -1522,7 +1522,7 @@ function getScoringMetadata() {
         ],
       },
       presets: [
-        PresetEffects.fnAshblazingSet(4),
+        PresetEffects.fnAshblazingSet(8),
         PresetEffects.VALOROUS_SET,
       ],
       sortOption: SortOption.FUA,

--- a/src/lib/defaultForm.js
+++ b/src/lib/defaultForm.js
@@ -145,7 +145,7 @@ export const defaultSetConditionals = {
   [Constants.Sets.PioneerDiverOfDeadWaters]: [undefined, 2],
   [Constants.Sets.WatchmakerMasterOfDreamMachinations]: [undefined, false],
   [Constants.Sets.IronCavalryAgainstTheScourge]: [undefined, true],
-  [Constants.Sets.TheWindSoaringValorous]: [undefined, true],
+  [Constants.Sets.TheWindSoaringValorous]: [undefined, false],
 
   [Constants.Sets.SpaceSealingStation]: [undefined, true],
   [Constants.Sets.FleetOfTheAgeless]: [undefined, true],


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Valorous is now off by default and enabled with a flag
* Activated prisoner set on Jiaoqiu by default
* Various ashblazing default tweaks

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

