### PR TITLE
fix: consistent eidolon prefix in conditionals

### DIFF
--- a/public/locales/en_US/conditionals.yaml
+++ b/public/locales/en_US/conditionals.yaml
@@ -1587,11 +1587,7 @@ Characters:
       eruditionTeammate:
         text: Erudition teammate
         content: >-
-          When the Enhanced Skill's primary target has "Interpretation," the multiplier for the DMG dealt increases, with each stack granting an increase of {{PrimaryScalingBonus}}%/{{AdjacentScalingBonus}}% on the primary target/other targets respectively.
-          ::BR::
-          If 2 or more characters follow the Path of Erudition in the team, each stack grants an additional increase of {{PrimaryScalingBonus}}%/{{AdjacentScalingBonus}}% on the primary target/other targets respectively.
-          ::BR::
-          A4: When entering battle, if the team has 2 or more characters following the Path of Erudition, then increases all allies' CRIT DMG by 80%.
+          When the Enhanced Skill's primary target has "Interpretation," the multiplier for the DMG dealt increases, with each stack granting an increase of {{PrimaryScalingBonus}}%/{{AdjacentScalingBonus}}% on the primary target/other targets respectively.::BR::If 2 or more characters follow the Path of Erudition in the team, each stack grants an additional increase of {{PrimaryScalingBonus}}%/{{AdjacentScalingBonus}}% on the primary target/other targets respectively.::BR::A4: When entering battle, if the team has 2 or more characters following the Path of Erudition, then increases all allies' CRIT DMG by 80%.
       ultAtkBuff:
         text: Ult ATK buff
         content: >-
@@ -1599,11 +1595,7 @@ Characters:
       interpretationStacks:
         text: Interpretation stacks
         content: >-
-          When the Enhanced Skill's primary target has "Interpretation," the multiplier for the DMG dealt increases, with each stack granting an increase of {{PrimaryScalingBonus}}%/{{AdjacentScalingBonus}}% on the primary target/other targets respectively.
-          ::BR::
-          If 2 or more characters follow the Path of Erudition in the team, each stack grants an additional increase of {{PrimaryScalingBonus}}%/{{AdjacentScalingBonus}}% on the primary target/other targets respectively.
-          ::BR::
-          E1: When Enhanced Skill calculates "Interpretation," additionally calculates 50% of the "Interpretation" stacks on the 1 target with the highest stacks out of the primary target and adjacent targets.
+          When the Enhanced Skill's primary target has "Interpretation," the multiplier for the DMG dealt increases, with each stack granting an increase of {{PrimaryScalingBonus}}%/{{AdjacentScalingBonus}}% on the primary target/other targets respectively.::BR::If 2 or more characters follow the Path of Erudition in the team, each stack grants an additional increase of {{PrimaryScalingBonus}}%/{{AdjacentScalingBonus}}% on the primary target/other targets respectively.::BR::E1: When Enhanced Skill calculates "Interpretation," additionally calculates 50% of the "Interpretation" stacks on the 1 target with the highest stacks out of the primary target and adjacent targets.
       totalInterpretationStacks:
         text: Answer stacks
         content: For every 1 stack of "Interpretation" inflicted on enemy targets, The Herta gains 1 stack of "Answer", up to 99 stacks. When using the Ultimate, every stack of "Answer" increases the Ultimate's DMG multiplier by 1%.
@@ -1705,11 +1697,7 @@ Characters:
           Mem's Support True DMG
         content: >-
           Advances the action of one designated ally by 100% and grants them "Mem's Support," lasting for 3 turns.
-          For every 1 instance of DMG dealt by the target that has "Mem's Support," additionally deals 1 instance of True DMG equal to {{TrueDmgScaling}}% of the original DMG.
-          ::BR::
-          E1: When an ally target has "Mem's Support," its effect also takes effect on the target's memosprite/memomaster.
-          ::BR::
-          E4: When an ally target with 0 Max Energy actively uses an ability, Mem can also gain 3% Charge, and the multiplier of the True DMG dealt by this target via "Mem's Support" additionally increases by 6%.
+          For every 1 instance of DMG dealt by the target that has "Mem's Support," additionally deals 1 instance of True DMG equal to {{TrueDmgScaling}}% of the original DMG.::BR::E1: When an ally target has "Mem's Support," its effect also takes effect on the target's memosprite/memomaster.::BR::E4: When an ally target with 0 Max Energy actively uses an ability, Mem can also gain 3% Charge, and the multiplier of the True DMG dealt by this target via "Mem's Support" additionally increases by 6%.
       energyTrueDmgValue:
         text: Max energy True DMG
         content: >-

--- a/public/locales/en_US/conditionals.yaml
+++ b/public/locales/en_US/conditionals.yaml
@@ -702,7 +702,7 @@ Characters:
         content: Enhanced Ult hits a random enemy for {{ultEnhancedExtraHitScaling}}% ATK per hit.
       e2UltAtkBuff:
         text: E2 Ult ATK buff
-        content: "E2: If the number of enemies on the field equals to 3 or more, increases ATK by 40% for 1 turn."
+        content: If the number of enemies on the field equals to 3 or more, increases ATK by 40% for 1 turn.
   Arlan:
     Content:
       selfCurrentHpPercent:
@@ -743,10 +743,10 @@ Characters:
         content: When using the Basic ATK, reduces the target's All-Type RES by 12% for 3 turns.
       e4DefBuff:
         text: E4 DEF buff
-        content: "E4: When triggering his Talent's follow-up attack, first increases Aventurine's DEF by 40% for 2 turns."
+        content: When triggering his Talent's follow-up attack, first increases Aventurine's DEF by 40% for 2 turns.
       e6ShieldStacks:
         text: E6 shield stacks
-        content: "E6: For every ally that holds a Shield, the DMG dealt by Aventurine increases by 50%, up to a maximum of 150%."
+        content: For every ally that holds a Shield, the DMG dealt by Aventurine increases by 50%, up to a maximum of 150%.
   Bailu:
     Content:
       healingMaxHpBuff:
@@ -757,10 +757,10 @@ Characters:
         content: Characters with Invigoration take 10% less DMG.
       e2UltHealingBuff:
         text: E2 Ult healing buff
-        content: "E2: Increases healing by 15% after Ultimate."
+        content: Increases healing by 15% after Ultimate.
       e4SkillHealingDmgBuffStacks:
         text: E4 Skill DMG boost stacks
-        content: "E4: Every healing provided by Bailu's Skill makes the recipient deal 10% more DMG for 2 turns. This effect can stack up to 3 times."
+        content: Every healing provided by Bailu's Skill makes the recipient deal 10% more DMG for 2 turns. This effect can stack up to 3 times.
   BlackSwan:
     Content:
       ehrToDmgBoost:
@@ -778,12 +778,10 @@ Characters:
           While afflicted with Arcana, enemy targets receive Wind DoT equal to {{dotScaling}}% of Black Swan's ATK at the start of each turn. Each stack of Arcana increases this DoT DMG multiplier by {{arcanaStackMultiplier}}%. Arcana can stack up to 50 times.::BR::When there are 3 or more Arcana stacks, deals Wind DoT to adjacent targets. When there are 7 or more Arcana stacks, enables the current DoT dealt this time to ignore 20% of the target's and adjacent targets' DEF.
       e1ResReduction:
         text: E1 RES shred
-        content: >-
-          E1: While Black Swan is active in battle, enemies afflicted with Wind Shear, Bleed, Burn, or Shock will have their corresponding Wind, Physical, Fire, or Lightning RES respectively reduced by 25%.
+        content: While Black Swan is active in battle, enemies afflicted with Wind Shear, Bleed, Burn, or Shock will have their corresponding Wind, Physical, Fire, or Lightning RES respectively reduced by 25%.
       e4EffResPen:
         text: E4 Effect RES shred
-        content: >-
-          E4: While in the Epiphany state, enemy targets have their Effect RES reduced by 10%.
+        content: While in the Epiphany state, enemy targets have their Effect RES reduced by 10%.
   Blade:
     Content:
       enhancedStateActive:
@@ -794,7 +792,7 @@ Characters:
         content: Ultimate DMG scales off of the tally of Blade's HP loss in the current battle. The tally of Blade's HP loss in the current battle is capped at {{hpPercentLostTotalMax}}% of his Max HP.
       e4MaxHpIncreaseStacks:
         text: E4 max HP stacks
-        content: "E4: Increases HP by 20%, stacks up to 2 times."
+        content: Increases HP by 20%, stacks up to 2 times.
   Boothill:
     Content:
       standoffActive:
@@ -860,10 +858,10 @@ Characters:
         content: Additionally deals Physical DMG equal to {{skillScaling}}% of Clara's ATK to enemies marked by Svarog with a Mark of Counter.
       e2UltAtkBuff:
         text: E2 Ult ATK buff
-        content: "E2: After using Ultimate, increases ATK by 30% for 2 turns."
+        content: After using Ultimate, increases ATK by 30% for 2 turns.
       e4DmgReductionBuff:
         text: E4 DMG reduction buff
-        content: "E4: Decreases DMG taken by 30%."
+        content: Decreases DMG taken by 30%.
   DanHeng:
     Content:
       talentPenBuff:
@@ -874,7 +872,7 @@ Characters:
         content: Basic ATK deals 40% more damage to Slowed enemies.
       e1EnemyHp50:
         text: E1 enemy HP ≥ 50% CR boost
-        content: "E1: When the target enemy's current HP percentage is greater than or equal to 50%, CRIT Rate increases by 12%."
+        content: When the target enemy's current HP percentage is greater than or equal to 50%, CRIT Rate increases by 12%.
   DrRatio:
     Content:
       summationStacks:
@@ -898,8 +896,7 @@ Characters:
         content: When using Skill, increases ATK by 48%, lasting for 3 turns.
       e1OriginalDmgBoost:
         text: E1 original DMG boost
-        content: >-
-          E1: After launching Boltsunder Blitz or Waraxe Skyward, additionally increases the Ultimate DMG dealt by Feixiao by an amount equal to 10% of the original DMG, stacking up to 5 times and lasting until the end of the Ultimate action.
+        content: After launching Boltsunder Blitz or Waraxe Skyward, additionally increases the Ultimate DMG dealt by Feixiao by an amount equal to 10% of the original DMG, stacking up to 5 times and lasting until the end of the Ultimate action.
       e4Buffs:
         text: E4 buffs
         content: The Toughness Reduction from the Talent's Follow-up ATK increases by 100% and, when launched, increases this unit's SPD by 8%, lasting for 2 turns.
@@ -989,8 +986,7 @@ Characters:
           Activates Matrix of Prescience, via which other team members will Distribute 65% of the DMG they receive (before this DMG is mitigated by any Shields) to Fu Xuan for 3 turns. While affected by Matrix of Prescience, all team members gain the Knowledge effect, which increases their respective Max HP by {{skillHpBuffValue}}% of Fu Xuan's Max HP, and increases CRIT Rate by {{skillCrBuffValue}}%.
       e6TeamHpLostPercent:
         text: E6 team HP lost
-        content: >-
-          E6: Once Matrix of Prescience is activated, it will keep a tally of the total HP lost by all team members in the current battle. Fu Xuan's Ultimate DMG will increase by 200% of this tally of HP loss. This tally is also capped at 120% of Fu Xuan's Max HP.
+        content: Once Matrix of Prescience is activated, it will keep a tally of the total HP lost by all team members in the current battle. Fu Xuan's Ultimate DMG will increase by 200% of this tally of HP loss. This tally is also capped at 120% of Fu Xuan's Max HP.
     TeammateContent:
       teammateHPValue:
         text: Fu Xuan's Combat HP
@@ -1008,18 +1004,18 @@ Characters:
         content: The Besotted state makes targets receive {{talentBesottedScaling}}% more Break DMG.
       e1ResBuff:
         text: E1 RES buff
-        content: "E1: When entering the battle, Gallagher regenerates 20 Energy and increases Effect RES by 50%."
+        content: When entering the battle, Gallagher regenerates 20 Energy and increases Effect RES by 50%.
       e2ResBuff:
         text: E2 RES buff
-        content: "E2: When using the Skill, removes 1 debuff from the target ally. At the same time, increases their Effect RES by 30%, lasting for 2 turns."
+        content: When using the Skill, removes 1 debuff from the target ally. At the same time, increases their Effect RES by 30%, lasting for 2 turns.
       e6BeBuff:
         text: E6 BE buff
-        content: "E6: Increases Gallagher's Break Effect by 20% and Weakness Break Efficiency by 20%."
+        content: Increases Gallagher's Break Effect by 20% and Weakness Break Efficiency by 20%.
   Gepard:
     Content:
       e4TeamResBuff:
         text: E4 team RES buff
-        content: "E4: When Gepard is in battle, all allies' Effect RES increases by 20%."
+        content: When Gepard is in battle, all allies' Effect RES increases by 20%.
   Guinaifen:
     Content:
       talentDebuffStacks:
@@ -1033,10 +1029,10 @@ Characters:
         content: When enabled, uses the Skill's 100% DoT chance instead of the Basic's 80% DoT chance.
       e1EffectResShred:
         text: E1 Effect RES shred
-        content: "E1: When Skill is used, there is a 100% base chance to reduce the attacked target enemy's Effect RES by 10% for 2 turns."
+        content: When Skill is used, there is a 100% base chance to reduce the attacked target enemy's Effect RES by 10% for 2 turns.
       e2BurnMultiBoost:
         text: E2 burn multi boost
-        content: "E2: When an enemy target is Burned, Guinaifen's Basic ATK and Skill can increase the DMG multiplier of their Burn status by 40%."
+        content: When an enemy target is Burned, Guinaifen's Basic ATK and Skill can increase the DMG multiplier of their Burn status by 40%.
   Hanya:
     Content:
       ultBuff:
@@ -1050,7 +1046,7 @@ Characters:
         content: Allies triggering Burden's Skill Point recovery effect have their ATK increased by 10% for 1 turn.
       e2SkillSpdBuff:
         text: E2 Skill SPD buff
-        content: "E2: After Skill, increases SPD by 20% for 1 turn."
+        content: After Skill, increases SPD by 20% for 1 turn.
     TeammateContent:
       teammateSPDValue:
         text: Hanya's SPD
@@ -1071,13 +1067,13 @@ Characters:
         content: Increases ATK by 40% for 3 turns.
       enemyHpLte50:
         text: E1 Basic scaling boost
-        content: "E1: If the enemy's HP percentage is at 50% or less, Herta's Basic ATK deals Additional Ice DMG equal to 40% of Herta's ATK."
+        content: If the enemy's HP percentage is at 50% or less, Herta's Basic ATK deals Additional Ice DMG equal to 40% of Herta's ATK.
       e2TalentCritStacks:
         text: E2 Talent CR stacks
-        content: "E2: Increases CRIT Rate by 3% per stack. Stacks up to 5 times."
+        content: Increases CRIT Rate by 3% per stack. Stacks up to 5 times.
       e6UltAtkBuff:
         text: E6 Ult ATK buff
-        content: "E6: After Ult, increases ATK by 25% for 1 turn."
+        content: After Ult, increases ATK by 25% for 1 turn.
   Himeko:
     Content:
       targetBurned:
@@ -1088,13 +1084,13 @@ Characters:
         content: When current HP percentage is 80% or higher, CRIT Rate increases by 15%.
       e1TalentSpdBuff:
         text: E1 SPD buff
-        content: "E1: After Victory Rush is triggered, Himeko's SPD increases by 20% for 2 turns."
+        content: After Victory Rush is triggered, Himeko's SPD increases by 20% for 2 turns.
       e2EnemyHp50DmgBoost:
         text: E2 enemy HP ≤ 50% DMG boost
-        content: "E2: Deals 15% more DMG to enemies whose HP percentage is 50% or less."
+        content: Deals 15% more DMG to enemies whose HP percentage is 50% or less.
       e6UltExtraHits:
         text: E6 Ult extra hits
-        content: "E6: Ultimate deals DMG 2 extra times. Extra hits deals 40% of the original DMG per hit."
+        content: Ultimate deals DMG 2 extra times. Extra hits deals 40% of the original DMG per hit.
   Hook:
     Content:
       enhancedSkill:
@@ -1112,10 +1108,10 @@ Characters:
         content: Increases all allies' ATK by {{ultBuffValue}}% for 2 turns after using Ultimate.
       skillBuff:
         text: E1 SPD buff
-        content: "E1: When Huohuo possesses Divine Provision, all allies' SPD increases by 12%."
+        content: When Huohuo possesses Divine Provision, all allies' SPD increases by 12%.
       e6DmgBuff:
         text: E6 DMG buff
-        content: "E6: When healing a target ally, increases the target ally's DMG dealt by 50% for 2 turns."
+        content: When healing a target ally, increases the target ally's DMG dealt by 50% for 2 turns.
   ImbibitorLunae:
     Content:
       basicEnhanced:
@@ -1131,7 +1127,7 @@ Characters:
         content: After each hit dealt during an attack, Dan Heng • Imbibitor Lunae gains 1 stack of Righteous Heart, increasing his DMG by {{righteousHeartDmgValue}}%. (applied to all hits)
       e6ResPenStacks:
         text: E6 RES PEN stacks
-        content: "E6: After any other ally uses their Ultimate, the Imaginary RES PEN of Dan Heng • Imbibitor Lunae's next Fulgurant Leap attack increases by 20%, up to 3 stacks."
+        content: After any other ally uses their Ultimate, the Imaginary RES PEN of Dan Heng • Imbibitor Lunae's next Fulgurant Leap attack increases by 20%, up to 3 stacks.
   Jade:
     Content:
       enhancedFollowUp:
@@ -1143,17 +1139,16 @@ Characters:
           When launching her Talent's follow-up attack, Jade immediately gains 5 stacks of Pawned Asset, with each stack increasing CRIT DMG by {{pawnedAssetCdScaling}}%, stacking up to 50 times. Each Pawned Asset stack from the Talent additionally increases Jade's ATK by 0.5%.
       e1FuaDmgBoost:
         text: E1 FUA DMG boost
-        content: >-
-          E1: The follow-up attack DMG from Jade's Talent increases by 32%. After the Debt Collector character attacks and the number of the enemy targets hit is either 2 or 1, Jade additionally gains 1 or 2 points of Charge respectively.
+        content: The follow-up attack DMG from Jade's Talent increases by 32%. After the Debt Collector character attacks and the number of the enemy targets hit is either 2 or 1, Jade additionally gains 1 or 2 points of Charge respectively.
       e2CrBuff:
         text: E2 CR buff
-        content: "E2: When there are 15 stacks of Pawned Asset, Jade's CRIT Rate increases by 18%."
+        content: When there are 15 stacks of Pawned Asset, Jade's CRIT Rate increases by 18%.
       e4DefShredBuff:
         text: E4 DEF shred buff
-        content: "E4: When using Ultimate, enables the DMG dealt by Jade to ignore 12% of enemy targets' DEF, lasting for 3 turns."
+        content: When using Ultimate, enables the DMG dealt by Jade to ignore 12% of enemy targets' DEF, lasting for 3 turns.
       e6ResShredBuff:
         text: E6 RES PEN buff
-        content: "E6: When the Debt Collector character exists on the field, Jade's Quantum RES PEN increases by 20%, and Jade gains the Debt Collector state."
+        content: When the Debt Collector character exists on the field, Jade's Quantum RES PEN increases by 20%, and Jade gains the Debt Collector state.
     TeammateContent:
       debtCollectorSpdBuff:
         text: Debt Collector SPD buff
@@ -1173,13 +1168,13 @@ Characters:
         content: For every 15% of Jiaoqiu's Effect Hit Rate that exceeds 80%, additionally increases ATK by 60%, up to 240%.
       e1DmgBoost:
         text: E1 DMG boost
-        content: "E1: Allies deal 40% increased DMG to enemy targets afflicted with Ashen Roast."
+        content: Allies deal 40% increased DMG to enemy targets afflicted with Ashen Roast.
       e2Dot:
         text: E2 DoT scaling
-        content: "E2: When an enemy target is afflicted with Ashen Roast, increases the multiplier for the Fire DoT dealt by Ashen Roast to this target by 300%."
+        content: When an enemy target is afflicted with Ashen Roast, increases the multiplier for the Fire DoT dealt by Ashen Roast to this target by 300%.
       e6ResShred:
         text: E6 RES shred
-        content: "E6: The maximum stack limit of Ashen Roast increases to 9, and each Ashen Roast stack reduces the target's All-Type RES by 3%."
+        content: The maximum stack limit of Ashen Roast increases to 9, and each Ashen Roast stack reduces the target's All-Type RES by 3%.
   Jingliu:
     Content:
       talentEnhancedState:
@@ -1192,11 +1187,10 @@ Characters:
           When Jingliu uses an attack in the Spectral Transmigration state, she consumes HP from all other allies and Jingliu's ATK increases based on the total HP consumed from all allies in this attack, capped at {{talentHpDrainAtkBuffMax}}% of her base ATK, lasting until the current attack ends.
       e1CdBuff:
         text: E1 Ult active
-        content: >-
-          E1: When using her Ultimate or Enhanced Skill, Jingliu's CRIT DMG increases by 24% for 1 turn. If only one enemy target is attacked, the target will additionally be dealt Ice DMG equal to 100% of Jingliu's ATK.
+        content: When using her Ultimate or Enhanced Skill, Jingliu's CRIT DMG increases by 24% for 1 turn. If only one enemy target is attacked, the target will additionally be dealt Ice DMG equal to 100% of Jingliu's ATK.
       e2SkillDmgBuff:
         text: E2 Skill buff
-        content: "E2: After using Ultimate, increases the DMG of the next Enhanced Skill by 80%."
+        content: After using Ultimate, increases the DMG of the next Enhanced Skill by 80%.
   JingYuan:
     Content:
       skillCritBuff:
@@ -1210,19 +1204,18 @@ Characters:
         content: Count of hits on target. Should usually be set to the same value as Lightning Lord Stacks.
       e2DmgBuff:
         text: E2 DMG boost
-        content: "E2: After Lightning-Lord takes action, DMG caused by Jing Yuan's Basic ATK, Skill, and Ultimate increases by 20% for 2 turns."
+        content: After Lightning-Lord takes action, DMG caused by Jing Yuan's Basic ATK, Skill, and Ultimate increases by 20% for 2 turns.
       e6FuaVulnerabilityStacks:
         text: E6 Vulnerable stacks
-        content: >-
-          E6: Each hit performed by the Lightning-Lord when it takes action will make the target enemy Vulnerable. While Vulnerable, enemies receive 12% more DMG until the end of the Lightning-Lord's current turn, stacking up to 3 times. (applies to all hits)
+        content: Each hit performed by the Lightning-Lord when it takes action will make the target enemy Vulnerable. While Vulnerable, enemies receive 12% more DMG until the end of the Lightning-Lord's current turn, stacking up to 3 times. (applies to all hits)
   Kafka:
     Content:
       e1DotDmgReceivedDebuff:
         text: E1 DoT vulnerability
-        content: "E1: When the Talent triggers a follow-up attack, there is a 100% base chance to increase the DoT received by the target by 30% for 2 turns."
+        content: When the Talent triggers a follow-up attack, there is a 100% base chance to increase the DoT received by the target by 30% for 2 turns.
       e2TeamDotBoost:
         text: E2 Team DoT DMG boost
-        content: "E2: While Kafka is on the field, DoT dealt by all allies increases by 25%."
+        content: While Kafka is on the field, DoT dealt by all allies increases by 25%.
   Lingsha:
     Content:
       beConversion:
@@ -1233,13 +1226,13 @@ Characters:
         content: While in Befog, targets receive {{BefogVulnerability}}% increased Break DMG.
       e1DefShred:
         text: E1 weakness break buffs
-        content: "E1: Lingsha's Weakness Break Efficiency increases by 50%. When an enemy unit's Weakness is Broken, reduces their DEF by 20%."
+        content: Lingsha's Weakness Break Efficiency increases by 50%. When an enemy unit's Weakness is Broken, reduces their DEF by 20%.
       e2BeBuff:
         text: E2 BE buff
-        content: "E2: When using Ultimate, increases all allies' Break Effect by 40%."
+        content: When using Ultimate, increases all allies' Break Effect by 40%.
       e6ResShred:
         text: E6 RES shred
-        content: "E6: While Fuyuan is on the field, reduces all Enemy units' All-Type RES by 20%."
+        content: While Fuyuan is on the field, reduces all Enemy units' All-Type RES by 20%.
   Luka:
     Content:
       basicEnhanced:
@@ -1253,18 +1246,18 @@ Characters:
         content: Increases the number of hits of Basic Enhanced.
       e1TargetBleeding:
         text: E1 target bleeding
-        content: "E1: When Luka takes action, if the target enemy is Bleeding, increases DMG dealt by Luka by 15% for 2 turns."
+        content: When Luka takes action, if the target enemy is Bleeding, increases DMG dealt by Luka by 15% for 2 turns.
       e4TalentStacks:
         text: E4 Talent stacks
-        content: "E4: For every stack of Fighting Will obtained, increases ATK by 5%, stacking up to 4 times."
+        content: For every stack of Fighting Will obtained, increases ATK by 5%, stacking up to 4 times.
   Luocha:
     Content:
       fieldActive:
         text: Field active
-        content: "E1: While the Field is active, ATK of all allies increases by 20%."
+        content: While the Field is active, ATK of all allies increases by 20%.
       e6ResReduction:
         text: E6 RES shred
-        content: "E6: When Ultimate is used, reduces all enemies' All-Type RES by 20% for 2 turns."
+        content: When Ultimate is used, reduces all enemies' All-Type RES by 20% for 2 turns.
   Lynx:
     Content:
       skillBuff:
@@ -1298,10 +1291,10 @@ Characters:
           After Shifu uses an attack or Ultimate, March 7th gains up to 1 point of Charge each time.::BR::Upon reaching 7 or more points of Charge, March 7th immediately takes action and increases the DMG she deals by {{TalentDmgBuff}}%.
       selfSpdBuff:
         text: E1 SPD buff
-        content: "E1: When Shifu is on the field, increases March 7th's SPD by 10%."
+        content: When Shifu is on the field, increases March 7th's SPD by 10%.
       e6CdBuff:
         text: E6 Basic CD boost
-        content: "E6: After using Ultimate, increases the CRIT DMG dealt by the next Enhanced Basic ATK by 50%."
+        content: After using Ultimate, increases the CRIT DMG dealt by the next Enhanced Basic ATK by 50%.
     TeammateContent:
       masterBuff:
         text: Shifu buff
@@ -1319,10 +1312,10 @@ Characters:
         content: When dealing DMG to Frozen enemies, increases CRIT DMG by 30%.
       e2DefReduction:
         text: E2 DEF shred
-        content: "E2: Reduces the target's DEF by 16% for 3 turns."
+        content: Reduces the target's DEF by 16% for 3 turns.
       e6UltDmgBoost:
         text: E6 Ult DMG boost
-        content: "E6: When using the Ultimate, increases own DMG by 30%, lasting until the end of the turn."
+        content: When using the Ultimate, increases own DMG by 30%, lasting until the end of the turn.
   Moze:
     Content:
       preyMark:
@@ -1331,7 +1324,7 @@ Characters:
           When Prey exists on the field, Moze will enter the Departed state.::BR::After allies attack Prey, Moze will additionally deal 1 instance of Lightning Additional DMG equal to {{PreyAdditionalMultiplier}}% of his ATK and consumes 1 point of Charge. For every 3 points of Charge consumed, Moze launches 1 follow-up attack to Prey, dealing Lightning DMG equal to {{FuaScaling}}% of his ATK. When Charge reaches 0, dispels the target's Prey state and resets the tally of Charge points required to launch follow-up attack.
       e2CdBoost:
         text: E2 CD boost
-        content: "E2: When all allies deal DMG to the enemy target marked as Prey, increases CRIT DMG by 40%."
+        content: When all allies deal DMG to the enemy target marked as Prey, increases CRIT DMG by 40%.
       e4DmgBuff:
         text: E4 DMG buff
         content: When using Ultimate, increases the DMG dealt by Moze by 30%, lasting for 2 turns.
@@ -1356,7 +1349,7 @@ Characters:
         content: When Exposed, enemies' DEF is reduced by {{ultDefPenValue}}% for 2 turns.
       e4SkillResShred:
         text: E4 Skill Ice RES shred
-        content: "E4: When using Skill, there is a 100% base chance to reduce the target enemy's Ice RES by 12% for 2 turns."
+        content: When using Skill, there is a 100% base chance to reduce the target enemy's Ice RES by 12% for 2 turns.
   Qingque:
     Content:
       basicEnhanced:
@@ -1444,10 +1437,10 @@ Characters:
           While inside the field, all allies' All-Type RES PEN increases by {{fieldResPenValue}}%.::BR::E1: While the Ultimate's field is deployed, the DMG dealt by all allies ignores 20% of the target's DEF.
       e2AtkBoost:
         text: E2 weakness ATK boost
-        content: "E2: With Ruan Mei on the field, all allies increase their ATK by 40% when dealing DMG to enemies with Weakness Break."
+        content: With Ruan Mei on the field, all allies increase their ATK by 40% when dealing DMG to enemies with Weakness Break.
       e4BeBuff:
         text: E4 BE buff
-        content: "E4: When an enemy target's Weakness is Broken, Ruan Mei's Break Effect increases by 100% for 3 turns."
+        content: When an enemy target's Weakness is Broken, Ruan Mei's Break Effect increases by 100% for 3 turns.
     TeammateContent:
       teamSpdBuff:
         text: Team SPD buff
@@ -1477,11 +1470,10 @@ Characters:
         content: "After using her skill, Seele's SPD by 25% for 2 turns.::BR::E2: The SPD Boost effect of Seele's Skill can stack up to 2 times."
       e1EnemyHp80CrBoost:
         text: E1 enemy HP ≤ 80% CR boost
-        content: "E1: When dealing DMG to an enemy whose HP percentage is 80% or lower, CRIT Rate increases by 15%."
+        content: When dealing DMG to an enemy whose HP percentage is 80% or lower, CRIT Rate increases by 15%.
       e6UltTargetDebuff:
         text: E6 Butterfly Flurry
-        content: >-
-          E6: After Seele uses her Ultimate, inflict the target enemy with Butterfly Flurry for 1 turn. Enemies suffering from Butterfly Flurry will take Additional Quantum DMG equal to 15% of Seele's Ultimate DMG every time they are attacked.
+        content: After Seele uses her Ultimate, inflict the target enemy with Butterfly Flurry for 1 turn. Enemies suffering from Butterfly Flurry will take Additional Quantum DMG equal to 15% of Seele's Ultimate DMG every time they are attacked.
   Serval:
     Content:
       targetShocked:
@@ -1586,7 +1578,7 @@ Characters:
           When an enemy has their Weakness Broken on the field, Sushang's SPD increases by {{talentSpdBuffValue}}% per stack for 2 turns.::BR::E6: Talent's SPD Boost is stackable and can stack up to 2 times.
       e2DmgReductionBuff:
         text: E2 DMG reduction buff
-        content: "E2: After triggering Sword Stance, the DMG taken by Sushang is reduced by 20% for 1 turn."
+        content: After triggering Sword Stance, the DMG taken by Sushang is reduced by 20% for 1 turn.
   TheHerta:
     Content:
       enhancedSkill:
@@ -1635,10 +1627,10 @@ Characters:
         content: Tingyun's SPD increases by 20% for 1 turn after using Skill.
       ultDmgBuff:
         text: Ult DMG buff
-        content: Regenerates 50 Energy for a single ally and increases the target's DMG by {{ultDmgBoost}}% for 2 turns.
+        content: "Regenerates 50 Energy for a single ally and increases the target's DMG by {{ultDmgBoost}}% for 2 turns.::BR::E6: Ultimate regenerates 10 more Energy for the target ally."
       ultSpdBuff:
         text: E1 Ult SPD buff
-        content: "E1: After using their Ultimate, the ally with Benediction gains a 20% increase in SPD for 1 turn."
+        content: After using their Ultimate, the ally with Benediction gains a 20% increase in SPD for 1 turn.
     TeammateContent:
       teammateAtkBuffValue:
         text: Skill ATK buff value
@@ -1654,8 +1646,7 @@ Characters:
         content: Numby enters the Windfall Bonanza! state and its DMG multiplier increases by {{enhancedStateFuaScalingBoost}}% and CRIT DMG increases by {{enhancedStateFuaCdBoost}}%.
       e1DebtorStacks:
         text: E1 Debtor stacks
-        content: >-
-          E1: When enemies afflicted with Proof of Debt receive follow-up attacks, they will enter the Debtor state. This can take effect only once within a single action. The Debtor state increases the CRIT DMG of follow-up attacks inflicted on the target enemies by 25%, stacking up to 2 times. When Proof of Debt is removed, the Debtor state is also removed.
+        content: When enemies afflicted with Proof of Debt receive follow-up attacks, they will enter the Debtor state. This can take effect only once within a single action. The Debtor state increases the CRIT DMG of follow-up attacks inflicted on the target enemies by 25%, stacking up to 2 times. When Proof of Debt is removed, the Debtor state is also removed.
   TrailblazerDestruction:
     Content:
       enhancedUlt:
@@ -1698,7 +1689,7 @@ Characters:
         content: When the shield is active, increases ATK by 15%.
       e6DefStacks:
         text: E6 DEF buff stacks
-        content: "E6: Increases DEF by 10% per stack."
+        content: Increases DEF by 10% per stack.
   TrailblazerRemembrance:
     Content:
       memoSkillHits:
@@ -1755,8 +1746,7 @@ Characters:
           Deals Imaginary DMG equal to {{skillScaling}}% of Welt's ATK to a single enemy and further deals DMG 2 extra times, with each time dealing Imaginary DMG equal to {{skillScaling}}% of Welt's ATK to a random enemy.
       e1EnhancedState:
         text: E1 enhanced state
-        content: >-
-          E1: After Welt uses his Ultimate, his abilities are enhanced. The next 2 times he uses his Basic ATK or Skill, deals Additional DMG to the target equal to 50% of his Basic ATK's DMG multiplier or 80% of his Skill's DMG multiplier respectively.
+        content: After Welt uses his Ultimate, his abilities are enhanced. The next 2 times he uses his Basic ATK or Skill, deals Additional DMG to the target equal to 50% of his Basic ATK's DMG multiplier or 80% of his Skill's DMG multiplier respectively.
   Xueyi:
     Content:
       beToDmgBoost:
@@ -1774,7 +1764,7 @@ Characters:
           When Karma reaches the max number of stacks, consumes all current Karma stacks and immediately launches a follow-up attack against an enemy target, dealing DMG for 3 times, with each time dealing Quantum DMG equal to {{fuaScaling}}% of Xueyi's ATK to a single random enemy.
       e4BeBuff:
         text: E4 BE buff
-        content: "E4: When using Ultimate, increases Break Effect by 40% for 2 turns."
+        content: When using Ultimate, increases Break Effect by 40% for 2 turns.
   Yanqing:
     Content:
       ultBuffActive:
@@ -1789,10 +1779,10 @@ Characters:
         content: When a CRIT Hit is triggered, increases SPD by 10% for 2 turns.
       e1TargetFrozen:
         text: E1 enemy frozen
-        content: "E1: When Yanqing attacks a Frozen enemy, he deals Additional Ice DMG equal to 60% of his ATK."
+        content: When Yanqing attacks a Frozen enemy, he deals Additional Ice DMG equal to 60% of his ATK.
       e4CurrentHp80:
         text: E4 self HP ≥ 80% RES PEN buff
-        content: "E4: When the current HP percentage is 80% or higher, Ice RES PEN increases by 12%."
+        content: When the current HP percentage is 80% or higher, Ice RES PEN increases by 12%.
   Yukong:
     Content:
       teamImaginaryDmgBoost:
@@ -1807,7 +1797,7 @@ Characters:
           If Roaring Bowstrings is active on Yukong when her Ultimate is used, additionally increases all allies' CRIT Rate by {{ultCrBuffValue}}% and CRIT DMG by {{ultCdBuffValue}}%. At the same time, deals Imaginary DMG equal to {{ultScaling}}% of Yukong's ATK to a single enemy.
       initialSpeedBuff:
         text: E1 initial SPD buff
-        content: "E1: At the start of battle, increases the SPD of all allies by 10% for 2 turns."
+        content: At the start of battle, increases the SPD of all allies by 10% for 2 turns.
   Yunli:
     Content:
       blockActive:
@@ -1826,7 +1816,7 @@ Characters:
         content: When using a Counter, increases Yunli's ATK by 30%, lasting for 1 turn.
       e1UltBuff:
         text: E1 Ult buff
-        content: "E1: Increases DMG dealt by Intuit: Slash and Intuit: Cull by 20%. Increases the number of additional DMG instances for Intuit: Cull by 3."
+        content: "Increases DMG dealt by Intuit: Slash and Intuit: Cull by 20%. Increases the number of additional DMG instances for Intuit: Cull by 3."
       e2DefShred:
         text: E2 FUA DEF PEN
         content: When dealing DMG via Counter, ignores 20% of the target's DEF.

--- a/src/types/resources.d.ts
+++ b/src/types/resources.d.ts
@@ -2510,7 +2510,7 @@ interface Resources {
           },
           "eruditionTeammate": {
             "text": "Erudition teammate",
-            "content": "When the Enhanced Skill's primary target has \"Interpretation,\" the multiplier for the DMG dealt increases, with each stack granting an increase of {{PrimaryScalingBonus}}%/{{AdjacentScalingBonus}}% on the primary target/other targets respectively. ::BR:: If 2 or more characters follow the Path of Erudition in the team, each stack grants an additional increase of {{PrimaryScalingBonus}}%/{{AdjacentScalingBonus}}% on the primary target/other targets respectively. ::BR:: A4: When entering battle, if the team has 2 or more characters following the Path of Erudition, then increases all allies' CRIT DMG by 80%."
+            "content": "When the Enhanced Skill's primary target has \"Interpretation,\" the multiplier for the DMG dealt increases, with each stack granting an increase of {{PrimaryScalingBonus}}%/{{AdjacentScalingBonus}}% on the primary target/other targets respectively.::BR::If 2 or more characters follow the Path of Erudition in the team, each stack grants an additional increase of {{PrimaryScalingBonus}}%/{{AdjacentScalingBonus}}% on the primary target/other targets respectively.::BR::A4: When entering battle, if the team has 2 or more characters following the Path of Erudition, then increases all allies' CRIT DMG by 80%."
           },
           "ultAtkBuff": {
             "text": "Ult ATK buff",
@@ -2518,7 +2518,7 @@ interface Resources {
           },
           "interpretationStacks": {
             "text": "Interpretation stacks",
-            "content": "When the Enhanced Skill's primary target has \"Interpretation,\" the multiplier for the DMG dealt increases, with each stack granting an increase of {{PrimaryScalingBonus}}%/{{AdjacentScalingBonus}}% on the primary target/other targets respectively. ::BR:: If 2 or more characters follow the Path of Erudition in the team, each stack grants an additional increase of {{PrimaryScalingBonus}}%/{{AdjacentScalingBonus}}% on the primary target/other targets respectively. ::BR:: E1: When Enhanced Skill calculates \"Interpretation,\" additionally calculates 50% of the \"Interpretation\" stacks on the 1 target with the highest stacks out of the primary target and adjacent targets."
+            "content": "When the Enhanced Skill's primary target has \"Interpretation,\" the multiplier for the DMG dealt increases, with each stack granting an increase of {{PrimaryScalingBonus}}%/{{AdjacentScalingBonus}}% on the primary target/other targets respectively.::BR::If 2 or more characters follow the Path of Erudition in the team, each stack grants an additional increase of {{PrimaryScalingBonus}}%/{{AdjacentScalingBonus}}% on the primary target/other targets respectively.::BR::E1: When Enhanced Skill calculates \"Interpretation,\" additionally calculates 50% of the \"Interpretation\" stacks on the 1 target with the highest stacks out of the primary target and adjacent targets."
           },
           "totalInterpretationStacks": {
             "text": "Answer stacks",
@@ -2650,7 +2650,7 @@ interface Resources {
           },
           "memsSupport": {
             "text": "Mem's Support True DMG",
-            "content": "Advances the action of one designated ally by 100% and grants them \"Mem's Support,\" lasting for 3 turns. For every 1 instance of DMG dealt by the target that has \"Mem's Support,\" additionally deals 1 instance of True DMG equal to {{TrueDmgScaling}}% of the original DMG. ::BR:: E1: When an ally target has \"Mem's Support,\" its effect also takes effect on the target's memosprite/memomaster. ::BR:: E4: When an ally target with 0 Max Energy actively uses an ability, Mem can also gain 3% Charge, and the multiplier of the True DMG dealt by this target via \"Mem's Support\" additionally increases by 6%."
+            "content": "Advances the action of one designated ally by 100% and grants them \"Mem's Support,\" lasting for 3 turns. For every 1 instance of DMG dealt by the target that has \"Mem's Support,\" additionally deals 1 instance of True DMG equal to {{TrueDmgScaling}}% of the original DMG.::BR::E1: When an ally target has \"Mem's Support,\" its effect also takes effect on the target's memosprite/memomaster.::BR::E4: When an ally target with 0 Max Energy actively uses an ability, Mem can also gain 3% Charge, and the multiplier of the True DMG dealt by this target via \"Mem's Support\" additionally increases by 6%."
           },
           "energyTrueDmgValue": {
             "text": "Max energy True DMG",

--- a/src/types/resources.d.ts
+++ b/src/types/resources.d.ts
@@ -1351,7 +1351,7 @@ interface Resources {
           },
           "e2UltAtkBuff": {
             "text": "E2 Ult ATK buff",
-            "content": "E2: If the number of enemies on the field equals to 3 or more, increases ATK by 40% for 1 turn."
+            "content": "If the number of enemies on the field equals to 3 or more, increases ATK by 40% for 1 turn."
           }
         }
       },
@@ -1407,11 +1407,11 @@ interface Resources {
           },
           "e4DefBuff": {
             "text": "E4 DEF buff",
-            "content": "E4: When triggering his Talent's follow-up attack, first increases Aventurine's DEF by 40% for 2 turns."
+            "content": "When triggering his Talent's follow-up attack, first increases Aventurine's DEF by 40% for 2 turns."
           },
           "e6ShieldStacks": {
             "text": "E6 shield stacks",
-            "content": "E6: For every ally that holds a Shield, the DMG dealt by Aventurine increases by 50%, up to a maximum of 150%."
+            "content": "For every ally that holds a Shield, the DMG dealt by Aventurine increases by 50%, up to a maximum of 150%."
           }
         }
       },
@@ -1427,11 +1427,11 @@ interface Resources {
           },
           "e2UltHealingBuff": {
             "text": "E2 Ult healing buff",
-            "content": "E2: Increases healing by 15% after Ultimate."
+            "content": "Increases healing by 15% after Ultimate."
           },
           "e4SkillHealingDmgBuffStacks": {
             "text": "E4 Skill DMG boost stacks",
-            "content": "E4: Every healing provided by Bailu's Skill makes the recipient deal 10% more DMG for 2 turns. This effect can stack up to 3 times."
+            "content": "Every healing provided by Bailu's Skill makes the recipient deal 10% more DMG for 2 turns. This effect can stack up to 3 times."
           }
         }
       },
@@ -1455,11 +1455,11 @@ interface Resources {
           },
           "e1ResReduction": {
             "text": "E1 RES shred",
-            "content": "E1: While Black Swan is active in battle, enemies afflicted with Wind Shear, Bleed, Burn, or Shock will have their corresponding Wind, Physical, Fire, or Lightning RES respectively reduced by 25%."
+            "content": "While Black Swan is active in battle, enemies afflicted with Wind Shear, Bleed, Burn, or Shock will have their corresponding Wind, Physical, Fire, or Lightning RES respectively reduced by 25%."
           },
           "e4EffResPen": {
             "text": "E4 Effect RES shred",
-            "content": "E4: While in the Epiphany state, enemy targets have their Effect RES reduced by 10%."
+            "content": "While in the Epiphany state, enemy targets have their Effect RES reduced by 10%."
           }
         }
       },
@@ -1475,7 +1475,7 @@ interface Resources {
           },
           "e4MaxHpIncreaseStacks": {
             "text": "E4 max HP stacks",
-            "content": "E4: Increases HP by 20%, stacks up to 2 times."
+            "content": "Increases HP by 20%, stacks up to 2 times."
           }
         }
       },
@@ -1561,11 +1561,11 @@ interface Resources {
           },
           "e2UltAtkBuff": {
             "text": "E2 Ult ATK buff",
-            "content": "E2: After using Ultimate, increases ATK by 30% for 2 turns."
+            "content": "After using Ultimate, increases ATK by 30% for 2 turns."
           },
           "e4DmgReductionBuff": {
             "text": "E4 DMG reduction buff",
-            "content": "E4: Decreases DMG taken by 30%."
+            "content": "Decreases DMG taken by 30%."
           }
         }
       },
@@ -1581,7 +1581,7 @@ interface Resources {
           },
           "e1EnemyHp50": {
             "text": "E1 enemy HP ≥ 50% CR boost",
-            "content": "E1: When the target enemy's current HP percentage is greater than or equal to 50%, CRIT Rate increases by 12%."
+            "content": "When the target enemy's current HP percentage is greater than or equal to 50%, CRIT Rate increases by 12%."
           }
         }
       },
@@ -1613,7 +1613,7 @@ interface Resources {
           },
           "e1OriginalDmgBoost": {
             "text": "E1 original DMG boost",
-            "content": "E1: After launching Boltsunder Blitz or Waraxe Skyward, additionally increases the Ultimate DMG dealt by Feixiao by an amount equal to 10% of the original DMG, stacking up to 5 times and lasting until the end of the Ultimate action."
+            "content": "After launching Boltsunder Blitz or Waraxe Skyward, additionally increases the Ultimate DMG dealt by Feixiao by an amount equal to 10% of the original DMG, stacking up to 5 times and lasting until the end of the Ultimate action."
           },
           "e4Buffs": {
             "text": "E4 buffs",
@@ -1711,7 +1711,7 @@ interface Resources {
           },
           "e6TeamHpLostPercent": {
             "text": "E6 team HP lost",
-            "content": "E6: Once Matrix of Prescience is activated, it will keep a tally of the total HP lost by all team members in the current battle. Fu Xuan's Ultimate DMG will increase by 200% of this tally of HP loss. This tally is also capped at 120% of Fu Xuan's Max HP."
+            "content": "Once Matrix of Prescience is activated, it will keep a tally of the total HP lost by all team members in the current battle. Fu Xuan's Ultimate DMG will increase by 200% of this tally of HP loss. This tally is also capped at 120% of Fu Xuan's Max HP."
           }
         },
         "TeammateContent": {
@@ -1737,15 +1737,15 @@ interface Resources {
           },
           "e1ResBuff": {
             "text": "E1 RES buff",
-            "content": "E1: When entering the battle, Gallagher regenerates 20 Energy and increases Effect RES by 50%."
+            "content": "When entering the battle, Gallagher regenerates 20 Energy and increases Effect RES by 50%."
           },
           "e2ResBuff": {
             "text": "E2 RES buff",
-            "content": "E2: When using the Skill, removes 1 debuff from the target ally. At the same time, increases their Effect RES by 30%, lasting for 2 turns."
+            "content": "When using the Skill, removes 1 debuff from the target ally. At the same time, increases their Effect RES by 30%, lasting for 2 turns."
           },
           "e6BeBuff": {
             "text": "E6 BE buff",
-            "content": "E6: Increases Gallagher's Break Effect by 20% and Weakness Break Efficiency by 20%."
+            "content": "Increases Gallagher's Break Effect by 20% and Weakness Break Efficiency by 20%."
           }
         }
       },
@@ -1753,7 +1753,7 @@ interface Resources {
         "Content": {
           "e4TeamResBuff": {
             "text": "E4 team RES buff",
-            "content": "E4: When Gepard is in battle, all allies' Effect RES increases by 20%."
+            "content": "When Gepard is in battle, all allies' Effect RES increases by 20%."
           }
         }
       },
@@ -1773,11 +1773,11 @@ interface Resources {
           },
           "e1EffectResShred": {
             "text": "E1 Effect RES shred",
-            "content": "E1: When Skill is used, there is a 100% base chance to reduce the attacked target enemy's Effect RES by 10% for 2 turns."
+            "content": "When Skill is used, there is a 100% base chance to reduce the attacked target enemy's Effect RES by 10% for 2 turns."
           },
           "e2BurnMultiBoost": {
             "text": "E2 burn multi boost",
-            "content": "E2: When an enemy target is Burned, Guinaifen's Basic ATK and Skill can increase the DMG multiplier of their Burn status by 40%."
+            "content": "When an enemy target is Burned, Guinaifen's Basic ATK and Skill can increase the DMG multiplier of their Burn status by 40%."
           }
         }
       },
@@ -1797,7 +1797,7 @@ interface Resources {
           },
           "e2SkillSpdBuff": {
             "text": "E2 Skill SPD buff",
-            "content": "E2: After Skill, increases SPD by 20% for 1 turn."
+            "content": "After Skill, increases SPD by 20% for 1 turn."
           }
         },
         "TeammateContent": {
@@ -1827,15 +1827,15 @@ interface Resources {
           },
           "enemyHpLte50": {
             "text": "E1 Basic scaling boost",
-            "content": "E1: If the enemy's HP percentage is at 50% or less, Herta's Basic ATK deals Additional Ice DMG equal to 40% of Herta's ATK."
+            "content": "If the enemy's HP percentage is at 50% or less, Herta's Basic ATK deals Additional Ice DMG equal to 40% of Herta's ATK."
           },
           "e2TalentCritStacks": {
             "text": "E2 Talent CR stacks",
-            "content": "E2: Increases CRIT Rate by 3% per stack. Stacks up to 5 times."
+            "content": "Increases CRIT Rate by 3% per stack. Stacks up to 5 times."
           },
           "e6UltAtkBuff": {
             "text": "E6 Ult ATK buff",
-            "content": "E6: After Ult, increases ATK by 25% for 1 turn."
+            "content": "After Ult, increases ATK by 25% for 1 turn."
           }
         }
       },
@@ -1851,15 +1851,15 @@ interface Resources {
           },
           "e1TalentSpdBuff": {
             "text": "E1 SPD buff",
-            "content": "E1: After Victory Rush is triggered, Himeko's SPD increases by 20% for 2 turns."
+            "content": "After Victory Rush is triggered, Himeko's SPD increases by 20% for 2 turns."
           },
           "e2EnemyHp50DmgBoost": {
             "text": "E2 enemy HP ≤ 50% DMG boost",
-            "content": "E2: Deals 15% more DMG to enemies whose HP percentage is 50% or less."
+            "content": "Deals 15% more DMG to enemies whose HP percentage is 50% or less."
           },
           "e6UltExtraHits": {
             "text": "E6 Ult extra hits",
-            "content": "E6: Ultimate deals DMG 2 extra times. Extra hits deals 40% of the original DMG per hit."
+            "content": "Ultimate deals DMG 2 extra times. Extra hits deals 40% of the original DMG per hit."
           }
         }
       },
@@ -1883,11 +1883,11 @@ interface Resources {
           },
           "skillBuff": {
             "text": "E1 SPD buff",
-            "content": "E1: When Huohuo possesses Divine Provision, all allies' SPD increases by 12%."
+            "content": "When Huohuo possesses Divine Provision, all allies' SPD increases by 12%."
           },
           "e6DmgBuff": {
             "text": "E6 DMG buff",
-            "content": "E6: When healing a target ally, increases the target ally's DMG dealt by 50% for 2 turns."
+            "content": "When healing a target ally, increases the target ally's DMG dealt by 50% for 2 turns."
           }
         }
       },
@@ -1907,7 +1907,7 @@ interface Resources {
           },
           "e6ResPenStacks": {
             "text": "E6 RES PEN stacks",
-            "content": "E6: After any other ally uses their Ultimate, the Imaginary RES PEN of Dan Heng • Imbibitor Lunae's next Fulgurant Leap attack increases by 20%, up to 3 stacks."
+            "content": "After any other ally uses their Ultimate, the Imaginary RES PEN of Dan Heng • Imbibitor Lunae's next Fulgurant Leap attack increases by 20%, up to 3 stacks."
           }
         }
       },
@@ -1923,19 +1923,19 @@ interface Resources {
           },
           "e1FuaDmgBoost": {
             "text": "E1 FUA DMG boost",
-            "content": "E1: The follow-up attack DMG from Jade's Talent increases by 32%. After the Debt Collector character attacks and the number of the enemy targets hit is either 2 or 1, Jade additionally gains 1 or 2 points of Charge respectively."
+            "content": "The follow-up attack DMG from Jade's Talent increases by 32%. After the Debt Collector character attacks and the number of the enemy targets hit is either 2 or 1, Jade additionally gains 1 or 2 points of Charge respectively."
           },
           "e2CrBuff": {
             "text": "E2 CR buff",
-            "content": "E2: When there are 15 stacks of Pawned Asset, Jade's CRIT Rate increases by 18%."
+            "content": "When there are 15 stacks of Pawned Asset, Jade's CRIT Rate increases by 18%."
           },
           "e4DefShredBuff": {
             "text": "E4 DEF shred buff",
-            "content": "E4: When using Ultimate, enables the DMG dealt by Jade to ignore 12% of enemy targets' DEF, lasting for 3 turns."
+            "content": "When using Ultimate, enables the DMG dealt by Jade to ignore 12% of enemy targets' DEF, lasting for 3 turns."
           },
           "e6ResShredBuff": {
             "text": "E6 RES PEN buff",
-            "content": "E6: When the Debt Collector character exists on the field, Jade's Quantum RES PEN increases by 20%, and Jade gains the Debt Collector state."
+            "content": "When the Debt Collector character exists on the field, Jade's Quantum RES PEN increases by 20%, and Jade gains the Debt Collector state."
           }
         },
         "TeammateContent": {
@@ -1961,15 +1961,15 @@ interface Resources {
           },
           "e1DmgBoost": {
             "text": "E1 DMG boost",
-            "content": "E1: Allies deal 40% increased DMG to enemy targets afflicted with Ashen Roast."
+            "content": "Allies deal 40% increased DMG to enemy targets afflicted with Ashen Roast."
           },
           "e2Dot": {
             "text": "E2 DoT scaling",
-            "content": "E2: When an enemy target is afflicted with Ashen Roast, increases the multiplier for the Fire DoT dealt by Ashen Roast to this target by 300%."
+            "content": "When an enemy target is afflicted with Ashen Roast, increases the multiplier for the Fire DoT dealt by Ashen Roast to this target by 300%."
           },
           "e6ResShred": {
             "text": "E6 RES shred",
-            "content": "E6: The maximum stack limit of Ashen Roast increases to 9, and each Ashen Roast stack reduces the target's All-Type RES by 3%."
+            "content": "The maximum stack limit of Ashen Roast increases to 9, and each Ashen Roast stack reduces the target's All-Type RES by 3%."
           }
         }
       },
@@ -1985,11 +1985,11 @@ interface Resources {
           },
           "e1CdBuff": {
             "text": "E1 Ult active",
-            "content": "E1: When using her Ultimate or Enhanced Skill, Jingliu's CRIT DMG increases by 24% for 1 turn. If only one enemy target is attacked, the target will additionally be dealt Ice DMG equal to 100% of Jingliu's ATK."
+            "content": "When using her Ultimate or Enhanced Skill, Jingliu's CRIT DMG increases by 24% for 1 turn. If only one enemy target is attacked, the target will additionally be dealt Ice DMG equal to 100% of Jingliu's ATK."
           },
           "e2SkillDmgBuff": {
             "text": "E2 Skill buff",
-            "content": "E2: After using Ultimate, increases the DMG of the next Enhanced Skill by 80%."
+            "content": "After using Ultimate, increases the DMG of the next Enhanced Skill by 80%."
           }
         }
       },
@@ -2009,11 +2009,11 @@ interface Resources {
           },
           "e2DmgBuff": {
             "text": "E2 DMG boost",
-            "content": "E2: After Lightning-Lord takes action, DMG caused by Jing Yuan's Basic ATK, Skill, and Ultimate increases by 20% for 2 turns."
+            "content": "After Lightning-Lord takes action, DMG caused by Jing Yuan's Basic ATK, Skill, and Ultimate increases by 20% for 2 turns."
           },
           "e6FuaVulnerabilityStacks": {
             "text": "E6 Vulnerable stacks",
-            "content": "E6: Each hit performed by the Lightning-Lord when it takes action will make the target enemy Vulnerable. While Vulnerable, enemies receive 12% more DMG until the end of the Lightning-Lord's current turn, stacking up to 3 times. (applies to all hits)"
+            "content": "Each hit performed by the Lightning-Lord when it takes action will make the target enemy Vulnerable. While Vulnerable, enemies receive 12% more DMG until the end of the Lightning-Lord's current turn, stacking up to 3 times. (applies to all hits)"
           }
         }
       },
@@ -2021,11 +2021,11 @@ interface Resources {
         "Content": {
           "e1DotDmgReceivedDebuff": {
             "text": "E1 DoT vulnerability",
-            "content": "E1: When the Talent triggers a follow-up attack, there is a 100% base chance to increase the DoT received by the target by 30% for 2 turns."
+            "content": "When the Talent triggers a follow-up attack, there is a 100% base chance to increase the DoT received by the target by 30% for 2 turns."
           },
           "e2TeamDotBoost": {
             "text": "E2 Team DoT DMG boost",
-            "content": "E2: While Kafka is on the field, DoT dealt by all allies increases by 25%."
+            "content": "While Kafka is on the field, DoT dealt by all allies increases by 25%."
           }
         }
       },
@@ -2041,15 +2041,15 @@ interface Resources {
           },
           "e1DefShred": {
             "text": "E1 weakness break buffs",
-            "content": "E1: Lingsha's Weakness Break Efficiency increases by 50%. When an enemy unit's Weakness is Broken, reduces their DEF by 20%."
+            "content": "Lingsha's Weakness Break Efficiency increases by 50%. When an enemy unit's Weakness is Broken, reduces their DEF by 20%."
           },
           "e2BeBuff": {
             "text": "E2 BE buff",
-            "content": "E2: When using Ultimate, increases all allies' Break Effect by 40%."
+            "content": "When using Ultimate, increases all allies' Break Effect by 40%."
           },
           "e6ResShred": {
             "text": "E6 RES shred",
-            "content": "E6: While Fuyuan is on the field, reduces all Enemy units' All-Type RES by 20%."
+            "content": "While Fuyuan is on the field, reduces all Enemy units' All-Type RES by 20%."
           }
         }
       },
@@ -2069,11 +2069,11 @@ interface Resources {
           },
           "e1TargetBleeding": {
             "text": "E1 target bleeding",
-            "content": "E1: When Luka takes action, if the target enemy is Bleeding, increases DMG dealt by Luka by 15% for 2 turns."
+            "content": "When Luka takes action, if the target enemy is Bleeding, increases DMG dealt by Luka by 15% for 2 turns."
           },
           "e4TalentStacks": {
             "text": "E4 Talent stacks",
-            "content": "E4: For every stack of Fighting Will obtained, increases ATK by 5%, stacking up to 4 times."
+            "content": "For every stack of Fighting Will obtained, increases ATK by 5%, stacking up to 4 times."
           }
         }
       },
@@ -2081,11 +2081,11 @@ interface Resources {
         "Content": {
           "fieldActive": {
             "text": "Field active",
-            "content": "E1: While the Field is active, ATK of all allies increases by 20%."
+            "content": "While the Field is active, ATK of all allies increases by 20%."
           },
           "e6ResReduction": {
             "text": "E6 RES shred",
-            "content": "E6: When Ultimate is used, reduces all enemies' All-Type RES by 20% for 2 turns."
+            "content": "When Ultimate is used, reduces all enemies' All-Type RES by 20% for 2 turns."
           }
         }
       },
@@ -2127,11 +2127,11 @@ interface Resources {
           },
           "selfSpdBuff": {
             "text": "E1 SPD buff",
-            "content": "E1: When Shifu is on the field, increases March 7th's SPD by 10%."
+            "content": "When Shifu is on the field, increases March 7th's SPD by 10%."
           },
           "e6CdBuff": {
             "text": "E6 Basic CD boost",
-            "content": "E6: After using Ultimate, increases the CRIT DMG dealt by the next Enhanced Basic ATK by 50%."
+            "content": "After using Ultimate, increases the CRIT DMG dealt by the next Enhanced Basic ATK by 50%."
           }
         },
         "TeammateContent": {
@@ -2157,11 +2157,11 @@ interface Resources {
           },
           "e2DefReduction": {
             "text": "E2 DEF shred",
-            "content": "E2: Reduces the target's DEF by 16% for 3 turns."
+            "content": "Reduces the target's DEF by 16% for 3 turns."
           },
           "e6UltDmgBoost": {
             "text": "E6 Ult DMG boost",
-            "content": "E6: When using the Ultimate, increases own DMG by 30%, lasting until the end of the turn."
+            "content": "When using the Ultimate, increases own DMG by 30%, lasting until the end of the turn."
           }
         }
       },
@@ -2173,7 +2173,7 @@ interface Resources {
           },
           "e2CdBoost": {
             "text": "E2 CD boost",
-            "content": "E2: When all allies deal DMG to the enemy target marked as Prey, increases CRIT DMG by 40%."
+            "content": "When all allies deal DMG to the enemy target marked as Prey, increases CRIT DMG by 40%."
           },
           "e4DmgBuff": {
             "text": "E4 DMG buff",
@@ -2208,7 +2208,7 @@ interface Resources {
           },
           "e4SkillResShred": {
             "text": "E4 Skill Ice RES shred",
-            "content": "E4: When using Skill, there is a 100% base chance to reduce the target enemy's Ice RES by 12% for 2 turns."
+            "content": "When using Skill, there is a 100% base chance to reduce the target enemy's Ice RES by 12% for 2 turns."
           }
         }
       },
@@ -2324,11 +2324,11 @@ interface Resources {
           },
           "e2AtkBoost": {
             "text": "E2 weakness ATK boost",
-            "content": "E2: With Ruan Mei on the field, all allies increase their ATK by 40% when dealing DMG to enemies with Weakness Break."
+            "content": "With Ruan Mei on the field, all allies increase their ATK by 40% when dealing DMG to enemies with Weakness Break."
           },
           "e4BeBuff": {
             "text": "E4 BE buff",
-            "content": "E4: When an enemy target's Weakness is Broken, Ruan Mei's Break Effect increases by 100% for 3 turns."
+            "content": "When an enemy target's Weakness is Broken, Ruan Mei's Break Effect increases by 100% for 3 turns."
           }
         },
         "TeammateContent": {
@@ -2370,11 +2370,11 @@ interface Resources {
           },
           "e1EnemyHp80CrBoost": {
             "text": "E1 enemy HP ≤ 80% CR boost",
-            "content": "E1: When dealing DMG to an enemy whose HP percentage is 80% or lower, CRIT Rate increases by 15%."
+            "content": "When dealing DMG to an enemy whose HP percentage is 80% or lower, CRIT Rate increases by 15%."
           },
           "e6UltTargetDebuff": {
             "text": "E6 Butterfly Flurry",
-            "content": "E6: After Seele uses her Ultimate, inflict the target enemy with Butterfly Flurry for 1 turn. Enemies suffering from Butterfly Flurry will take Additional Quantum DMG equal to 15% of Seele's Ultimate DMG every time they are attacked."
+            "content": "After Seele uses her Ultimate, inflict the target enemy with Butterfly Flurry for 1 turn. Enemies suffering from Butterfly Flurry will take Additional Quantum DMG equal to 15% of Seele's Ultimate DMG every time they are attacked."
           }
         }
       },
@@ -2498,7 +2498,7 @@ interface Resources {
           },
           "e2DmgReductionBuff": {
             "text": "E2 DMG reduction buff",
-            "content": "E2: After triggering Sword Stance, the DMG taken by Sushang is reduced by 20% for 1 turn."
+            "content": "After triggering Sword Stance, the DMG taken by Sushang is reduced by 20% for 1 turn."
           }
         }
       },
@@ -2550,11 +2550,11 @@ interface Resources {
           },
           "ultDmgBuff": {
             "text": "Ult DMG buff",
-            "content": "Regenerates 50 Energy for a single ally and increases the target's DMG by {{ultDmgBoost}}% for 2 turns."
+            "content": "Regenerates 50 Energy for a single ally and increases the target's DMG by {{ultDmgBoost}}% for 2 turns.::BR::E6: Ultimate regenerates 10 more Energy for the target ally."
           },
           "ultSpdBuff": {
             "text": "E1 Ult SPD buff",
-            "content": "E1: After using their Ultimate, the ally with Benediction gains a 20% increase in SPD for 1 turn."
+            "content": "After using their Ultimate, the ally with Benediction gains a 20% increase in SPD for 1 turn."
           }
         },
         "TeammateContent": {
@@ -2576,7 +2576,7 @@ interface Resources {
           },
           "e1DebtorStacks": {
             "text": "E1 Debtor stacks",
-            "content": "E1: When enemies afflicted with Proof of Debt receive follow-up attacks, they will enter the Debtor state. This can take effect only once within a single action. The Debtor state increases the CRIT DMG of follow-up attacks inflicted on the target enemies by 25%, stacking up to 2 times. When Proof of Debt is removed, the Debtor state is also removed."
+            "content": "When enemies afflicted with Proof of Debt receive follow-up attacks, they will enter the Debtor state. This can take effect only once within a single action. The Debtor state increases the CRIT DMG of follow-up attacks inflicted on the target enemies by 25%, stacking up to 2 times. When Proof of Debt is removed, the Debtor state is also removed."
           }
         }
       },
@@ -2634,7 +2634,7 @@ interface Resources {
           },
           "e6DefStacks": {
             "text": "E6 DEF buff stacks",
-            "content": "E6: Increases DEF by 10% per stack."
+            "content": "Increases DEF by 10% per stack."
           }
         }
       },
@@ -2692,7 +2692,7 @@ interface Resources {
           },
           "e1EnhancedState": {
             "text": "E1 enhanced state",
-            "content": "E1: After Welt uses his Ultimate, his abilities are enhanced. The next 2 times he uses his Basic ATK or Skill, deals Additional DMG to the target equal to 50% of his Basic ATK's DMG multiplier or 80% of his Skill's DMG multiplier respectively."
+            "content": "After Welt uses his Ultimate, his abilities are enhanced. The next 2 times he uses his Basic ATK or Skill, deals Additional DMG to the target equal to 50% of his Basic ATK's DMG multiplier or 80% of his Skill's DMG multiplier respectively."
           }
         }
       },
@@ -2716,7 +2716,7 @@ interface Resources {
           },
           "e4BeBuff": {
             "text": "E4 BE buff",
-            "content": "E4: When using Ultimate, increases Break Effect by 40% for 2 turns."
+            "content": "When using Ultimate, increases Break Effect by 40% for 2 turns."
           }
         }
       },
@@ -2736,11 +2736,11 @@ interface Resources {
           },
           "e1TargetFrozen": {
             "text": "E1 enemy frozen",
-            "content": "E1: When Yanqing attacks a Frozen enemy, he deals Additional Ice DMG equal to 60% of his ATK."
+            "content": "When Yanqing attacks a Frozen enemy, he deals Additional Ice DMG equal to 60% of his ATK."
           },
           "e4CurrentHp80": {
             "text": "E4 self HP ≥ 80% RES PEN buff",
-            "content": "E4: When the current HP percentage is 80% or higher, Ice RES PEN increases by 12%."
+            "content": "When the current HP percentage is 80% or higher, Ice RES PEN increases by 12%."
           }
         }
       },
@@ -2760,7 +2760,7 @@ interface Resources {
           },
           "initialSpeedBuff": {
             "text": "E1 initial SPD buff",
-            "content": "E1: At the start of battle, increases the SPD of all allies by 10% for 2 turns."
+            "content": "At the start of battle, increases the SPD of all allies by 10% for 2 turns."
           }
         }
       },
@@ -2784,7 +2784,7 @@ interface Resources {
           },
           "e1UltBuff": {
             "text": "E1 Ult buff",
-            "content": "E1: Increases DMG dealt by Intuit: Slash and Intuit: Cull by 20%. Increases the number of additional DMG instances for Intuit: Cull by 3."
+            "content": "Increases DMG dealt by Intuit: Slash and Intuit: Cull by 20%. Increases the number of additional DMG instances for Intuit: Cull by 3."
           },
           "e2DefShred": {
             "text": "E2 FUA DEF PEN",


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Fixed conditional ocntent text being inconsistent in adding `E1`/`E2`/`E4`/`E6` prefixes for conditionals relating to the Eidolon alone

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

