### PR TITLE
hotfix: Aglaea speed stacks increments at E5 instead of E4

### DIFF
--- a/src/lib/conditionals/character/1400/Aglaea.ts
+++ b/src/lib/conditionals/character/1400/Aglaea.ts
@@ -27,7 +27,7 @@ export default (e: Eidolon, withContent: boolean): CharacterConditionalsControll
   const memoSkillScaling = memoSkill(e, 1.10, 1.21)
   const memoTalentSpd = memoTalent(e, 55, 57.2)
 
-  const memoSpdStacksMax = e > 4 ? 7 : 6
+  const memoSpdStacksMax = e >= 4 ? 7 : 6
 
   const defaults = {
     buffPriority: BUFF_PRIORITY_SELF,


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Fixed Aglaea speed stack limit to increment at E4 instead of E5

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

