### PR TITLE
fix: dedupe preset application code, fix path/element presets not app…

### DIFF
--- a/src/lib/optimization/defaultForm.ts
+++ b/src/lib/optimization/defaultForm.ts
@@ -1,5 +1,6 @@
 import { CombatBuffs, Constants, DEFAULT_MEMO_DISPLAY, DEFAULT_STAT_DISPLAY, Sets } from 'lib/constants/constants'
 import DB from 'lib/state/db'
+import { applyScoringMetadataPresets, applySetConditionalPresets } from 'lib/tabs/tabOptimizer/optimizerForm/components/RecommendedPresetsButton'
 import { TsUtils } from 'lib/utils/TsUtils'
 import { Form, Teammate } from 'types/form'
 
@@ -85,20 +86,8 @@ export function getDefaultForm(initialCharacter: { id: string }) {
     ...defaultEnemyOptions(),
   })
 
-  // Disable elemental conditions by default if the character is not of the same element
-  const element = DB.getMetadata().characters[initialCharacter?.id]?.element
-  if (element) {
-    defaultForm.setConditionals![Sets.GeniusOfBrilliantStars][1] = element === 'Quantum'
-    defaultForm.setConditionals![Sets.ForgeOfTheKalpagniLantern][1] = element === 'Fire'
-  }
-
-  // TODO: very gross, dedupe
-  if (scoringMetadata?.presets) {
-    const presets = scoringMetadata.presets || []
-    for (const preset of presets) {
-      preset.apply(defaultForm)
-    }
-  }
+  applySetConditionalPresets(defaultForm as Form)
+  applyScoringMetadataPresets(defaultForm as Form, scoringMetadata)
 
   if (scoringMetadata?.simulation?.comboAbilities) {
     defaultForm.comboAbilities = scoringMetadata.simulation.comboAbilities

--- a/src/lib/tabs/tabOptimizer/optimizerForm/components/RecommendedPresetsButton.tsx
+++ b/src/lib/tabs/tabOptimizer/optimizerForm/components/RecommendedPresetsButton.tsx
@@ -269,22 +269,16 @@ export function applySpdPreset(spd: number, characterId: string | undefined) {
    */
 
   // We dont use the clone here because serializing messes up the applyPreset functions
-  const presets = character.scoringMetadata.presets || []
   const sortOption = metadata.sortOption
   form.resultSort = sortOption.key
   setSortColumn(sortOption.combatGridColumn)
-  for (const preset of presets) {
-    preset.apply(form)
-  }
 
   window.optimizerForm.setFieldsValue(form)
   window.onOptimizerFormValuesChange({}, form)
 }
 
 export function applyMetadataPresetToForm(form: Form, scoringMetadata: ScoringMetadata) {
-  const characterMetadata = DB.getMetadata().characters[form.characterId]
   Utils.mergeUndefinedValues(form, getDefaultForm())
-  Utils.mergeUndefinedValues(form.setConditionals, defaultSetConditionals)
 
   form.comboAbilities = scoringMetadata?.simulation?.comboAbilities || [null, 'BASIC']
   form.comboDot = scoringMetadata?.simulation?.comboDot || 0
@@ -300,6 +294,23 @@ export function applyMetadataPresetToForm(form: Form, scoringMetadata: ScoringMe
   form.weights.headHands = form.weights.headHands || 0
   form.weights.bodyFeet = form.weights.bodyFeet || 0
   form.weights.sphereRope = form.weights.sphereRope || 0
+
+  applySetConditionalPresets(form)
+  applyScoringMetadataPresets(form, scoringMetadata)
+}
+
+export function applyScoringMetadataPresets(form: Form, scoringMetadata: ScoringMetadata) {
+  if (scoringMetadata?.presets) {
+    const presets = scoringMetadata.presets || []
+    for (const preset of presets) {
+      preset.apply(form)
+    }
+  }
+}
+
+export function applySetConditionalPresets(form: Form) {
+  const characterMetadata = DB.getMetadata().characters[form.characterId]
+  Utils.mergeUndefinedValues(form.setConditionals, defaultSetConditionals)
 
   // Disable elemental conditions by default if the character is not of the same element
   const element = characterMetadata.element


### PR DESCRIPTION
…lied to scoring

# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Fixing a bug where scoring had hero disabled for aglaea, clean up a bit

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

