### PR TITLE
feat: banana defaults for summoners, some ui tweaks

### DIFF
--- a/src/lib/characterPreview/CharacterScoringSummary.tsx
+++ b/src/lib/characterPreview/CharacterScoringSummary.tsx
@@ -555,7 +555,7 @@ export function CharacterCardCombatStats(props: {
     rows.push(
       <Flex key={Utils.randomId()} justify='space-between' align='center' style={{ width: '100%' }}>
         <img src={Assets.getStatIcon(stat)} style={{ width: iconSize, height: iconSize, marginRight: 3 }}/>
-        <Flex gap={3} align='center'>
+        <Flex gap={1} align='center'>
           <StatTextSm>
             {t(`ReadableStats.${stat as StatsValues}`)}
           </StatTextSm>

--- a/src/lib/interactions/notifications.tsx
+++ b/src/lib/interactions/notifications.tsx
@@ -1,4 +1,4 @@
-import { DiscordOutlined, UnorderedListOutlined } from '@ant-design/icons'
+import { UnorderedListOutlined } from '@ant-design/icons'
 import { Button, Flex, Space } from 'antd'
 import i18next from 'i18next'
 import { CURRENT_OPTIMIZER_VERSION } from 'lib/constants/constants'
@@ -37,32 +37,6 @@ export function checkForUpdatesNotification(version: string) {
         </Button>
       </Space>
     )
-
-    const translationsBtn = (
-      <Space>
-        <Button
-          type='primary' icon={<DiscordOutlined/>}
-          onClick={() => {
-            window.notificationApi.destroy()
-            window.open('https://discord.gg/rDmB4Un7qg', '_blank')
-          }}
-        >
-          Discord
-        </Button>
-        <Button type='default' onClick={() => window.notificationApi.destroy()}>
-          {
-            i18next.t('notifications:Changelog.Dismiss')
-          }
-        </Button>
-      </Space>
-    )
-
-    window.notificationApi.success({
-      message: 'I18N launch!',
-      description: 'Looking for contributors to help to translate content into other languages. Check out the Discord server for more info!',
-      btn: translationsBtn,
-      duration: 30,
-    })
 
     window.notificationApi.success({
       message: i18next.t('notifications:Changelog.Message'), // 'New updates!',

--- a/src/lib/state/metadata.ts
+++ b/src/lib/state/metadata.ts
@@ -3224,6 +3224,7 @@ function getScoringMetadata(): Record<string, ScoringMetadata> {
           ...SPREAD_RELICS_2P_GENERAL_CONDITIONALS,
         ],
         ornamentSets: [
+          Sets.TheWondrousBananAmusementPark,
           Sets.InertSalsotto,
           ...SPREAD_ORNAMENTS_2P_FUA,
           ...SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
@@ -3527,15 +3528,14 @@ function getScoringMetadata(): Record<string, ScoringMetadata> {
         comboDot: 0,
         comboBreak: 0,
         relicSets: [
-          [Sets.TheWondrousBananAmusementPark, Sets.TheWondrousBananAmusementPark],
           [Sets.TheAshblazingGrandDuke, Sets.TheAshblazingGrandDuke],
           ...SPREAD_RELICS_2P_GENERAL_CONDITIONALS,
         ],
         ornamentSets: [
+          Sets.TheWondrousBananAmusementPark,
           Sets.InertSalsotto,
           ...SPREAD_ORNAMENTS_2P_FUA,
           ...SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
-          Sets.RutilantArena,
         ],
         teammates: [
           {

--- a/src/lib/state/metadata.ts
+++ b/src/lib/state/metadata.ts
@@ -3527,6 +3527,7 @@ function getScoringMetadata(): Record<string, ScoringMetadata> {
         comboDot: 0,
         comboBreak: 0,
         relicSets: [
+          [Sets.TheWondrousBananAmusementPark, Sets.TheWondrousBananAmusementPark],
           [Sets.TheAshblazingGrandDuke, Sets.TheAshblazingGrandDuke],
           ...SPREAD_RELICS_2P_GENERAL_CONDITIONALS,
         ],

--- a/src/lib/tabs/tabHome/HomeTab.tsx
+++ b/src/lib/tabs/tabHome/HomeTab.tsx
@@ -306,7 +306,9 @@ function SearchBar() {
         allowClear
         size='large'
         defaultValue={scorerId}
-        onSearch={(uuid: string) => {
+        onSearch={(uuid: string, event, info) => {
+          if (info?.source == 'clear') return
+
           const validated = TsUtils.validateUuid(uuid)
           if (!validated) {
             return Message.warning(t('Message')/* 'Invalid input - This should be your 9 digit ingame UUID' */)


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Banana default for topaz / jing yuan
* Remove the i18n announcement banner
* Fix uuid input clear button

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

