### PR TITLE
feat: add set upgrades to main upgrades, disable gallagher skill default, display tweaks

### DIFF
--- a/src/lib/characterPreview/CharacterCardCombatStats.tsx
+++ b/src/lib/characterPreview/CharacterCardCombatStats.tsx
@@ -98,7 +98,7 @@ function aggregateCombatStats(xa: Float32Array, ca: Float32Array, upgradeStats: 
         ? localeNumber_000(TsUtils.precisionRound(value, 4))
         : localeNumber_0(Utils.truncate10ths(TsUtils.precisionRound(value, 4)))
     } else if (!flat) {
-      display = localeNumber_0(Utils.truncate10ths(value * 100))
+      display = localeNumber_0(Utils.truncate10ths(TsUtils.precisionRound(value * 100, 4)))
     }
 
     displayWrappers.push({

--- a/src/lib/characterPreview/CharacterScoringSummary.tsx
+++ b/src/lib/characterPreview/CharacterScoringSummary.tsx
@@ -247,7 +247,7 @@ export const CharacterScoringSummary = (props: {
           </Flex>
         </Flex>
 
-        <Flex vertical gap={20}>
+        <Flex vertical gap={20} style={{ lineHeight: '22px' }}>
           <pre style={{ margin: '0 auto', color: highlight ? color : '' }}>
             {t(`CharacterPreview.ScoringColumn.${props.type}.Abilities`)}
           </pre>

--- a/src/lib/characterPreview/ShowcaseBuildAnalysis.tsx
+++ b/src/lib/characterPreview/ShowcaseBuildAnalysis.tsx
@@ -159,7 +159,7 @@ function MemoizedCharacterScoringSummary(props: {
   displayRelics: SingleRelicByPart
   showcaseMetadata: ShowcaseMetadata
 }) {
-  const delayedProps = useDelayedProps(props, 200)
+  const delayedProps = useDelayedProps(props, 250)
 
   const memoizedCharacterScoringSummary = useMemo(() => {
     return delayedProps

--- a/src/lib/characterPreview/summary/DpsScoreMainStatUpgradesTable.tsx
+++ b/src/lib/characterPreview/summary/DpsScoreMainStatUpgradesTable.tsx
@@ -5,6 +5,7 @@ import { iconSize } from 'lib/constants/constantsUi'
 import { Assets } from 'lib/rendering/assets'
 import { SimulationScore } from 'lib/scoring/simScoringUtils'
 import { SimulationStatUpgrade } from 'lib/simulations/scoringUpgrades'
+import { SimulationRequest } from 'lib/simulations/statSimulationTypes'
 import { arrowColor, arrowDirection } from 'lib/tabs/tabOptimizer/analysis/StatsDiffCard'
 import { cardShadowNonInset } from 'lib/tabs/tabOptimizer/optimizerForm/layout/FormCard'
 import { localeNumber_0, localeNumber_00 } from 'lib/utils/i18nUtils'
@@ -14,6 +15,7 @@ import { useTranslation } from 'react-i18next'
 type MainStatUpgradeItem = {
   stat: MainStats
   part: Parts
+  setUpgradeRequest?: SimulationRequest
   scorePercentUpgrade: number
   scoreValueUpgrade: number
   damagePercentUpgrade: number
@@ -40,6 +42,15 @@ export function DpsScoreMainStatUpgradesTable(props: {
     }
   }).sort((a, b) => b.scorePercentUpgrade - a.scorePercentUpgrade)
 
+  const setUpgrade = simScore.setUpgrades[0]
+  if ((setUpgrade.percent ?? 0) - simScore.percent > 0.001) {
+    dataSource.unshift({
+      key: 'setUpgrade',
+      setUpgradeRequest: setUpgrade.simulation.request,
+      ...sharedSimResultComparator(simScore, setUpgrade),
+    } as unknown as MainStatUpgradeItem)
+  }
+
   const columns: TableProps<MainStatUpgradeItem>['columns'] = [
     {
       title: t('MainStatUpgrade'), // Main Stat Upgrade
@@ -48,12 +59,23 @@ export function DpsScoreMainStatUpgradesTable(props: {
       width: 200,
       rowScope: 'row',
       render: (stat: MainStats, upgrade: MainStatUpgradeItem) => (
-        <Flex align='center' gap={5}>
-          <img src={Assets.getPart(upgrade.part)} style={{ width: iconSize, height: iconSize, marginLeft: 3, marginRight: 3 }}/>
-          <span>➔</span>
-          <img src={Assets.getStatIcon(stat)} style={{ width: iconSize, height: iconSize }}/>
-          <span>{`${tCommon(`ShortReadableStats.${stat}`)}`}</span>
-        </Flex>
+        upgrade.setUpgradeRequest
+          ? (
+            <Flex align='center' gap={3}>
+              <img src={Assets.getSetImage(upgrade.setUpgradeRequest.simRelicSet1)} style={{ width: iconSize, height: iconSize }}/>
+              <img src={Assets.getSetImage(upgrade.setUpgradeRequest.simRelicSet2)} style={{ width: iconSize, height: iconSize }}/>
+              <span> </span>
+              <img src={Assets.getSetImage(upgrade.setUpgradeRequest.simOrnamentSet)} style={{ width: iconSize, height: iconSize, marginLeft: 3 }}/>
+            </Flex>
+          )
+          : (
+            <Flex align='center' gap={5}>
+              <img src={Assets.getPart(upgrade.part)} style={{ width: iconSize, height: iconSize, marginLeft: 3, marginRight: 3 }}/>
+              <span>➔</span>
+              <img src={Assets.getStatIcon(stat)} style={{ width: iconSize, height: iconSize }}/>
+              <span>{`${tCommon(`ShortReadableStats.${stat}`)}`}</span>
+            </Flex>
+          )
       ),
     },
     // @ts-ignore

--- a/src/lib/characterPreview/summary/SubstatRollsSummary.tsx
+++ b/src/lib/characterPreview/summary/SubstatRollsSummary.tsx
@@ -5,6 +5,7 @@ import { diminishingReturnsFormula, spdDiminishingReturnsFormula } from 'lib/sco
 import { SimulationRequest } from 'lib/simulations/statSimulationTypes'
 import { VerticalDivider } from 'lib/ui/Dividers'
 import { numberToLocaleString } from 'lib/utils/i18nUtils'
+import { TsUtils } from 'lib/utils/TsUtils'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -99,10 +100,10 @@ function ScoringNumberParens(props: {
   precision?: number
 }) {
   const precision = props.precision ?? 1
-  const value = props.number ?? 0
-  const parens = props.parens ?? 0
+  const value = TsUtils.precisionRound(props.number ?? 0)
+  const parens = TsUtils.precisionRound(props.parens ?? 0)
   const show = value != 0
-  const showParens = parens != 0
+  const showParens = parens > 0
 
   return (
     <Flex gap={5} justify='space-between'>

--- a/src/lib/conditionals/character/1300/Gallagher.ts
+++ b/src/lib/conditionals/character/1300/Gallagher.ts
@@ -44,14 +44,14 @@ export default (e: Eidolon, withContent: boolean): CharacterConditionalsControll
     basicEnhanced: true,
     breakEffectToOhbBoost: true,
     e1ResBuff: true,
-    e2ResBuff: true,
+    e2ResBuff: false,
     e6BeBuff: true,
     targetBesotted: true,
   }
 
   const teammateDefaults = {
     targetBesotted: true,
-    e2ResBuff: true,
+    e2ResBuff: false,
   }
 
   const content: ContentDefinition<typeof defaults> = {

--- a/src/lib/scoring/dpsScore.ts
+++ b/src/lib/scoring/dpsScore.ts
@@ -19,8 +19,6 @@ export function getShowcaseSimScoringExecution(
   teamSelection: string,
   showcaseTemporaryOptions: ShowcaseTemporaryOptions = {},
 ): AsyncSimScoringExecution {
-  console.log('Start async')
-
   const characterMetadata = DB.getMetadata().characters[character.id]
   const simulationMetadata = resolveDpsScoreSimulationMetadata(character, teamSelection)
   const singleRelicByPart = displayRelics as SingleRelicByPart
@@ -50,12 +48,9 @@ export function getShowcaseSimScoringExecution(
   }
 
   async function runSimulation() {
-    console.log('Executing async operation')
-
     try {
       const simulationOrchestrator = await runDpsScoreBenchmarkOrchestrator(character, simulationMetadata!, singleRelicByPart, showcaseTemporaryOptions)
       const simulationScore = simulationOrchestrator.simulationScore
-      console.log('Orchestrator', simulationOrchestrator)
       console.log('Percent', simulationScore?.percent)
 
       if (!simulationScore) return null
@@ -76,7 +71,6 @@ export function getShowcaseSimScoringExecution(
 
   asyncResult.promise = runSimulation()
 
-  console.log('Return async')
   return asyncResult
 }
 


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Gallagher skills were on by default for the e2 res buff, disabling
* Adding set upgrades to main stats chart now that the toggle is gone
* Various display tweaks

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

