### PR TITLE
fix: relicStatText international formatting

### DIFF
--- a/src/lib/tabs/tabRelics/relicPreview/RelicStatText.tsx
+++ b/src/lib/tabs/tabRelics/relicPreview/RelicStatText.tsx
@@ -12,8 +12,8 @@ export default RelicStatText
 
 function generateStyling(language?: Languages) {
   switch (language) {
-    case 'fr':
-    case 'pt':
+    case 'fr_FR':
+    case 'pt_BR':
       return `
         white-space: nowrap;
         letter-spacing: -0.2px;


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Fixed relic stat text using 2 letter locale codes

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->
before:
![firefox_25-01-18-35-44](https://github.com/user-attachments/assets/d3604687-5357-4bb6-8219-58b41c489987)
after:
![firefox_25-01-18-35-20](https://github.com/user-attachments/assets/e675f2af-cec5-4554-b980-d760754ba2ec)

