### PR TITLE
feat: compare reroll potential vs currently equipped potential

### DIFF
--- a/src/lib/tabs/tabRelics/RelicFilterBar.tsx
+++ b/src/lib/tabs/tabRelics/RelicFilterBar.tsx
@@ -146,7 +146,7 @@ export default function RelicFilterBar(props: {
     // views as a pure function of props, but because relics (and other state) are updated mutably in
     // a number of places, we need these manual refresh invocations
     setTimeout(() => {
-      characterSelectorChange(currentlySelectedCharacterId!)
+      characterSelectorChange(currentlySelectedCharacterId)
     }, 100)
   }
 
@@ -157,11 +157,11 @@ export default function RelicFilterBar(props: {
   // will correctly re-trigger it)
   useEffect(() => {
     if (DB.getState().settings[SettingOptions.RelicPotentialLoadBehavior.name] == SettingOptions.RelicPotentialLoadBehavior.ScoreAtStartup) {
-      characterSelectorChange(currentlySelectedCharacterId!)
+      characterSelectorChange(currentlySelectedCharacterId)
     }
   }, [])
 
-  function characterSelectorChange(characterId: string, singleRelic?: Relic) {
+  function characterSelectorChange(characterId: string | undefined, singleRelic?: Relic) {
     const relics = singleRelic ? [singleRelic] : Object.values(DB.getRelicsById())
     console.log('idChange', characterId)
 
@@ -176,11 +176,13 @@ export default function RelicFilterBar(props: {
     // NOTE: we cannot cache these results between renders by keying on the relic/characterId because
     // both relic stats and char weights can be edited
     for (const relic of relics) {
-      const weights: Partial<RelicScoringWeights> = characterId ? relicScorer.getFutureRelicScore(relic, characterId) : {
-        current: 0,
-        best: 0,
-        average: 0,
-      }
+      const weights: Partial<RelicScoringWeights> = characterId
+        ? relicScorer.getFutureRelicScore(relic, characterId)
+        : {
+          current: 0,
+          best: 0,
+          average: 0,
+        }
       weights.potentialSelected = characterId ? relicScorer.scoreRelicPotential(relic, characterId) : { bestPct: 0, averagePct: 0, rerollAvgPct: 0 }
       weights.potentialAllAll = { bestPct: 0, averagePct: 0, rerollAvgPct: 0 }
       weights.potentialAllCustom = { bestPct: 0, averagePct: 0, rerollAvgPct: 0 }
@@ -217,7 +219,11 @@ export default function RelicFilterBar(props: {
       }
 
       weights.rerollAvgSelectedDelta = weights.rerollAvgSelected == 0 ? 0 : (weights.rerollAvgSelected - weights.potentialSelected.averagePct)
-
+      weights.rerollAvgSelectedEquippedDelta = 0
+      if (characterId && DB.getCharacterById(characterId).equipped[relic.part]) {
+        const equippedRelic = DB.getCharacterById(characterId).equipped[relic.part]!
+        weights.rerollAvgSelectedEquippedDelta = weights.rerollAvgSelected - relicScorer.scoreRelicPotential(DB.getRelicById(equippedRelic), characterId).averagePct
+      }
       relic.weights = weights as RelicScoringWeights
     }
 
@@ -260,11 +266,11 @@ export default function RelicFilterBar(props: {
   }
 
   function rescoreClicked() {
-    characterSelectorChange(currentlySelectedCharacterId!)
+    characterSelectorChange(currentlySelectedCharacterId)
   }
 
   function rescoreSingleRelic(singleRelic: Relic) {
-    characterSelectorChange(currentlySelectedCharacterId!, singleRelic)
+    characterSelectorChange(currentlySelectedCharacterId, singleRelic)
   }
 
   window.rescoreSingleRelic = rescoreSingleRelic
@@ -359,6 +365,7 @@ export default function RelicFilterBar(props: {
                 maxTagCount='responsive'
                 style={{ flex: 1 }}
                 listHeight={750}
+                dropdownStyle={{ width: 'fit-content' }}
               />
             </Flex>
           </Flex>
@@ -457,6 +464,7 @@ export type RelicScoringWeights = {
   rerollAllCustom: PotentialWeights
   rerollAvgSelected: number
   rerollAvgSelectedDelta: number
+  rerollAvgSelectedEquippedDelta: number
 }
 
 type PotentialWeights = {

--- a/src/lib/tabs/tabRelics/RelicsTab.jsx
+++ b/src/lib/tabs/tabRelics/RelicsTab.jsx
@@ -252,16 +252,25 @@ export default function RelicsTab() {
           label: t('RelicGrid.ValueColumns.SelectedCharacter.MaxPotCol.Label'),
           percent: true,
         },
+        // Selected Char\nReroll Avg | Selected character: Reroll average potential
         {
           column: t('RelicGrid.ValueColumns.SelectedCharacter.RerollAvg.Header'),
           value: 'weights.rerollAvgSelected',
           label: t('RelicGrid.ValueColumns.SelectedCharacter.RerollAvg.Label'),
           percent: true,
         },
+        // Selected Char\nΔ Reroll Avg | Selected character: Reroll average delta potential
         {
           column: t('RelicGrid.ValueColumns.SelectedCharacter.RerollAvgDelta.Header'),
           value: 'weights.rerollAvgSelectedDelta',
           label: t('RelicGrid.ValueColumns.SelectedCharacter.RerollAvgDelta.Label'),
+          percent: true,
+        },
+        // Selected Char\n∆ Reroll AVG\nvs equipped | Selected character: Reroll average delta potential vs equipped
+        {
+          column: 'Selected Char\n∆ Reroll AVG\nvs equipped',
+          value: 'weights.rerollAvgSelectedEquippedDelta',
+          label: 'Selected character: Reroll average delta potential vs equipped',
           percent: true,
         },
       ],
@@ -283,6 +292,7 @@ export default function RelicsTab() {
           label: t('RelicGrid.ValueColumns.CustomCharacters.MaxPotCol.Label'),
           percent: true,
         },
+        // Custom Chars\nAvg Reroll | Custom characters: Average reroll potential
         {
           column: t('RelicGrid.ValueColumns.CustomCharacters.RerollAvg.Header'),
           value: 'weights.rerollAllCustom.rerollAvgPct',
@@ -308,6 +318,7 @@ export default function RelicsTab() {
           label: t('RelicGrid.ValueColumns.AllCharacters.MaxPotCol.Label'),
           percent: true,
         },
+        // All Chars\nAvg Reroll | All characters: Average reroll potential
         {
           column: t('RelicGrid.ValueColumns.AllCharacters.RerollAvg.Header'),
           value: 'weights.rerollAllAll.rerollAvgPct',

--- a/src/lib/utils/TsUtils.ts
+++ b/src/lib/utils/TsUtils.ts
@@ -51,12 +51,10 @@ export const TsUtils = {
   },
 
   uuid: (): string => {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
     return uuidv4()
   },
 
   uuidAlphaOnly: (): string => {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
     return uuidv4().replace(/[^a-zA-Z0-9]/g, '')
   },
 


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Added value column to compare relic reroll avg to the average potential for equipped relic in same slot for selected character
* label and column header still need to be finalised, currently too long imo and may cause length issues once translated

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

