### PR TITLE
fix: disable force-spd-boots scoring to fix kafka

### DIFF
--- a/src/lib/characterScorer.ts
+++ b/src/lib/characterScorer.ts
@@ -378,7 +378,13 @@ export function scoreCharacterSimulation(
     // DEBUG
     candidateBenchmarkSim.key = JSON.stringify(candidateBenchmarkSim.request)
     candidateBenchmarkSim.name = ''
-    candidateBenchmarkSims.push(candidateBenchmarkSim)
+
+    if (partialSimulationWrapper.simulation.request.stats[Stats.SPD] > 26 && partialSimulationWrapper.simulation.request.simFeet != Stats.SPD) {
+      // Reject non speed boot builds that exceed the speed cap. 48 - 11 * 2 = 26 max subs that can go in to SPD
+      console.log('Rejected candidate sim')
+    } else {
+      candidateBenchmarkSims.push(candidateBenchmarkSim)
+    }
   }
 
   // Try to minimize the penalty modifier before optimizing sim score
@@ -1013,7 +1019,8 @@ function generatePartialSimulations(
   originalBaseSpeed: number,
 ) {
   const characterSpdStat = calculateCharacterSpdStat(character)
-  const forceSpdBoots = originalBaseSpeed - characterSpdStat > 40 // 4 min spd rolls per piece
+  // const forceSpdBoots = originalBaseSpeed - characterSpdStat > 40 // 4 min spd rolls per piece
+  const forceSpdBoots = false // Always calculate both boots
   const feetParts: string[] = forceSpdBoots ? [Stats.SPD] : metadata.parts[Parts.Feet]
 
   const { relicSet1, relicSet2, ornamentSet } = simulationSets


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Fixing bug with SPD boots being forced, removing that restriction and adding a limit on speed rolls for an acceptable sim

Before:

![image](https://github.com/user-attachments/assets/abab820f-98f0-4627-86d3-6228ff76003c)

After: 

![image](https://github.com/user-attachments/assets/a198cb7f-b09d-4963-bf10-2e0c228ae80c)


## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

