### PR TITLE
feat: subdps benchmarks, eff res default 30%, est tbp refresh fixes, current potential bug, reroll avg calculation

### DIFF
--- a/src/lib/characterPreview/summary/EstimatedTbpRelicsDisplay.tsx
+++ b/src/lib/characterPreview/summary/EstimatedTbpRelicsDisplay.tsx
@@ -43,7 +43,7 @@ export const EstimatedTbpRelicsDisplay = (props: {
     }
 
     cachedId = characterId
-    const cacheKey = hashEstTbpRun(displayRelics, characterId, scoringType, scoringMetadata.stats)
+    const cacheKey = hashEstTbpRun(displayRelics, characterId, scoringType, scoringMetadata)
     const cached = cachedRelics[cacheKey]
     if (cached) {
       // Deduplicate any requests against the static IN_PROGRESS object

--- a/src/lib/characterPreview/summary/statScoringSummaryController.ts
+++ b/src/lib/characterPreview/summary/statScoringSummaryController.ts
@@ -114,9 +114,10 @@ export function flatReduction(stat: string) {
 }
 
 // Scoring type isnt strictly needed in the hash but it helps work around some rendering issues with switching score type
-export function hashEstTbpRun(displayRelics: SingleRelicByPart, characterId: string, scoringType: ScoringType, weights: Record<string, number>) {
+export function hashEstTbpRun(displayRelics: SingleRelicByPart, characterId: string, scoringType: ScoringType, scoringMetadata: ScoringMetadata) {
   return TsUtils.objectHash({
-    weights,
+    weights: scoringMetadata.stats,
+    parts: scoringMetadata.parts,
     scoringType,
     characterId,
     relicsHash: Object.values(displayRelics).map(hashRelic),

--- a/src/lib/optimization/defaultForm.ts
+++ b/src/lib/optimization/defaultForm.ts
@@ -113,7 +113,7 @@ export function defaultEnemyOptions() {
     enemyLevel: 95,
     enemyCount: 1,
     enemyResistance: 0.2,
-    enemyEffectResistance: 0.2,
+    enemyEffectResistance: 0.3,
     enemyMaxToughness: 360,
     enemyElementalWeak: true,
     enemyWeaknessBroken: false,

--- a/src/lib/overlays/modals/ScoringModal.tsx
+++ b/src/lib/overlays/modals/ScoringModal.tsx
@@ -115,8 +115,12 @@ export default function ScoringModal() {
 
     const defaultScoringMetadata = DB.getMetadata().characters[scoringAlgorithmFocusCharacter].scoringMetadata
     const displayScoringMetadata = getScoringValuesForDisplay(defaultScoringMetadata)
+    const scoringMetadataToMerge: Partial<ScoringMetadata> = {
+      stats: defaultScoringMetadata.stats,
+      parts: defaultScoringMetadata.parts,
+    }
 
-    DB.updateCharacterScoreOverrides(scoringAlgorithmFocusCharacter, defaultScoringMetadata)
+    DB.updateCharacterScoreOverrides(scoringAlgorithmFocusCharacter, scoringMetadataToMerge as ScoringMetadata)
     scoringAlgorithmForm.setFieldsValue(displayScoringMetadata)
   }
 
@@ -126,7 +130,11 @@ export default function ScoringModal() {
       const charactersById = window.store.getState().charactersById
       for (const character of Object.keys(charactersById)) {
         const defaultScoringMetadata = DB.getMetadata().characters[character].scoringMetadata
-        DB.updateCharacterScoreOverrides(character, defaultScoringMetadata)
+        const scoringMetadataToMerge: Partial<ScoringMetadata> = {
+          stats: defaultScoringMetadata.stats,
+          parts: defaultScoringMetadata.parts,
+        }
+        DB.updateCharacterScoreOverrides(character, scoringMetadataToMerge as ScoringMetadata)
       }
 
       // Update values for current screen

--- a/src/lib/relics/relicScorerPotential.ts
+++ b/src/lib/relics/relicScorerPotential.ts
@@ -635,7 +635,7 @@ export class RelicScorer {
 
       for (const substat of relic.substats) {
         const stat = substat.stat
-        const value = SubStatValues[stat][5].high * meta.stats[stat] * normalization[stat]
+        const value = SubStatValues[stat][5].mid * meta.stats[stat] * normalization[stat]
         if (stat == bestSub.stat) {
           rerollValue += value * (totalRolls + 1)
         } else {

--- a/src/lib/relics/relicScorerPotential.ts
+++ b/src/lib/relics/relicScorerPotential.ts
@@ -509,7 +509,7 @@ export class RelicScorer {
     const remainingRolls = Math.ceil((maxEnhance(relic.grade as 2 | 3 | 4 | 5) - relic.enhance) / 3) - (4 - relic.substats.length)
     const mainstatBonus = mainStatBonus(relic.part, relic.main.stat, meta)
     const idealScore = this.getOptimalPartScore(relic.part, relic.main.stat, id)
-    const current = Math.max(0, (this.substatScore(relic, id).score + mainstatBonus) / idealScore * 100 * percentToScore + mainstatDeduction)
+    const current = Math.max(0, (this.substatScore(relic, id).score + mainstatDeduction) / idealScore * 100 * percentToScore + mainstatBonus)
 
     // evaluate the best possible outcome
     const bestSubstats: { stat: SubStats; value: number }[] = [{ stat: 'HP', value: 0 }, { stat: 'HP', value: 0 }, { stat: 'HP', value: 0 }, { stat: 'HP', value: 0 }]

--- a/src/lib/simulations/orchestrator/runCustomBenchmarkOrchestrator.ts
+++ b/src/lib/simulations/orchestrator/runCustomBenchmarkOrchestrator.ts
@@ -42,23 +42,25 @@ function generateSimulationMetadata(benchmarkForm: BenchmarkForm) {
     benchmarkForm.teammate2!,
   ]
 
+  metadata.deprioritizeBuffs = benchmarkForm.subDps
+
   return metadata
 }
 
 function generateSimulationSets(benchmarkForm: BenchmarkForm) {
   return {
-    relicSet1: benchmarkForm.simRelicSet1,
-    relicSet2: benchmarkForm.simRelicSet2,
-    ornamentSet: benchmarkForm.simOrnamentSet,
+    relicSet1: benchmarkForm.simRelicSet1!,
+    relicSet2: benchmarkForm.simRelicSet2!,
+    ornamentSet: benchmarkForm.simOrnamentSet!,
   }
 }
 
 function generateSimulationRequest(benchmarkForm: BenchmarkForm) {
   const request: SimulationRequest = {
     name: '',
-    simRelicSet1: benchmarkForm.simRelicSet1,
-    simRelicSet2: benchmarkForm.simRelicSet2,
-    simOrnamentSet: benchmarkForm.simOrnamentSet,
+    simRelicSet1: benchmarkForm.simRelicSet1!,
+    simRelicSet2: benchmarkForm.simRelicSet2!,
+    simOrnamentSet: benchmarkForm.simOrnamentSet!,
     simBody: Stats.HP_P,
     simFeet: Stats.HP_P,
     simPlanarSphere: Stats.HP_P,

--- a/src/lib/simulations/orchestrator/runDpsScoreBenchmarkOrchestrator.ts
+++ b/src/lib/simulations/orchestrator/runDpsScoreBenchmarkOrchestrator.ts
@@ -19,6 +19,7 @@ export async function runDpsScoreBenchmarkOrchestrator(
   orchestrator.setSimSetsWithSimRequest()
   orchestrator.setSimForm(character.form)
   orchestrator.setFlags()
+
   orchestrator.setBaselineBuild()
   orchestrator.setOriginalBuild(showcaseTemporaryOptions.spdBenchmark)
 

--- a/src/lib/simulations/tests/customBenchmark/benchmarkOrchestratorTestUtils.ts
+++ b/src/lib/simulations/tests/customBenchmark/benchmarkOrchestratorTestUtils.ts
@@ -28,6 +28,7 @@ export async function expectBenchmarkResultsToMatch(
     lightConeSuperimposition: character.lightConeSuperimposition,
     basicSpd: basicSpd,
     errRope: mains.simLinkRope == Stats.ERR,
+    subDps: false,
     simRelicSet1: sets.simRelicSet1,
     simRelicSet2: sets.simRelicSet2,
     simOrnamentSet: sets.simOrnamentSet,

--- a/src/lib/tabs/tabBenchmarks/BenchmarkResults.tsx
+++ b/src/lib/tabs/tabBenchmarks/BenchmarkResults.tsx
@@ -167,6 +167,7 @@ function PercentageTabs({ dataSource100, dataSource200 }: { dataSource100: Bench
       size='large'
       type='card'
       tabBarGutter={5}
+      defaultActiveKey='200'
       items={items}
       tabBarStyle={{ width: '100%', margin: 0 }}
     />

--- a/src/lib/tabs/tabBenchmarks/BenchmarkResults.tsx
+++ b/src/lib/tabs/tabBenchmarks/BenchmarkResults.tsx
@@ -296,7 +296,7 @@ function renderComboDmg() {
 
 function renderDeltaPercent() {
   return (n: number) => {
-    const increase = n <= 0
+    const increase = n <= 0.0001
     const icon = increase ? '⬤' : '▼'
     const color = arrowColor(increase)
 
@@ -305,7 +305,7 @@ function renderDeltaPercent() {
         <span style={{ fontSize: 10, lineHeight: '17px', color: color }}>
           {icon}
         </span>
-        {n == 0 ? '' : `-${localeNumber_0(n)}%`}
+        {increase ? '' : `-${localeNumber_0(n)}%`}
       </Flex>
     )
   }

--- a/src/lib/tabs/tabBenchmarks/BenchmarksTab.tsx
+++ b/src/lib/tabs/tabBenchmarks/BenchmarksTab.tsx
@@ -57,6 +57,7 @@ const defaultForm: Partial<BenchmarkForm> = {
   characterEidolon: 0,
   lightConeSuperimposition: 1,
   errRope: false,
+  subDps: false,
 }
 
 export default function BenchmarksTab(): ReactElement {
@@ -202,6 +203,12 @@ function RightPanel() {
           <InputNumber style={{ width: width }} size='small'/>
         </BenchmarkSetting>
         <BenchmarkSetting label='Energy regen rope' itemName='errRope'>
+          <Radio.Group buttonStyle='solid' size='small' block style={{ width: width }}>
+            <Radio.Button value={true}><CheckOutlined/></Radio.Button>
+            <Radio.Button value={false}><CloseOutlined/></Radio.Button>
+          </Radio.Group>
+        </BenchmarkSetting>
+        <BenchmarkSetting label='Sub DPS' itemName='subDps'>
           <Radio.Group buttonStyle='solid' size='small' block style={{ width: width }}>
             <Radio.Button value={true}><CheckOutlined/></Radio.Button>
             <Radio.Button value={false}><CloseOutlined/></Radio.Button>

--- a/src/lib/tabs/tabBenchmarks/UseBenchmarksTabStore.tsx
+++ b/src/lib/tabs/tabBenchmarks/UseBenchmarksTabStore.tsx
@@ -9,6 +9,7 @@ export type BenchmarkForm = {
   lightConeSuperimposition: number
   basicSpd: number
   errRope: boolean
+  subDps: boolean
   simRelicSet1?: string
   simRelicSet2?: string
   simOrnamentSet?: string

--- a/src/lib/tabs/tabBenchmarks/benchmarksTabController.ts
+++ b/src/lib/tabs/tabBenchmarks/benchmarksTabController.ts
@@ -144,6 +144,7 @@ export function handleCharacterSelectChange(id: string, form: FormInstance<Bench
     simRelicSet1: simulationMetadata.relicSets[0]?.[0],
     simRelicSet2: simulationMetadata.relicSets[0]?.[1],
     simOrnamentSet: simulationMetadata.ornamentSets[0],
+    subDps: simulationMetadata.deprioritizeBuffs,
   })
 
   const state = useBenchmarksTabStore.getState()

--- a/src/lib/tabs/tabBenchmarks/benchmarksTabController.ts
+++ b/src/lib/tabs/tabBenchmarks/benchmarksTabController.ts
@@ -117,23 +117,6 @@ function invalidBenchmarkForm(benchmarkForm: BenchmarkForm) {
   return false
 }
 
-// If these fields are different, then benchmarks can't be compared
-function generatePartialHash(benchmarkForm: BenchmarkForm) {
-  const hashObject = {
-    characterId: benchmarkForm.characterId,
-    lightCone: benchmarkForm.lightCone,
-    characterEidolon: benchmarkForm.characterEidolon,
-    lightConeSuperimposition: benchmarkForm.lightConeSuperimposition,
-    basicSpd: benchmarkForm.basicSpd,
-    errRope: benchmarkForm.errRope,
-    teammate0: benchmarkForm.teammate0,
-    teammate1: benchmarkForm.teammate1,
-    teammate2: benchmarkForm.teammate2,
-  }
-
-  return TsUtils.objectHash(hashObject)
-}
-
 export function handleCharacterSelectChange(id: string, form: FormInstance<BenchmarkForm>) {
   if (!id) return
 

--- a/src/lib/tabs/tabBenchmarks/benchmarksTabController.ts
+++ b/src/lib/tabs/tabBenchmarks/benchmarksTabController.ts
@@ -144,7 +144,7 @@ export function handleCharacterSelectChange(id: string, form: FormInstance<Bench
     simRelicSet1: simulationMetadata.relicSets[0]?.[0],
     simRelicSet2: simulationMetadata.relicSets[0]?.[1],
     simOrnamentSet: simulationMetadata.ornamentSets[0],
-    subDps: simulationMetadata.deprioritizeBuffs,
+    subDps: !!simulationMetadata.deprioritizeBuffs,
   })
 
   const state = useBenchmarksTabStore.getState()


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* `mainstatBonus` and `mainstatDeduction` were swapped for current potential
* Reroll avg was using max rolls instead of mid rolls
* Enemy default eff res 20% -> 30%, mostly affects black swan to get her closer to 120% ehr
* Resetting scoring algorithm no longer resets teams
* Add subdps options to custom benchmarks
* Fixing est tbp caching issues

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

