### PR TITLE
fix: inaccurate verified roll counts should be verified before running est tbp

### DIFF
--- a/src/lib/relics/relicRollGrader.ts
+++ b/src/lib/relics/relicRollGrader.ts
@@ -1,4 +1,6 @@
 import { SubStatValues } from 'lib/constants/constants'
+import { StatCalculator } from 'lib/relics/statCalculator'
+import { TsUtils } from 'lib/utils/TsUtils'
 import { StatRolls, UnaugmentedRelic } from 'types/relic'
 
 // FIXME LOW
@@ -42,16 +44,20 @@ export const RelicRollGrader = {
   },
 
   calculateRelicSubstatRolls(relic: UnaugmentedRelic) {
-    // verified relics have their roll counts and steps already determined
-    if (relic.verified && !relic.substats.some((substat) => substat.rolls == null)) return
-
     // Skip non 5 star relics for simplicity
     if (relic.grade < 5) {
       relic.substats.map((x) => {
-        // x.rolls = { high: 0, mid: 0, low: 0 }
+        x.rolls = { high: 0, mid: 0, low: 0 }
         x.addedRolls = 0
       })
       return
+    }
+
+    // Verified relics *should* have their rolls correct - validate that the roll counts match the stat value before continuing
+    if (relic.verified && !relic.substats.some((substat) => substat.rolls == null)) {
+      if (validatedRolls(relic)) {
+        return
+      }
     }
 
     let totalAddedRolls = 0
@@ -78,4 +84,20 @@ export const RelicRollGrader = {
       highestRolledSubstat.addedRolls -= 1
     }
   },
+}
+
+function validatedRolls(relic: UnaugmentedRelic) {
+  for (const substat of relic.substats) {
+    const stat = substat.stat
+    const rolls = substat.rolls!
+    const value = rolls.low * StatCalculator.getMaxedSubstatValue(stat, 0.8)
+      + rolls.mid * StatCalculator.getMaxedSubstatValue(stat, 0.9)
+      + rolls.high * StatCalculator.getMaxedSubstatValue(stat, 1.0)
+
+    if (TsUtils.precisionRound(value) != TsUtils.precisionRound(substat.value)) {
+      return false
+    }
+  }
+
+  return true
 }


### PR DESCRIPTION

# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Fixing an issue where verified relics with incorrect rolls counts were causing invalid est tbp results.
* The roll counts should add up to the stat value on the relic, so validate it before skipping otherwise recount the rolls with the heuristsic

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

