### PR TITLE
hotfix: gpu filters should unsuppress their corresponding calculations

### DIFF
--- a/src/lib/gpu/injection/generateWgsl.ts
+++ b/src/lib/gpu/injection/generateWgsl.ts
@@ -22,30 +22,30 @@ export function generateWgsl(context: OptimizerContext, request: Form, relics: R
   wgsl = injectRatingFilters(wgsl, request, gpuParams)
   wgsl = injectSetFilters(wgsl, gpuParams)
   wgsl = injectComputedStats(wgsl, gpuParams)
-  wgsl = injectSuppressions(wgsl, context, gpuParams)
+  wgsl = injectSuppressions(wgsl, request, context, gpuParams)
 
   return wgsl
 }
 
-function injectSuppressions(wgsl: string, context: OptimizerContext, gpuParams: GpuConstants) {
+function injectSuppressions(wgsl: string, request: Form, context: OptimizerContext, gpuParams: GpuConstants) {
   if (context.path != PathNames.Remembrance) {
     wgsl = suppress(wgsl, 'COPY MEMOSPRITE BASIC STATS')
     wgsl = suppress(wgsl, 'MEMOSPRITE DAMAGE CALCS')
     wgsl = suppress(wgsl, 'MC ASSIGNMENT')
   }
 
-  if (context.resultSort != SortOption.EHP.key && !gpuParams.DEBUG) {
+  if (context.resultSort != SortOption.EHP.key && !gpuParams.DEBUG && request.minEhp == 0 && request.maxEhp == Constants.MAX_INT) {
     wgsl = suppress(wgsl, 'EHP CALC')
   }
 
   if (context.resultSort != SortOption.COMBO.key && !gpuParams.DEBUG) {
-    if (context.resultSort != SortOption.DOT.key) wgsl = suppress(wgsl, 'DOT CALC')
-    if (context.resultSort != SortOption.BASIC.key) wgsl = suppress(wgsl, 'BASIC CALC')
-    if (context.resultSort != SortOption.SKILL.key) wgsl = suppress(wgsl, 'SKILL CALC')
-    if (context.resultSort != SortOption.ULT.key) wgsl = suppress(wgsl, 'ULT CALC')
-    if (context.resultSort != SortOption.FUA.key) wgsl = suppress(wgsl, 'FUA CALC')
-    if (context.resultSort != SortOption.MEMO_SKILL.key) wgsl = suppress(wgsl, 'MEMO_SKILL CALC')
-    if (context.resultSort != SortOption.MEMO_TALENT.key) wgsl = suppress(wgsl, 'MEMO_TALENT CALC')
+    if (context.resultSort != SortOption.DOT.key && request.minDot == 0 && request.maxDot == Constants.MAX_INT) wgsl = suppress(wgsl, 'DOT CALC')
+    if (context.resultSort != SortOption.BASIC.key && request.minBasic == 0 && request.maxBasic == Constants.MAX_INT) wgsl = suppress(wgsl, 'BASIC CALC')
+    if (context.resultSort != SortOption.SKILL.key && request.minSkill == 0 && request.maxSkill == Constants.MAX_INT) wgsl = suppress(wgsl, 'SKILL CALC')
+    if (context.resultSort != SortOption.ULT.key && request.minUlt == 0 && request.maxUlt == Constants.MAX_INT) wgsl = suppress(wgsl, 'ULT CALC')
+    if (context.resultSort != SortOption.FUA.key && request.minFua == 0 && request.maxFua == Constants.MAX_INT) wgsl = suppress(wgsl, 'FUA CALC')
+    if (context.resultSort != SortOption.MEMO_SKILL.key && request.minMemoSkill == 0 && request.maxMemoSkill == Constants.MAX_INT) wgsl = suppress(wgsl, 'MEMO_SKILL CALC')
+    if (context.resultSort != SortOption.MEMO_TALENT.key && request.minMemoTalent == 0 && request.maxMemoTalent == Constants.MAX_INT) wgsl = suppress(wgsl, 'MEMO_TALENT CALC')
   }
 
   return wgsl

--- a/src/lib/gpu/webgpuInternals.ts
+++ b/src/lib/gpu/webgpuInternals.ts
@@ -36,7 +36,7 @@ export function initializeGpuPipeline(
   if (DEBUG && !silent) {
     console.log(wgsl)
   } else {
-    // console.log(wgsl)
+    console.log(wgsl)
   }
 
   const computePipeline = generatePipeline(device, wgsl)

--- a/src/lib/gpu/webgpuInternals.ts
+++ b/src/lib/gpu/webgpuInternals.ts
@@ -36,7 +36,7 @@ export function initializeGpuPipeline(
   if (DEBUG && !silent) {
     console.log(wgsl)
   } else {
-    console.log(wgsl)
+    // console.log(wgsl)
   }
 
   const computePipeline = generatePipeline(device, wgsl)


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* I added some optimizations to suppress unnecessary calculations for the combo but forgot filters need them, inject the suppression only if filters are default

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

