### PR TITLE
feat: delay and memoize showcase analysis for faster card render

### DIFF
--- a/src/hooks/useDelayedProps.ts
+++ b/src/hooks/useDelayedProps.ts
@@ -1,0 +1,16 @@
+import { useEffect, useState } from 'react'
+
+// Delays rendering a component for performance, useful to memoize heavy component renders
+export function useDelayedProps<T>(props: T, delay = 100) {
+  const [delayedProps, setDelayedProps] = useState<T | null>(null)
+
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      setDelayedProps(props)
+    }, delay)
+
+    return () => clearTimeout(timeout)
+  }, [props, delay])
+
+  return delayedProps
+}

--- a/src/lib/characterPreview/CharacterPreview.tsx
+++ b/src/lib/characterPreview/CharacterPreview.tsx
@@ -15,7 +15,7 @@ import {
   showcaseOnEditPortraitOk,
 } from 'lib/characterPreview/characterPreviewController'
 import { CharacterStatSummary } from 'lib/characterPreview/CharacterStatSummary'
-import { MemoizedShowcaseBuildAnalysis } from 'lib/characterPreview/ShowcaseBuildAnalysis'
+import { ShowcaseBuildAnalysis } from 'lib/characterPreview/ShowcaseBuildAnalysis'
 import { ShowcaseCharacterHeader } from 'lib/characterPreview/ShowcaseCharacterHeader'
 import { DEFAULT_SHOWCASE_COLOR } from 'lib/characterPreview/showcaseCustomizationController'
 import ShowcaseCustomizationSidebar, {
@@ -403,7 +403,7 @@ export function CharacterPreview(props: {
       {/* Showcase analysis footer */}
       {source != ShowcaseSource.BUILDS_MODAL
       && (
-        <MemoizedShowcaseBuildAnalysis
+        <ShowcaseBuildAnalysis
           token={token}
           simScoringResult={simScoringResult!}
           combatScoreDetails={combatScoreDetails}

--- a/src/lib/characterPreview/CharacterPreviewComponents.tsx
+++ b/src/lib/characterPreview/CharacterPreviewComponents.tsx
@@ -22,8 +22,8 @@ function isMobileOrSafari() {
 }
 
 // Mobile/Safari shadows don't render correctly on the Y axis
-export const showcaseShadow = isMobileOrSafari() ? 'rgb(0, 0, 0) 1px 0px 6px' : 'rgb(0, 0, 0) 1px 1px 6px'
-export const showcaseShadowInsetAddition = ', inset rgb(255 255 255 / 15%) 0px 0px 2px'
+export const showcaseShadow = isMobileOrSafari() ? 'rgb(0, 0, 0) 1px 0px 6px' : 'rgb(0, 0, 0) 1px 1px 7px'
+export const showcaseShadowInsetAddition = ', inset rgb(255 255 255 / 25%) 0px 0px 2px'
 export const showcaseOutlineLight = 'rgba(255, 255, 255, 0.20) solid 1px'
 export const showcaseOutline = 'rgba(255, 255, 255, 0.40) solid 1px'
 export const showcaseBackdropFilter = 'blur(3px)'

--- a/src/lib/characterPreview/ShowcaseBuildAnalysis.tsx
+++ b/src/lib/characterPreview/ShowcaseBuildAnalysis.tsx
@@ -1,13 +1,13 @@
 import { Flex, Segmented, Typography } from 'antd'
 import type { GlobalToken } from 'antd/es/theme/interface'
+import { useDelayedProps } from 'hooks/useDelayedProps'
 import { ShowcaseMetadata } from 'lib/characterPreview/characterPreviewController'
 import { CharacterScoringSummary } from 'lib/characterPreview/CharacterScoringSummary'
 import { CHARACTER_SCORE, COMBAT_STATS, DAMAGE_UPGRADES, NONE_SCORE, SIMULATION_SCORE } from 'lib/constants/constants'
 import { SavedSessionKeys } from 'lib/constants/constantsSession'
 import { SimulationScore } from 'lib/scoring/simScoringUtils'
 import { SaveState } from 'lib/state/saveState'
-import { TsUtils } from 'lib/utils/TsUtils'
-import React from 'react'
+import React, { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
 const { Text } = Typography
@@ -22,22 +22,26 @@ interface ShowcaseBuildAnalysisProps {
   setCombatScoreDetails: (s: string) => void
 }
 
-// !! NOTE - Props are manually memoized for performance, remember to update the comparator
-// Currently the memo doesn't actually help if the component is unmounted
 export function ShowcaseBuildAnalysis(props: ShowcaseBuildAnalysisProps) {
   const { t } = useTranslation(['charactersTab', 'modals', 'common'])
+  const delayedProps = useDelayedProps(props, 250)
+
+  const memoizedCharacterScoringSummary = useMemo(() => {
+    return delayedProps ? <CharacterScoringSummary simScoringResult={delayedProps.simScoringResult}/> : null
+  }, [delayedProps])
+
+  if (!delayedProps) return null
 
   console.log('======================================================================= RENDER ShowcaseBuildAnalysis')
 
   const {
     token,
-    simScoringResult,
     combatScoreDetails,
     showcaseMetadata,
     scoringType,
     setScoringType,
     setCombatScoreDetails,
-  } = props
+  } = delayedProps
 
   const {
     characterMetadata,
@@ -132,25 +136,7 @@ export function ShowcaseBuildAnalysis(props: ShowcaseBuildAnalysisProps) {
           />
         </Flex>
       </Flex>
-      <CharacterScoringSummary simScoringResult={simScoringResult}/>
+      {memoizedCharacterScoringSummary}
     </Flex>
   )
 }
-
-const arePropsEqual = (
-  prevProps: ShowcaseBuildAnalysisProps,
-  nextProps: ShowcaseBuildAnalysisProps,
-): boolean => {
-  return (
-    prevProps.token === nextProps.token &&
-    prevProps.scoringType === nextProps.scoringType &&
-    prevProps.combatScoreDetails === nextProps.combatScoreDetails &&
-    TsUtils.objectHash(prevProps.simScoringResult) === TsUtils.objectHash(nextProps.simScoringResult) &&
-    TsUtils.objectHash(prevProps.showcaseMetadata) === TsUtils.objectHash(nextProps.showcaseMetadata)
-  )
-}
-
-export const MemoizedShowcaseBuildAnalysis = React.memo(
-  ShowcaseBuildAnalysis,
-  arePropsEqual,
-)

--- a/src/lib/characterPreview/ShowcaseBuildAnalysis.tsx
+++ b/src/lib/characterPreview/ShowcaseBuildAnalysis.tsx
@@ -24,13 +24,6 @@ interface ShowcaseBuildAnalysisProps {
 
 export function ShowcaseBuildAnalysis(props: ShowcaseBuildAnalysisProps) {
   const { t } = useTranslation(['charactersTab', 'modals', 'common'])
-  const delayedProps = useDelayedProps(props, 250)
-
-  const memoizedCharacterScoringSummary = useMemo(() => {
-    return delayedProps ? <CharacterScoringSummary simScoringResult={delayedProps.simScoringResult}/> : null
-  }, [delayedProps])
-
-  if (!delayedProps) return null
 
   console.log('======================================================================= RENDER ShowcaseBuildAnalysis')
 
@@ -41,7 +34,7 @@ export function ShowcaseBuildAnalysis(props: ShowcaseBuildAnalysisProps) {
     scoringType,
     setScoringType,
     setCombatScoreDetails,
-  } = delayedProps
+  } = props
 
   const {
     characterMetadata,
@@ -136,7 +129,18 @@ export function ShowcaseBuildAnalysis(props: ShowcaseBuildAnalysisProps) {
           />
         </Flex>
       </Flex>
-      {memoizedCharacterScoringSummary}
+      <MemoizedCharacterScoringSummary simScoringResult={props.simScoringResult}/>
     </Flex>
   )
+}
+
+function MemoizedCharacterScoringSummary(props: { simScoringResult?: SimulationScore }) {
+  const delayedProps = useDelayedProps(props, 150)
+
+  const memoizedCharacterScoringSummary = useMemo(() => {
+    return delayedProps ? <CharacterScoringSummary simScoringResult={delayedProps.simScoringResult}/> : null
+  }, [delayedProps])
+
+  if (!delayedProps) return null
+  return memoizedCharacterScoringSummary
 }

--- a/src/lib/tabs/tabRelics/RelicPreview.tsx
+++ b/src/lib/tabs/tabRelics/RelicPreview.tsx
@@ -1,7 +1,9 @@
 import { Card, Divider, Flex } from 'antd'
+import i18next from 'i18next'
 import { showcaseShadow, showcaseShadowInsetAddition, ShowcaseSource } from 'lib/characterPreview/CharacterPreviewComponents'
 import { NONE_SCORE } from 'lib/constants/constants'
 import { iconSize } from 'lib/constants/constantsUi'
+import { Languages } from 'lib/i18n/i18n'
 import { RelicScoringResult } from 'lib/relics/relicScorerPotential'
 import { Assets } from 'lib/rendering/assets'
 
@@ -92,59 +94,55 @@ export function RelicPreview(props: {
         boxShadow: source == null ? undefined : showcaseShadow + showcaseShadowInsetAddition,
       }}
     >
-      <Flex
-        vertical
-        justify={JUSTIFY}
-        style={{
-          height: 255,
-        }}
-      >
-        <Flex justify='space-between' align='center'>
-          <img
-            style={{
-              height: ICON_SIZE,
-              width: ICON_SIZE,
-            }}
-            title={relic.set}
-            src={relicSrc}
-          />
-          <Flex vertical align='center'>
-            <Flex align='center' gap={5}>
-              {Renderer.renderGrade(relic)}
-              <Flex style={{ width: 30 }} justify='space-around'>
-                <RelicStatText>
-                  {relic.id != undefined ? `+${relic.enhance}` : ''}
-                </RelicStatText>
-              </Flex>
+      <RelicStatText language={i18next.resolvedLanguage as Languages}>
+        <Flex
+          vertical
+          justify={JUSTIFY}
+          style={{
+            height: 255,
+          }}
+        >
+          <Flex justify='space-between' align='center'>
+            <img
+              style={{
+                height: ICON_SIZE,
+                width: ICON_SIZE,
+              }}
+              title={relic.set}
+              src={relicSrc}
+            />
+            <Flex align='center' gap={8}>
+              <span>{Renderer.renderGrade(relic)}</span>
+              <span>{relic.id != undefined ? `+${relic.enhance}` : ''}</span>
             </Flex>
+            <img
+              style={{
+                height: ICON_SIZE,
+                width: ICON_SIZE,
+                borderRadius: ICON_SIZE / 2,
+                outline: relic.equippedBy ? '1px solid rgba(150, 150, 150, 0.25)' : undefined,
+                backgroundColor: relic.equippedBy ? 'rgba(0, 0, 0, 0.1)' : undefined,
+              }}
+              src={equippedBySrc}
+            />
           </Flex>
-          <img
-            style={{
-              height: ICON_SIZE,
-              width: ICON_SIZE,
-              borderRadius: ICON_SIZE / 2,
-              outline: relic.equippedBy ? '1px solid rgba(150, 150, 150, 0.25)' : undefined,
-              backgroundColor: relic.equippedBy ? 'rgba(0, 0, 0, 0.1)' : undefined,
-            }}
-            src={equippedBySrc}
-          />
+
+          <Divider style={{ margin: '6px 0px 6px 0px' }}/>
+
+          {GenerateStat(relic.main as SubstatDetails, true, relic)}
+
+          <Divider style={{ margin: '6px 0px 6px 0px' }}/>
+
+          <Flex vertical gap={STAT_GAP}>
+            {GenerateStat(relic.substats[0], false, relic)}
+            {GenerateStat(relic.substats[1], false, relic)}
+            {GenerateStat(relic.substats[2], false, relic)}
+            {GenerateStat(relic.substats[3], false, relic)}
+          </Flex>
+
+          {scoringType != NONE_SCORE && <ScoreFooter score={score}/>}
         </Flex>
-
-        <Divider style={{ margin: '6px 0px 6px 0px' }}/>
-
-        {GenerateStat(relic.main as SubstatDetails, true, relic)}
-
-        <Divider style={{ margin: '6px 0px 6px 0px' }}/>
-
-        <Flex vertical gap={STAT_GAP}>
-          {GenerateStat(relic.substats[0], false, relic)}
-          {GenerateStat(relic.substats[1], false, relic)}
-          {GenerateStat(relic.substats[2], false, relic)}
-          {GenerateStat(relic.substats[3], false, relic)}
-        </Flex>
-
-        {scoringType != NONE_SCORE && <ScoreFooter score={score}/>}
-      </Flex>
+      </RelicStatText>
     </Card>
   )
 }
@@ -178,13 +176,9 @@ function ScoreFooter(props: { score?: RelicScoringResult }) {
       <Flex justify='space-between'>
         <Flex>
           <img src={icon} style={{ width: iconSize, height: iconSize, marginRight: 2, marginLeft: -3 }}></img>
-          <RelicStatText>
-            {(scored) ? `${t('Score')}${asterisk ? ' *' : ''}` : ''}
-          </RelicStatText>
+          {(scored) ? `${t('Score')}${asterisk ? ' *' : ''}` : ''}
         </Flex>
-        <RelicStatText>
-          {(scored) ? `${score.score} (${score.rating})` : ''}
-        </RelicStatText>
+        {(scored) ? `${score.score} (${score.rating})` : ''}
       </Flex>
     </>
   )

--- a/src/lib/tabs/tabRelics/relicPreview/GenerateStat.tsx
+++ b/src/lib/tabs/tabRelics/relicPreview/GenerateStat.tsx
@@ -1,12 +1,9 @@
 import { Flex } from 'antd'
-import i18next from 'i18next'
 import { RightIcon } from 'icons/RightIcon'
 import { SubStats } from 'lib/constants/constants'
 import { iconSize } from 'lib/constants/constantsUi'
-import { Languages } from 'lib/i18n/i18n'
 import { Assets } from 'lib/rendering/assets'
 import { Renderer } from 'lib/rendering/renderer'
-import RelicStatText from 'lib/tabs/tabRelics/relicPreview/RelicStatText'
 import { Utils } from 'lib/utils/utils'
 import { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -22,17 +19,7 @@ export type SubstatDetails = {
 export const GenerateStat = (stat: SubstatDetails, main: boolean, relic: Relic) => {
   const { t } = useTranslation('common')
   if (!stat?.stat || stat.value == null) {
-    return (
-      <Flex justify='space-between'>
-        <Flex>
-          <img
-            src={Assets.getBlank()}
-            style={{ width: iconSize, height: iconSize, marginRight: 2, marginLeft: -3 }}
-          >
-          </img>
-        </Flex>
-      </Flex>
-    )
+    return <></>
   }
 
   let displayValue
@@ -51,22 +38,18 @@ export const GenerateStat = (stat: SubstatDetails, main: boolean, relic: Relic) 
           style={{ width: iconSize, height: iconSize, marginRight: 2, marginLeft: -3 }}
         >
         </img>
-        <RelicStatText language={i18next.resolvedLanguage as Languages}>{t(`ReadableStats.${stat.stat}`)}</RelicStatText>
+        {t(`ReadableStats.${stat.stat}`)}
       </Flex>
       {!main
         ? (
-          // <Tooltip title={`Roll quality: ${RelicRollGrader.calculateStatSum(stat.rolls)}%`}>
           <Flex justify='space-between' style={{ width: '41.5%' }}>
             <Flex gap={0} align='center'>
               {stat.addedRolls != null && generateRolls(stat)}
             </Flex>
-            <RelicStatText>{displayValue}</RelicStatText>
+            {displayValue}
           </Flex>
-          // </Tooltip>
         )
-        : (
-          <RelicStatText>{displayValue}</RelicStatText>
-        )}
+        : <>{displayValue}</>}
     </Flex>
   )
 }


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Added a useDelayedProps hook
* Delaying render of showcase analysis so the card goes faster
* Cleaning up the broken showcase memo logic
* Remove redundant Text tags

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

