### PR TITLE
fix: character tab sizing

### DIFF
--- a/src/lib/characterPreview/ShowcaseDpsScore.tsx
+++ b/src/lib/characterPreview/ShowcaseDpsScore.tsx
@@ -90,7 +90,7 @@ export function ShowcaseDpsScorePanel(props: {
 }
 
 export function ShowcaseCombatScoreDetailsFooter(props: {
-  combatScoreDetails: string,
+  combatScoreDetails: string
   simScoringResult: SimulationScore
 }) {
   const {
@@ -98,25 +98,27 @@ export function ShowcaseCombatScoreDetailsFooter(props: {
     simScoringResult,
   } = props
 
-  return <>
-    {
-      combatScoreDetails == DAMAGE_UPGRADES &&
-      (
-        <Flex vertical gap={defaultGap}>
-          <CharacterCardScoringStatUpgrades result={simScoringResult}/>
-        </Flex>
-      )
-    }
+  return (
+    <>
+      {
+        combatScoreDetails == DAMAGE_UPGRADES
+        && (
+          <Flex vertical gap={defaultGap}>
+            <CharacterCardScoringStatUpgrades result={simScoringResult}/>
+          </Flex>
+        )
+      }
 
-    {
-      combatScoreDetails == COMBAT_STATS &&
-      (
-        <Flex vertical gap={defaultGap}>
-          <CharacterCardCombatStats result={simScoringResult}/>
-        </Flex>
-      )
-    }
-  </>
+      {
+        combatScoreDetails == COMBAT_STATS
+        && (
+          <Flex vertical gap={defaultGap}>
+            <CharacterCardCombatStats result={simScoringResult}/>
+          </Flex>
+        )
+      }
+    </>
+  )
 }
 
 function CharacterPreviewScoringTeammate(props: {
@@ -331,7 +333,11 @@ function ShowcaseTeamSelectPanel(props: {
       options={[
         {
           value: DEFAULT_TEAM,
-          label: t('modals:ScoreFooter.TeamOptions.Default')/* Default */,
+          label: (
+            <Flex justify='center' align='center'>
+              {t('modals:ScoreFooter.TeamOptions.Default')/* Default */}
+            </Flex>
+          ),
         },
         {
           label: (
@@ -342,7 +348,11 @@ function ShowcaseTeamSelectPanel(props: {
         },
         {
           value: CUSTOM_TEAM,
-          label: t('modals:ScoreFooter.TeamOptions.Custom')/* Custom */,
+          label: (
+            <Flex justify='center' align='center'>
+              {t('modals:ScoreFooter.TeamOptions.Custom')/* Custom */}
+            </Flex>
+          ),
         },
       ]}
     />

--- a/src/lib/tabs/tabCharacters/CharacterTab.jsx
+++ b/src/lib/tabs/tabCharacters/CharacterTab.jsx
@@ -66,8 +66,8 @@ function cellNameRenderer(params) {
     ? characterNameString.split(' (')
       .map((section) => section.trim())
       .map((section, index) => index === 1 ? ` (${section} ` : section)
-    : characterNameString.includes('-')
-      ? characterNameString.split('-')// some languages use a dash instead of a dot
+    : characterNameString.includes(' - ')
+      ? characterNameString.split(' - ')// some languages use a dash instead of a dot
       : characterNameString.split('•')
 
   const nameSectionRender = nameSections

--- a/src/lib/tabs/tabCharacters/CharacterTab.jsx
+++ b/src/lib/tabs/tabCharacters/CharacterTab.jsx
@@ -66,7 +66,9 @@ function cellNameRenderer(params) {
     ? characterNameString.split(' (')
       .map((section) => section.trim())
       .map((section, index) => index === 1 ? ` (${section} ` : section)
-    : characterNameString.split('•')
+    : characterNameString.includes('-')
+      ? characterNameString.split('-')// some languages use a dash instead of a dot
+      : characterNameString.split('•')
 
   const nameSectionRender = nameSections
     .map((section, index) => (
@@ -237,7 +239,7 @@ export default function CharacterTab() {
       field: '',
       headerName: t('GridHeaders.Priority')/* Priority */,
       cellRenderer: cellRankRenderer,
-      width: 55,
+      width: 60,
       rowDrag: true,
     },
     { field: '', headerName: t('GridHeaders.Character')/* Character */, flex: 1, cellRenderer: cellNameRenderer },
@@ -552,7 +554,7 @@ export default function CharacterTab() {
             <DownOutlined/>
           </Button>
         </Dropdown>
-        <Flex vertical gap={8} style={{ minWidth: 230 }}>
+        <Flex vertical gap={8} style={{ minWidth: 240 }}>
           <div
             id='characterGrid' className='ag-theme-balham-dark' style={{
               ...{ display: 'block', width: '100%', height: parentH },

--- a/src/lib/tabs/tabCharacters/CharacterTab.jsx
+++ b/src/lib/tabs/tabCharacters/CharacterTab.jsx
@@ -66,9 +66,8 @@ function cellNameRenderer(params) {
     ? characterNameString.split(' (')
       .map((section) => section.trim())
       .map((section, index) => index === 1 ? ` (${section} ` : section)
-    : characterNameString.includes(' - ')
-      ? characterNameString.split(' - ')// some languages use a dash instead of a dot
-      : characterNameString.split('•')
+    : characterNameString.split(/ - |•/) // some languages use a dash instead of a dot
+      .map((section) => section.trim())
 
   const nameSectionRender = nameSections
     .map((section, index) => (
@@ -557,9 +556,9 @@ export default function CharacterTab() {
         <Flex vertical gap={8} style={{ minWidth: 240 }}>
           <div
             id='characterGrid' className='ag-theme-balham-dark' style={{
-              ...{ display: 'block', width: '100%', height: parentH },
-              ...getGridTheme(token),
-            }}
+            ...{ display: 'block', width: '100%', height: parentH },
+            ...getGridTheme(token),
+          }}
           >
             <AgGridReact
               ref={characterGrid}


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Changed character tab grid to accomodate for PT on chromium
* Added name splitting by `-` alongside `•`
* Changed team selector in character card to avoid truncating labels

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->
![msedge_24-11-27-32-19](https://github.com/user-attachments/assets/f3c72dc7-e4da-4e37-b18a-18c720754de1)

