### PR TITLE
hotfix: light cone superimposition stats should deactivate on path mismatch

### DIFF
--- a/src/lib/optimization/context/calculateContext.ts
+++ b/src/lib/optimization/context/calculateContext.ts
@@ -113,12 +113,14 @@ function generateEnemyContext(request: Form, context: Partial<OptimizerContext>)
 }
 
 function generateBaseStatsContext(request: Form, context: Partial<OptimizerContext>) {
-  const lightConeMetadata = DB.getMetadata().lightCones[request.lightCone]
-  const lightConeStats = lightConeMetadata?.stats || emptyLightCone()
-  const lightConeSuperimposition = lightConeMetadata?.superimpositions[request.lightConeSuperimposition] || {}
-
   const characterMetadata = DB.getMetadata().characters[request.characterId]
   const characterStats = characterMetadata.stats
+
+  const lightConeMetadata = DB.getMetadata().lightCones[request.lightCone]
+  const lightConeStats = lightConeMetadata?.stats || emptyLightCone()
+  const lightConeSuperimposition = characterMetadata.path == lightConeMetadata.path
+    ? (lightConeMetadata?.superimpositions[request.lightConeSuperimposition] || {})
+    : {}
 
   const statsBreakdown: CharacterStatsBreakdown = {
     base: {


### PR DESCRIPTION

# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Light cone superimposition stats should deactivate on path mismatch

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

