### PR TITLE
feat: cap scoring weights at [0, 1], clean up scoring modal, fix relic set stat boosts

### DIFF
--- a/src/lib/optimization/config/setsConfig.ts
+++ b/src/lib/optimization/config/setsConfig.ts
@@ -379,7 +379,7 @@ export const RelicSetsConfig: Record<keyof typeof SetsRelics, SetsDefinition> = 
       c.CR.buff(0.04, Source.PioneerDiverOfDeadWaters)
     },
     p4x: (x: ComputedStatsArray, context: OptimizerContext, setConditionals: SetConditional) => {
-      x.CD.buff(pioneerSetIndexToCd[setConditionals.valuePioneerDiverOfDeadWaters], Source.PioneerDiverOfDeadWaters)
+      x.CD_BOOST.buff(pioneerSetIndexToCd[setConditionals.valuePioneerDiverOfDeadWaters], Source.PioneerDiverOfDeadWaters)
       if (setConditionals.valuePioneerDiverOfDeadWaters > 2) {
         x.CR.buff(0.04, Source.PioneerDiverOfDeadWaters)
       }

--- a/src/lib/optimization/config/setsConfig.ts
+++ b/src/lib/optimization/config/setsConfig.ts
@@ -317,9 +317,9 @@ export const RelicSetsConfig: Record<keyof typeof SetsRelics, SetsDefinition> = 
       context.elementalDamageType == Stats.Imaginary_DMG && c.IMAGINARY_DMG_BOOST.buff(0.10, Source.WastelanderOfBanditryDesert)
     },
     p4x: (x: ComputedStatsArray, context: OptimizerContext, setConditionals: SetConditional) => {
-      x.CD.buff(0.10 * (setConditionals.valueWastelanderOfBanditryDesert == 2 ? 1 : 0), Source.WastelanderOfBanditryDesert)
+      x.CD_BOOST.buff(0.10 * (setConditionals.valueWastelanderOfBanditryDesert == 2 ? 1 : 0), Source.WastelanderOfBanditryDesert)
       if (setConditionals.valueWastelanderOfBanditryDesert > 0) {
-        x.CR.buff(0.10, Source.WastelanderOfBanditryDesert)
+        x.CR_BOOST.buff(0.10, Source.WastelanderOfBanditryDesert)
       }
     },
   },

--- a/src/lib/overlays/modals/ScoringModal.tsx
+++ b/src/lib/overlays/modals/ScoringModal.tsx
@@ -5,6 +5,7 @@ import { Assets } from 'lib/rendering/assets'
 import DB from 'lib/state/db'
 import CharacterSelect from 'lib/tabs/tabOptimizer/optimizerForm/components/CharacterSelect'
 import { ColorizedLinkWithIcon } from 'lib/ui/ColorizedLink'
+import { VerticalDivider } from 'lib/ui/Dividers'
 import { TsUtils } from 'lib/utils/TsUtils'
 import React, { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -62,15 +63,15 @@ export default function ScoringModal() {
     }
   }, [scoringAlgorithmFocusCharacter, scoringModalOpen, scoringAlgorithmForm])
 
-  const panelWidth = 225
+  const panelWidth = 220
   const defaultGap = 5
-  const selectWidth = 360
+  const selectWidth = 260
 
   function StatValueRow(props: { stat: string }) {
     return (
       <Flex justify='flex-start' style={{ width: panelWidth }} align='center' gap={5}>
         <Form.Item name={['stats', props.stat]}>
-          <InputNumberStyled controls={false} size='small'/>
+          <InputNumberStyled controls={false} size='small' min={0} max={1}/>
         </Form.Item>
         <Flex>
           <img src={Assets.getStatIcon(props.stat)} style={{ width: 25, height: 25, marginRight: 3 }}></img>
@@ -186,149 +187,139 @@ export default function ScoringModal() {
 
         <TitleDivider>{t('Scoring.StatWeightsHeader')/* Stat weights */}</TitleDivider>
 
-        <Flex gap={10} vertical>
-          <Flex gap={20} justify='space-between'>
-            <Flex vertical gap={5}>
-              <Form.Item name='characterId'>
-                <CharacterSelect
-                  value=''
-                  selectStyle={{}}
-                  onChange={characterSelectorChange}
-                />
-              </Form.Item>
-              <div style={{ height: 230, width: panelWidth, overflow: 'hidden' }}>
-                <img src={previewSrc} style={{ width: panelWidth }}/>
-              </div>
-            </Flex>
-            <Flex vertical gap={3}>
-              <StatValueRow stat={Stats.ATK}/>
-              <StatValueRow stat={Stats.HP}/>
-              <StatValueRow stat={Stats.DEF}/>
-              <StatValueRow stat={Stats.SPD}/>
-              <StatValueRow stat={Stats.CR}/>
-              <StatValueRow stat={Stats.CD}/>
-              <StatValueRow stat={Stats.EHR}/>
-              <StatValueRow stat={Stats.RES}/>
-              <StatValueRow stat={Stats.BE}/>
-            </Flex>
-            <Flex vertical gap={3}>
-              <StatValueRow stat={Stats.ERR}/>
-              <StatValueRow stat={Stats.OHB}/>
-              <StatValueRow stat={Stats.Physical_DMG}/>
-              <StatValueRow stat={Stats.Fire_DMG}/>
-              <StatValueRow stat={Stats.Ice_DMG}/>
-              <StatValueRow stat={Stats.Lightning_DMG}/>
-              <StatValueRow stat={Stats.Wind_DMG}/>
-              <StatValueRow stat={Stats.Quantum_DMG}/>
-              <StatValueRow stat={Stats.Imaginary_DMG}/>
+        <Flex gap={20}>
+          <Flex vertical gap={5}>
+            <Form.Item name='characterId'>
+              <CharacterSelect
+                value=''
+                selectStyle={{}}
+                onChange={characterSelectorChange}
+              />
+            </Form.Item>
+            <div style={{ height: 230, width: panelWidth, overflow: 'hidden' }}>
+              <img src={previewSrc} style={{ width: panelWidth }}/>
+            </div>
+          </Flex>
+
+          <VerticalDivider/>
+
+          <Flex vertical>
+            <Flex justify='space-between'>
+              <Flex vertical gap={defaultGap * 2}>
+                <Flex vertical gap={1} justify='flex-start'>
+                  <Text style={{ marginLeft: 5 }}>
+                    {t('common:Parts.Body')}
+                  </Text>
+                  <Form.Item name={['parts', Parts.Body]}>
+                    <Select
+                      mode='multiple'
+                      allowClear
+                      style={{
+                        width: selectWidth,
+                      }}
+                      placeholder={t('common:Parts.Body')}
+                      maxTagCount='responsive'
+                    >
+                      <Select.Option value={Stats.HP_P}>{t(`common:Stats.${Stats.HP_P}`)}</Select.Option>
+                      <Select.Option value={Stats.ATK_P}>{t(`common:Stats.${Stats.ATK_P}`)}</Select.Option>
+                      <Select.Option value={Stats.DEF_P}>{t(`common:Stats.${Stats.DEF_P}`)}</Select.Option>
+                      <Select.Option value={Stats.CR}>{t(`common:Stats.${Stats.CR}`)}</Select.Option>
+                      <Select.Option value={Stats.CD}>{t(`common:Stats.${Stats.CD}`)}</Select.Option>
+                      <Select.Option value={Stats.OHB}>{t(`common:Stats.${Stats.OHB}`)}</Select.Option>
+                      <Select.Option value={Stats.EHR}>{t(`common:Stats.${Stats.EHR}`)}</Select.Option>
+                    </Select>
+                  </Form.Item>
+                </Flex>
+
+                <Flex vertical gap={1} justify='flex-start'>
+                  <Text style={{ marginLeft: 5 }}>
+                    {t('common:Parts.Feet')}
+                  </Text>
+                  <Form.Item name={['parts', Parts.Feet]}>
+                    <Select
+                      mode='multiple'
+                      allowClear
+                      style={{
+                        width: selectWidth,
+                      }}
+                      placeholder={t('common:Parts.Feet')}
+                      maxTagCount='responsive'
+                    >
+                      <Select.Option value={Stats.HP_P}>{t(`common:Stats.${Stats.HP_P}`)}</Select.Option>
+                      <Select.Option value={Stats.ATK_P}>{t(`common:Stats.${Stats.ATK_P}`)}</Select.Option>
+                      <Select.Option value={Stats.DEF_P}>{t(`common:Stats.${Stats.DEF_P}`)}</Select.Option>
+                      <Select.Option value={Stats.SPD}>{t(`common:Stats.${Stats.SPD}`)}</Select.Option>
+                    </Select>
+                  </Form.Item>
+                </Flex>
+                <Flex vertical gap={1} justify='flex-start'>
+                  <Text style={{ marginLeft: 5 }}>
+                    {t('common:Parts.PlanarSphere')}
+                  </Text>
+                  <Form.Item name={['parts', Parts.PlanarSphere]}>
+                    <Select
+                      mode='multiple'
+                      allowClear
+                      style={{
+                        width: selectWidth,
+                      }}
+                      placeholder={t('common:Parts.PlanarSphere')}
+                      listHeight={400}
+                      maxTagCount='responsive'
+                    >
+                      <Select.Option value={Stats.HP_P}>{t(`common:Stats.${Stats.HP_P}`)}</Select.Option>
+                      <Select.Option value={Stats.ATK_P}>{t(`common:Stats.${Stats.ATK_P}`)}</Select.Option>
+                      <Select.Option value={Stats.DEF_P}>{t(`common:Stats.${Stats.DEF_P}`)}</Select.Option>
+                      <Select.Option value={Stats.Physical_DMG}>{t(`common:Stats.${Stats.Physical_DMG}`)}</Select.Option>
+                      <Select.Option value={Stats.Fire_DMG}>{t(`common:Stats.${Stats.Fire_DMG}`)}</Select.Option>
+                      <Select.Option value={Stats.Ice_DMG}>{t(`common:Stats.${Stats.Ice_DMG}`)}</Select.Option>
+                      <Select.Option value={Stats.Lightning_DMG}>{t(`common:Stats.${Stats.Lightning_DMG}`)}</Select.Option>
+                      <Select.Option value={Stats.Wind_DMG}>{t(`common:Stats.${Stats.Wind_DMG}`)}</Select.Option>
+                      <Select.Option value={Stats.Quantum_DMG}>{t(`common:Stats.${Stats.Quantum_DMG}`)}</Select.Option>
+                      <Select.Option value={Stats.Imaginary_DMG}>{t(`common:Stats.${Stats.Imaginary_DMG}`)}</Select.Option>
+                    </Select>
+                  </Form.Item>
+                </Flex>
+
+                <Flex vertical gap={1} justify='flex-start'>
+                  <Text style={{ marginLeft: 5 }}>
+                    {t('common:Parts.LinkRope')}
+                  </Text>
+
+                  <Form.Item name={['parts', Parts.LinkRope]}>
+                    <Select
+                      mode='multiple'
+                      allowClear
+                      style={{
+                        width: selectWidth,
+                      }}
+                      placeholder={t('common:Parts.LinkRope')}
+                      maxTagCount='responsive'
+                    >
+                      <Select.Option value={Stats.HP_P}>{t(`common:Stats.${Stats.HP_P}`)}</Select.Option>
+                      <Select.Option value={Stats.ATK_P}>{t(`common:Stats.${Stats.ATK_P}`)}</Select.Option>
+                      <Select.Option value={Stats.DEF_P}>{t(`common:Stats.${Stats.DEF_P}`)}</Select.Option>
+                      <Select.Option value={Stats.BE}>{t(`common:Stats.${Stats.BE}`)}</Select.Option>
+                      <Select.Option value={Stats.ERR}>{t(`common:Stats.${Stats.ERR}`)}</Select.Option>
+                    </Select>
+                  </Form.Item>
+                </Flex>
+              </Flex>
             </Flex>
           </Flex>
-        </Flex>
 
-        <TitleDivider>{t('Scoring.MainstatsHeader')/* Optimal mainstats */}</TitleDivider>
+          <VerticalDivider/>
 
-        <Flex justify='space-between'>
-          <Flex vertical gap={defaultGap * 2}>
-            <Flex vertical gap={1} justify='flex-start'>
-              <Text style={{ marginLeft: 5 }}>
-                {t('common:Parts.Body')}
-              </Text>
-              <Form.Item name={['parts', Parts.Body]}>
-                <Select
-                  mode='multiple'
-                  allowClear
-                  style={{
-                    width: selectWidth,
-                  }}
-                  placeholder={t('common:Parts.Body')}
-                  maxTagCount='responsive'
-                >
-                  <Select.Option value={Stats.HP_P}>{t(`common:Stats.${Stats.HP_P}`)}</Select.Option>
-                  <Select.Option value={Stats.ATK_P}>{t(`common:Stats.${Stats.ATK_P}`)}</Select.Option>
-                  <Select.Option value={Stats.DEF_P}>{t(`common:Stats.${Stats.DEF_P}`)}</Select.Option>
-                  <Select.Option value={Stats.CR}>{t(`common:Stats.${Stats.CR}`)}</Select.Option>
-                  <Select.Option value={Stats.CD}>{t(`common:Stats.${Stats.CD}`)}</Select.Option>
-                  <Select.Option value={Stats.OHB}>{t(`common:Stats.${Stats.OHB}`)}</Select.Option>
-                  <Select.Option value={Stats.EHR}>{t(`common:Stats.${Stats.EHR}`)}</Select.Option>
-                </Select>
-              </Form.Item>
-            </Flex>
-
-            <Flex vertical gap={1} justify='flex-start'>
-              <Text style={{ marginLeft: 5 }}>
-                {t('common:Parts.Feet')}
-              </Text>
-              <Form.Item name={['parts', Parts.Feet]}>
-                <Select
-                  mode='multiple'
-                  allowClear
-                  style={{
-                    width: selectWidth,
-                  }}
-                  placeholder={t('common:Parts.Feet')}
-                  maxTagCount='responsive'
-                >
-                  <Select.Option value={Stats.HP_P}>{t(`common:Stats.${Stats.HP_P}`)}</Select.Option>
-                  <Select.Option value={Stats.ATK_P}>{t(`common:Stats.${Stats.ATK_P}`)}</Select.Option>
-                  <Select.Option value={Stats.DEF_P}>{t(`common:Stats.${Stats.DEF_P}`)}</Select.Option>
-                  <Select.Option value={Stats.SPD}>{t(`common:Stats.${Stats.SPD}`)}</Select.Option>
-                </Select>
-              </Form.Item>
-            </Flex>
-          </Flex>
-          <Flex vertical gap={defaultGap * 2}>
-            <Flex vertical gap={1} justify='flex-start'>
-              <Text style={{ marginLeft: 5 }}>
-                {t('common:Parts.PlanarSphere')}
-              </Text>
-              <Form.Item name={['parts', Parts.PlanarSphere]}>
-                <Select
-                  mode='multiple'
-                  allowClear
-                  style={{
-                    width: selectWidth,
-                  }}
-                  placeholder={t('common:Parts.PlanarSphere')}
-                  listHeight={400}
-                  maxTagCount='responsive'
-                >
-                  <Select.Option value={Stats.HP_P}>{t(`common:Stats.${Stats.HP_P}`)}</Select.Option>
-                  <Select.Option value={Stats.ATK_P}>{t(`common:Stats.${Stats.ATK_P}`)}</Select.Option>
-                  <Select.Option value={Stats.DEF_P}>{t(`common:Stats.${Stats.DEF_P}`)}</Select.Option>
-                  <Select.Option value={Stats.Physical_DMG}>{t(`common:Stats.${Stats.Physical_DMG}`)}</Select.Option>
-                  <Select.Option value={Stats.Fire_DMG}>{t(`common:Stats.${Stats.Fire_DMG}`)}</Select.Option>
-                  <Select.Option value={Stats.Ice_DMG}>{t(`common:Stats.${Stats.Ice_DMG}`)}</Select.Option>
-                  <Select.Option value={Stats.Lightning_DMG}>{t(`common:Stats.${Stats.Lightning_DMG}`)}</Select.Option>
-                  <Select.Option value={Stats.Wind_DMG}>{t(`common:Stats.${Stats.Wind_DMG}`)}</Select.Option>
-                  <Select.Option value={Stats.Quantum_DMG}>{t(`common:Stats.${Stats.Quantum_DMG}`)}</Select.Option>
-                  <Select.Option value={Stats.Imaginary_DMG}>{t(`common:Stats.${Stats.Imaginary_DMG}`)}</Select.Option>
-                </Select>
-              </Form.Item>
-            </Flex>
-
-            <Flex vertical gap={1} justify='flex-start'>
-              <Text style={{ marginLeft: 5 }}>
-                {t('common:Parts.LinkRope')}
-              </Text>
-
-              <Form.Item name={['parts', Parts.LinkRope]}>
-                <Select
-                  mode='multiple'
-                  allowClear
-                  style={{
-                    width: selectWidth,
-                  }}
-                  placeholder={t('common:Parts.LinkRope')}
-                  maxTagCount='responsive'
-                >
-                  <Select.Option value={Stats.HP_P}>{t(`common:Stats.${Stats.HP_P}`)}</Select.Option>
-                  <Select.Option value={Stats.ATK_P}>{t(`common:Stats.${Stats.ATK_P}`)}</Select.Option>
-                  <Select.Option value={Stats.DEF_P}>{t(`common:Stats.${Stats.DEF_P}`)}</Select.Option>
-                  <Select.Option value={Stats.BE}>{t(`common:Stats.${Stats.BE}`)}</Select.Option>
-                  <Select.Option value={Stats.ERR}>{t(`common:Stats.${Stats.ERR}`)}</Select.Option>
-                </Select>
-              </Form.Item>
-            </Flex>
+          <Flex vertical gap={3}>
+            <StatValueRow stat={Stats.ATK}/>
+            <StatValueRow stat={Stats.HP}/>
+            <StatValueRow stat={Stats.DEF}/>
+            <StatValueRow stat={Stats.SPD}/>
+            <StatValueRow stat={Stats.CR}/>
+            <StatValueRow stat={Stats.CD}/>
+            <StatValueRow stat={Stats.EHR}/>
+            <StatValueRow stat={Stats.RES}/>
+            <StatValueRow stat={Stats.BE}/>
           </Flex>
         </Flex>
 

--- a/src/lib/relics/relicFilters.ts
+++ b/src/lib/relics/relicFilters.ts
@@ -1,4 +1,4 @@
-import { Constants, Parts, RelicSetFilterOptions } from 'lib/constants/constants'
+import { Constants, Parts, RelicSetFilterOptions, SubStatValues } from 'lib/constants/constants'
 import { RelicsByPart, SingleRelicByPart } from 'lib/gpu/webgpuTypes'
 import { StatToKey } from 'lib/optimization/computedStatsArray'
 import DB from 'lib/state/db'
@@ -10,16 +10,14 @@ import { Relic } from 'types/relic'
 export const RelicFilters = {
   calculateWeightScore: (request: Form, relics: Relic[]) => {
     const weights = request.weights || {}
-    const baseStats = DB.getMetadata().characters[request.characterId].stats
 
-    // TODO: This no longer uses 2x base, we're using a fixed scaling value for flats now
     const statScalings = {
       [Constants.Stats.HP_P]: 64.8 / 43.2,
       [Constants.Stats.ATK_P]: 64.8 / 43.2,
       [Constants.Stats.DEF_P]: 64.8 / 54,
-      [Constants.Stats.HP]: 1 / (baseStats[Constants.Stats.HP] * 2 * 0.01) * (64.8 / 43.2),
-      [Constants.Stats.ATK]: 1 / (baseStats[Constants.Stats.ATK] * 2 * 0.01) * (64.8 / 43.2),
-      [Constants.Stats.DEF]: 1 / (baseStats[Constants.Stats.DEF] * 2 * 0.01) * (64.8 / 54),
+      [Constants.Stats.HP]: (64.8 / 43.2) * SubStatValues[Constants.Stats.HP_P][5].high / SubStatValues[Constants.Stats.HP][5].high,
+      [Constants.Stats.ATK]: (64.8 / 43.2) * SubStatValues[Constants.Stats.ATK_P][5].high / SubStatValues[Constants.Stats.ATK][5].high,
+      [Constants.Stats.DEF]: (64.8 / 54) * SubStatValues[Constants.Stats.DEF_P][5].high / SubStatValues[Constants.Stats.DEF][5].high,
       [Constants.Stats.CR]: 64.8 / 32.4,
       [Constants.Stats.CD]: 64.8 / 64.8,
       [Constants.Stats.OHB]: 64.8 / 34.5,

--- a/src/lib/relics/relicFilters.ts
+++ b/src/lib/relics/relicFilters.ts
@@ -7,25 +7,25 @@ import { Utils } from 'lib/utils/utils'
 import { Form } from 'types/form'
 import { Relic } from 'types/relic'
 
+const statScalings = {
+  [Constants.Stats.HP_P]: 64.8 / 43.2,
+  [Constants.Stats.ATK_P]: 64.8 / 43.2,
+  [Constants.Stats.DEF_P]: 64.8 / 54,
+  [Constants.Stats.HP]: (64.8 / 43.2) * SubStatValues[Constants.Stats.HP_P][5].high / SubStatValues[Constants.Stats.HP][5].high,
+  [Constants.Stats.ATK]: (64.8 / 43.2) * SubStatValues[Constants.Stats.ATK_P][5].high / SubStatValues[Constants.Stats.ATK][5].high,
+  [Constants.Stats.DEF]: (64.8 / 54) * SubStatValues[Constants.Stats.DEF_P][5].high / SubStatValues[Constants.Stats.DEF][5].high,
+  [Constants.Stats.CR]: 64.8 / 32.4,
+  [Constants.Stats.CD]: 64.8 / 64.8,
+  [Constants.Stats.OHB]: 64.8 / 34.5,
+  [Constants.Stats.EHR]: 64.8 / 43.2,
+  [Constants.Stats.RES]: 64.8 / 43.2,
+  [Constants.Stats.SPD]: 64.8 / 25,
+  [Constants.Stats.BE]: 64.8 / 64.8,
+}
+
 export const RelicFilters = {
   calculateWeightScore: (request: Form, relics: Relic[]) => {
     const weights = request.weights || {}
-
-    const statScalings = {
-      [Constants.Stats.HP_P]: 64.8 / 43.2,
-      [Constants.Stats.ATK_P]: 64.8 / 43.2,
-      [Constants.Stats.DEF_P]: 64.8 / 54,
-      [Constants.Stats.HP]: (64.8 / 43.2) * SubStatValues[Constants.Stats.HP_P][5].high / SubStatValues[Constants.Stats.HP][5].high,
-      [Constants.Stats.ATK]: (64.8 / 43.2) * SubStatValues[Constants.Stats.ATK_P][5].high / SubStatValues[Constants.Stats.ATK][5].high,
-      [Constants.Stats.DEF]: (64.8 / 54) * SubStatValues[Constants.Stats.DEF_P][5].high / SubStatValues[Constants.Stats.DEF][5].high,
-      [Constants.Stats.CR]: 64.8 / 32.4,
-      [Constants.Stats.CD]: 64.8 / 64.8,
-      [Constants.Stats.OHB]: 64.8 / 34.5,
-      [Constants.Stats.EHR]: 64.8 / 43.2,
-      [Constants.Stats.RES]: 64.8 / 43.2,
-      [Constants.Stats.SPD]: 64.8 / 25,
-      [Constants.Stats.BE]: 64.8 / 64.8,
-    }
 
     weights[Constants.Stats.ATK] = weights[Constants.Stats.ATK_P]
     weights[Constants.Stats.DEF] = weights[Constants.Stats.DEF_P]

--- a/src/lib/state/db.ts
+++ b/src/lib/state/db.ts
@@ -301,20 +301,6 @@ window.store = create((set) => {
   return store
 })
 
-// TODO: define specific overrides
-// export type ScoringMetadataOverride = {
-//   "simulation": {
-//   },
-//   "stats": {
-//   },
-//   "parts": {
-//   },
-//   "sortOption": {
-//   },
-//   "characterId": "1003",
-//   "modified": false
-// }
-
 export const DB = {
   getMetadata: (): DBMetadata => state.metadata,
   setMetadata: (metadata: DBMetadata) => state.metadata = metadata,
@@ -596,11 +582,13 @@ export const DB = {
           } else {
             // Otherwise mark any modified as modified
             let statWeightsModified = false
-            for (const stat of Object.values(Constants.Stats)) {
-              if (Utils.nullUndefinedToZero(scoringMetadataOverrides.stats[stat]) != Utils.nullUndefinedToZero(defaultScoringMetadata.stats[stat])) {
+            for (const stat of Constants.SubStats) {
+              const weight = scoringMetadataOverrides.stats[stat]
+              if (Utils.nullUndefinedToZero(weight) != Utils.nullUndefinedToZero(defaultScoringMetadata.stats[stat])) {
                 statWeightsModified = true
-                break
               }
+              if (weight < 0) scoringMetadataOverrides.stats[stat] = 0
+              if (weight > 1) scoringMetadataOverrides.stats[stat] = 1
             }
 
             if (statWeightsModified) {

--- a/src/lib/tabs/tabOptimizer/optimizerForm/layout/FormCard.tsx
+++ b/src/lib/tabs/tabOptimizer/optimizerForm/layout/FormCard.tsx
@@ -37,7 +37,7 @@ export default function FormCard(props: {
       style={{
         borderRadius: 5,
         backgroundColor: token.colorBgContainer,
-        height: props.height ?? 410,
+        height: props.height ?? 400,
         padding: props.style?.padding ?? defaultPadding,
         boxShadow: cardShadow,
         overflow: props.style?.overflow,


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Pioneer / Wastelander should be on-hit stat boosts not buffs
* Cap weights at [0, 1]
* Update score modal

![image](https://github.com/user-attachments/assets/b653186c-f0d8-486c-aa01-434ced04f4bd)


## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

