### PR TITLE
fix: correctly display 0 mainstats in DPS summary

### DIFF
--- a/src/components/characterPreview/CharacterScoringSummary.tsx
+++ b/src/components/characterPreview/CharacterScoringSummary.tsx
@@ -495,10 +495,10 @@ export const CharacterScoringSummary = (props: { simScoringResult: SimulationSco
           </pre>{/* Character main stats/100% benchmark main stats/200% perfect main stats */}
           <Flex gap={defaultGap} justify='space-around'>
             <Flex vertical gap={10}>
-              <ScoringStat stat={t(`common:ReadableStats.${request.simBody}`)} part={Parts.Body}/>
-              <ScoringStat stat={t(`common:ReadableStats.${request.simFeet}`)} part={Parts.Feet}/>
-              <ScoringStat stat={t(`common:ReadableStats.${request.simPlanarSphere}`)} part={Parts.PlanarSphere}/>
-              <ScoringStat stat={t(`common:ReadableStats.${request.simLinkRope}`)} part={Parts.LinkRope}/>
+              <ScoringStat stat={request.simBody !== 'NONE' ? t(`common:ReadableStats.${request.simBody}`) : ''} part={Parts.Body}/>
+              <ScoringStat stat={request.simFeet !== 'NONE' ? t(`common:ReadableStats.${request.simFeet}`) : ''} part={Parts.Feet}/>
+              <ScoringStat stat={request.simPlanarSphere !== 'NONE' ? t(`common:ReadableStats.${request.simPlanarSphere}`) : ''} part={Parts.PlanarSphere}/>
+              <ScoringStat stat={request.simLinkRope !== 'NONE' ? t(`common:ReadableStats.${request.simLinkRope}`) : ''} part={Parts.LinkRope}/>
             </Flex>
           </Flex>
         </Flex>


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* 

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

