### PR TITLE
fix: swan e4 missing toggle effect

### DIFF
--- a/public/locales/en_US/conditionals.yaml
+++ b/public/locales/en_US/conditionals.yaml
@@ -719,6 +719,10 @@ Characters:
         text: E1 RES shred
         content: >-
           E1: While Black Swan is active in battle, enemies afflicted with Wind Shear, Bleed, Burn, or Shock will have their corresponding Wind, Physical, Fire, or Lightning RES respectively reduced by 25%.
+      e4EffResPen:
+        text: E4 Effect RES shred
+        content: >-
+          E4: While in the Epiphany state, enemy targets have their Effect RES reduced by 10%
   Blade:
     Content:
       enhancedStateActive:

--- a/src/lib/conditionals/character/1300/BlackSwan.ts
+++ b/src/lib/conditionals/character/1300/BlackSwan.ts
@@ -34,11 +34,13 @@ export default (e: Eidolon, withContent: boolean): CharacterConditionalsControll
     defDecreaseDebuff: true,
     arcanaStacks: 7,
     e1ResReduction: true,
+    e4EffResPen: true,
   }
   const teammateDefaults = {
     epiphanyDebuff: true,
     defDecreaseDebuff: true,
     e1ResReduction: true,
+    e4EffResPen: true,
   }
 
   const content: ContentDefinition<typeof defaults> = {
@@ -78,12 +80,20 @@ export default (e: Eidolon, withContent: boolean): CharacterConditionalsControll
       content: t('Content.e1ResReduction.content'),
       disabled: e < 1,
     },
+    e4EffResPen: {
+      id: 'e4EffResPen',
+      formItem: 'switch',
+      text: t('Content.e4EffResPen.text'),
+      content: t('Content.e4EffResPen.content'),
+      disabled: e < 4,
+    },
   }
 
   const teammateContent: ContentDefinition<typeof teammateDefaults> = {
     epiphanyDebuff: content.epiphanyDebuff,
     defDecreaseDebuff: content.defDecreaseDebuff,
     e1ResReduction: content.e1ResReduction,
+    e4EffResPen: content.e4EffResPen,
   }
 
   return {
@@ -120,6 +130,8 @@ export default (e: Eidolon, withContent: boolean): CharacterConditionalsControll
       x.FIRE_RES_PEN.buffTeam((e >= 1 && m.e1ResReduction) ? 0.25 : 0, Source.NONE)
       x.PHYSICAL_RES_PEN.buffTeam((e >= 1 && m.e1ResReduction) ? 0.25 : 0, Source.NONE)
       x.LIGHTNING_RES_PEN.buffTeam((e >= 1 && m.e1ResReduction) ? 0.25 : 0, Source.NONE)
+
+      x.EFFECT_RES_PEN.buffTeam((e >= 4 && m.epiphanyDebuff && m.e4EffResPen) ? 0.10 : 0, Source.NONE)
     },
     finalizeCalculations: (x: ComputedStatsArray) => standardAtkFinalizer(x),
     gpuFinalizeCalculations: () => gpuStandardAtkFinalizer(),


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Swan's E4 never got updated after Effect RES implementation, adding 10% team toggle

![image](https://github.com/user-attachments/assets/3187ddf5-a8bf-4c7b-acbb-91a30e09ffdc)


## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

