### PR TITLE
fix: translation tweaks

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,10 +37,6 @@ const App = () => {
     checkForUpdatesNotification(DB.getState().version)
   }, [])
 
-  useEffect(() => {
-    console.log('setting language to:', i18n.resolvedLanguage)
-  }, [i18n.resolvedLanguage])
-
   return (
     <ConfigProvider theme={globalThemeConfig}>
       {messageContextHolder}

--- a/src/lib/characterPreview/BuffsAnalysisDisplay.tsx
+++ b/src/lib/characterPreview/BuffsAnalysisDisplay.tsx
@@ -136,7 +136,7 @@ function BuffTag(props: { buff: Buff; size: BuffDisplaySize }) {
       <Flex justify='space-between' style={{ width: size }}>
         <Flex gap={3} style={{ minWidth: 70 }}>
           <span>
-            {`${(percent ? TsUtils.precisionRound(buff.value * 100, 2) : TsUtils.precisionRound(buff.value, 0)).toLocaleString(currentLocale())}`}
+            {`${(percent ? TsUtils.precisionRound(buff.value * 100, 2) : TsUtils.precisionRound(buff.value, 0)).toLocaleString(currentLocale(), { useGrouping: false })}`}
           </span>
           <span>
             {`${percent ? '%' : ''}`}

--- a/src/lib/characterPreview/CharacterScoringSummary.tsx
+++ b/src/lib/characterPreview/CharacterScoringSummary.tsx
@@ -20,6 +20,7 @@ import { ColorizedLinkWithIcon } from 'lib/ui/ColorizedLink'
 import { VerticalDivider } from 'lib/ui/Dividers'
 import { HeaderText } from 'lib/ui/HeaderText'
 import { filterUnique } from 'lib/utils/arrayUtils'
+import { numberToLocaleString } from 'lib/utils/i18nUtils'
 import { TsUtils } from 'lib/utils/TsUtils'
 import { Utils } from 'lib/utils/utils'
 import React, { ReactElement } from 'react'
@@ -73,6 +74,7 @@ export const CharacterScoringSummary = (props: {
     label: string
     number?: number
     precision?: number
+    useGrouping?: boolean
   }) {
     const precision = props.precision ?? 1
     const value = props.number ?? 0
@@ -80,7 +82,7 @@ export const CharacterScoringSummary = (props: {
     return (
       <Flex gap={15} justify='space-between'>
         <pre style={{ margin: 0 }}>{props.label}</pre>
-        <pre style={{ margin: 0, textAlign: 'right' }}>{show && value.toFixed(precision)}</pre>
+        <pre style={{ margin: 0, textAlign: 'right' }}>{show && numberToLocaleString(value, precision, props.useGrouping)}</pre>
       </Flex>
     )
   }
@@ -101,9 +103,9 @@ export const CharacterScoringSummary = (props: {
       <Flex gap={5} justify='space-between'>
         <pre style={{ margin: 0 }}>{props.label}</pre>
         <pre style={{ margin: 0, textAlign: 'right' }}>
-          {show && value.toFixed(precision)}
+          {show && numberToLocaleString(value, precision)}
           {showParens && <span style={{ margin: 3 }}>-</span>}
-          {showParens && `${parens.toFixed(1)}`}
+          {showParens && numberToLocaleString(parens, 1)}
         </pre>
       </Flex>
     )
@@ -174,16 +176,16 @@ export const CharacterScoringSummary = (props: {
               margin: 0,
               width: 200,
             }}
-          >{`+1x ${t('CharacterPreview.SubstatUpgradeComparisons.Roll')}: ${t(`common:ShortStats.${upgradeStat as SubStats}`)} +${rollValue.toFixed(1)}${suffix}`}
+          >{`+1x ${t('CharacterPreview.SubstatUpgradeComparisons.Roll')}: ${t(`common:ShortStats.${upgradeStat as SubStats}`)} +${numberToLocaleString(rollValue, 1)}${suffix}`}
           </pre>
           <pre style={{ margin: 0, width: 250 }}>
-            {`${t('common:Score')}: +${((upgradePercent - basePercent) * 100).toFixed(2)}% -> ${(statUpgrade.percent! * 100).toFixed(2)}%`}
+            {`${t('common:Score')}: +${numberToLocaleString((upgradePercent - basePercent) * 100, 2)}% -> ${numberToLocaleString(statUpgrade.percent! * 100, 2)}%`}
           </pre>
           <pre style={{ margin: 0, width: 300 }}>
-            {`${t('CharacterPreview.SubstatUpgradeComparisons.Damage')}: +${(upgradeSimScore - originalScore).toFixed(1)} -> ${upgradeSimScore.toFixed(1)}`}
+            {`${t('CharacterPreview.SubstatUpgradeComparisons.Damage')}: +${numberToLocaleString(upgradeSimScore - originalScore, 1)} -> ${numberToLocaleString(upgradeSimScore, 1)}`}
           </pre>
           <pre style={{ margin: 0, width: 150 }}>
-            {`${t('CharacterPreview.SubstatUpgradeComparisons.Damage')} %: +${((upgradeSimScore - originalScore) / originalScore * 100).toFixed(3)}%`}
+            {`${t('CharacterPreview.SubstatUpgradeComparisons.Damage')} %: +${numberToLocaleString((upgradeSimScore - originalScore) / originalScore * 100, 3)}%`}
           </pre>
         </Flex>,
       )
@@ -644,11 +646,13 @@ export function CharacterCardCombatStats(props: {
       ? Utils.precisionRound(xa[Key.ELEMENTAL_DMG], 2) != Utils.precisionRound(result.originalSimResult.ca[Key.ELEMENTAL_DMG], 2)
       : Utils.precisionRound(xa[StatToKey[stat]], 2) != Utils.precisionRound(result.originalSimResult.ca[StatToKey[stat]], 2)
 
-    let display = `${Math.floor(value)}`
+    let display = numberToLocaleString(Math.floor(value))
     if (stat == Stats.SPD) {
-      display = preciseSpd ? TsUtils.precisionRound(value, 4).toFixed(3) : Utils.truncate10ths(TsUtils.precisionRound(value, 4)).toFixed(1)
+      display = preciseSpd
+        ? numberToLocaleString(TsUtils.precisionRound(value, 4), 3)
+        : numberToLocaleString(Utils.truncate10ths(TsUtils.precisionRound(value, 4)), 1)
     } else if (!flat) {
-      display = Utils.truncate10ths(value * 100).toFixed(1)
+      display = numberToLocaleString(Utils.truncate10ths(value * 100), 1)
     }
 
     const statName = stat.includes('DMG Boost') ? t('DamagePercent') : t(`ReadableStats.${stat}`)
@@ -709,7 +713,7 @@ export function CharacterCardScoringStatUpgrades(props: {
         <img src={Assets.getStatIcon(stat)} style={{ width: iconSize, height: iconSize, marginRight: 3 }}/>
         <StatTextSm>{`+1x ${t(`ShortReadableStats.${stat as SubStats}`)}`}</StatTextSm>
         <Divider style={{ margin: 'auto 10px', flexGrow: 1, width: 'unset', minWidth: 'unset' }} dashed/>
-        <StatTextSm>{`+ ${(upgradeDmg * 100).toFixed(2)}%`}</StatTextSm>
+        <StatTextSm>{`+ ${numberToLocaleString((upgradeDmg * 100), 2)}%`}</StatTextSm>
       </Flex>,
     )
   }
@@ -727,7 +731,7 @@ export function CharacterCardScoringStatUpgrades(props: {
         <img src={Assets.getPart(part)} style={{ width: iconSize, height: iconSize, marginRight: 3 }}/>
         <StatTextSm>{`➔ ${t(`ShortReadableStats.${stat as MainStats}`)}`}</StatTextSm>
         <Divider style={{ margin: 'auto 10px', flexGrow: 1, width: 'unset', minWidth: 'unset' }} dashed/>
-        <StatTextSm>{`+ ${(upgradeDmg * 100).toFixed(2)}%`}</StatTextSm>
+        <StatTextSm>{`+ ${numberToLocaleString((upgradeDmg * 100), 2)}%`}</StatTextSm>
       </Flex>,
     )
   }
@@ -742,7 +746,7 @@ export function CharacterCardScoringStatUpgrades(props: {
         <img src={Assets.getSetImage(setUpgrade.simulation.request.simRelicSet2)} style={{ width: iconSize, height: iconSize, marginRight: 5 }}/>
         <img src={Assets.getSetImage(setUpgrade.simulation.request.simOrnamentSet)} style={{ width: iconSize, height: iconSize, marginRight: 3 }}/>
         <Divider style={{ margin: 'auto 10px', flexGrow: 1, width: 'unset', minWidth: 'unset' }} dashed/>
-        <StatTextSm>{`+ ${(upgradeDmg * 100).toFixed(2)}%`}</StatTextSm>
+        <StatTextSm>{`+ ${numberToLocaleString((upgradeDmg * 100), 2)}%`}</StatTextSm>
       </Flex>,
     )
   }

--- a/src/lib/characterPreview/ShowcaseDpsScore.tsx
+++ b/src/lib/characterPreview/ShowcaseDpsScore.tsx
@@ -14,6 +14,7 @@ import { getSimScoreGrade } from 'lib/scoring/characterScorer'
 import { SimulationScore } from 'lib/scoring/simScoringUtils'
 import DB from 'lib/state/db'
 import { HeaderText } from 'lib/ui/HeaderText'
+import { numberToLocaleString } from 'lib/utils/i18nUtils'
 import { Utils } from 'lib/utils/utils'
 import React, { CSSProperties, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -212,7 +213,7 @@ export function ShowcaseDpsScoreHeader(props: {
           t(
             'CharacterPreview.ScoreHeader.Score',
             {
-              score: Utils.truncate10ths(Math.max(0, result.percent * 100)).toFixed(1),
+              score: numberToLocaleString(Utils.truncate10ths(Math.max(0, result.percent * 100)), 1),
               grade: getSimScoreGrade(result.percent, verified, numRelics, lightCone),
             },
           )

--- a/src/lib/characterPreview/StatRow.tsx
+++ b/src/lib/characterPreview/StatRow.tsx
@@ -100,7 +100,9 @@ export function getStatRenderValues(statValue: number, customValue: number, stat
     value1000thsPrecision = numberToLocaleString(Utils.precisionRound(customValue), 3)
   } else if (stat == Constants.Stats.SPD) {
     const is1000thSpeed = checkSpeedInBreakpoint(statValue)
-    valueDisplay = numberToLocaleString((is1000thSpeed || preciseSpd) ? Utils.precisionRound(statValue, 3) : Utils.truncate10ths(Utils.precisionRound(statValue, 3)), 1)
+    valueDisplay = is1000thSpeed || preciseSpd
+      ? numberToLocaleString(Utils.precisionRound(statValue, 3), 3)
+      : numberToLocaleString(Utils.truncate10ths(Utils.precisionRound(statValue, 3)), 1)
     value1000thsPrecision = numberToLocaleString(Utils.precisionRound(statValue), 3)
   } else if (Utils.isFlat(stat)) {
     valueDisplay = numberToLocaleString(Math.floor(statValue), 0)

--- a/src/lib/i18n/LanguageSelector.tsx
+++ b/src/lib/i18n/LanguageSelector.tsx
@@ -34,11 +34,15 @@ export function LanguageSelector() {
       options={selectOptions}
       optionRender={(option) => option.data.label}
       onChange={(e: string) => {
-        void i18n.changeLanguage(e)
-        // !!do not replace this check with isBeta!!
-        if (BASE_PATH === BasePath.BETA) {
-          e === 'aa_ER' ? window.jipt.start() : window.jipt.stop()
-        }
+        i18n.changeLanguage(e)
+          .then(() => {
+            // !!do not replace this check with isBeta!!
+            if (BASE_PATH === BasePath.BETA) {
+              e === 'aa_ER' ? window.jipt.start() : window.jipt.stop()
+            }
+            window.store.getState().setCurrentLocale(i18n.resolvedLanguage?.replace('_', '-'))
+            console.log('setting language to:', i18n.resolvedLanguage)
+          })
       }}
       style={{ width: 135, marginRight: 6, height: 36 }}
       placement='bottomLeft'

--- a/src/lib/rendering/renderer.tsx
+++ b/src/lib/rendering/renderer.tsx
@@ -10,7 +10,7 @@ import { Relic, Stat } from 'types/relic'
 export const Renderer = {
   floor: (x: { value: number }) => {
     if (x?.value == undefined) return ''
-    return Math.floor(x.value)
+    return numberToLocaleString(Math.floor(x.value))
   },
 
   x100Tenths: (x: { value: number }) => {

--- a/src/lib/state/db.ts
+++ b/src/lib/state/db.ts
@@ -126,6 +126,7 @@ window.store = create((set) => {
   const store: HsrOptimizerStore = {
     version: CURRENT_OPTIMIZER_VERSION,
     colorTheme: Themes.BLUE,
+    currentLocale: undefined,
     globalThemeConfig: getGlobalThemeConfigFromColorTheme(Themes.BLUE),
 
     formValues: undefined,
@@ -234,6 +235,7 @@ window.store = create((set) => {
 
     setComboState: (x) => set(() => ({ comboState: x })),
     setVersion: (x) => set(() => ({ version: x })),
+    setCurrentLocale: (x) => set(() => ({ currentLocale: x })),
     setActiveKey: (x) => set(() => ({ activeKey: x })),
     setFormValues: (x) => set(() => ({ formValues: x })),
     setCharacters: (x) => set(() => ({ characters: x })),

--- a/src/lib/tabs/tabOptimizer/Sidebar.tsx
+++ b/src/lib/tabs/tabOptimizer/Sidebar.tsx
@@ -60,8 +60,8 @@ function getGpuOptions(computeEngine: ComputeEngine) {
 
 function PermutationDisplay(props: { total?: number; right: number; left: string }) {
   const rightText = props.total
-    ? `${numberToLocaleString(props.right)} / ${numberToLocaleString(props.total)} - (${numberToLocaleString(Math.ceil(props.right / props.total * 100))}%)`
-    : `${numberToLocaleString(props.right)}`
+    ? `${numberToLocaleString(props.right, 0, true)} / ${numberToLocaleString(props.total, 0, true)} - (${numberToLocaleString(Math.ceil(props.right / props.total * 100), 0, true)}%)`
+    : `${numberToLocaleString(props.right, 0, true)}`
   return (
     <Flex justify='space-between'>
       <Text style={{ lineHeight: '24px' }}>
@@ -197,12 +197,12 @@ function calculateProgressText(
   return optimizationInProgress
     ? i18next.t('optimizerTab:Sidebar.ProgressText.TimeRemaining', {
       // {{rate}} / sec — ${{timeRemaining}} left
-      rate: numberToLocaleString(Math.floor(perSecond)),
+      rate: numberToLocaleString(Math.floor(perSecond), 0, true),
       timeRemaining: Utils.msToReadable(msRemaining),
     })
     : i18next.t('optimizerTab:Sidebar.ProgressText.Finished', {
       // {{rate}} / sec — Finished
-      rate: numberToLocaleString(Math.floor(perSecond)),
+      rate: numberToLocaleString(Math.floor(perSecond), 0, true),
     })
 }
 
@@ -479,13 +479,13 @@ function OptimizerControlsGroup(props: { isFullSize: boolean }) {
       </Flex>
 
       {!props.isFullSize
-        && (
-          <Flex vertical gap={3} style={{ flex: 1, minWidth: 211 }}>
-            <HeaderText>{t('ComputeEngine')/* Compute engine */}</HeaderText>
-            <ComputeEngineSelect/>
-            <ProgressDisplay/>
-          </Flex>
-        )}
+      && (
+        <Flex vertical gap={3} style={{ flex: 1, minWidth: 211 }}>
+          <HeaderText>{t('ComputeEngine')/* Compute engine */}</HeaderText>
+          <ComputeEngineSelect/>
+          <ProgressDisplay/>
+        </Flex>
+      )}
     </Flex>
   )
 }

--- a/src/lib/tabs/tabOptimizer/analysis/DamageSplitsChart.tsx
+++ b/src/lib/tabs/tabOptimizer/analysis/DamageSplitsChart.tsx
@@ -167,7 +167,7 @@ const CustomTooltip = (props: { active: boolean; payload: BarsTooltipData[]; lab
       }}
     >
       <span style={{ fontSize: 14, fontWeight: 'bold' }}>{t(bar)}</span>
-      <span>{numberToLocaleString(Math.floor(damageItem.value))}</span>
+      <span>{numberToLocaleString(Math.floor(damageItem.value), 0, true)}</span>
     </Flex>
   )
 }

--- a/src/lib/tabs/tabOptimizer/analysis/SubstatUpgrades.tsx
+++ b/src/lib/tabs/tabOptimizer/analysis/SubstatUpgrades.tsx
@@ -94,7 +94,7 @@ export function DamageUpgrades(props: {
         width: 110,
         render: (n: number) => (
           <>
-            {n == 0 ? '' : `${numberToLocaleString(n, 1)}`}
+            {n == 0 ? '' : `${numberToLocaleString(n, 1, true)}`}
           </>
         ),
       },
@@ -105,7 +105,7 @@ export function DamageUpgrades(props: {
         width: 110,
         render: (n: number) => (
           <>
-            {n == 0 ? '' : `${numberToLocaleString(Utils.truncate100ths(n * 100), 2)}%`}
+            {n == 0 ? '' : `${numberToLocaleString(Utils.truncate100ths(n * 100), 2, true)}%`}
           </>
         ),
       },

--- a/src/lib/utils/i18nUtils.ts
+++ b/src/lib/utils/i18nUtils.ts
@@ -1,11 +1,9 @@
-import i18next from 'i18next'
-
 // to use in place of toFixed()
-export function numberToLocaleString(number: number, decimals: number = 0) {
-  return number.toLocaleString(currentLocale(), { maximumFractionDigits: decimals, minimumFractionDigits: decimals })
+export function numberToLocaleString(number: number, decimals: number = 0, useGrouping = false) {
+  return number.toLocaleString(currentLocale(), { maximumFractionDigits: decimals, minimumFractionDigits: decimals, useGrouping })
 }
 
 // can be used for toLocaleString() when a variable number of decimals is desired
 export function currentLocale() {
-  return i18next.resolvedLanguage!.replace('_', '-')
+  return window.store.getState().currentLocale!
 }

--- a/src/types/store.d.ts
+++ b/src/types/store.d.ts
@@ -43,6 +43,7 @@ type RelicTabFilters = {
 export type HsrOptimizerStore = {
   version: string
   colorTheme: ColorThemeOverrides
+  currentLocale: string | undefined
   optimizerGrid: unknown
   optimizerTabFocusCharacter?: CharacterId
   characterTabFocusCharacter?: CharacterId
@@ -100,6 +101,7 @@ export type HsrOptimizerStore = {
   optimizerExpandedPanelBuildData: BuildData | null
   optimizerSelectedRowData: OptimizerDisplayDataStatSim | null
   optimizerBuffGroups: Record<BUFF_TYPE, Record<string, Buff[]>> | undefined
+  setCurrentLocale: (locale: string | undefined) => void
   setSettings: (settings: UserSettings) => void
   setOptimizationId: (id: string) => void
   setSettingsDrawerOpen: (open: boolean) => void


### PR DESCRIPTION
add locale formatting to more numbers in character tab cache currentLocale()

# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Removed unwanted grouping in locale formatted numbers
* Added caching for `currentLocale()`
* Added localised formatting to more numbers

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

