### PR TITLE
feat: showcase ui adjustments

### DIFF
--- a/public/locales/en/common.yaml
+++ b/public/locales/en/common.yaml
@@ -111,6 +111,7 @@ ShortSpacedStats:
   Wind DMG Boost: "$t(gameData:Elements.Wind)"
   Quantum DMG Boost: "$t(gameData:Elements.Quantum)"
   Imaginary DMG Boost: "$t(gameData:Elements.Imaginary)"
+DamagePercent: DMG %
 ReadableStats:
   HP%: HP %
   HP: HP

--- a/src/lib/characterPreview/CharacterPreview.tsx
+++ b/src/lib/characterPreview/CharacterPreview.tsx
@@ -1,6 +1,6 @@
 import { ConfigProvider, Flex, theme } from 'antd'
 import getDesignToken from 'antd/lib/theme/getDesignToken'
-import { ShowcaseSource } from 'lib/characterPreview/CharacterPreviewComponents'
+import { showcaseShadow, ShowcaseSource } from 'lib/characterPreview/CharacterPreviewComponents'
 import {
   getArtistName,
   getPreviewRelics,
@@ -295,21 +295,22 @@ export function CharacterPreview(props: {
           }
 
           {/* Character details middle panel */}
-          <Flex vertical justify='space-between' gap={8}>
+          <Flex vertical justify='space-between' gap={8} style={{}}>
             <Flex
               vertical
               style={{
                 width: middleColumnWidth,
                 height: '100%',
-                border: `1px solid ${derivedShowcaseTheme.cardBorderColor}`,
                 borderRadius: 8,
-                zIndex: 1,
+                zIndex: 10,
                 backgroundColor: derivedShowcaseTheme.cardBackgroundColor,
                 transition: showcaseTransition(),
                 flex: 1,
                 paddingRight: 2,
                 paddingLeft: 2,
                 paddingBottom: 3,
+                boxShadow: showcaseShadow,
+                border: `1px solid ${derivedShowcaseTheme.cardBorderColor}`,
               }}
               justify='space-between'
             >

--- a/src/lib/characterPreview/CharacterPreviewComponents.tsx
+++ b/src/lib/characterPreview/CharacterPreviewComponents.tsx
@@ -10,7 +10,7 @@ export enum ShowcaseSource {
 }
 
 export const showcaseOutline = 'rgba(255, 255, 255, 0.4) solid 1px'
-export const showcaseShadow = 'rgba(0, 0, 0, 0.5) 1px 1px 1px 1px'
+export const showcaseShadow = 'rgb(0 0 0 / 75%) 1px 1px 4px'
 export const showcaseDropShadowFilter = 'drop-shadow(rgb(0, 0, 0) 1px 1px 3px)'
 export const showcaseButtonStyle: CSSProperties = {
   flex: 'auto',
@@ -37,14 +37,13 @@ export function OverlayText(props: {
       <Text
         style={{
           position: 'absolute',
-          backgroundColor: 'rgba(0, 0, 0, 0.75)',
+          backgroundColor: 'rgba(0, 0, 0, 0.85)',
           padding: '2px 14px',
           borderRadius: 4,
           fontSize: 12,
           whiteSpace: 'nowrap',
           textShadow: '0px 0px 10px black',
           outline: showcaseOutline,
-          filter: showcaseDropShadowFilter,
           lineHeight: '12px',
         }}
       >

--- a/src/lib/characterPreview/CharacterScoringSummary.tsx
+++ b/src/lib/characterPreview/CharacterScoringSummary.tsx
@@ -551,13 +551,15 @@ export function CharacterCardCombatStats(props: {
       display = Utils.truncate10ths(value * 100).toFixed(1)
     }
 
+    const statName = stat.includes('DMG Boost') ? t('DamagePercent') : t(`ReadableStats.${stat as StatsValues}`)
+
     // Best arrows 🠙 🠡 🡑 🠙 ↑ ↑ ⬆
     rows.push(
       <Flex key={Utils.randomId()} justify='space-between' align='center' style={{ width: '100%' }}>
         <img src={Assets.getStatIcon(stat)} style={{ width: iconSize, height: iconSize, marginRight: 3 }}/>
         <Flex gap={1} align='center'>
           <StatTextSm>
-            {t(`ReadableStats.${stat as StatsValues}`)}
+            {statName}
           </StatTextSm>
           {upgraded && <Arrow/>}
         </Flex>

--- a/src/lib/characterPreview/ShowcaseLightCone.tsx
+++ b/src/lib/characterPreview/ShowcaseLightCone.tsx
@@ -1,5 +1,5 @@
 import { Flex, Typography } from 'antd'
-import { showcaseDropShadowFilter, showcaseOutline, showcaseShadow, ShowcaseSource } from 'lib/characterPreview/CharacterPreviewComponents'
+import { showcaseOutline, showcaseShadow, ShowcaseSource } from 'lib/characterPreview/CharacterPreviewComponents'
 import { ShowcaseDisplayDimensions, ShowcaseMetadata } from 'lib/characterPreview/characterPreviewController'
 import StatText, { StatTextEllipses } from 'lib/characterPreview/StatText'
 import { middleColumnWidth, parentW } from 'lib/constants/constantsUi'
@@ -87,12 +87,12 @@ export function ShowcaseLightConeSmall(props: {
         style={{
           width: `${tempLcParentW}px`,
           height: `${tempLcParentH}px`,
+          position: 'relative',
           overflow: 'hidden',
-          zIndex: 2,
+          zIndex: 20,
           borderRadius: '8px',
           border: showcaseOutline,
-          filter: showcaseDropShadowFilter,
-          position: 'relative',
+          boxShadow: showcaseShadow,
         }}
         onClick={() => {
           if (source == ShowcaseSource.SHOWCASE_TAB) {
@@ -162,8 +162,9 @@ export function ShowcaseLightConeLarge(props: {
         height: `${tempLcParentH}px`,
         overflow: 'hidden',
         borderRadius: '8px',
+        zIndex: 20,
         border: showcaseOutline,
-        filter: showcaseDropShadowFilter,
+        boxShadow: showcaseShadow,
       }}
       onClick={() => {
         if (source == ShowcaseSource.SHOWCASE_TAB) {

--- a/src/lib/characterPreview/ShowcasePortrait.tsx
+++ b/src/lib/characterPreview/ShowcasePortrait.tsx
@@ -1,7 +1,7 @@
 import { EditOutlined } from '@ant-design/icons'
 import { Button, ConfigProvider, Flex, Typography } from 'antd'
 import CharacterCustomPortrait from 'lib/characterPreview/CharacterCustomPortrait'
-import { showcaseButtonStyle, showcaseDropShadowFilter, showcaseOutline, ShowcaseSource } from 'lib/characterPreview/CharacterPreviewComponents'
+import { showcaseButtonStyle, showcaseOutline, showcaseShadow, ShowcaseSource } from 'lib/characterPreview/CharacterPreviewComponents'
 import { ShowcaseDisplayDimensions } from 'lib/characterPreview/characterPreviewController'
 import { parentH, parentW } from 'lib/constants/constantsUi'
 import EditImageModal from 'lib/overlays/modals/EditImageModal'
@@ -71,11 +71,11 @@ export function ShowcasePortrait(props: {
       style={{
         width: `${parentW}px`,
         height: `${tempParentH}px`,
+        position: 'relative',
         overflow: 'hidden',
         borderRadius: '8px',
         border: showcaseOutline,
-        filter: showcaseDropShadowFilter,
-        position: 'relative',
+        boxShadow: showcaseShadow,
       }}
     >
       {

--- a/src/lib/characterPreview/ShowcaseStatScore.tsx
+++ b/src/lib/characterPreview/ShowcaseStatScore.tsx
@@ -15,7 +15,7 @@ export function ShowcaseStatScore(props: {
 
   return (
     <Flex vertical>
-      <StatText style={{ fontSize: 17, fontWeight: 600, textAlign: 'center', color: '#e1a564' }}>
+      <StatText style={{ fontSize: 17, fontWeight: 500, letterSpacing: -0.15, textAlign: 'center', color: '#e1a564' }}>
         {t('CharacterPreview.CharacterScore', {
           score: scoringResults.totalScore.toFixed(0),
           grade: scoringResults.totalScore == 0 ? '' : '(' + scoringResults.totalRating + ')',

--- a/src/lib/tabs/tabRelics/RelicPreview.tsx
+++ b/src/lib/tabs/tabRelics/RelicPreview.tsx
@@ -1,5 +1,5 @@
 import { Card, Divider, Flex } from 'antd'
-import { ShowcaseSource } from 'lib/characterPreview/CharacterPreviewComponents'
+import { showcaseShadow, ShowcaseSource } from 'lib/characterPreview/CharacterPreviewComponents'
 import { iconSize } from 'lib/constants/constantsUi'
 import { RelicScoringResult } from 'lib/relics/relicScorerPotential'
 import { Assets } from 'lib/rendering/assets'
@@ -82,6 +82,7 @@ export function RelicPreview(props: {
         backgroundColor: showcaseTheme?.cardBackgroundColor,
         borderColor: showcaseTheme?.cardBorderColor,
         transition: showcaseTransition(),
+        boxShadow: showcaseShadow,
       }}
     >
       <Flex vertical justify='space-between' style={{ height: 255 }}>

--- a/src/lib/utils/colorUtils.ts
+++ b/src/lib/utils/colorUtils.ts
@@ -32,7 +32,7 @@ export function darkModeModifier(color: Color, darkMode: boolean) {
 }
 
 export function showcaseCardBorderColor(color: string, darkMode: boolean) {
-  const finalColor = chroma(color).saturate(0.9).luminance(0.125).alpha(0.85)
+  const finalColor = chroma(color).desaturate(0.2).luminance(0.1).brighten(0.75).alpha(0.75)
   return darkModeModifier(finalColor, darkMode).css()
 }
 

--- a/src/lib/utils/colorUtils.ts
+++ b/src/lib/utils/colorUtils.ts
@@ -15,7 +15,7 @@ export function showcaseCardBackgroundColor(color: string, darkMode: boolean) {
 
   const finalColor = adjustedColor
     .luminance(scaleTowardsRange(adjustedColor.luminance(), 0.025, 0.0275, 0.97))
-    .alpha(0.875)
+    .alpha(0.85)
 
   // console.log(finalColor.luminance())
   // console.log(finalColor.hsl())
@@ -32,7 +32,7 @@ export function darkModeModifier(color: Color, darkMode: boolean) {
 }
 
 export function showcaseCardBorderColor(color: string, darkMode: boolean) {
-  const finalColor = chroma(color).desaturate(0.2).luminance(0.1).brighten(0.75).alpha(0.75)
+  const finalColor = chroma(color).desaturate(0.2).luminance(0.1).brighten(0.75).alpha(0.65)
   return darkModeModifier(finalColor, darkMode).css()
 }
 

--- a/src/style/style.css
+++ b/src/style/style.css
@@ -445,11 +445,11 @@ a {
 }
 
 .ant-card-hoverable:hover {
-    border-color: rgba(255, 255, 255, 0.40) !important;
+    border-color: rgba(255, 255, 255, 0.45) !important;
 }
 
 .lightConeCard:hover {
-    border-color: rgba(255, 255, 255, 0.55) !important;
+    border-color: rgba(255, 255, 255, 0.6) !important;
     cursor: pointer;
 }
 
@@ -643,4 +643,8 @@ a {
 
 .select-no-padding .ant-select-arrow {
     font-size: 10px !important;
+}
+
+.characterPreview .ant-typography {
+    color: rgb(255 255 255 / 90%);
 }


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Updated showcase borders, background colors
* Shrink character score text slightly
* Converted elemental damage types to "DMG %" on upgrades panel as some would overflow
* Brighten showcase white text slightly

![image](https://github.com/user-attachments/assets/cde00a44-a7b5-43c8-ab49-22d5858ea9ba)


## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [ ] I have added commit messages that are descriptive and meaningful.
- [ ] I have tested the changes locally.
- [ ] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

