### PR TITLE
hotfix: effect res and dmg res labels were swapped

### DIFF
--- a/src/lib/tabs/tabOptimizer/optimizerForm/components/EnemyConfigurationsDrawer.tsx
+++ b/src/lib/tabs/tabOptimizer/optimizerForm/components/EnemyConfigurationsDrawer.tsx
@@ -40,10 +40,10 @@ export const EnemyConfigurationsDrawer = () => {
 
   const enemyResistanceOptions = useMemo(() => {
     const options: { value: number; label: string }[] = []
-    for (let i = 20; i <= 60; i += 20) {
+    for (let i = 0; i <= 40; i += 10) {
       options.push({
         value: i / 100,
-        label: t('EffResOptionLabel', { resistance: i }), // `${i}% Damage RES`,
+        label: t('DmgResOptionLabel', { resistance: i }), // `${i}% Damage RES`,
       })
     }
 
@@ -52,10 +52,10 @@ export const EnemyConfigurationsDrawer = () => {
 
   const enemyEffectResistanceOptions = useMemo(() => {
     const options: { value: number; label: string }[] = []
-    for (let i = 0; i <= 40; i += 10) {
+    for (let i = 20; i <= 60; i += 20) {
       options.push({
         value: i / 100,
-        label: t('DmgResOptionLabel', { resistance: i }), // `${i}% Effect RES`,
+        label: t('EffResOptionLabel', { resistance: i }), // `${i}% Effect RES`,
       })
     }
 

--- a/src/lib/tabs/tabOptimizer/optimizerForm/components/EnemyConfigurationsDrawer.tsx
+++ b/src/lib/tabs/tabOptimizer/optimizerForm/components/EnemyConfigurationsDrawer.tsx
@@ -40,7 +40,7 @@ export const EnemyConfigurationsDrawer = () => {
 
   const enemyResistanceOptions = useMemo(() => {
     const options: { value: number; label: string }[] = []
-    for (let i = 0; i <= 40; i += 10) {
+    for (let i = 20; i <= 60; i += 20) {
       options.push({
         value: i / 100,
         label: t('DmgResOptionLabel', { resistance: i }), // `${i}% Damage RES`,
@@ -52,7 +52,7 @@ export const EnemyConfigurationsDrawer = () => {
 
   const enemyEffectResistanceOptions = useMemo(() => {
     const options: { value: number; label: string }[] = []
-    for (let i = 20; i <= 60; i += 20) {
+    for (let i = 0; i <= 40; i += 10) {
       options.push({
         value: i / 100,
         label: t('EffResOptionLabel', { resistance: i }), // `${i}% Effect RES`,


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Effect RES / Dmg RES labels were swapped by accident, changing them back

![image](https://github.com/user-attachments/assets/e62520b2-0a8e-45af-98ab-374d9c6bc200)
![image](https://github.com/user-attachments/assets/8cc7ce5c-c314-40ad-8cfc-944d46e189c3)


## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

