### PR TITLE
feat: documentation migration, change sacerdos to a selector in advanced rotations, equivalent sets

### DIFF
--- a/docs/guides/en/dps-score.md
+++ b/docs/guides/en/dps-score.md
@@ -1,0 +1,142 @@
+# DPS Score
+
+## What is DPS Score?
+
+DPS Score is a damage calculation based metric for accurately scoring how optimal the character's relics are for maximizing damage in combat.
+
+This score is calculated by using the optimizer to simulate the character's combat stats and rates the build based on how much the relics contribute to damage, for a more accurate evaluation than scores based solely on stat weights.
+
+The scoring calculation takes into consideration:
+
+* Character eidolons / light cone / superimpositions
+* Teammate eidolons / light cone / superimpositions
+* Combat passives and buffs from abilities and light cones
+* Team composition and teammate buffs
+* Character ability rotations
+* Stat breakpoints
+* Stat overcapping
+* Relic set effects
+* Super break
+* ...etc
+
+## How is it calculated?
+
+At its heart, this score is calculated using a Basic / Skill / Ult / FuA / DoT / Break ability damage rotation predefined per character. These simulations use the optimizer's default conditional settings for the character / teammates / light cones / relic sets, and the damage sum is then used to compare between builds.
+
+### Simulation benchmarks
+
+The scoring algorithm generates three builds to measure the damage of the original character against.
+
+* Baseline (0%) - No substats, no main stats
+* Benchmark (100%) - A strong build, generated following certain rules with a realistic distribution of 48x min rolls
+* Perfection (200%) - The perfect build, generated with an ideal distribution of 54x max rolled substats
+
+The original character's build is scored based on how its Combo DMG compares to the benchmark percentages.The benchmark and perfection builds will always match the original character's SPD.
+
+### 100% benchmark ruleset
+
+The 100% benchmark character is designed to be a strong and realistic build that is difficult to reach, but attainable with some character investment into relic farming. The following ruleset defines how the build is generated and why it differs from the perfect build.
+
+* The default damage simulation uses a common team composition and the character's BiS relic + ornament set
+* The 100% benchmark uses the same eidolon and superimposition as the original character, at level 80 and maxed traces
+* The 100% benchmark has 4 main stats and 48 total substats: 8 from each gear slot
+* Each substat is equivalent to a 5 star relic's low roll value, except for SPD which uses mid rolls
+* First, 2 substats are allocated to each substat type, except for SPD
+* Substats are then allocated to SPD to match the original character's in-combat SPD
+* The remaining substats are then distributed to the other stats options to maximize the build's damage output
+* The resulting build must be a substat distribution that is possible to make with the in-game sub and main stat restrictions (for example, relics with a main stat cannot also have the same substat, and no duplicate substat slots per piece, etc)
+* An artificial diminishing returns penalty is applied to substats with greater than `12 - (2 * main stats)` rolls, to simulate the difficulty of obtaining multiple rolls in a single stat
+
+This process is repeated through all the possible main stat permutations and substat distributions until the highest damage simulation is found. That build's damage is then used as the standard for a 100% DPS Score.
+
+### 200% benchmark ruleset
+
+The 200% perfection character follows a similar generation process with a few differences.
+
+* 54x max roll substats
+* No diminishing returns penalty
+* All substats are ideally distributed, but the build must still be possible to make
+
+### Score normalization
+
+All simulation scores are normalized by deducting a baseline damage simulation. The baseline uses the same eidolon and light cone, but no main stats and no substats. This adjusts for the base amount of damage that a character's kit deals, so that the DPS Score can then measure the resulting damage contribution of each additional substat.
+
+### Relic / ornament sets
+
+Each character has a defined BiS set, and a few other equivalent sets that can be considered similar in performance. If the original character's sets matches any of the acceptable sets, the character will be scored against a benchmark generated matching that set, otherwise the original character will be scored against the BiS.
+
+### Stat breakpoint penalty
+
+Certain characters will have breakpoints that are forced. For example, 120% combat EHR on Black Swan to maximize her passive EHR to DMG conversion, and to land Arcana stacks. Failing to reach the breakpoint will penalize the DPS Score for the missing percentage. This penalty applies to both the original character and the benchmark simulations but not the baseline.
+
+### Formula
+
+The resulting formula is:
+
+* If DMG < 100% benchmark
+    * `DMG Score = (character dmg - 0% baseline dmg) / (100% benchmark dmg - 0% baseline dmg)`
+* If DMG ≥ 100% benchmark
+    * `DMG Score = 1 + (character dmg - 100% benchmark dmg) / (200% perfect dmg - 100% benchmark dmg)`
+
+## What are the grade thresholds?
+
+Grading is based on the benchmark as 100% and perfection as 200%.
+
+```
+* 135% - WTF+ ↑ 9%
+* 126% - WTF  ↑ 8%
+* 118% - SSS+ ↑ 7%
+* 111% - SSS  ↑ 6%
+* 105% - SS+  ↑ 5%
+* 100% - SS   [Benchmark]
+* 95% - S+
+* 90% - S
+* 85% - A+
+* 80% - A
+* 75% - B+
+* 70% - B
+* 65% - C+
+* 60% - C
+* 55% - D+
+* 50% - D
+* 45% - F+
+* 40% - F
+```
+
+## FAQs
+
+### Why does the sim match speed?
+
+Speed is controlled separately from the other stats because damage isn't comparable between different speed thresholds. For example, higher speed can actually result in lower damage with Bronya as a teammate if the speed tuning is thrown off. To make damage comparisons fair, we equalize the speed variable by forcing the sim's substats to match the original character's combat speed.
+
+### Why does a build score lower even though it has higher Sim Damage?
+
+The benchmark sims have to equalize speed, so if the higher damage build has lower speed, then it will be compared to benchmark builds at that same lower speed, and therefore may score lower. In general this means that the sim will reallocate every reduced speed roll into a damage stat instead.
+
+### What's the reasoning behind the benchmark simulation rules?
+
+The simulation rules were designed to create a realistic benchmark build for 100% DPS Score, which should be difficult to achieve yet possible with character investment. After trialing many methodologies for generating simulation stats, this set of rules produced the most consistent and reasonable 100% benchmarks across all characters and builds.
+
+The spread of 2 substats across all stat options provides some baseline consistency, and simulates how substats are imperfectly distributed in actual player builds. The spread rolls also help to balance out characters that are more stat hungry and require multiple stats to be effective, vs characters that only need two or three stats.
+
+Applying diminishing returns to high stacking substats is a way to make the benchmark fair for characters that primarily scale off of a single stat, for example Boothill and break effect. The ideal distribution will want every relic roll to go into break effect, but stacking 5x rolls of a single stat on a relic is extremely rare / unrealistic in practice, so the simulation rules add diminishing returns to account for that.
+
+### Why are the scores different for different teams?
+
+Team buffs and synergy will change the ideal benchmark simulation's score. For example, a benchmark sim with Fu Xuan on the team may invest more substats into Crit DMG instead of Crit Rate since her passive Crit Rate will change the optimal distribution of crit rolls. Teams should be customized to fit the actual teammates used for the character ingame for an accurate score.
+
+### Why are certain stat breakpoints forced?
+
+The only forced breakpoints currently are Effect Hit Rate minimums for DoT characters. Take Black Swan for example, the purpose of forcing the sim to use her 120% breakpoint is so it can't just ignore EHR to chase more maximum DoT damage. EHR is more than just DMG conversion as it also lets her land Arcana debuffs to reach her 7th Arcana stack for DEF pen. The penalty is calculated as a 1% deduction per missing roll from the breakpoint.
+
+`dmg scale = min(1, (breakpoint - combat stat) / (min stat value))`
+
+### How were the default simulation teams / sets chosen?
+
+The defaults come from a combination of usage statistics and community guidance. Best in slot sets and teammates will change with new game updates, so the default parameters may also change. Please visit the Discord server for suggestions and feedback on the scoring design.
+
+### Why is a character scoring low?
+
+The `Damage Upgrades` section will give a quick overview of the sets and stats that could be improved. Substat upgrades will show the damage increase for a single max roll. For a more detailed explanation, the full simulation is detailed below the character card, including the benchmark character's stat distribution, basic stats, combat stats, and main stats. Comparing the original character's stats to the benchmark character's stats is helpful to show the difference in builds and see where to improve.
+
+An often underestimated component of the build is completed BiS set effects. Set effects can play a large part in optimizing a character's potential damage output and rainbow or broken sets will often score worse than full sets.

--- a/docs/guides/en/stat-score.md
+++ b/docs/guides/en/stat-score.md
@@ -1,0 +1,112 @@
+# Stat Score
+
+## Substat weight methodology
+
+Substat weights are graded on a 0.0 to 1.0 scale in increments of 0.25, based on how valuable each stat is to the character. Weights are evaluated based on the following general ruleset:
+
+* Speed weight:
+    * SPD is given a value of 1.0 for every character. This is due to the importance of speed tuning in team compositions, and the optimizer should be used to maximize each character's stats at a certain speed breakpoint.
+
+
+* CRIT Rate / CRIT Damage weight:
+    * Crit DPS in general are given the weights 0.75 ATK | 1.0 SPD | 1.0 CR | 1.0 CD, unless they have any other special scaling.
+    * ATK is weighted slightly than CR and CD rolls because in general crit substats will provide a higher boost to damage.
+
+
+* HP / DEF weight:
+    * Defensive supports are given 2.0 weight to distribute between HP and DEF.
+    * For each additional (0.75 | 1.0) stat weight that they scale with, deduct 0.5 down to a minimum of 1.0.
+    * If 2.0 still remains and one of the stats is worth more than the other (Huohuo and HP% for example), assign a 1.0 / 0.75 split.
+    * Offensive supports follow the same ruleset, except they start with 1.5 weight to distribute between HP and DEF.
+
+* RES weight:
+    * Support characters are granted 0.5 RES weight by default, with an additional 0.25 weight if they have synergy with RES or have critical team-saving abilities.
+
+These weights are the defaults, but each player may have different preferences.
+Feel free to adjust the weights to fit a certain playstyle.
+DPS characters should rely on the optimizer and Combat Score to evaluate their performance in combat,
+since substats scores don't take into account external factors like team buffs or passive effects.
+
+## Stat score calculations
+
+Relic scores are calculated by `Score = substatScore / idealScore * 0.582`.
+This allows for characters with fewer desired stats to achieve scores comparable to characters with many desired stats.
+
+The idealScore is the substatScore for a theoretical perfect relic.
+By adjusting the score to the maximum possible relic, this means that when a weighted substat is occupied by the main stat,
+the score value of the remaining substat weights increases.
+
+The substatScore is calculated by `SubstatScore = weight * normalization * value`.
+The weight of each stat is defined above, on a scale of 0 to 1.
+The normalization of each stat is calculated based on the ratio of their main stat values to Crit DMG with max value `64.8`:
+
+```
+CD BE = 64.8 / 64.8 == 1.0
+DEF% = 64.8 / 54.0 == 1.2
+HP% ATK% EHR RES = 64.8 / 43.2 == 1.5
+CR = 64.8 / 32.4 == 2
+SPD = 64.8 / 25.032 == 2.59
+OHB = 64.8 / 34.561 == 1.87
+ERR = 64.8 / 19.439 == 3.33
+ELEMENTAL DMG = 64.8 / 38.88 == 1.67
+```
+
+Flat ATK/HP/DEF have a separate calculation:
+Their weights are automatically calculated based on the weights given to their respective % counterparts
+`% stat weight * flat stat low roll / (baseStats[stat] * 2 * % stat low roll)`.
+The weight calculation for flat atk for Seele for example would be: `0.75 * 19 / (baseStats.ATK * 2 * 0.03888) = 0.75 * 19 / (640.33 * 2 * 0.03888) = 0.28619`.
+
+The normalization is calculated based on the normalization for the respective % counterparts:
+`64.8 / % main stat value * % stat high roll value / flat stat high roll value`.
+In combination with the adjusted weights, this allows for flat stats to be accurately scored when compared against their % counterparts.
+
+A letter grade is assigned based on the number of normalized min rolls of each substat.
+The score for each min roll is equivalent to `5.1`
+The general scale for grade by rolls is:
+
+```
+F = 1
+D = 2
+C = 3
+B = 4
+A = 5
+S = 6
+SS = 7
+SSS = 8
+WTF = 9
+```
+
+With a + rating assigned for an additional half roll.
+
+Character scores are calculated by `Score = sum(relic scores) + sum(main stat scores)`.
+Only the feet/body/sphere/rope relics have main stat scores.
+The main stat score for a 5 star maxed relic is 64.8 if the main stat is optimal, otherwise scaled down by the stat weight.
+Non 5 star relic scores are also scaled down by their maximum enhance.
+Characters are expected to have 3 full sets, so 3 rolls worth of score is deducted for each missing set.
+
+Relics with main stats (body/feet/sphere/rope) are granted extra rolls to compensate for the difficulty of obtaining optimal main stats with desired substats.
+These numbers were calculated by a simulation of relic rolls accounting for main stat drop rate and expected substat value.
+These rolls are first multiplied by the min roll value of `5.1` and then, if the main stat is not optimal, scaled down by the stat weight to obtain the bonus score value.
+
+```
+Body — HP %: 1.3
+Body — ATK %: 1.3
+Body — DEF %: 1.3
+Body — CR: 1.7
+Body — CD: 1.7
+Body — OHB: 1.7
+Body — EHR: 1.7
+Feet — HP %: 1.0
+Feet — ATK %: 1.0
+Feet — DEF %: 1.0
+Feet — SPD: 1.6
+Sphere — HP %: 1.6
+Sphere — ATK %: 1.6
+Sphere — DEF %: 1.6
+Sphere — Elemental DMG %: 1.8
+Rope — HP %: 1.1
+Rope — ATK %: 1.1
+Rope — DEF %: 1.1
+Rope — BE: 1.4
+Rope — ERR: 2.0
+```

--- a/src/components/optimizerTab/optimizerForm/FormSetConditionals.jsx
+++ b/src/components/optimizerTab/optimizerForm/FormSetConditionals.jsx
@@ -56,7 +56,7 @@ export function FormSetConditionals() {
       options.push({
         display: t('SelectOptions.Sacerdos.Display', { stackCount: i }), // i + 'x',
         value: i,
-        label: t('SelectOptions.Sacerdos.Label', { stackCount: i, buffValue: 18 * i }), // `${i} stacks (+${i * 8}% CR)`,
+        label: t('SelectOptions.Sacerdos.Label', { stackCount: i, buffValue: 18 * i }), // `${i} stacks (+${i * 8}% CD)`,
       })
     }
 

--- a/src/lib/characterScorer.ts
+++ b/src/lib/characterScorer.ts
@@ -466,7 +466,7 @@ function simulateMaximumBuild(
   baselineSimResult: SimulationResult,
 ) {
   // Convert the benchmark spd rolls to max spd rolls
-  const spdRolls = bestSim.request.stats[Stats.SPD] * benchmarkScoringParams.speedRollValue / maximumScoringParams.speedRollValue
+  const spdRolls = TsUtils.precisionRound(bestSim.request.stats[Stats.SPD] * benchmarkScoringParams.speedRollValue / maximumScoringParams.speedRollValue, 3)
   const maximumSimulations: Simulation[] = []
 
   // Spheres with DMG % are unique because they can alter a build due to DMG % not being a substat.

--- a/src/lib/dataParser.js
+++ b/src/lib/dataParser.js
@@ -16,6 +16,7 @@ const lightCones = gameData.lightCones
 
 const RELICS_2P_BREAK_EFFECT_SPEED = [
   Sets.MessengerTraversingHackerspace,
+  Sets.SacerdosRelivedOrdeal,
   Sets.ThiefOfShootingMeteor,
   Sets.WatchmakerMasterOfDreamMachinations,
   Sets.IronCavalryAgainstTheScourge,
@@ -1517,6 +1518,7 @@ function getScoringMetadata() {
         comboDot: 0,
         comboBreak: 0,
         relicSets: [
+          [Sets.ScholarLostInErudition, Sets.ScholarLostInErudition],
           [Sets.PioneerDiverOfDeadWaters, Sets.PioneerDiverOfDeadWaters],
           ...SPREAD_RELICS_2P_GENERAL_CONDITIONALS,
         ],
@@ -1730,6 +1732,7 @@ function getScoringMetadata() {
         comboBreak: 0,
         relicSets: [
           [Sets.PioneerDiverOfDeadWaters, Sets.PioneerDiverOfDeadWaters],
+          [Sets.ScholarLostInErudition, Sets.ScholarLostInErudition],
           ...SPREAD_RELICS_2P_GENERAL_CONDITIONALS,
         ],
         ornamentSets: [
@@ -1984,6 +1987,7 @@ function getScoringMetadata() {
         comboDot: 0,
         comboBreak: 0,
         relicSets: [
+          [Sets.ScholarLostInErudition, Sets.ScholarLostInErudition],
           [Sets.BandOfSizzlingThunder, Sets.BandOfSizzlingThunder],
           ...SPREAD_RELICS_2P_GENERAL_CONDITIONALS,
         ],
@@ -2269,6 +2273,7 @@ function getScoringMetadata() {
         comboBreak: 0,
         relicSets: [
           [SetsRelics.GeniusOfBrilliantStars, SetsRelics.GeniusOfBrilliantStars],
+          [Sets.ScholarLostInErudition, Sets.ScholarLostInErudition],
           ...SPREAD_RELICS_2P_GENERAL_CONDITIONALS,
         ],
         ornamentSets: [
@@ -2372,6 +2377,7 @@ function getScoringMetadata() {
         comboDot: 0,
         comboBreak: 0,
         relicSets: [
+          [Sets.ScholarLostInErudition, Sets.ScholarLostInErudition],
           [Sets.BandOfSizzlingThunder, Sets.BandOfSizzlingThunder],
           ...SPREAD_RELICS_2P_GENERAL_CONDITIONALS,
         ],
@@ -2819,6 +2825,7 @@ function getScoringMetadata() {
         comboBreak: 0,
         relicSets: [
           [Sets.PioneerDiverOfDeadWaters, Sets.PioneerDiverOfDeadWaters],
+          [Sets.ScholarLostInErudition, Sets.ScholarLostInErudition],
           ...SPREAD_RELICS_2P_GENERAL_CONDITIONALS,
         ],
         ornamentSets: [
@@ -3180,6 +3187,7 @@ function getScoringMetadata() {
         comboBreak: 0,
         relicSets: [
           [Sets.GeniusOfBrilliantStars, Sets.GeniusOfBrilliantStars],
+          [Sets.SacerdosRelivedOrdeal, Sets.SacerdosRelivedOrdeal],
           ...SPREAD_RELICS_2P_GENERAL_CONDITIONALS,
         ],
         ornamentSets: [
@@ -3588,6 +3596,7 @@ function getScoringMetadata() {
         comboDot: 0,
         comboBreak: 1,
         relicSets: [
+          [Sets.ScholarLostInErudition, Sets.ScholarLostInErudition],
           [Sets.ChampionOfStreetwiseBoxing, Sets.ChampionOfStreetwiseBoxing],
           [Sets.IronCavalryAgainstTheScourge, Sets.IronCavalryAgainstTheScourge],
           ...SPREAD_RELICS_2P_GENERAL_CONDITIONALS,
@@ -3787,6 +3796,7 @@ function getScoringMetadata() {
         comboDot: 0,
         comboBreak: 0,
         relicSets: [
+          [Sets.ScholarLostInErudition, Sets.ScholarLostInErudition],
           [Sets.PioneerDiverOfDeadWaters, Sets.PioneerDiverOfDeadWaters],
           [Sets.HunterOfGlacialForest, Sets.HunterOfGlacialForest],
           ...SPREAD_RELICS_2P_GENERAL_CONDITIONALS,
@@ -4420,6 +4430,7 @@ function getScoringMetadata() {
         comboBreak: 0,
         relicSets: [
           [Sets.TheWindSoaringValorous, Sets.TheWindSoaringValorous],
+          [Sets.EagleOfTwilightLine, Sets.EagleOfTwilightLine],
           ...SPREAD_RELICS_2P_GENERAL_CONDITIONALS,
         ],
         ornamentSets: [
@@ -4935,6 +4946,7 @@ function getScoringMetadata() {
         comboDot: 0,
         comboBreak: 0,
         relicSets: [
+          [Sets.ScholarLostInErudition, Sets.ScholarLostInErudition],
           [Sets.ChampionOfStreetwiseBoxing, Sets.ChampionOfStreetwiseBoxing],
           ...SPREAD_RELICS_2P_GENERAL_CONDITIONALS,
         ],
@@ -5685,6 +5697,7 @@ function getScoringMetadata() {
         comboBreak: 0,
         relicSets: [
           [Sets.PioneerDiverOfDeadWaters, Sets.PioneerDiverOfDeadWaters],
+          [Sets.ScholarLostInErudition, Sets.ScholarLostInErudition],
           [Sets.HunterOfGlacialForest, Sets.HunterOfGlacialForest],
           ...SPREAD_RELICS_2P_GENERAL_CONDITIONALS,
         ],
@@ -6085,6 +6098,7 @@ function getScoringMetadata() {
         comboDot: 0,
         comboBreak: 1,
         relicSets: [
+          [Sets.ScholarLostInErudition, Sets.ScholarLostInErudition],
           [Sets.ChampionOfStreetwiseBoxing, Sets.ChampionOfStreetwiseBoxing],
           ...SPREAD_RELICS_2P_GENERAL_CONDITIONALS,
         ],
@@ -6188,6 +6202,7 @@ function getScoringMetadata() {
         comboDot: 0,
         comboBreak: 1,
         relicSets: [
+          [Sets.ScholarLostInErudition, Sets.ScholarLostInErudition],
           [Sets.ChampionOfStreetwiseBoxing, Sets.ChampionOfStreetwiseBoxing],
           ...SPREAD_RELICS_2P_GENERAL_CONDITIONALS,
         ],

--- a/src/lib/optimizer/rotation/setConditionalContent.ts
+++ b/src/lib/optimizer/rotation/setConditionalContent.ts
@@ -105,7 +105,9 @@ export const ConditionalSetMetadata: { [key: string]: SetMetadata } = {
     modifiable: true,
   },
   [Sets.SacerdosRelivedOrdeal]: {
-    type: ConditionalDataType.BOOLEAN,
+    type: ConditionalDataType.SELECT,
+    modifiable: true,
+    selectionOptions: SetContentSacerdosRelivedOrdealOptions(),
   },
   [Sets.ScholarLostInErudition]: {
     type: ConditionalDataType.BOOLEAN,
@@ -176,6 +178,19 @@ export const ConditionalSetMetadata: { [key: string]: SetMetadata } = {
     type: ConditionalDataType.BOOLEAN,
     modifiable: true,
   },
+}
+
+function SetContentSacerdosRelivedOrdealOptions() {
+  const options: SelectOptionContent[] = []
+  for (let i = 0; i <= 2; i++) {
+    options.push({
+      display: i + 'x',
+      value: i,
+      label: `${i} stacks (+${i * 18}% CD)`,
+    })
+  }
+
+  return options
 }
 
 function SetContentChampionOfStreetwiseBoxing() {


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Sacerdos should be a selector/partition
* Move scoring docs into md files
* Update equivalents sets for scholar/sacerdos - some new BIS

![image](https://github.com/user-attachments/assets/3655f1af-aedf-4c17-9887-e321a8338549)


## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

