### PR TITLE
feat: main / sub stat upgrade charts on showcase

### DIFF
--- a/public/locales/en_US/charactersTab.yaml
+++ b/public/locales/en_US/charactersTab.yaml
@@ -100,12 +100,15 @@ CharacterPreview:
   DMGUpgrades: Damage Upgrades
   SubstatUpgradeComparisons:
     Header: Substat upgrade comparisons
+    MainStatHeader: Main stat upgrade comparisons
     Roll: roll
     Damage: Damage
-  MainStatUpgradeComparisons:
-    Header: Main stat upgrade comparisons
-    Roll: roll
-    Damage: Damage
+    MainStatUpgrade: Main Stat Upgrade
+    SubStatUpgrade: Substat Upgrade
+    DpsScorePercentUpgrade: DPS Score Δ %
+    UpgradedDpsScore: Upgraded DPS Score
+    ComboDmgPercentUpgrade: Combo DMG Δ %
+    ComboDmgUpgrade: Combo DMG Δ
   BuildAnalysis:
     ScoringNote: >-
       DPS Score rates build quality by comparing an ability rotation's damage to benchmark builds with the same team / lightcones / eidolons.

--- a/public/locales/en_US/charactersTab.yaml
+++ b/public/locales/en_US/charactersTab.yaml
@@ -102,6 +102,10 @@ CharacterPreview:
     Header: Substat upgrade comparisons
     Roll: roll
     Damage: Damage
+  MainStatUpgradeComparisons:
+    Header: Main stat upgrade comparisons
+    Roll: roll
+    Damage: Damage
   BuildAnalysis:
     ScoringNote: >-
       DPS Score rates build quality by comparing an ability rotation's damage to benchmark builds with the same team / lightcones / eidolons.

--- a/src/lib/characterPreview/CharacterScoringSummary.tsx
+++ b/src/lib/characterPreview/CharacterScoringSummary.tsx
@@ -4,15 +4,15 @@ import { BuffDisplaySize, BuffsAnalysisDisplay } from 'lib/characterPreview/Buff
 import { CharacterStatSummary } from 'lib/characterPreview/CharacterStatSummary'
 import { damageStats } from 'lib/characterPreview/StatRow'
 import { StatTextSm } from 'lib/characterPreview/StatText'
+import { DpsScoreMainStatUpgradesTable } from 'lib/characterPreview/summary/DpsScoreMainStatUpgradesTable'
+import { DpsScoreSubstatUpgradesTable } from 'lib/characterPreview/summary/DpsScoreSubstatUpgradesTable'
 import { ElementToDamage, MainStats, Parts, Stats, StatsValues, SubStats } from 'lib/constants/constants'
 import { SavedSessionKeys } from 'lib/constants/constantsSession'
 import { defaultGap, iconSize } from 'lib/constants/constantsUi'
 import { toBasicStatsObject } from 'lib/optimization/basicStatsArray'
 import { Key, StatToKey, toComputedStatsObject } from 'lib/optimization/computedStatsArray'
 import { SortOption, SortOptionProperties } from 'lib/optimization/sortOptions'
-import { StatCalculator } from 'lib/relics/statCalculator'
 import { Assets } from 'lib/rendering/assets'
-import { SimulationStatUpgrade } from 'lib/scoring/characterScorer'
 import { diminishingReturnsFormula, SimulationScore, spdDiminishingReturnsFormula } from 'lib/scoring/simScoringUtils'
 import { Simulation } from 'lib/simulations/statSimulationController'
 import DB from 'lib/state/db'
@@ -150,50 +150,6 @@ export const CharacterScoringSummary = (props: {
     return (
       <Flex align='center' gap={15}>
         <pre style={{ margin: 0 }}>{`#${props.index} - ${displayValue as string}`}</pre>
-      </Flex>
-    )
-  }
-
-  function ScoringStatUpgrades() {
-    const rows: ReactElement[] = []
-    const originalScore = result.originalSimScore
-    const basePercent = result.percent
-
-    for (const substatUpgrade of result.substatUpgrades) {
-      const statUpgrade: SimulationStatUpgrade = substatUpgrade
-      const upgradeSimScore = statUpgrade.simulationResult.simScore
-      const upgradePercent = statUpgrade.percent!
-      const upgradeStat = statUpgrade.stat!
-      const isFlat = Utils.isFlat(statUpgrade.stat)
-      const suffix = isFlat ? '' : '%'
-      const rollValue = TsUtils.precisionRound(StatCalculator.getMaxedSubstatValue(upgradeStat as SubStats, 0.8))
-
-      rows.push(
-        <Flex key={Utils.randomId()} align='center' gap={10}>
-          <img src={Assets.getStatIcon(upgradeStat)} style={{ height: 30 }}/>
-          <pre
-            style={{
-              margin: 0,
-              width: 200,
-            }}
-          >{`+1x ${t('CharacterPreview.SubstatUpgradeComparisons.Roll')}: ${t(`common:ShortStats.${upgradeStat as SubStats}`)} +${localeNumber_0(rollValue)}${suffix}`}
-          </pre>
-          <pre style={{ margin: 0, width: 250 }}>
-            {`${t('common:Score')}: +${localeNumber_00((upgradePercent - basePercent) * 100)}% -> ${localeNumber_00(statUpgrade.percent! * 100)}%`}
-          </pre>
-          <pre style={{ margin: 0, width: 300 }}>
-            {`${t('CharacterPreview.SubstatUpgradeComparisons.Damage')}: +${localeNumber_0(upgradeSimScore - originalScore)} -> ${localeNumber_0(upgradeSimScore)}`}
-          </pre>
-          <pre style={{ margin: 0, width: 150 }}>
-            {`${t('CharacterPreview.SubstatUpgradeComparisons.Damage')} %: +${localeNumber_000((upgradeSimScore - originalScore) / originalScore * 100)}%`}
-          </pre>
-        </Flex>,
-      )
-    }
-
-    return (
-      <Flex vertical gap={defaultGap}>
-        {rows}
       </Flex>
     )
   }
@@ -550,13 +506,18 @@ export const CharacterScoringSummary = (props: {
         />
       </Flex>
 
-      <Flex gap={defaultGap} justify='space-around'>
-        <Flex vertical gap={defaultGap}>
-          <pre style={{ marginLeft: 'auto', marginRight: 'auto' }}>
-            {t('CharacterPreview.SubstatUpgradeComparisons.Header')/* Substat upgrade comparisons */}
-          </pre>
-          <ScoringStatUpgrades/>
-        </Flex>
+      <Flex gap={defaultGap} vertical style={{ width: '100%' }} align='center'>
+        <pre style={{ fontSize: 20, textDecoration: 'underline' }}>
+          {t('CharacterPreview.MainStatUpgradeComparisons.Header')/* Main stat upgrade comparisons */}
+        </pre>
+        <DpsScoreMainStatUpgradesTable simScore={result}/>
+      </Flex>
+
+      <Flex gap={defaultGap} vertical style={{ width: '100%' }} align='center'>
+        <pre style={{ fontSize: 20, textDecoration: 'underline' }}>
+          {t('CharacterPreview.SubstatUpgradeComparisons.Header')/* Substat upgrade comparisons */}
+        </pre>
+        <DpsScoreSubstatUpgradesTable simScore={result}/>
       </Flex>
 
       <Flex justify='space-around' style={{ marginTop: 15 }}>

--- a/src/lib/characterPreview/CharacterScoringSummary.tsx
+++ b/src/lib/characterPreview/CharacterScoringSummary.tsx
@@ -508,16 +508,16 @@ export const CharacterScoringSummary = (props: {
 
       <Flex gap={defaultGap} vertical style={{ width: '100%' }} align='center'>
         <pre style={{ fontSize: 20, textDecoration: 'underline' }}>
-          {t('CharacterPreview.MainStatUpgradeComparisons.Header')/* Main stat upgrade comparisons */}
+          {t('CharacterPreview.SubstatUpgradeComparisons.Header')/* Substat upgrade comparisons */}
         </pre>
-        <DpsScoreMainStatUpgradesTable simScore={result}/>
+        <DpsScoreSubstatUpgradesTable simScore={result}/>
       </Flex>
 
       <Flex gap={defaultGap} vertical style={{ width: '100%' }} align='center'>
         <pre style={{ fontSize: 20, textDecoration: 'underline' }}>
-          {t('CharacterPreview.SubstatUpgradeComparisons.Header')/* Substat upgrade comparisons */}
+          {t('CharacterPreview.SubstatUpgradeComparisons.MainStatHeader')/* Main stat upgrade comparisons */}
         </pre>
-        <DpsScoreSubstatUpgradesTable simScore={result}/>
+        <DpsScoreMainStatUpgradesTable simScore={result}/>
       </Flex>
 
       <Flex justify='space-around' style={{ marginTop: 15 }}>

--- a/src/lib/characterPreview/summary/DpsScoreMainStatUpgradesTable.tsx
+++ b/src/lib/characterPreview/summary/DpsScoreMainStatUpgradesTable.tsx
@@ -1,0 +1,133 @@
+import { Flex, Table, TableProps } from 'antd'
+import { MainStats, Parts } from 'lib/constants/constants'
+import { iconSize } from 'lib/constants/constantsUi'
+import { Assets } from 'lib/rendering/assets'
+import { SimulationScore } from 'lib/scoring/simScoringUtils'
+import { arrowColor, arrowDirection } from 'lib/tabs/tabOptimizer/analysis/StatsDiffCard'
+import { cardShadowNonInset } from 'lib/tabs/tabOptimizer/optimizerForm/layout/FormCard'
+import { localeNumber_0, localeNumber_00 } from 'lib/utils/i18nUtils'
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+
+type MainStatUpgradeItem = {
+  stat: MainStats
+  part: Parts
+  // rollValue: number
+  scorePercentUpgrade: number
+  scoreValueUpgrade: number
+  damagePercentUpgrade: number
+  damageValueUpgrade: number
+}
+
+export function DpsScoreMainStatUpgradesTable(props: {
+  simScore: SimulationScore
+}) {
+  const { t } = useTranslation('optimizerTab', { keyPrefix: 'ExpandedDataPanel.SubstatUpgrades' })
+  const { t: tCommon } = useTranslation(['common', 'charactersTab'])
+
+  const { simScore } = props
+  const upgrades = simScore.mainUpgrades
+
+  console.log(simScore)
+  console.log(simScore.mainUpgrades)
+  const dataSource: MainStatUpgradeItem[] = upgrades.map((upgrade) => {
+    const stat = upgrade.stat! as MainStats
+    const part = upgrade.part! as Parts
+    return {
+      key: part + stat,
+      stat: stat,
+      part: part,
+      scorePercentUpgrade: (upgrade.percent! - simScore.percent) * 100, // OK
+      scoreValueUpgrade: upgrade.percent! * 100,
+      damagePercentUpgrade: (upgrade.simulationResult.simScore - simScore.originalSimScore) / simScore.originalSimScore * 100,
+      damageValueUpgrade: (upgrade.simulationResult.simScore - simScore.originalSimScore),
+    }
+  }).sort((a, b) => b.scorePercentUpgrade - a.scorePercentUpgrade)
+
+  const columns: TableProps<MainStatUpgradeItem>['columns'] = [
+    {
+      title: 'Main Stat Upgrade',
+      dataIndex: 'stat',
+      align: 'center',
+      width: 200,
+      rowScope: 'row',
+      render: (stat: MainStats, upgrade: MainStatUpgradeItem) => (
+        <Flex align='center' gap={5}>
+          <img src={Assets.getPart(upgrade.part)} style={{ width: iconSize, height: iconSize, marginLeft: 3, marginRight: 3 }}/>
+          <span>➔</span>
+          <img src={Assets.getStatIcon(stat)} style={{ width: iconSize, height: iconSize }}/>
+          <span>{`${tCommon(`ShortReadableStats.${stat}`)}`}</span>
+        </Flex>
+      ),
+    },
+    {
+      title: 'DPS Score Δ %',
+      dataIndex: 'scorePercentUpgrade',
+      align: 'center',
+      render: (n: number) => (
+        <Flex align='center' justify='center' gap={5}>
+          <Arrow up={n >= 0}/>
+          {` ${localeNumber_00(n)}%`}
+        </Flex>
+      ),
+    },
+    {
+      title: 'Updated DPS Score',
+      dataIndex: 'scoreValueUpgrade',
+      align: 'center',
+      render: (n: number) => (
+        <>
+          {`${localeNumber_0(Math.max(0, n))}%`}
+        </>
+      ),
+    },
+    {
+      title: 'Combo DMG Δ %',
+      dataIndex: 'damagePercentUpgrade',
+      align: 'center',
+      render: (n: number) => (
+        <Flex align='center' justify='center' gap={5}>
+          <Arrow up={n >= 0}/>
+          {` ${localeNumber_00(n)}%`}
+        </Flex>
+      ),
+    },
+    {
+      title: 'Combo DMG Δ',
+      dataIndex: 'damageValueUpgrade',
+      align: 'center',
+      render: (n: number) => (
+        <>
+          {localeNumber_0(n)}
+        </>
+      ),
+    },
+  ]
+
+  return (
+    <Table<MainStatUpgradeItem>
+      className='remove-table-bottom-border'
+      columns={columns}
+      dataSource={dataSource}
+      pagination={false}
+      size='small'
+      style={tableStyle}
+    />
+  )
+}
+
+export const tableStyle = {
+  width: '100%',
+  border: '1px solid #354b7d',
+  boxShadow: cardShadowNonInset,
+  borderRadius: 5,
+  overflow: 'hidden',
+}
+
+export function Arrow(props: { up: boolean }) {
+  return (
+    <span style={{ color: arrowColor(props.up), fontSize: 10 }}>
+      {arrowDirection(props.up)}
+    </span>
+  )
+}

--- a/src/lib/characterPreview/summary/DpsScoreMainStatUpgradesTable.tsx
+++ b/src/lib/characterPreview/summary/DpsScoreMainStatUpgradesTable.tsx
@@ -68,6 +68,7 @@ export function DpsScoreMainStatUpgradesTable(props: {
       pagination={false}
       size='small'
       style={tableStyle}
+      locale={{ emptyText: '' }}
     />
   )
 }

--- a/src/lib/characterPreview/summary/DpsScoreSubstatUpgradesTable.tsx
+++ b/src/lib/characterPreview/summary/DpsScoreSubstatUpgradesTable.tsx
@@ -60,6 +60,7 @@ export function DpsScoreSubstatUpgradesTable(props: {
       pagination={false}
       size='small'
       style={tableStyle}
+      locale={{ emptyText: '' }}
     />
   )
 }

--- a/src/lib/characterPreview/summary/DpsScoreSubstatUpgradesTable.tsx
+++ b/src/lib/characterPreview/summary/DpsScoreSubstatUpgradesTable.tsx
@@ -1,18 +1,14 @@
 import { Flex, Table, TableProps } from 'antd'
-import { Arrow, tableStyle } from 'lib/characterPreview/summary/DpsScoreMainStatUpgradesTable'
+import { sharedScoreUpgradeColumns, sharedSimResultComparator, tableStyle } from 'lib/characterPreview/summary/DpsScoreMainStatUpgradesTable'
 import { SubStats } from 'lib/constants/constants'
 import { iconSize } from 'lib/constants/constantsUi'
-import { StatCalculator } from 'lib/relics/statCalculator'
 import { Assets } from 'lib/rendering/assets'
 import { SimulationScore } from 'lib/scoring/simScoringUtils'
-import { localeNumber_0, localeNumber_00 } from 'lib/utils/i18nUtils'
-import { TsUtils } from 'lib/utils/TsUtils'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 
 type SubstatUpgradeItem = {
   stat: SubStats
-  rollValue: number
   scorePercentUpgrade: number
   scoreValueUpgrade: number
   damagePercentUpgrade: number
@@ -22,7 +18,7 @@ type SubstatUpgradeItem = {
 export function DpsScoreSubstatUpgradesTable(props: {
   simScore: SimulationScore
 }) {
-  const { t } = useTranslation('optimizerTab', { keyPrefix: 'ExpandedDataPanel.SubstatUpgrades' })
+  const { t } = useTranslation('charactersTab', { keyPrefix: 'CharacterPreview.SubstatUpgradeComparisons' })
   const { t: tCommon } = useTranslation('common', { keyPrefix: 'ShortSpacedStats' })
 
   const { simScore } = props
@@ -32,17 +28,13 @@ export function DpsScoreSubstatUpgradesTable(props: {
     return {
       key: stat,
       stat: stat,
-      rollValue: TsUtils.precisionRound(StatCalculator.getMaxedSubstatValue(stat, 1.0)),
-      scorePercentUpgrade: (upgrade.percent! - simScore.percent) * 100, // OK
-      scoreValueUpgrade: upgrade.percent! * 100,
-      damagePercentUpgrade: (upgrade.simulationResult.simScore - simScore.originalSimScore) / simScore.originalSimScore * 100,
-      damageValueUpgrade: (upgrade.simulationResult.simScore - simScore.originalSimScore),
+      ...sharedSimResultComparator(simScore, upgrade),
     }
   })
 
   const columns: TableProps<SubstatUpgradeItem>['columns'] = [
     {
-      title: 'Substat Upgrade',
+      title: t('SubStatUpgrade'), // Substat Upgrade
       dataIndex: 'stat',
       align: 'center',
       width: 200,
@@ -56,48 +48,8 @@ export function DpsScoreSubstatUpgradesTable(props: {
         </Flex>
       ),
     },
-    {
-      title: 'DPS Score Δ %',
-      dataIndex: 'scorePercentUpgrade',
-      align: 'center',
-      render: (n: number) => (
-        <Flex align='center' justify='center' gap={5}>
-          <Arrow up/>
-          {` ${localeNumber_00(n)}%`}
-        </Flex>
-      ),
-    },
-    {
-      title: 'Updated DPS Score',
-      dataIndex: 'scoreValueUpgrade',
-      align: 'center',
-      render: (n: number) => (
-        <>
-          {`${localeNumber_0(Math.max(0, n))}%`}
-        </>
-      ),
-    },
-    {
-      title: 'Combo DMG Δ %',
-      dataIndex: 'damagePercentUpgrade',
-      align: 'center',
-      render: (n: number) => (
-        <Flex align='center' justify='center' gap={5}>
-          <Arrow up/>
-          {` ${localeNumber_00(n)}%`}
-        </Flex>
-      ),
-    },
-    {
-      title: 'Combo DMG Δ',
-      dataIndex: 'damageValueUpgrade',
-      align: 'center',
-      render: (n: number) => (
-        <>
-          {localeNumber_0(n)}
-        </>
-      ),
-    },
+    // @ts-ignore
+    ...sharedScoreUpgradeColumns(t),
   ]
 
   return (

--- a/src/lib/characterPreview/summary/DpsScoreSubstatUpgradesTable.tsx
+++ b/src/lib/characterPreview/summary/DpsScoreSubstatUpgradesTable.tsx
@@ -1,0 +1,113 @@
+import { Flex, Table, TableProps } from 'antd'
+import { Arrow, tableStyle } from 'lib/characterPreview/summary/DpsScoreMainStatUpgradesTable'
+import { SubStats } from 'lib/constants/constants'
+import { iconSize } from 'lib/constants/constantsUi'
+import { StatCalculator } from 'lib/relics/statCalculator'
+import { Assets } from 'lib/rendering/assets'
+import { SimulationScore } from 'lib/scoring/simScoringUtils'
+import { localeNumber_0, localeNumber_00 } from 'lib/utils/i18nUtils'
+import { TsUtils } from 'lib/utils/TsUtils'
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+
+type SubstatUpgradeItem = {
+  stat: SubStats
+  rollValue: number
+  scorePercentUpgrade: number
+  scoreValueUpgrade: number
+  damagePercentUpgrade: number
+  damageValueUpgrade: number
+}
+
+export function DpsScoreSubstatUpgradesTable(props: {
+  simScore: SimulationScore
+}) {
+  const { t } = useTranslation('optimizerTab', { keyPrefix: 'ExpandedDataPanel.SubstatUpgrades' })
+  const { t: tCommon } = useTranslation('common', { keyPrefix: 'ShortSpacedStats' })
+
+  const { simScore } = props
+  const upgrades = simScore.substatUpgrades
+  const dataSource: SubstatUpgradeItem[] = upgrades.map((upgrade) => {
+    const stat = upgrade.stat! as SubStats
+    return {
+      key: stat,
+      stat: stat,
+      rollValue: TsUtils.precisionRound(StatCalculator.getMaxedSubstatValue(stat, 1.0)),
+      scorePercentUpgrade: (upgrade.percent! - simScore.percent) * 100, // OK
+      scoreValueUpgrade: upgrade.percent! * 100,
+      damagePercentUpgrade: (upgrade.simulationResult.simScore - simScore.originalSimScore) / simScore.originalSimScore * 100,
+      damageValueUpgrade: (upgrade.simulationResult.simScore - simScore.originalSimScore),
+    }
+  })
+
+  const columns: TableProps<SubstatUpgradeItem>['columns'] = [
+    {
+      title: 'Substat Upgrade',
+      dataIndex: 'stat',
+      align: 'center',
+      width: 200,
+      rowScope: 'row',
+      render: (text: SubStats, upgrade: SubstatUpgradeItem) => (
+        <Flex>
+          <img src={Assets.getStatIcon(text)} style={{ width: iconSize, height: iconSize, marginLeft: 3, marginRight: 3 }}/>
+          <span style={{ marginRight: 10 }}>
+            {`+1x roll ${tCommon(text)} `}
+          </span>
+        </Flex>
+      ),
+    },
+    {
+      title: 'DPS Score Δ %',
+      dataIndex: 'scorePercentUpgrade',
+      align: 'center',
+      render: (n: number) => (
+        <Flex align='center' justify='center' gap={5}>
+          <Arrow up/>
+          {` ${localeNumber_00(n)}%`}
+        </Flex>
+      ),
+    },
+    {
+      title: 'Updated DPS Score',
+      dataIndex: 'scoreValueUpgrade',
+      align: 'center',
+      render: (n: number) => (
+        <>
+          {`${localeNumber_0(Math.max(0, n))}%`}
+        </>
+      ),
+    },
+    {
+      title: 'Combo DMG Δ %',
+      dataIndex: 'damagePercentUpgrade',
+      align: 'center',
+      render: (n: number) => (
+        <Flex align='center' justify='center' gap={5}>
+          <Arrow up/>
+          {` ${localeNumber_00(n)}%`}
+        </Flex>
+      ),
+    },
+    {
+      title: 'Combo DMG Δ',
+      dataIndex: 'damageValueUpgrade',
+      align: 'center',
+      render: (n: number) => (
+        <>
+          {localeNumber_0(n)}
+        </>
+      ),
+    },
+  ]
+
+  return (
+    <Table<SubstatUpgradeItem>
+      className='remove-table-bottom-border'
+      columns={columns}
+      dataSource={dataSource}
+      pagination={false}
+      size='small'
+      style={tableStyle}
+    />
+  )
+}

--- a/src/lib/optimization/rotation/comboStateTransform.ts
+++ b/src/lib/optimization/rotation/comboStateTransform.ts
@@ -6,13 +6,7 @@ import { DynamicConditional } from 'lib/gpu/conditionals/dynamicConditionals'
 import { Source } from 'lib/optimization/buffSource'
 import { calculateContextConditionalRegistry } from 'lib/optimization/calculateConditionals'
 import { baseComputedStatsArray, ComputedStatsArray, ComputedStatsArrayCore, Key } from 'lib/optimization/computedStatsArray'
-import {
-  ComboConditionalCategory,
-  ComboConditionals,
-  ComboSelectConditional,
-  ComboState,
-  initializeComboState,
-} from 'lib/tabs/tabOptimizer/combo/comboDrawerController'
+import { ComboConditionalCategory, ComboConditionals, ComboSelectConditional, ComboState, initializeComboState } from 'lib/tabs/tabOptimizer/combo/comboDrawerController'
 import { CharacterConditionalsController, ConditionalValueMap, LightConeConditionalsController } from 'types/conditionals'
 import { Form, OptimizerForm } from 'types/form'
 import { OptimizerAction, OptimizerContext, SetConditional } from 'types/optimizer'

--- a/src/lib/scoring/characterScorer.ts
+++ b/src/lib/scoring/characterScorer.ts
@@ -355,7 +355,7 @@ export function scoreCharacterSimulation(
 
   // ===== Calculate upgrades =====
 
-  const { substatUpgradeResults, setUpgradeResults, mainUpgradeResults } = generateStatImprovements(
+  const { substatUpgradeResults, setUpgradeResults, mainUpgradeResults, mainUpgradeResultsByPart } = generateStatImprovements(
     originalSimResult,
     originalSim, candidateBenchmarkSims[0],
     simulationForm,
@@ -399,6 +399,7 @@ export function scoreCharacterSimulation(
     substatUpgrades: substatUpgradeResults,
     setUpgrades: setUpgradeResults,
     mainUpgrades: mainUpgradeResults,
+    mainUpgradeResultsByPart: mainUpgradeResultsByPart,
 
     simulationForm: simulationForm,
     simulationMetadata: metadata,
@@ -471,6 +472,12 @@ function generateStatImprovements(
 
   // Upgrade mains
   const mainUpgradeResults: SimulationStatUpgrade[] = []
+  const mainUpgradeResultsByPart: Record<MainStatParts, SimulationStatUpgrade[]> = {
+    [Parts.Body]: [],
+    [Parts.Feet]: [],
+    [Parts.PlanarSphere]: [],
+    [Parts.LinkRope]: [],
+  }
 
   const forceErrRope = isErrRopeForced(simulationForm, metadata, originalSim)
 
@@ -490,12 +497,14 @@ function generateStatImprovements(
         substatRollsModifier: (num: number) => num,
       })[0]
       applyScoringFunction(mainUpgradeResult)
-      mainUpgradeResults.push({
+      const simulationStatUpgrade = {
         stat: upgradeMainStat,
         part: part,
         simulation: originalSimClone,
         simulationResult: mainUpgradeResult,
-      })
+      }
+      mainUpgradeResults.push(simulationStatUpgrade)
+      mainUpgradeResultsByPart[part].push(simulationStatUpgrade)
     }
   }
 
@@ -504,9 +513,9 @@ function generateStatImprovements(
   upgradeMain(Parts.PlanarSphere)
   upgradeMain(Parts.LinkRope)
 
-  // console.log('Stat improvements', originalSimResult, originalSim, metadata, substatUpgradeResults)
+  console.log('Stat improvements', mainUpgradeResults)
 
-  return { substatUpgradeResults, setUpgradeResults, mainUpgradeResults }
+  return { substatUpgradeResults, setUpgradeResults, mainUpgradeResults, mainUpgradeResultsByPart }
 }
 
 const partsToFilterMapping = {

--- a/src/lib/scoring/simScoringUtils.ts
+++ b/src/lib/scoring/simScoringUtils.ts
@@ -1,4 +1,4 @@
-import { Parts, Stats } from 'lib/constants/constants'
+import { MainStatParts, Parts, Stats } from 'lib/constants/constants'
 import { SingleRelicByPart } from 'lib/gpu/webgpuTypes'
 import { OptimizerDisplayData } from 'lib/optimization/bufferPacker'
 import { SimulationStatUpgrade } from 'lib/scoring/characterScorer'
@@ -54,6 +54,7 @@ export type SimulationScore = {
   substatUpgrades: SimulationStatUpgrade[]
   setUpgrades: SimulationStatUpgrade[]
   mainUpgrades: SimulationStatUpgrade[]
+  mainUpgradeResultsByPart: Record<MainStatParts, SimulationStatUpgrade[]>
 
   simulationForm: Form
   simulationMetadata: SimulationMetadata

--- a/src/lib/state/metadata.ts
+++ b/src/lib/state/metadata.ts
@@ -5465,6 +5465,7 @@ function getScoringMetadata(): Record<string, ScoringMetadata> {
       simulation: {
         parts: {
           [Parts.Body]: [
+            Stats.ATK_P,
             Stats.CR,
             Stats.CD,
           ],

--- a/src/lib/state/metadata.ts
+++ b/src/lib/state/metadata.ts
@@ -6976,8 +6976,8 @@ function getScoringMetadata(): Record<string, ScoringMetadata> {
           ...SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
         ],
         ornamentSets: [
-          Sets.RutilantArena,
           Sets.BoneCollectionsSereneDemesne,
+          Sets.RutilantArena,
           ...SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
         ],
         teammates: [

--- a/src/lib/tabs/tabOptimizer/analysis/StatsDiffCard.tsx
+++ b/src/lib/tabs/tabOptimizer/analysis/StatsDiffCard.tsx
@@ -127,6 +127,14 @@ function RenderValue(props: { value: string | number; stat: string; comboDiff?: 
 const GREEN = '#95ef90'
 const RED = '#ff97a9'
 
+export function arrowColor(increase: boolean) {
+  return increase ? GREEN : RED
+}
+
+export function arrowDirection(increase: boolean) {
+  return increase ? '▲' : '▼'
+}
+
 function DiffRender(props: { oldValue: number; newValue: number; stat: string }) {
   const { newValue, oldValue, stat } = props
 
@@ -134,8 +142,8 @@ function DiffRender(props: { oldValue: number; newValue: number; stat: string })
 
   const increase = newValue > oldValue
   const diff = increase ? visualDiff(newValue, oldValue, stat) : visualDiff(oldValue, newValue, stat)
-  const icon = increase ? '▲' : '▼'
-  const color = increase ? GREEN : RED
+  const icon = arrowDirection(increase)
+  const color = arrowColor(increase)
   const { valueDisplay } = getStatDiffRenderValues(diff, diff, stat)
 
   return (

--- a/src/lib/tabs/tabOptimizer/analysis/SubstatUpgrades.tsx
+++ b/src/lib/tabs/tabOptimizer/analysis/SubstatUpgrades.tsx
@@ -113,7 +113,7 @@ export function DamageUpgrades(props: {
 
     displays.push(
       <Table<StatUpgradeItem>
-        className='stat-upgrade-table'
+        className='remove-table-bottom-border'
         key={group.key}
         columns={columns}
         dataSource={group.upgrades}

--- a/src/style/style.css
+++ b/src/style/style.css
@@ -698,7 +698,7 @@ a {
     font-family: "Consolas", "Courier New", "Menlo", "Monaco", monospace !important;
 }
 
-.stat-upgrade-table .ant-table-row:last-child .ant-table-cell {
+.remove-table-bottom-border .ant-table-row:last-child .ant-table-cell {
     border-bottom: none !important;
 }
 

--- a/src/types/resources.d.ts
+++ b/src/types/resources.d.ts
@@ -131,8 +131,13 @@ interface Resources {
         "Roll": "roll",
         "Damage": "Damage"
       },
+      "MainStatUpgradeComparisons": {
+        "Header": "Main stat upgrade comparisons",
+        "Roll": "roll",
+        "Damage": "Damage"
+      },
       "BuildAnalysis": {
-        "ScoringNote": "Note: DPS Score & Combo DMG are scoring metrics for a single ability rotation, and not meant for cross-team comparisons",
+        "ScoringNote": "DPS Score rates build quality by comparing an ability rotation's damage to benchmark builds with the same team / lightcones / eidolons. Scores and Combo DMG are measured relative only to the chosen team setup, and should not be compared across different configurations.",
         "Header": "Character build analysis",
         "SimulationTeammates": "Simulation teammates",
         "SimulationSets": "Simulation sets",
@@ -4040,7 +4045,7 @@ interface Resources {
         "ReliquaryDesc": {
           "Title": "(Recommended) IceDynamix Reliquary Archiver",
           "Link": "Github",
-          "OnlineMsg": "Status: Updated for patch {{version}} — New download required",
+          "OnlineMsg": "Status: Updated for patch {{version}}",
           "OfflineMsg": "***** Status: Down for maintenance after {{version}} patch *****",
           "l1": "Accurate speed decimals, instant scan",
           "l2": "Imports full inventory and character roster"
@@ -4383,6 +4388,26 @@ interface Resources {
           "SuccessMessage": "Reset Minimum Break filter",
           "Description": "Minimum break damage may be too high",
           "ButtonText": "Reset Minimum Break filter"
+        },
+        "MAX_MEMO_SKILL": {
+          "SuccessMessage": "Reset Maximum Memo Skill filter",
+          "Description": "Maximum Memo Skill damage may be too low",
+          "ButtonText": "Reset Maximum Memo Skill filter"
+        },
+        "MIN_MEMO_SKILL": {
+          "SuccessMessage": "Reset Minimum Memo Skill filter",
+          "Description": "Minimum Memo Skill damage may be too high",
+          "ButtonText": "Reset Minimum Memo Skill filter"
+        },
+        "MAX_MEMO_TALENT": {
+          "SuccessMessage": "Reset Maximum Memo Talent filter",
+          "Description": "Maximum Memo Talent damage may be too low",
+          "ButtonText": "Reset Maximum Memo Talent filter"
+        },
+        "MIN_MEMO_TALENT": {
+          "SuccessMessage": "Reset Minimum Memo Talent filter",
+          "Description": "Minimum Memo Talent damage may be too high",
+          "ButtonText": "Reset Minimum Memo Talent filter"
         },
         "MAX_HEAL": {
           "SuccessMessage": "Reset Maximum HEAL filter",
@@ -4905,7 +4930,7 @@ interface Resources {
         "Differentiator": "When enabled, the CRIT Rate buff is applied to Combat stat calculations.",
         "Penacony": "When enabled, the DMG% buff will apply to the wearer's memosprite.",
         "Sigonia": "The selected CRIT DMG buff is applied to Combat stat calculations, assuming the character has defeated that number of enemies.",
-        "Izumo": "When enabled, assumes there is another ally with the same path, and applies the 12% CRIT Rate buff to Combat stat calculations.",
+        "Izumo": "When enabled, if there is an ally with the same path, applies the 12% CRIT Rate buff to Combat stat calculations.",
         "Duran": "The selected buff is applied to damage calculations based on the number of stacks.",
         "Kalpagni": "When enabled, applies the Break Effect buff to combat stat calculations.",
         "Lushaka": "The selected buff is applied to damage calculations.",

--- a/src/types/resources.d.ts
+++ b/src/types/resources.d.ts
@@ -128,13 +128,15 @@ interface Resources {
       "DMGUpgrades": "Damage Upgrades",
       "SubstatUpgradeComparisons": {
         "Header": "Substat upgrade comparisons",
+        "MainStatHeader": "Main stat upgrade comparisons",
         "Roll": "roll",
-        "Damage": "Damage"
-      },
-      "MainStatUpgradeComparisons": {
-        "Header": "Main stat upgrade comparisons",
-        "Roll": "roll",
-        "Damage": "Damage"
+        "Damage": "Damage",
+        "MainStatUpgrade": "Main Stat Upgrade",
+        "SubStatUpgrade": "Substat Upgrade",
+        "DpsScorePercentUpgrade": "DPS Score Δ %",
+        "UpgradedDpsScore": "Upgraded DPS Score",
+        "ComboDmgPercentUpgrade": "Combo DMG Δ %",
+        "ComboDmgUpgrade": "Combo DMG Δ"
       },
       "BuildAnalysis": {
         "ScoringNote": "DPS Score rates build quality by comparing an ability rotation's damage to benchmark builds with the same team / lightcones / eidolons. Scores and Combo DMG are measured relative only to the chosen team setup, and should not be compared across different configurations.",


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Adding main / sub upgrade displays, including negatives

![image](https://github.com/user-attachments/assets/d3ec5a7b-3582-49bd-aa06-1e751b414098)

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

