### PR TITLE
fix: sparkle sacerdos, null optimizer grid startup

### DIFF
--- a/src/lib/tabs/tabOptimizer/analysis/expandedDataPanelController.ts
+++ b/src/lib/tabs/tabOptimizer/analysis/expandedDataPanelController.ts
@@ -104,7 +104,7 @@ export function generateAnalysisData(currentRowData: OptimizerDisplayData, selec
 }
 
 export function getPinnedRowData() {
-  const currentPinned = window.optimizerGrid.current?.api.getGridOption('pinnedTopRowData') as OptimizerDisplayData[] ?? []
+  const currentPinned = window.optimizerGrid?.current?.api.getGridOption('pinnedTopRowData') as OptimizerDisplayData[] ?? []
   return currentPinned && currentPinned.length ? currentPinned[0] : null
 }
 

--- a/src/lib/tabs/tabOptimizer/optimizerForm/components/TeammateCard.tsx
+++ b/src/lib/tabs/tabOptimizer/optimizerForm/components/TeammateCard.tsx
@@ -103,6 +103,7 @@ function calculateTeammateSets(teammateCharacter: Character) {
       if (set == Sets.SacerdosRelivedOrdeal) {
         if (
           teammateCharacter.id == '1313' // Sunday
+          || teammateCharacter.id == '1306' // Sparkle
         ) {
           activeTeammateSets.teamRelicSet = SACERDOS_RELIVED_ORDEAL_2_STACK
         } else {


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Sacerdos 2x was removed by mistake for sparkle
* Fix a call on null optimizer grid for pinned data on startup

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

