### PR TITLE
refactor: warp tab cleanup, add 3.1 income options

### DIFF
--- a/src/lib/characterPreview/ShowcaseCustomizationSidebar.tsx
+++ b/src/lib/characterPreview/ShowcaseCustomizationSidebar.tsx
@@ -303,7 +303,7 @@ export const ShowcaseCustomizationSidebar = forwardRef<ShowcaseCustomizationSide
                   size='small'
                   controls={false}
                   style={{ width: '100%' }}
-                  value={nonZeroOrUndefined(window.store.getState().showcaseTemporaryOptions[characterId]?.spdBenchmark)}
+                  value={sanitizePositiveNumberElseUndefined(window.store.getState().showcaseTemporaryOptions[characterId]?.spdBenchmark)}
                   addonAfter={(
                     <SelectSpdPresets
                       spdFilter={simScoringResult?.originalSpd}
@@ -481,7 +481,7 @@ function clipboardClicked(elementId: string, action: string, setLoading: (b: boo
   }, 100)
 }
 
-function nonZeroOrUndefined(n?: number) {
+function sanitizePositiveNumberElseUndefined(n?: number) {
   return n == undefined || n < 0 ? undefined : n
 }
 

--- a/src/lib/tabs/tabHome/HomeTab.tsx
+++ b/src/lib/tabs/tabHome/HomeTab.tsx
@@ -1,6 +1,6 @@
 import { ExportOutlined, SearchOutlined } from '@ant-design/icons'
 import { RightOutlined } from '@ant-design/icons/lib/icons'
-import { Button, Card, Collapse, Divider, Flex, Input } from 'antd'
+import { Button, Card, Collapse, Divider, Flex, Input, InputRef, Space } from 'antd'
 import i18next from 'i18next'
 import { Languages } from 'lib/i18n/i18n'
 import { Message } from 'lib/interactions/message'
@@ -8,7 +8,7 @@ import { Assets } from 'lib/rendering/assets'
 import { AppPages } from 'lib/state/db.js'
 import { ColorizedLinkWithIcon } from 'lib/ui/ColorizedLink'
 import { TsUtils } from 'lib/utils/TsUtils'
-import React from 'react'
+import React, { useRef } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 
 const headerHeight = 900
@@ -281,6 +281,8 @@ function Header() {
 function SearchBar() {
   const scorerId = window.store((s) => s.scorerId)
   const { t } = useTranslation('hometab', { keyPrefix: 'SearchBar' })
+  const inputRef = useRef<InputRef>(null)
+
   return (
     <Flex
       vertical
@@ -299,28 +301,36 @@ function SearchBar() {
           <ColorizedLinkWithIcon text={t('Api') /* Uses Enka.Network */} noUnderline={true} url='https://enka.network/?hsr'/>
         </Flex>
       </Flex>
-      <Input.Search
-        placeholder={t('Placeholder')/* 'UID' */}
-        enterButton={(
-          <Flex gap={5} style={{ marginRight: 5 }}>
-            <SearchOutlined style={{ marginRight: 10 }}/> {t('Search')/* Search */}
-          </Flex>
-        )}
-        allowClear
-        size='large'
-        defaultValue={scorerId}
-        onSearch={(uuid: string, _event, info) => {
-          if (info?.source == 'clear') return
+      <Space.Compact style={{ width: '100%' }}>
+        <Button
+          size='large'
+          type='primary'
+          icon={<SearchOutlined/>}
+          style={{ width: 60 }}
+          onClick={() => {
+            const uuid = inputRef?.current?.input?.value
+            if (!uuid) return
 
-          const validated = TsUtils.validateUuid(uuid)
-          if (!validated) {
-            return Message.warning(t('Message')/* 'Invalid input - This should be your 9 digit ingame UUID' */)
-          }
+            const validated = TsUtils.validateUuid(uuid)
+            if (!validated) {
+              return Message.warning(t('Message')/* 'Invalid input - This should be your 9 digit ingame UUID' */)
+            }
 
-          window.history.pushState({}, '', `/hsr-optimizer#showcase?id=${uuid}`)
-          window.store.getState().setActiveKey(AppPages.SHOWCASE)
-        }}
-      />
+            window.history.pushState({}, '', `/hsr-optimizer#showcase?id=${uuid}`)
+            window.store.getState().setActiveKey(AppPages.SHOWCASE)
+          }}
+        />
+        <Input
+          ref={inputRef}
+          placeholder={t('Placeholder')/* 'UID' */}
+          style={{
+            width: '100%',
+          }}
+          allowClear
+          size='large'
+          defaultValue={scorerId}
+        />
+      </Space.Compact>
     </Flex>
   )
 }

--- a/src/lib/tabs/tabWarp/WarpCalculatorTab.tsx
+++ b/src/lib/tabs/tabWarp/WarpCalculatorTab.tsx
@@ -2,7 +2,16 @@ import { ThunderboltFilled } from '@ant-design/icons'
 import { Button, Card, Flex, Form, InputNumber, Radio, Select, SelectProps, Table, TableProps, Tag, Typography } from 'antd'
 import chroma from 'chroma-js'
 import { Assets } from 'lib/rendering/assets'
-import { DEFAULT_WARP_REQUEST, simulateWarps, WarpIncome, WarpIncomeValuesMapping, WarpMilestoneResult, WarpStrategy } from 'lib/tabs/tabWarp/warpCalculatorController'
+import {
+  DEFAULT_WARP_REQUEST,
+  NONE_WARP_INCOME_OPTION,
+  simulateWarps,
+  WarpIncomeDefinition,
+  WarpIncomeOptions,
+  WarpIncomeType,
+  WarpMilestoneResult,
+  WarpStrategy,
+} from 'lib/tabs/tabWarp/warpCalculatorController'
 import { VerticalDivider } from 'lib/ui/Dividers'
 import { HeaderText } from 'lib/ui/HeaderText'
 import { Utils } from 'lib/utils/utils'
@@ -20,7 +29,9 @@ export default function WarpCalculatorTab(): React.JSX.Element {
           Warp Planner
         </pre>
       </Flex>
+
       <Inputs/>
+
       <Results/>
     </Flex>
   )
@@ -31,6 +42,9 @@ function Inputs() {
   const [form] = Form.useForm()
 
   const initialValues = useMemo(() => {
+    if (!WarpIncomeOptions.find(option => option.id == warpRequest.income)) {
+      warpRequest.income = NONE_WARP_INCOME_OPTION.id
+    }
     return Object.assign({}, DEFAULT_WARP_REQUEST, warpRequest)
   }, [])
 
@@ -299,21 +313,30 @@ function PityInputs(props: { banner: string }) {
 }
 
 function generateIncomeOptions() {
-  const options: SelectProps['options'] = Object.entries(WarpIncomeValuesMapping).map(([incomeType, values]) => ({
-    value: incomeType,
-    label: incomeType == WarpIncome.NONE
+  const options: SelectProps['options'] = WarpIncomeOptions.map((option) => ({
+    value: option.id,
+    label: option.type == WarpIncomeType.NONE
       ? 'None'
       : (
-        <Flex align='center' gap={5}>
-          {`[${values.label}] +${values.passes}`}
+        <Flex align='center' gap={3}>
+          <IncomeOptionLabel option={option}/>
+          {`+${option.passes.toLocaleString()}`}
           <img style={{ height: 18 }} src={Assets.getPass()}/>
-          {`+${values.jades.toLocaleString()}`}
+          {`+${option.jades.toLocaleString()}`}
           <img style={{ height: 18 }} src={Assets.getJade()}/>
         </Flex>
       ),
   }))
 
   return options
+}
+
+function IncomeOptionLabel(props: { option: WarpIncomeDefinition }) {
+  return (
+    <div style={{ marginRight: 2 }}>
+      {`[v${props.option.version} ${props.option.type}]: `}
+    </div>
+  )
 }
 
 function generateStrategyOptions() {

--- a/src/lib/tabs/tabWarp/WarpCalculatorTab.tsx
+++ b/src/lib/tabs/tabWarp/WarpCalculatorTab.tsx
@@ -156,13 +156,13 @@ function Results() {
 
   const columns: TableProps<WarpMilestoneResult>['columns'] = [
     {
-      title: 'Target',
+      title: 'Goal',
       dataIndex: 'key',
       key: 'key',
       align: 'center',
       width: 200,
       render: (key: string, record: WarpMilestoneResult) => (
-        <Flex style={{ position: 'relative', marginLeft: 5, marginRight: 5, height: '100%' }} align='center'>
+        <Flex style={{ position: 'relative', marginLeft: 5, height: '100%' }} align='center'>
           <div
             style={{
               display: record.wins < chanceThreshold ? 'none' : 'block',
@@ -170,7 +170,7 @@ function Results() {
               borderRadius: 4,
               position: 'absolute',
               height: '100%',
-              backgroundColor: chroma.scale(['rgba(216,109,109,0.87)', '#f7f65ade', '#91db60de']).domain([0, 0.75, 1])(record.wins).hex(),
+              backgroundColor: chroma.scale(['#df524bcc', '#efe959cc', '#89d86dcc']).domain([0, 0.33, 1])(record.wins).hex(),
               zIndex: 1,
             }}
           />
@@ -187,8 +187,8 @@ function Results() {
     },
     {
       title: (
-        <Flex justify='center' align='center' gap={2}>
-          {`Success probability with ${warpResult.request.warps.toLocaleString()}`}
+        <Flex justify='center' align='center' gap={5}>
+          {`Success chance with ${warpResult.request.warps.toLocaleString()}`}
           <img style={{ height: 18 }} src={Assets.getPass()}/>
         </Flex>
       ),
@@ -198,7 +198,14 @@ function Results() {
       render: (n: number) => `${Utils.truncate10ths(n * 100).toFixed(1)}%`,
     },
     {
-      title: 'Average # of warps required',
+      // title: 'Average # of warps required',
+      title: (
+        <Flex justify='center' align='center' gap={5}>
+          {`Average # of`}
+          <img style={{ height: 18 }} src={Assets.getPass()}/>
+          {`required`}
+        </Flex>
+      ),
       dataIndex: 'warps',
       align: 'center',
       width: 250,
@@ -225,6 +232,7 @@ function Results() {
         <pre style={{ margin: 0 }}>
           <Flex align='center' gap={5}>
             <span>{'Total warps available:'}</span>
+
             {`( ${warpResult.request.totalJade.toLocaleString()}`}
             <img style={{ height: 18 }} src={Assets.getJade()}/>
             <span>{') + ('}</span>
@@ -239,7 +247,7 @@ function Results() {
 
       <Flex vertical gap={10} style={{ width: '100%' }}>
         <Table<WarpMilestoneResult>
-          style={{ width: '100%' }} s
+          style={{ width: '100%' }}
           columns={columns}
           dataSource={warpTableData}
           pagination={false}

--- a/src/lib/tabs/tabWarp/warpCalculatorController.ts
+++ b/src/lib/tabs/tabWarp/warpCalculatorController.ts
@@ -14,6 +14,9 @@ export enum WarpIncome {
   F2P_3_0 = 'F2P_3_0',
   EXPRESS_3_0 = 'EXPRESS_3_0',
   EXPRESS_BP_3_0 = 'EXPRESS_BP_3_0',
+  F2P_3_1 = 'F2P_3_1',
+  EXPRESS_3_1 = 'EXPRESS_3_1',
+  EXPRESS_BP_3_1 = 'EXPRESS_BP_3_1',
 }
 
 export const WarpIncomeValuesMapping: Record<WarpIncome, WarpIncomeValues> = {
@@ -36,6 +39,21 @@ export const WarpIncomeValuesMapping: Record<WarpIncome, WarpIncomeValues> = {
     passes: 29,
     jades: 17950,
     label: 'v3.0 Express & BP',
+  },
+  [WarpIncome.F2P_3_1]: {
+    passes: 20,
+    jades: 13355,
+    label: 'v3.1 F2P',
+  },
+  [WarpIncome.EXPRESS_3_1]: {
+    passes: 20,
+    jades: 17135,
+    label: 'v3.1 Express',
+  },
+  [WarpIncome.EXPRESS_BP_3_1]: {
+    passes: 24,
+    jades: 17815,
+    label: 'v3.1 Express & BP',
   },
 }
 

--- a/src/lib/tabs/tabWarp/warpCalculatorController.ts
+++ b/src/lib/tabs/tabWarp/warpCalculatorController.ts
@@ -1,61 +1,35 @@
 import { SaveState } from 'lib/state/saveState'
 import { characterCumulative, characterDistribution, lightConeCumulative, lightConeDistribution } from 'lib/tabs/tabWarp/warpRates'
 
-// 626 to e6 and 960 to e6s5, 952 with 0.78125 on lc
+// Notes: 626 to e6 and 960 to e6s5, 952 with 0.78125 on lc
 
 const characterWarpCap = 90
 const lightConeWarpCap = 80
 const simulations = 100000
 const character5050 = 0.5625
-const lightCone5050 = 0.78125 // 0.78125 or 0.75
+const lightCone5050 = 0.78125
 
-export enum WarpIncome {
-  NONE = 'NONE',
-  F2P_3_0 = 'F2P_3_0',
-  EXPRESS_3_0 = 'EXPRESS_3_0',
-  EXPRESS_BP_3_0 = 'EXPRESS_BP_3_0',
-  F2P_3_1 = 'F2P_3_1',
-  EXPRESS_3_1 = 'EXPRESS_3_1',
-  EXPRESS_BP_3_1 = 'EXPRESS_BP_3_1',
+export enum WarpIncomeType {
+  NONE = 'None',
+  F2P = 'F2P',
+  EXPRESS = 'Express',
+  BP_EXPRESS = 'BP & Express'
 }
 
-export const WarpIncomeValuesMapping: Record<WarpIncome, WarpIncomeValues> = {
-  [WarpIncome.NONE]: {
-    passes: 0,
-    jades: 0,
-    label: 'None',
-  },
-  [WarpIncome.F2P_3_0]: {
-    passes: 25,
-    jades: 13490,
-    label: 'v3.0 F2P',
-  },
-  [WarpIncome.EXPRESS_3_0]: {
-    passes: 25,
-    jades: 17270,
-    label: 'v3.0 Express',
-  },
-  [WarpIncome.EXPRESS_BP_3_0]: {
-    passes: 29,
-    jades: 17950,
-    label: 'v3.0 Express & BP',
-  },
-  [WarpIncome.F2P_3_1]: {
-    passes: 20,
-    jades: 13355,
-    label: 'v3.1 F2P',
-  },
-  [WarpIncome.EXPRESS_3_1]: {
-    passes: 20,
-    jades: 17135,
-    label: 'v3.1 Express',
-  },
-  [WarpIncome.EXPRESS_BP_3_1]: {
-    passes: 24,
-    jades: 17815,
-    label: 'v3.1 Express & BP',
-  },
-}
+export const NONE_WARP_INCOME_OPTION = generateOption('NONE', WarpIncomeType.NONE, 0, 0)
+
+// Modified each patch
+export const WarpIncomeOptions: WarpIncomeDefinition[] = [
+  NONE_WARP_INCOME_OPTION,
+
+  generateOption('3.0', WarpIncomeType.F2P, 25, 13490),
+  generateOption('3.0', WarpIncomeType.EXPRESS, 25, 17270),
+  generateOption('3.0', WarpIncomeType.BP_EXPRESS, 29, 17950),
+
+  generateOption('3.1', WarpIncomeType.F2P, 20, 13355),
+  generateOption('3.1', WarpIncomeType.EXPRESS, 20, 17135),
+  generateOption('3.1', WarpIncomeType.BP_EXPRESS, 24, 17815),
+]
 
 export enum WarpStrategy {
   E0 = 0, // E0 -> S1 -> E6 -> S5
@@ -71,7 +45,7 @@ export enum WarpStrategy {
 export type WarpRequest = {
   passes: number
   jades: number
-  income: WarpIncome
+  income: string
   strategy: WarpStrategy
   pityCharacter: number
   guaranteedCharacter: false
@@ -93,7 +67,7 @@ export enum WarpType {
 export const DEFAULT_WARP_REQUEST: WarpRequest = {
   passes: 0,
   jades: 0,
-  income: WarpIncome.NONE,
+  income: NONE_WARP_INCOME_OPTION.id,
   strategy: WarpStrategy.E0,
   pityCharacter: 0,
   guaranteedCharacter: false,
@@ -101,10 +75,12 @@ export const DEFAULT_WARP_REQUEST: WarpRequest = {
   guaranteedLightCone: false,
 }
 
-type WarpIncomeValues = {
+export type WarpIncomeDefinition = {
   passes: number
   jades: number
-  label: string
+  id: string
+  version: string
+  type: WarpIncomeType
 }
 
 type WarpMilestone = {
@@ -114,6 +90,20 @@ type WarpMilestone = {
   guaranteed: boolean
   redistributedCumulative: number[]
   warpCap: number
+}
+
+function generateOption(version: string, type: WarpIncomeType, passes: number, jades: number) {
+  return {
+    passes,
+    jades,
+    version,
+    type,
+    id: generateOptionKey(version, type),
+  }
+}
+
+function generateOptionKey(version: string, type: WarpIncomeType) {
+  return `${version}/${type}`
 }
 
 export function simulateWarps(originalRequest: WarpRequest) {
@@ -160,12 +150,7 @@ export function simulateWarps(originalRequest: WarpRequest) {
   for (const milestone of milestones) {
     milestoneResults[milestone.label].warps /= simulations
     milestoneResults[milestone.label].wins /= simulations
-    // console.log(`${milestone.label}: ${milestoneResults[milestone.label].warps}`)
   }
-
-  // for (const milestone of milestones) {
-  //   console.log(`${milestone.label}: ${milestoneResults[milestone.label].wins}`)
-  // }
 
   const warpResult: WarpResult = {
     milestoneResults: milestoneResults,
@@ -263,7 +248,7 @@ export type EnrichedWarpRequest = {
 } & WarpRequest
 
 function enrichWarpRequest(request: WarpRequest) {
-  const additionalIncome = WarpIncomeValuesMapping[request.income] ?? WarpIncomeValuesMapping[WarpIncome.NONE]
+  const additionalIncome = WarpIncomeOptions.find(option => option.id == request.income) ?? NONE_WARP_INCOME_OPTION
   const totalJade = request.jades + additionalIncome.jades
   const totalPasses = request.passes + additionalIncome.passes
   const totalWarps = Math.floor(totalJade / 160) + totalPasses

--- a/src/lib/utils/colorUtils.ts
+++ b/src/lib/utils/colorUtils.ts
@@ -32,7 +32,7 @@ export function darkModeModifier(color: Color, darkMode: boolean) {
 }
 
 export function showcaseCardBorderColor(color: string, darkMode: boolean) {
-  const finalColor = chroma(color).desaturate(0.5).luminance(0.1).brighten(0.9).alpha(0.7)
+  const finalColor = chroma(color).desaturate(0.7).luminance(0.1).brighten(0.9).alpha(0.7)
   return darkModeModifier(finalColor, darkMode).css()
 }
 

--- a/src/style/style.css
+++ b/src/style/style.css
@@ -664,7 +664,7 @@ a {
 
 .warp-table-row .ant-table-cell {
     height: 45px !important;
-    padding: 0px !important;
+    padding: 0 !important;
     padding-top: 6px !important;
     padding-bottom: 6px !important;
     font-size: 16px !important;


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Making it easier to update the income options, adding 3.1 income
* Home tab Search bar swap
![image](https://github.com/user-attachments/assets/9fb0eda8-d9e2-4764-bf17-5312a7ea9708)


## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

