### PR TITLE
fix: various scoring bug fixes

### DIFF
--- a/docs/guides/en/dps-score.md
+++ b/docs/guides/en/dps-score.md
@@ -2,9 +2,11 @@
 
 ## What is DPS Score?
 
-DPS Score is a damage calculation based metric for accurately scoring how optimal the character's relics are for maximizing damage in combat.
+DPS Score is a damage calculation based metric for accurately scoring how optimal the character's relics are for
+maximizing damage in combat.
 
-This score is calculated by using the optimizer to simulate the character's combat stats and rates the build based on how much the relics contribute to damage, for a more accurate evaluation than scores based solely on stat weights.
+This score is calculated by using the optimizer to simulate the character's combat stats and rates the build based on
+how much the relics contribute to damage, for a more accurate evaluation than scores based solely on stat weights.
 
 The scoring calculation takes into consideration:
 
@@ -21,7 +23,9 @@ The scoring calculation takes into consideration:
 
 ## How is it calculated?
 
-At its heart, this score is calculated using a Basic / Skill / Ult / FuA / DoT / Break ability damage rotation predefined per character. These simulations use the optimizer's default conditional settings for the character / teammates / light cones / relic sets, and the damage sum is then used to compare between builds.
+At its heart, this score is calculated using a Basic / Skill / Ult / FuA / DoT / Break ability damage rotation
+predefined per character. These simulations use the optimizer's default conditional settings for the character /
+teammates / light cones / relic sets, and the damage sum is then used to compare between builds.
 
 ### Simulation benchmarks
 
@@ -31,11 +35,14 @@ The scoring algorithm generates three builds to measure the damage of the origin
 * Benchmark (100%) - A strong build, generated following certain rules with a realistic distribution of 48x min rolls
 * Perfection (200%) - The perfect build, generated with an ideal distribution of 54x max rolled substats
 
-The original character's build is scored based on how its Combo DMG compares to the benchmark percentages.The benchmark and perfection builds will always match the original character's SPD.
+The original character's build is scored based on how its Combo DMG compares to the benchmark percentages.The benchmark
+and perfection builds will always match the original character's SPD.
 
 ### 100% benchmark ruleset
 
-The 100% benchmark character is designed to be a strong and realistic build that is difficult to reach, but attainable with some character investment into relic farming. The following ruleset defines how the build is generated and why it differs from the perfect build.
+The 100% benchmark character is designed to be a strong and realistic build that is difficult to reach, but attainable
+with some character investment into relic farming. The following ruleset defines how the build is generated and why it
+differs from the perfect build.
 
 * The default damage simulation uses a common team composition and the character's BiS relic + ornament set
 * The 100% benchmark uses the same eidolon and superimposition as the original character, at level 80 and maxed traces
@@ -44,10 +51,14 @@ The 100% benchmark character is designed to be a strong and realistic build that
 * First, 2 substats are allocated to each substat type, except for SPD
 * Substats are then allocated to SPD to match the original character's in-combat SPD
 * The remaining substats are then distributed to the other stats options to maximize the build's damage output
-* The resulting build must be a substat distribution that is possible to make with the in-game sub and main stat restrictions (for example, relics with a main stat cannot also have the same substat, and no duplicate substat slots per piece, etc)
-* An artificial diminishing returns penalty is applied to substats with greater than `12 - (2 * main stats)` rolls, to simulate the difficulty of obtaining multiple rolls in a single stat
+* The resulting build must be a substat distribution that is possible to make with the in-game sub and main stat
+  restrictions (for example, relics with a main stat cannot also have the same substat, and no duplicate substat slots
+  per piece, etc)
+* An artificial diminishing returns penalty is applied to substats with greater than `12 - (2 * main stats)` rolls, to
+  simulate the difficulty of obtaining multiple rolls in a single stat
 
-This process is repeated through all the possible main stat permutations and substat distributions until the highest damage simulation is found. That build's damage is then used as the standard for a 100% DPS Score.
+This process is repeated through all the possible main stat permutations and substat distributions until the highest
+damage simulation is found. That build's damage is then used as the standard for a 100% DPS Score.
 
 ### 200% benchmark ruleset
 
@@ -59,15 +70,22 @@ The 200% perfection character follows a similar generation process with a few di
 
 ### Score normalization
 
-All simulation scores are normalized by deducting a baseline damage simulation. The baseline uses the same eidolon and light cone, but no main stats and no substats. This adjusts for the base amount of damage that a character's kit deals, so that the DPS Score can then measure the resulting damage contribution of each additional substat.
+All simulation scores are normalized by deducting a baseline damage simulation. The baseline uses the same eidolon and
+light cone, but no main stats and no substats. This adjusts for the base amount of damage that a character's kit deals,
+so that the DPS Score can then measure the resulting damage contribution of each additional substat.
 
 ### Relic / ornament sets
 
-Each character has a defined BiS set, and a few other equivalent sets that can be considered similar in performance. If the original character's sets matches any of the acceptable sets, the character will be scored against a benchmark generated matching that set, otherwise the original character will be scored against the BiS.
+Each character has a defined BiS set, and a few other equivalent sets that can be considered similar in performance. If
+the original character's sets matches any of the acceptable sets, the character will be scored against a benchmark
+generated matching that set, otherwise the original character will be scored against the BiS.
 
 ### Stat breakpoint penalty
 
-Certain characters will have breakpoints that are forced. For example, 120% combat EHR on Black Swan to maximize her passive EHR to DMG conversion, and to land Arcana stacks. Failing to reach the breakpoint will penalize the DPS Score for the missing percentage. This penalty applies to both the original character and the benchmark simulations but not the baseline.
+Certain characters will have breakpoints that are forced. For example, 120% combat EHR on Black Swan to maximize her
+passive EHR to DMG conversion, and to land Arcana stacks. Failing to reach the breakpoint will penalize the DPS Score
+for the missing percentage. This penalty applies to both the original character and the benchmark simulations but not
+the baseline.
 
 ### Formula
 
@@ -83,12 +101,13 @@ The resulting formula is:
 Grading is based on the benchmark as 100% and perfection as 200%.
 
 ```
-* 135% - WTF+ ↑ 9%
-* 126% - WTF  ↑ 8%
-* 118% - SSS+ ↑ 7%
-* 111% - SSS  ↑ 6%
-* 105% - SS+  ↑ 5%
-* 100% - SS   [Benchmark]
+* 150% - AEON  [Verified relics only]
+* 135% - WTF+  ↑ 9%
+* 126% - WTF   ↑ 8%
+* 118% - SSS+  ↑ 7%
+* 111% - SSS   ↑ 6%
+* 105% - SS+   ↑ 5%
+* 100% - SS    [Benchmark]
 * 95% - S+
 * 90% - S
 * 85% - A+
@@ -107,36 +126,61 @@ Grading is based on the benchmark as 100% and perfection as 200%.
 
 ### Why does the sim match speed?
 
-Speed is controlled separately from the other stats because damage isn't comparable between different speed thresholds. For example, higher speed can actually result in lower damage with Bronya as a teammate if the speed tuning is thrown off. To make damage comparisons fair, we equalize the speed variable by forcing the sim's substats to match the original character's combat speed.
+Speed is controlled separately from the other stats because damage isn't comparable between different speed thresholds.
+For example, higher speed can actually result in lower damage with Bronya as a teammate if the speed tuning is thrown
+off. To make damage comparisons fair, we equalize the speed variable by forcing the sim's substats to match the original
+character's combat speed.
 
 ### Why does a build score lower even though it has higher Sim Damage?
 
-The benchmark sims have to equalize speed, so if the higher damage build has lower speed, then it will be compared to benchmark builds at that same lower speed, and therefore may score lower. In general this means that the sim will reallocate every reduced speed roll into a damage stat instead.
+The benchmark sims have to equalize speed, so if the higher damage build has lower speed, then it will be compared to
+benchmark builds at that same lower speed, and therefore may score lower. In general this means that the sim will
+reallocate every reduced speed roll into a damage stat instead.
 
 ### What's the reasoning behind the benchmark simulation rules?
 
-The simulation rules were designed to create a realistic benchmark build for 100% DPS Score, which should be difficult to achieve yet possible with character investment. After trialing many methodologies for generating simulation stats, this set of rules produced the most consistent and reasonable 100% benchmarks across all characters and builds.
+The simulation rules were designed to create a realistic benchmark build for 100% DPS Score, which should be difficult
+to achieve yet possible with character investment. After trialing many methodologies for generating simulation stats,
+this set of rules produced the most consistent and reasonable 100% benchmarks across all characters and builds.
 
-The spread of 2 substats across all stat options provides some baseline consistency, and simulates how substats are imperfectly distributed in actual player builds. The spread rolls also help to balance out characters that are more stat hungry and require multiple stats to be effective, vs characters that only need two or three stats.
+The spread of 2 substats across all stat options provides some baseline consistency, and simulates how substats are
+imperfectly distributed in actual player builds. The spread rolls also help to balance out characters that are more stat
+hungry and require multiple stats to be effective, vs characters that only need two or three stats.
 
-Applying diminishing returns to high stacking substats is a way to make the benchmark fair for characters that primarily scale off of a single stat, for example Boothill and break effect. The ideal distribution will want every relic roll to go into break effect, but stacking 5x rolls of a single stat on a relic is extremely rare / unrealistic in practice, so the simulation rules add diminishing returns to account for that.
+Applying diminishing returns to high stacking substats is a way to make the benchmark fair for characters that primarily
+scale off of a single stat, for example Boothill and break effect. The ideal distribution will want every relic roll to
+go into break effect, but stacking 5x rolls of a single stat on a relic is extremely rare / unrealistic in practice, so
+the simulation rules add diminishing returns to account for that.
 
 ### Why are the scores different for different teams?
 
-Team buffs and synergy will change the ideal benchmark simulation's score. For example, a benchmark sim with Fu Xuan on the team may invest more substats into Crit DMG instead of Crit Rate since her passive Crit Rate will change the optimal distribution of crit rolls. Teams should be customized to fit the actual teammates used for the character ingame for an accurate score.
+Team buffs and synergy will change the ideal benchmark simulation's score. For example, a benchmark sim with Fu Xuan on
+the team may invest more substats into Crit DMG instead of Crit Rate since her passive Crit Rate will change the optimal
+distribution of crit rolls. Teams should be customized to fit the actual teammates used for the character ingame for an
+accurate score.
 
 ### Why are certain stat breakpoints forced?
 
-The only forced breakpoints currently are Effect Hit Rate minimums for DoT characters. Take Black Swan for example, the purpose of forcing the sim to use her 120% breakpoint is so it can't just ignore EHR to chase more maximum DoT damage. EHR is more than just DMG conversion as it also lets her land Arcana debuffs to reach her 7th Arcana stack for DEF pen. The penalty is calculated as a 1% deduction per missing roll from the breakpoint.
+The only forced breakpoints currently are Effect Hit Rate minimums for DoT characters. Take Black Swan for example, the
+purpose of forcing the sim to use her 120% breakpoint is so it can't just ignore EHR to chase more maximum DoT damage.
+EHR is more than just DMG conversion as it also lets her land Arcana debuffs to reach her 7th Arcana stack for DEF pen.
+The penalty is calculated as a 1% deduction per missing roll from the breakpoint.
 
 `dmg scale = min(1, (breakpoint - combat stat) / (min stat value))`
 
 ### How were the default simulation teams / sets chosen?
 
-The defaults come from a combination of usage statistics and community guidance. Best in slot sets and teammates will change with new game updates, so the default parameters may also change. Please visit the Discord server for suggestions and feedback on the scoring design.
+The defaults come from a combination of usage statistics and community guidance. Best in slot sets and teammates will
+change with new game updates, so the default parameters may also change. Please visit the Discord server for suggestions
+and feedback on the scoring design.
 
 ### Why is a character scoring low?
 
-The `Damage Upgrades` section will give a quick overview of the sets and stats that could be improved. Substat upgrades will show the damage increase for a single max roll. For a more detailed explanation, the full simulation is detailed below the character card, including the benchmark character's stat distribution, basic stats, combat stats, and main stats. Comparing the original character's stats to the benchmark character's stats is helpful to show the difference in builds and see where to improve.
+The `Damage Upgrades` section will give a quick overview of the sets and stats that could be improved. Substat upgrades
+will show the damage increase for a single max roll. For a more detailed explanation, the full simulation is detailed
+below the character card, including the benchmark character's stat distribution, basic stats, combat stats, and main
+stats. Comparing the original character's stats to the benchmark character's stats is helpful to show the difference in
+builds and see where to improve.
 
-An often underestimated component of the build is completed BiS set effects. Set effects can play a large part in optimizing a character's potential damage output and rainbow or broken sets will often score worse than full sets.
+An often underestimated component of the build is completed BiS set effects. Set effects can play a large part in
+optimizing a character's potential damage output and rainbow or broken sets will often score worse than full sets.

--- a/src/components/CharacterPreview.jsx
+++ b/src/components/CharacterPreview.jsx
@@ -351,6 +351,7 @@ export function CharacterPreview(props) {
 
   function ScoreHeader(props) {
     const result = props.result
+    const verified = Object.values(props.relics).filter((x) => x?.verified).length == 6
 
     const textStyle = {
       fontSize: 17,
@@ -372,7 +373,7 @@ export function CharacterPreview(props) {
               'CharacterPreview.ScoreHeader.Score',
               {
                 score: Utils.truncate10ths(Math.max(0, result.percent * 100)).toFixed(1),
-                grade: getSimScoreGrade(result.percent),
+                grade: getSimScoreGrade(result.percent, verified),
               },
             )
             /* DPS Score {{score}}% {{grade}} */
@@ -792,7 +793,7 @@ export function CharacterPreview(props) {
                 />
                 {
                   simScoringResult
-                  && <ScoreHeader result={simScoringResult}/>
+                  && <ScoreHeader result={simScoringResult} relics={displayRelics}/>
                 }
                 {
                   simScoringResult

--- a/src/components/characterPreview/CharacterScoringSummary.tsx
+++ b/src/components/characterPreview/CharacterScoringSummary.tsx
@@ -7,7 +7,7 @@ import { VerticalDivider } from 'components/Dividers'
 import { HeaderText } from 'components/HeaderText'
 import { UpArrow } from 'icons/UpArrow'
 import { Assets } from 'lib/assets'
-import { SimulationScore, SimulationStatUpgrade } from 'lib/characterScorer'
+import { diminishingReturnsFormula, SimulationScore, SimulationStatUpgrade } from 'lib/characterScorer'
 import { ElementToDamage, MainStats, Parts, Stats, StatsValues, SubStats } from 'lib/constants'
 import { defaultGap, iconSize } from 'lib/constantsUi'
 import DB from 'lib/db'
@@ -58,6 +58,25 @@ export const CharacterScoringSummary = (props: { simScoringResult: SimulationSco
       <Flex gap={15} justify='space-between'>
         <pre style={{ margin: 0 }}>{props.label}</pre>
         <pre style={{ margin: 0, textAlign: 'right' }}>{show && value.toFixed(precision)}</pre>
+      </Flex>
+    )
+  }
+
+  function ScoringNumberParens(props: { label: string; number?: number; parens?: number; precision?: number }) {
+    const precision = props.precision ?? 1
+    const value = props.number ?? 0
+    const parens = props.parens ?? 0
+    const show = value != 0
+    const showParens = parens != 0
+
+    return (
+      <Flex gap={5} justify='space-between'>
+        <pre style={{ margin: 0 }}>{props.label}</pre>
+        <pre style={{ margin: 0, textAlign: 'right' }}>
+          {show && value.toFixed(precision)}
+          {showParens && <span style={{ margin: 3 }}>-</span>}
+          {showParens && `${parens.toFixed(1)}`}
+        </pre>
       </Flex>
     )
   }
@@ -180,6 +199,30 @@ export const CharacterScoringSummary = (props: { simScoringResult: SimulationSco
     basicStats[elementalDmgValue] = basicStats.ELEMENTAL_DMG
     combatStats[elementalDmgValue] = combatStats.ELEMENTAL_DMG
 
+    const diminishingReturns: Record<string, number> = {}
+    if (props.type == 'Benchmark') {
+      for (const [stat, rolls] of Object.entries(request.stats)) {
+        const mainsCount = [
+          request.simBody,
+          request.simFeet,
+          request.simPlanarSphere,
+          request.simLinkRope,
+          Stats.ATK,
+          Stats.HP,
+        ].filter((x) => x == stat).length
+        if (stat == Stats.SPD) {
+          diminishingReturns[stat] = 0
+        } else {
+          diminishingReturns[stat] = rolls - diminishingReturnsFormula(mainsCount, rolls)
+        }
+      }
+
+      console.log(diminishingReturns)
+    }
+
+    const stats = request.stats
+    const precision = props.precision
+
     return (
       <Flex vertical gap={25}>
         <Flex vertical gap={defaultGap}>
@@ -221,22 +264,23 @@ export const CharacterScoringSummary = (props: { simScoringResult: SimulationSco
             {t(`CharacterPreview.ScoringColumn.${props.type}.Substats`)}
           </pre>
           {/* Character subs (min rolls)/100% benchmark subs (min rolls)/200% perfect subs (max rolls) */}
-          <Flex gap={30} justify='space-around'>
-            <Flex vertical gap={defaultGap} style={{ width: 100 }}>
-              <ScoringNumber label={t(`common:ShortStats.${Stats.ATK_P}`) + ':'} number={request.stats[Stats.ATK_P]} precision={props.precision}/>
-              <ScoringNumber label={t(`common:ShortStats.${Stats.ATK}`) + ':'} number={request.stats[Stats.ATK]} precision={props.precision}/>
-              <ScoringNumber label={t(`common:ShortStats.${Stats.HP_P}`) + ':'} number={request.stats[Stats.HP_P]} precision={props.precision}/>
-              <ScoringNumber label={t(`common:ShortStats.${Stats.HP}`) + ':'} number={request.stats[Stats.HP]} precision={props.precision}/>
-              <ScoringNumber label={t(`common:ShortStats.${Stats.DEF_P}`) + ':'} number={request.stats[Stats.DEF_P]} precision={props.precision}/>
-              <ScoringNumber label={t(`common:ShortStats.${Stats.DEF}`) + ':'} number={request.stats[Stats.DEF]} precision={props.precision}/>
+          <Flex justify='space-between'>
+            <Flex vertical gap={defaultGap} style={{ width: 125, paddingLeft: 5 }}>
+              <ScoringNumberParens label={t(`common:ShortStats.${Stats.ATK_P}`) + ':'} number={stats[Stats.ATK_P]} parens={diminishingReturns[Stats.ATK_P]} precision={precision}/>
+              <ScoringNumberParens label={t(`common:ShortStats.${Stats.ATK}`) + ':'} number={stats[Stats.ATK]} parens={diminishingReturns[Stats.ATK]} precision={precision}/>
+              <ScoringNumberParens label={t(`common:ShortStats.${Stats.HP_P}`) + ':'} number={stats[Stats.HP_P]} parens={diminishingReturns[Stats.HP_P]} precision={precision}/>
+              <ScoringNumberParens label={t(`common:ShortStats.${Stats.HP}`) + ':'} number={stats[Stats.HP]} parens={diminishingReturns[Stats.HP]} precision={precision}/>
+              <ScoringNumberParens label={t(`common:ShortStats.${Stats.DEF_P}`) + ':'} number={stats[Stats.DEF_P]} parens={diminishingReturns[Stats.DEF_P]} precision={precision}/>
+              <ScoringNumberParens label={t(`common:ShortStats.${Stats.DEF}`) + ':'} number={stats[Stats.DEF]} parens={diminishingReturns[Stats.DEF]} precision={precision}/>
             </Flex>
-            <Flex vertical gap={defaultGap} style={{ width: 100 }}>
-              <ScoringNumber label={t(`common:ShortStats.${Stats.SPD}`) + ':'} number={request.stats[Stats.SPD]} precision={2}/>
-              <ScoringNumber label={t(`common:ShortStats.${Stats.CR}`) + ':'} number={request.stats[Stats.CR]} precision={props.precision}/>
-              <ScoringNumber label={t(`common:ShortStats.${Stats.CD}`) + ':'} number={request.stats[Stats.CD]} precision={props.precision}/>
-              <ScoringNumber label={t(`common:ShortStats.${Stats.EHR}`) + ':'} number={request.stats[Stats.EHR]} precision={props.precision}/>
-              <ScoringNumber label={t(`common:ShortStats.${Stats.RES}`) + ':'} number={request.stats[Stats.RES]} precision={props.precision}/>
-              <ScoringNumber label={t(`common:ShortStats.${Stats.BE}`) + ':'} number={request.stats[Stats.BE]} precision={props.precision}/>
+            <VerticalDivider/>
+            <Flex vertical gap={defaultGap} style={{ width: 125, paddingRight: 5 }}>
+              <ScoringNumberParens label={t(`common:ShortStats.${Stats.SPD}`) + ':'} number={stats[Stats.SPD]} parens={diminishingReturns[Stats.SPD]} precision={2}/>
+              <ScoringNumberParens label={t(`common:ShortStats.${Stats.CR}`) + ':'} number={stats[Stats.CR]} parens={diminishingReturns[Stats.CR]} precision={precision}/>
+              <ScoringNumberParens label={t(`common:ShortStats.${Stats.CD}`) + ':'} number={stats[Stats.CD]} parens={diminishingReturns[Stats.CD]} precision={precision}/>
+              <ScoringNumberParens label={t(`common:ShortStats.${Stats.EHR}`) + ':'} number={stats[Stats.EHR]} parens={diminishingReturns[Stats.EHR]} precision={precision}/>
+              <ScoringNumberParens label={t(`common:ShortStats.${Stats.RES}`) + ':'} number={stats[Stats.RES]} parens={diminishingReturns[Stats.RES]} precision={precision}/>
+              <ScoringNumberParens label={t(`common:ShortStats.${Stats.BE}`) + ':'} number={stats[Stats.BE]} parens={diminishingReturns[Stats.BE]} precision={precision}/>
             </Flex>
           </Flex>
         </Flex>

--- a/src/components/characterPreview/CharacterScoringSummary.tsx
+++ b/src/components/characterPreview/CharacterScoringSummary.tsx
@@ -431,8 +431,8 @@ function addOnHitStats(simulationScore: SimulationScore) {
 
   x.ELEMENTAL_DMG += x[`${ability}_BOOST`]
   if (ability != SortOption.DOT.key) {
-    x.CR += x[`${ability}_CR_BOOST`]
-    x.CD += x[`${ability}_CD_BOOST`]
+    x[Stats.CR] += x[`${ability}_CR_BOOST`]
+    x[Stats.CD] += x[`${ability}_CD_BOOST`]
   }
 }
 

--- a/src/components/optimizerTab/conditionals/LightConeConditionalDisplay.tsx
+++ b/src/components/optimizerTab/conditionals/LightConeConditionalDisplay.tsx
@@ -43,6 +43,13 @@ export const LightConeConditionalDisplay = memo((props: LightConeConditionalDisp
 
   return (
     <Flex vertical gap={5}>
+      {(teammateIndex == null)
+      && (
+        <Flex justify='space-between' align='center'>
+          <HeaderText>{t('LightconePassives')/* Light cone passives */}</HeaderText>
+          <TooltipImage type={Hint.lightConePassives()}/>
+        </Flex>
+      )}
       <DisplayFormControl content={content} teammateIndex={teammateIndex}/>
     </Flex>
   )

--- a/src/lib/characterScorer.ts
+++ b/src/lib/characterScorer.ts
@@ -196,6 +196,11 @@ type PartialSimulationWrapper = {
   speedRollsDeduction: number
 }
 
+type SimulationFlags = {
+  addBreakEffect: boolean
+  overcapCritRate: boolean
+}
+
 export function scoreCharacterSimulation(
   character: Character,
   displayRelics: RelicBuild,
@@ -227,7 +232,7 @@ export function scoreCharacterSimulation(
   const metadata = defaultMetadata
   const relicsByPart = cloneRelicsFillEmptySlots(displayRelics)
 
-  const cacheKey = Utils.objectHash({
+  const cacheKey = TsUtils.objectHash({
     characterId,
     characterEidolon,
     lightCone,
@@ -246,42 +251,49 @@ export function scoreCharacterSimulation(
     return null
   }
 
+  const simulationFlags: SimulationFlags = {
+    addBreakEffect: false,
+    overcapCritRate: false,
+  }
+
   // Optimize requested stats
   const substats: string[] = metadata.substats
 
   // Special handling for break effect carries
-  let addBreakEffect = false
   if (metadata.comboBreak > 0) {
     // Add break if the combo uses it
-    addBreakEffect = true
+    simulationFlags.addBreakEffect = true
   }
   if (defaultMetadata.teammates.find((x) => x.characterId == '8005' || x.characterId == '8006' || x.characterId == '1225')) {
     // Add break if the harmony trailblazer | fugue is on the team
-    addBreakEffect = true
+    simulationFlags.addBreakEffect = true
   }
-  if (addBreakEffect && !substats.includes(Stats.BE)) {
+  if (simulationFlags.addBreakEffect && !substats.includes(Stats.BE)) {
     substats.push(Stats.BE)
   }
-  if (addBreakEffect && !metadata.parts[Parts.LinkRope].includes(Stats.BE)) {
+  if (simulationFlags.addBreakEffect && !metadata.parts[Parts.LinkRope].includes(Stats.BE)) {
     metadata.parts[Parts.LinkRope].push(Stats.BE)
   }
-  if (addBreakEffect
+  if (simulationFlags.addBreakEffect
     && !metadata.relicSets.find((sets) =>
       sets[0] == sets[1] && sets[1] == Sets.IronCavalryAgainstTheScourge)) {
     metadata.relicSets.push([Sets.IronCavalryAgainstTheScourge, Sets.IronCavalryAgainstTheScourge])
   }
-  if (addBreakEffect
+  if (simulationFlags.addBreakEffect
     && !metadata.relicSets.find((sets) =>
       sets[0] == sets[1] && sets[1] == Sets.IronCavalryAgainstTheScourge)) {
     metadata.relicSets.push([Sets.IronCavalryAgainstTheScourge, Sets.IronCavalryAgainstTheScourge])
   }
-  if (addBreakEffect
+  if (simulationFlags.addBreakEffect
     && !metadata.ornamentSets.find((set) => set == Sets.TaliaKingdomOfBanditry)) {
     metadata.ornamentSets.push(Sets.TaliaKingdomOfBanditry)
   }
-  if (addBreakEffect
+  if (simulationFlags.addBreakEffect
     && !metadata.ornamentSets.find((set) => set == Sets.ForgeOfTheKalpagniLantern)) {
     metadata.ornamentSets.push(Sets.ForgeOfTheKalpagniLantern)
+  }
+  if (defaultMetadata.teammates.find((x) => x.characterId == '1313' && x.characterEidolon == 6)) {
+    simulationFlags.overcapCritRate = true
   }
 
   // Set up default request
@@ -363,7 +375,7 @@ export function scoreCharacterSimulation(
 
     // Define min/max limits
     const minSubstatRollCounts = calculateMinSubstatRollCounts(partialSimulationWrapper, benchmarkScoringParams)
-    const maxSubstatRollCounts = calculateMaxSubstatRollCounts(partialSimulationWrapper, metadata, benchmarkScoringParams, baselineSimResult)
+    const maxSubstatRollCounts = calculateMaxSubstatRollCounts(partialSimulationWrapper, metadata, benchmarkScoringParams, baselineSimResult, simulationFlags)
 
     // Start the sim search at the max then iterate downwards
     Object.values(SubStats).map((stat) => partialSimulationWrapper.simulation.request.stats[stat] = maxSubstatRollCounts[stat])
@@ -408,6 +420,7 @@ export function scoreCharacterSimulation(
     context,
     applyScoringFunction,
     baselineSimResult,
+    simulationFlags,
   )
   const maximumSimResult = maximumSim.result
   applyScoringFunction(maximumSimResult)
@@ -488,6 +501,7 @@ function simulateMaximumBuild(
   context: OptimizerContext,
   applyScoringFunction: ScoringFunction,
   baselineSimResult: SimulationResult,
+  simulationFlags: SimulationFlags,
 ) {
   // Convert the benchmark spd rolls to max spd rolls
   const spdRolls = TsUtils.precisionRound(bestSim.request.stats[Stats.SPD] * benchmarkScoringParams.speedRollValue / maximumScoringParams.speedRollValue, 3)
@@ -506,7 +520,7 @@ function simulateMaximumBuild(
     }
 
     const minSubstatRollCounts = calculateMinSubstatRollCounts(partialSimulationWrapper, maximumScoringParams)
-    const maxSubstatRollCounts = calculateMaxSubstatRollCounts(partialSimulationWrapper, metadata, maximumScoringParams, baselineSimResult)
+    const maxSubstatRollCounts = calculateMaxSubstatRollCounts(partialSimulationWrapper, metadata, maximumScoringParams, baselineSimResult, simulationFlags)
     Object.values(SubStats).map((x) => partialSimulationWrapper.simulation.request.stats[x] = maxSubstatRollCounts[x])
     const maxSim = computeOptimalSimulation(
       partialSimulationWrapper,
@@ -903,6 +917,7 @@ function calculateMaxSubstatRollCounts(
   metadata: SimulationMetadata,
   scoringParams: ScoringParams,
   baselineSimResult: SimulationResult,
+  simulationFlags: SimulationFlags,
 ): SimulationStats {
   const request = partialSimulationWrapper.simulation.request
   const maxCounts = {
@@ -961,16 +976,18 @@ function calculateMaxSubstatRollCounts(
   // Overcapped 30 * 3.24 + 5 = 102.2% crit
   // Main stat  20 * 3.24 + 32.4 + 5 = 102.2% crit
   // Assumes maximum 100 CR is needed ever
-  const critValue = StatCalculator.getMaxedSubstatValue(Stats.CR, scoringParams.quality)
-  const missingCrit = Math.max(0, 100 - baselineSimResult.x[Stats.CR] * 100)
-  maxCounts[Stats.CR] = Math.max(scoringParams.baselineFreeRolls, Math.max(scoringParams.enforcePossibleDistribution
-    ? 6
-    : 0, Math.min(
-    request.simBody == Stats.CR
-      ? Math.ceil((missingCrit - 32.4) / critValue)
-      : Math.ceil(missingCrit / critValue),
-    maxCounts[Stats.CR],
-  )))
+  if (!simulationFlags.overcapCritRate) {
+    const critValue = StatCalculator.getMaxedSubstatValue(Stats.CR, scoringParams.quality)
+    const missingCrit = Math.max(0, 100 - baselineSimResult.x[Stats.CR] * 100)
+    maxCounts[Stats.CR] = Math.max(scoringParams.baselineFreeRolls, Math.max(scoringParams.enforcePossibleDistribution
+      ? 6
+      : 0, Math.min(
+      request.simBody == Stats.CR
+        ? Math.ceil((missingCrit - 32.4) / critValue)
+        : Math.ceil(missingCrit / critValue),
+      maxCounts[Stats.CR],
+    )))
+  }
 
   // Simplify EHR so the sim is not wasting permutations
   // Assumes 20 enemy effect RES

--- a/src/lib/characterScorer.ts
+++ b/src/lib/characterScorer.ts
@@ -69,9 +69,13 @@ function substatRollsModifier(rolls: number, stat: string, relics: { [key: strin
   // Diminishing returns
 
   const mainsCount = Object.values(relics)
-    .filter((x) => x.augmentedStats.mainStat == stat)
+    .filter((x) => x.augmentedStats!.mainStat == stat)
     .length
 
+  return diminishingReturnsFormula(mainsCount, rolls)
+}
+
+export function diminishingReturnsFormula(mainsCount: number, rolls: number) {
   const lowerLimit = 12 - 2 * mainsCount
   if (rolls <= lowerLimit) {
     return rolls

--- a/src/lib/characterScorer.ts
+++ b/src/lib/characterScorer.ts
@@ -1253,10 +1253,13 @@ export function calculatePenaltyMultiplier(
 }
 
 // Score on 1.00 scale
-export function getSimScoreGrade(score) {
+export function getSimScoreGrade(score: number, verified: boolean) {
   let best = 'WTF+'
   const percent = TsUtils.precisionRound(score * 100)
   for (const [key, value] of Object.entries(SimScoreGrades)) {
+    if (key == 'AEON' && !verified) {
+      continue
+    }
     best = key
     if (percent >= value) {
       return best
@@ -1427,6 +1430,7 @@ function simSorter(a: Simulation, b: Simulation) {
 
 // Gradual scale
 const SimScoreGrades = {
+  'AEON': 150, // +15
   'WTF+': 135, // +10
   'WTF': 126, // +9
   'SSS+': 118, // +8

--- a/src/lib/dataParser.ts
+++ b/src/lib/dataParser.ts
@@ -6567,7 +6567,7 @@ function getScoringMetadata() {
         maxBonusRolls: {},
         comboAbilities: [null, ULT, BASIC, BASIC, BASIC],
         comboDot: 0,
-        comboBreak: 5,
+        comboBreak: 3,
         relicSets: [
           [Sets.IronCavalryAgainstTheScourge, Sets.IronCavalryAgainstTheScourge],
         ],

--- a/src/lib/dataParser.ts
+++ b/src/lib/dataParser.ts
@@ -6543,6 +6543,7 @@ function getScoringMetadata() {
           ],
           [Parts.Feet]: [
             Stats.SPD,
+            Stats.ATK_P,
           ],
           [Parts.PlanarSphere]: [
             Stats.ATK_P,
@@ -6566,7 +6567,7 @@ function getScoringMetadata() {
         maxBonusRolls: {},
         comboAbilities: [null, ULT, BASIC, BASIC, BASIC],
         comboDot: 0,
-        comboBreak: 1,
+        comboBreak: 5,
         relicSets: [
           [Sets.IronCavalryAgainstTheScourge, Sets.IronCavalryAgainstTheScourge],
         ],

--- a/src/lib/relicScorerPotential.ts
+++ b/src/lib/relicScorerPotential.ts
@@ -303,6 +303,13 @@ export class RelicScorer {
   }
 
   getCurrentRelicScore(relic: Relic, id: CharacterId) {
+    if (!relic) {
+      return {
+        score: 0,
+        rating: '',
+        mainStatScore: 0,
+      }
+    }
     const metaHash = this.getRelicScoreMeta(id).hash
     let currentScore = this.currentRelicScore.get(relic.id)?.get(metaHash)
     if (!currentScore) {


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* On-hit stats were missing from combat stats preview
* Light cone conditionals header was accidentally removed
* Fix sunday CR overcap scoring
* Give fugue 3 breaks for scoring, add atk boots
* Fix crash with empty relic
* Add AEON tier dps scoring

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

