### PR TITLE
hotfix: stored combo state's abilities shouldnt overwrite form abilities

### DIFF
--- a/src/lib/tabs/tabOptimizer/combo/comboDrawerController.tsx
+++ b/src/lib/tabs/tabOptimizer/combo/comboDrawerController.tsx
@@ -776,7 +776,7 @@ function change(changeConditional: {
   }
 }
 
-export function updateConditionalChange(changeEvent: Form) {
+export function updateConditionalChange(changeEvent: Form, allValues: Form) {
   console.log('updateConditionalChange', changeEvent)
 
   const comboState = window.store.getState().comboState
@@ -793,6 +793,8 @@ export function updateConditionalChange(changeEvent: Form) {
 
   if (changeEvent.teammate2?.characterConditionals) change(changeEvent.teammate2.characterConditionals, comboState.comboTeammate2?.characterConditionals ?? {})
   if (changeEvent.teammate2?.lightConeConditionals) change(changeEvent.teammate2.lightConeConditionals, comboState.comboTeammate2?.lightConeConditionals ?? {})
+
+  comboState.comboAbilities = allValues.comboAbilities
 
   window.store.getState().setComboState({ ...comboState })
   updateFormState(comboState)

--- a/src/lib/tabs/tabOptimizer/optimizerForm/OptimizerForm.tsx
+++ b/src/lib/tabs/tabOptimizer/optimizerForm/OptimizerForm.tsx
@@ -50,7 +50,7 @@ export default function OptimizerForm() {
     const keys = Object.keys(changedValues)
 
     if (keys.length == 1 && (keys[0] == 'characterConditionals' || keys[0] == 'lightConeConditionals' || keys[0] == 'setConditionals' || keys[0].startsWith('teammate'))) {
-      updateConditionalChange(changedValues)
+      updateConditionalChange(changedValues, allValues)
     }
 
     if (bypass) {


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Bug report: https://discord.com/channels/800607517074784256/1189053007741067294/1364420228704108707
* Caused by the stored combo state in DB overwriting the form's combo abilities. Passing in the full form to preserve the combo but needs a followup investigation about the rest of the fields too

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

