### PR TITLE
[Bug] Weighted rolls per relic values not preserved

### DIFF
--- a/src/components/optimizerTab/optimizerForm/RecommendedPresetsButton.tsx
+++ b/src/components/optimizerTab/optimizerForm/RecommendedPresetsButton.tsx
@@ -225,7 +225,7 @@ export function applyMetadataPresetToForm(form, scoringMetadata) {
   form.mainFeet = scoringMetadata.parts[Constants.Parts.Feet]
   form.mainPlanarSphere = scoringMetadata.parts[Constants.Parts.PlanarSphere]
   form.mainLinkRope = scoringMetadata.parts[Constants.Parts.LinkRope]
-  form.weights = scoringMetadata.stats
+  form.weights = { ...form.weights, ...scoringMetadata.stats }
   form.weights.headHands = form.weights.headHands || 0
   form.weights.bodyFeet = form.weights.bodyFeet || 0
   form.weights.sphereRope = form.weights.sphereRope || 0


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
In the Character Optimizer tab, the 'Weighted Rolls per Relic' values reset to 0 upon selecting a recommended preset. The code has now been updated to preserve user-set values. This looked like the original intent of the code.

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.