### PR TITLE
feat: hide rating filters into collapse

### DIFF
--- a/src/components/RelicScorerTab.jsx
+++ b/src/components/RelicScorerTab.jsx
@@ -461,10 +461,10 @@ function CharacterPreviewSelection(props) {
   return (
     <Flex style={{ width: 1300, marginLeft: 25 }} justify='space-around'>
       <Flex vertical align='center' gap={5} style={{ marginBottom: 100, width: 1068 }}>
-        <Flex vertical style={{ display: (props.availableCharacters.length > 0) ? 'flex' : 'none' }}>
+        <Flex vertical style={{ display: (props.availableCharacters.length > 0) ? 'flex' : 'none', width: '100%' }}>
           <Sidebar presetClicked={presetClicked} optimizeClicked={optimizeClicked} activeKey={activeKey}/>
-          <Flex gap={10} style={{ display: (props.availableCharacters.length > 0) ? 'flex' : 'none' }}>
-            <Button onClick={clipboardClicked} style={{ width: 230 }} icon={<CameraOutlined/>} loading={screenshotLoading} type='primary'>
+          <Flex style={{ display: (props.availableCharacters.length > 0) ? 'flex' : 'none' }} justify='space-between'>
+            <Button onClick={clipboardClicked} style={{ width: 225 }} icon={<CameraOutlined/>} loading={screenshotLoading} type='primary'>
               Copy screenshot
             </Button>
             <Button style={{ width: 40 }} icon={<DownloadOutlined/>} onClick={downloadClicked} loading={downloadLoading}/>

--- a/src/components/optimizerTab/OptimizerForm.jsx
+++ b/src/components/optimizerTab/OptimizerForm.jsx
@@ -17,7 +17,7 @@ import TeammateCard from 'components/optimizerTab/optimizerForm/TeammateCard'
 import CharacterSelectorDisplay from 'components/optimizerTab/optimizerForm/CharacterSelectorDisplay.tsx'
 import RelicMainSetFilters from 'components/optimizerTab/optimizerForm/RelicMainSetFilters'
 import { SubstatWeightFilters } from 'components/optimizerTab/optimizerForm/SubstatWeightFilters'
-import { MinMaxRatingFilters, MinMaxStatFilters } from 'components/optimizerTab/optimizerForm/ResultFilters'
+import { MinMaxStatFilters } from 'components/optimizerTab/optimizerForm/ResultFilters'
 import { CombatBuffsDrawer } from 'components/optimizerTab/optimizerForm/CombatBuffsDrawer'
 import { OptimizerTabCharacterPanel } from 'components/optimizerTab/optimizerForm/OptimizerTabCharacterPanel'
 import { LightConeConditionals } from 'lib/lightConeConditionals'
@@ -180,7 +180,6 @@ export default function OptimizerForm() {
             </FormCard>
 
             <FormCard>
-              <MinMaxRatingFilters/>
             </FormCard>
 
             <FormCard>

--- a/src/components/optimizerTab/optimizerForm/RelicSetTagRenderer.tsx
+++ b/src/components/optimizerTab/optimizerForm/RelicSetTagRenderer.tsx
@@ -68,7 +68,7 @@ export function RelicSetTagRenderer(props) {
 
   return (
     <Tag
-      closable={closable}
+      closable={false}
       onClose={onClose}
       style={{ display: 'flex', flexDirection: 'row', paddingInline: '1px', marginInlineEnd: '4px', height: 22, alignItems: 'center', overflow: 'hidden' }}
     >

--- a/src/components/optimizerTab/optimizerForm/ResultFilters.tsx
+++ b/src/components/optimizerTab/optimizerForm/ResultFilters.tsx
@@ -30,7 +30,7 @@ export const MinMaxStatFilters = () => {
           <FilterRow name='Err' label='ERR'/>
         </Flex>
         <Flex
-          style={{ height: 20, width: '100%', cursor: 'pointer' }}
+          style={{ height: 20, width: '100%', marginTop: -4, cursor: 'pointer' }}
           justify='space-around'
           align='flex-start'
           onClick={() => setView('Ratings')}
@@ -55,7 +55,7 @@ export const MinMaxStatFilters = () => {
         <FilterRow name='Break' label='BREAK'/>
         <FilterRow name='Combo' label='COMBO'/>
         <Flex
-          style={{ height: 20, width: '100%', cursor: 'pointer' }}
+          style={{ height: 20, width: '100%', marginTop: -4, cursor: 'pointer' }}
           justify='space-around'
           align='flex-start'
           onClick={() => setView('Stats')}

--- a/src/components/optimizerTab/optimizerForm/ResultFilters.tsx
+++ b/src/components/optimizerTab/optimizerForm/ResultFilters.tsx
@@ -4,47 +4,65 @@ import { TooltipImage } from 'components/TooltipImage.jsx'
 import { Hint } from 'lib/hint.jsx'
 import FilterRow from 'components/optimizerTab/optimizerForm/FilterRow.tsx'
 import { optimizerTabDefaultGap } from 'components/optimizerTab/optimizerTabConstants.ts'
+import { CaretDownOutlined } from '@ant-design/icons'
+import { useState } from 'react'
 
 export const MinMaxStatFilters = () => {
-  return (
-    <Flex vertical gap={optimizerTabDefaultGap}>
-      <Flex justify='space-between' align='center'>
-        <HeaderText>Stat min / max filters</HeaderText>
-        <TooltipImage type={Hint.statFilters()}/>
-      </Flex>
-      <Flex vertical gap={5}>
-        <FilterRow name='Hp' label='HP'/>
-        <FilterRow name='Atk' label='ATK'/>
-        <FilterRow name='Def' label='DEF'/>
-        <FilterRow name='Spd' label='SPD'/>
-        <FilterRow name='Cr' label='CR'/>
-        <FilterRow name='Cd' label='CD'/>
-        <FilterRow name='Ehr' label='EHR'/>
-        <FilterRow name='Res' label='RES'/>
-        <FilterRow name='Be' label='BE'/>
-        <FilterRow name='Err' label='ERR'/>
-      </Flex>
-    </Flex>
-  )
-}
+  const [view, setView] = useState('Stats')
 
-export const MinMaxRatingFilters = () => {
   return (
-    <Flex vertical gap={optimizerTabDefaultGap}>
-      <Flex justify='space-between' align='center'>
-        <HeaderText>Rating min / max filters</HeaderText>
-        <TooltipImage type={Hint.ratingFilters()}/>
+    <div>
+      <Flex vertical gap={optimizerTabDefaultGap} style={{ display: view == 'Stats' ? 'flex' : 'none' }}>
+        <Flex justify='space-between' align='center'>
+          <HeaderText>Stat min / max filters</HeaderText>
+          <TooltipImage type={Hint.statFilters()}/>
+        </Flex>
+        <Flex vertical gap={5}>
+          <FilterRow name='Hp' label='HP'/>
+          <FilterRow name='Atk' label='ATK'/>
+          <FilterRow name='Def' label='DEF'/>
+          <FilterRow name='Spd' label='SPD'/>
+          <FilterRow name='Cr' label='CR'/>
+          <FilterRow name='Cd' label='CD'/>
+          <FilterRow name='Ehr' label='EHR'/>
+          <FilterRow name='Res' label='RES'/>
+          <FilterRow name='Be' label='BE'/>
+          <FilterRow name='Err' label='ERR'/>
+        </Flex>
+        <Flex
+          style={{ height: 20, width: '100%', cursor: 'pointer' }}
+          justify='space-around'
+          align='flex-start'
+          onClick={() => setView('Ratings')}
+        >
+          <CaretDownOutlined/>
+        </Flex>
       </Flex>
 
-      <FilterRow name='Weight' label='WEIGHT'/>
-      <FilterRow name='Ehp' label='EHP'/>
-      <FilterRow name='Basic' label='BASIC'/>
-      <FilterRow name='Skill' label='SKILL'/>
-      <FilterRow name='Ult' label='ULT'/>
-      <FilterRow name='Fua' label='FUA'/>
-      <FilterRow name='Dot' label='DOT'/>
-      <FilterRow name='Break' label='BREAK'/>
-      <FilterRow name='Combo' label='COMBO'/>
-    </Flex>
+      <Flex vertical gap={optimizerTabDefaultGap} style={{ display: view == 'Ratings' ? 'flex' : 'none' }}>
+        <Flex justify='space-between' align='center'>
+          <HeaderText>Rating min / max filters</HeaderText>
+          <TooltipImage type={Hint.ratingFilters()}/>
+        </Flex>
+
+        <FilterRow name='Weight' label='WEIGHT'/>
+        <FilterRow name='Ehp' label='EHP'/>
+        <FilterRow name='Basic' label='BASIC'/>
+        <FilterRow name='Skill' label='SKILL'/>
+        <FilterRow name='Ult' label='ULT'/>
+        <FilterRow name='Fua' label='FUA'/>
+        <FilterRow name='Dot' label='DOT'/>
+        <FilterRow name='Break' label='BREAK'/>
+        <FilterRow name='Combo' label='COMBO'/>
+        <Flex
+          style={{ height: 20, width: '100%', cursor: 'pointer' }}
+          justify='space-around'
+          align='flex-start'
+          onClick={() => setView('Stats')}
+        >
+          <CaretDownOutlined/>
+        </Flex>
+      </Flex>
+    </div>
   )
 }


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Hiding the ratings filters since those are rarely used, hidden into an expandable

![image](https://github.com/user-attachments/assets/eb653918-c185-47fd-b029-ddc5c56bf234)

* Remove closable on relic filters bc it doesnt work
![image](https://github.com/user-attachments/assets/e9fa0cfd-7bf3-42c5-9530-8d1f7fae2fe1)



## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

