### PR TITLE
feat: translate benchmarks tab

### DIFF
--- a/public/locales/en_US/benchmarksTab.yaml
+++ b/public/locales/en_US/benchmarksTab.yaml
@@ -1,0 +1,34 @@
+Title: Benchmark Generator
+LeftPanel:
+  Header: Benchmark
+MiddlePanel:
+  CharacterHeader: Character
+  LCHeader: Light Cone
+  TeammatesHeader: Teammates
+RightPanel:
+  Settings:
+    Header: Settings
+    SPD: Benchmark basic SPD
+    ERR: Energy regen rope
+    SubDPS: Sub DPS
+  SetsHeader: Benchmark sets
+  ButtonText:
+    Generate: Generate benchmarks
+    Clear: Clear
+ResultsGrid:
+  Combo: Combo DMG
+  Delta: Delta
+  Sets: Sets
+ResultsTabs:
+  WithSpeed:
+    100: 100% Benchmark Builds ({{Speed}} SPD)
+    200: 200% Benchmark Builds ({{Speed}} SPD)
+  WithoutSpeed:
+    100: 100% Benchmark Builds
+    200: 200% Benchmark Builds
+ResultsPanel:
+  BasicStats: Basic Stats
+  CombatStats: Combat Stats
+  Rolls: Substat Rolls
+  Combo: Combo Rotation
+  Damage: Ability Damage

--- a/src/lib/characterPreview/summary/AbilityDamageSummary.tsx
+++ b/src/lib/characterPreview/summary/AbilityDamageSummary.tsx
@@ -1,26 +1,27 @@
 import { Flex } from 'antd'
-import { t } from 'i18next'
 import { defaultGap } from 'lib/constants/constantsUi'
 import { Key } from 'lib/optimization/computedStatsArray'
 import { RunStatSimulationsResult } from 'lib/simulations/statSimulationTypes'
 import { numberToLocaleString } from 'lib/utils/i18nUtils'
+import { useTranslation } from 'react-i18next'
 
 type AbilityDamageSummaryProps = {
   simResult: RunStatSimulationsResult
 }
 
 export function AbilityDamageSummary({ simResult }: AbilityDamageSummaryProps) {
+  const { t } = useTranslation('common', { keyPrefix: 'ShortDMGTypes' })
   return (
     <Flex gap={defaultGap} justify='space-around'>
       <Flex vertical gap={4} style={{ width: 230 }}>
-        <ScoringNumber label={String(t('common:ShortDMGTypes.Basic')) + ':'} number={simResult.xa[Key.BASIC_DMG]} precision={1}/>
-        <ScoringNumber label={String(t('common:ShortDMGTypes.Skill')) + ':'} number={simResult.xa[Key.SKILL_DMG]} precision={1}/>
-        <ScoringNumber label={String(t('common:ShortDMGTypes.Ult')) + ':'} number={simResult.xa[Key.ULT_DMG]} precision={1}/>
-        <ScoringNumber label={String(t('common:ShortDMGTypes.Fua')) + ':'} number={simResult.xa[Key.FUA_DMG]} precision={1}/>
-        <ScoringNumber label={String(t('common:ShortDMGTypes.Memo_Skill')) + ':'} number={simResult.xa[Key.MEMO_SKILL_DMG]} precision={1}/>
-        <ScoringNumber label={String(t('common:ShortDMGTypes.Memo_Talent')) + ':'} number={simResult.xa[Key.MEMO_TALENT_DMG]} precision={1}/>
-        <ScoringNumber label={String(t('common:ShortDMGTypes.Dot')) + ':'} number={simResult.xa[Key.DOT_DMG]} precision={1}/>
-        <ScoringNumber label={String(t('common:ShortDMGTypes.Break')) + ':'} number={simResult.xa[Key.BREAK_DMG]} precision={1}/>
+        <ScoringNumber label={String(t('Basic')) + ':'} number={simResult.xa[Key.BASIC_DMG]} precision={1}/>
+        <ScoringNumber label={String(t('Skill')) + ':'} number={simResult.xa[Key.SKILL_DMG]} precision={1}/>
+        <ScoringNumber label={String(t('Ult')) + ':'} number={simResult.xa[Key.ULT_DMG]} precision={1}/>
+        <ScoringNumber label={String(t('Fua')) + ':'} number={simResult.xa[Key.FUA_DMG]} precision={1}/>
+        <ScoringNumber label={String(t('Memo_Skill')) + ':'} number={simResult.xa[Key.MEMO_SKILL_DMG]} precision={1}/>
+        <ScoringNumber label={String(t('Memo_Talent')) + ':'} number={simResult.xa[Key.MEMO_TALENT_DMG]} precision={1}/>
+        <ScoringNumber label={String(t('Dot')) + ':'} number={simResult.xa[Key.DOT_DMG]} precision={1}/>
+        <ScoringNumber label={String(t('Break')) + ':'} number={simResult.xa[Key.BREAK_DMG]} precision={1}/>
       </Flex>
     </Flex>
   )

--- a/src/lib/characterPreview/summary/ComboRotationSummary.tsx
+++ b/src/lib/characterPreview/summary/ComboRotationSummary.tsx
@@ -34,12 +34,12 @@ function ScoringAbility(props: {
   comboTurnAbilities: TurnAbilityName[]
   index: number
 }) {
-  const { t, i18n } = useTranslation(['charactersTab', 'common'])
+  const { t } = useTranslation('optimizerTab', { keyPrefix: 'ComboFilter' })
 
   const abilityName = props.comboTurnAbilities[props.index]
   if (!abilityName || abilityName == NULL_TURN_ABILITY_NAME) return <></>
 
-  const displayValue = toI18NVisual(toTurnAbility(abilityName))
+  const displayValue = toI18NVisual(toTurnAbility(abilityName), t)
 
   return (
     <Flex align='center' gap={15}>

--- a/src/lib/i18n/LanguageSelector.tsx
+++ b/src/lib/i18n/LanguageSelector.tsx
@@ -39,7 +39,11 @@ export function LanguageSelector() {
           .then(() => {
             // !!do not replace this check with isBeta!!
             if (BASE_PATH === BasePath.BETA) {
-              e === 'aa_ER' ? window.jipt.start() : window.jipt.stop()
+              if (e === 'aa_ER') {
+                window.jipt.start()
+              } else {
+                window.jipt.stop()
+              }
             }
             console.log('setting language to:', i18n.resolvedLanguage)
           })

--- a/src/lib/i18n/i18n.ts
+++ b/src/lib/i18n/i18n.ts
@@ -26,6 +26,7 @@ const namespaces = [
   'settings',
   'sidebar',
   'warpCalculatorTab',
+  'benchmarksTab',
 ] as const
 export type Namespaces = typeof namespaces[number]
 

--- a/src/lib/optimization/rotation/turnAbilityConfig.ts
+++ b/src/lib/optimization/rotation/turnAbilityConfig.ts
@@ -17,7 +17,7 @@ export enum TurnMarker {
   WHOLE = 'WHOLE',
 }
 
-export const ComboOptionsLabelMapping: Record<AbilityKind, string> = {
+export const ComboOptionsLabelMapping: Record<AbilityKind, AbilityLabel> = {
   [AbilityKind.NULL]: 'None',
   [AbilityKind.BASIC]: 'Basic',
   [AbilityKind.SKILL]: 'Skill',
@@ -28,6 +28,17 @@ export const ComboOptionsLabelMapping: Record<AbilityKind, string> = {
   [AbilityKind.MEMO_SKILL]: 'MemoSkill',
   [AbilityKind.MEMO_TALENT]: 'MemoTalent',
 }
+
+type AbilityLabel =
+  | 'None'
+  | 'Basic'
+  | 'Skill'
+  | 'Ult'
+  | 'Fua'
+  | 'Dot'
+  | 'Break'
+  | 'MemoSkill'
+  | 'MemoTalent'
 
 export type TurnAbilityName =
   | `${TurnMarker}_${Exclude<AbilityKind, AbilityKind.NULL>}`

--- a/src/lib/tabs/tabBenchmarks/BenchmarkResults.tsx
+++ b/src/lib/tabs/tabBenchmarks/BenchmarkResults.tsx
@@ -1,7 +1,7 @@
 import { CaretDownOutlined, CaretRightOutlined } from '@ant-design/icons'
 import { Flex, Table, TableProps, Tabs, TabsProps, Tag, Typography } from 'antd'
 import chroma from 'chroma-js'
-import i18next from 'i18next'
+import i18next, { TFunction } from 'i18next'
 import { CharacterStatSummary } from 'lib/characterPreview/CharacterStatSummary'
 import { AbilityDamageSummary } from 'lib/characterPreview/summary/AbilityDamageSummary'
 import { ComboRotationSummary } from 'lib/characterPreview/summary/ComboRotationSummary'
@@ -18,8 +18,10 @@ import { useBenchmarksTabStore } from 'lib/tabs/tabBenchmarks/UseBenchmarksTabSt
 import { arrowColor } from 'lib/tabs/tabOptimizer/analysis/StatsDiffCard'
 import { VerticalDivider } from 'lib/ui/Dividers'
 import { HeaderText } from 'lib/ui/HeaderText'
-import { localeNumber_0 } from 'lib/utils/i18nUtils'
+import { currentLocale, localeNumber_0 } from 'lib/utils/i18nUtils'
 import { TsUtils } from 'lib/utils/TsUtils'
+import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
 
 const { Text } = Typography
 
@@ -41,53 +43,56 @@ type BenchmarkRow = {
   orchestrator: BenchmarkSimulationOrchestrator
 }
 
-const columns: TableProps<BenchmarkRow>['columns'] = [
-  {
-    title: 'Combo DMG',
-    dataIndex: 'comboDmg',
-    align: 'center',
-    render: renderComboDmg(),
-    width: 200,
-  },
-  {
-    title: 'Delta',
-    dataIndex: 'deltaPercent',
-    align: 'center',
-    render: renderDeltaPercent(),
-    width: 100,
-  },
-  {
-    title: 'Body',
-    dataIndex: 'simBody',
-    align: 'center',
-    render: renderStat(),
-  },
-  {
-    title: 'Feet',
-    dataIndex: 'simFeet',
-    align: 'center',
-    render: renderStat(),
-  },
-  {
-    title: 'Planar Sphere',
-    dataIndex: 'simPlanarSphere',
-    align: 'center',
-    render: renderStat(),
-  },
-  {
-    title: 'Link Rope',
-    dataIndex: 'simLinkRope',
-    align: 'center',
-    render: renderStat(),
-  },
-  {
-    title: 'Sets',
-    dataIndex: 'simRelicSet1',
-    align: 'center',
-    render: renderSets(),
-    width: 150,
-  },
-]
+function generateColumns(t: TFunction<'benchmarksTab', 'ResultsGrid'>): TableProps<BenchmarkRow>['columns'] {
+  const tCommon = i18next.getFixedT(null, 'common', 'Parts')
+  return [
+    {
+      title: t('Combo'), // 'Combo DMG'
+      dataIndex: 'comboDmg',
+      align: 'center',
+      render: renderComboDmg(),
+      width: 200,
+    },
+    {
+      title: t('Delta'), // 'Delta'
+      dataIndex: 'deltaPercent',
+      align: 'center',
+      render: renderDeltaPercent(),
+      width: 100,
+    },
+    {
+      title: tCommon('Body'), // 'Body'
+      dataIndex: 'simBody',
+      align: 'center',
+      render: renderStat(),
+    },
+    {
+      title: tCommon('Feet'), // 'Feet'
+      dataIndex: 'simFeet',
+      align: 'center',
+      render: renderStat(),
+    },
+    {
+      title: tCommon('PlanarSphere'), // 'Planar Sphere'
+      dataIndex: 'simPlanarSphere',
+      align: 'center',
+      render: renderStat(),
+    },
+    {
+      title: tCommon('LinkRope'), // 'Link Rope'
+      dataIndex: 'simLinkRope',
+      align: 'center',
+      render: renderStat(),
+    },
+    {
+      title: t('Sets'), // 'Sets'
+      dataIndex: 'simRelicSet1',
+      align: 'center',
+      render: renderSets(),
+      width: 150,
+    },
+  ]
+}
 
 export function BenchmarkResults() {
   const { orchestrators } = useBenchmarksTabStore()
@@ -103,6 +108,9 @@ export function BenchmarkResults() {
 
 function BenchmarkTable({ dataSource }: { dataSource: BenchmarkRow[] }) {
   const { loading } = useBenchmarksTabStore()
+  const { t } = useTranslation('benchmarksTab', { keyPrefix: 'ResultsGrid' })
+
+  const columns = useMemo(() => generateColumns(t), [t])
 
   return (
     <div
@@ -145,19 +153,19 @@ function BenchmarkTable({ dataSource }: { dataSource: BenchmarkRow[] }) {
 
 function PercentageTabs({ dataSource100, dataSource200 }: { dataSource100: BenchmarkRow[]; dataSource200: BenchmarkRow[] }) {
   const spd = dataSource100[0]?.orchestrator.flags.benchmarkBasicSpdTarget
-  const suffix = spd == null ? '' : `(${TsUtils.precisionRound(spd)} SPD)`
-  const items: TabsProps['items'] = [
+  const { t } = useTranslation('benchmarksTab', { keyPrefix: `ResultsTabs.${spd == null ? 'WithoutSpeed' : 'WithSpeed'}` })
+  const items: TabsProps['items'] = useMemo(() => [
     {
       key: '100',
-      label: `100% Benchmark Builds ${suffix}`,
+      label: t('100', { Speed: TsUtils.precisionRound(spd).toLocaleString(currentLocale()) }),
       children: <BenchmarkTable dataSource={dataSource100}/>,
     },
     {
       key: '200',
-      label: `200% Perfection Builds ${suffix}`,
+      label: t('200', { Speed: TsUtils.precisionRound(spd).toLocaleString(currentLocale()) }),
       children: <BenchmarkTable dataSource={dataSource200}/>,
     },
-  ]
+  ], [t, spd, dataSource100, dataSource200])
 
   return (
     <Tabs
@@ -174,6 +182,7 @@ function PercentageTabs({ dataSource100, dataSource200 }: { dataSource100: Bench
 }
 
 function ExpandedRow({ row }: { row: BenchmarkRow }) {
+  const { t } = useTranslation('benchmarksTab', { keyPrefix: 'ResultsPanel' })
   const simulation = row.simulation
   const orchestrator = row.orchestrator
   const result = simulation.result!
@@ -185,7 +194,7 @@ function ExpandedRow({ row }: { row: BenchmarkRow }) {
   return (
     <Flex style={{ margin: 8 }} gap={10} justify='space-around'>
       <Flex vertical style={{ minWidth: 300 }} align='center' gap={5}>
-        <HeaderText style={{ fontSize: 16 }}>Basic Stats</HeaderText>
+        <HeaderText style={{ fontSize: 16 }}>{t('BasicStats')/* Basic Stats */}</HeaderText>
 
         <CharacterStatSummary
           characterId={characterId}
@@ -200,7 +209,7 @@ function ExpandedRow({ row }: { row: BenchmarkRow }) {
       <VerticalDivider/>
 
       <Flex vertical style={{ minWidth: 300 }} align='center' gap={5}>
-        <HeaderText style={{ fontSize: 16 }}>Combat Stats</HeaderText>
+        <HeaderText style={{ fontSize: 16 }}>{t('CombatStats')/* Combat Stats */}</HeaderText>
 
         <CharacterStatSummary
           characterId={characterId}
@@ -215,7 +224,7 @@ function ExpandedRow({ row }: { row: BenchmarkRow }) {
       <VerticalDivider/>
 
       <Flex vertical align='center' gap={5}>
-        <HeaderText style={{ fontSize: 16 }}>Substat Rolls</HeaderText>
+        <HeaderText style={{ fontSize: 16 }}>{t('Rolls')/* Substat Rolls */}</HeaderText>
 
         <SubstatRollsSummary
           simRequest={simulation.request}
@@ -229,12 +238,12 @@ function ExpandedRow({ row }: { row: BenchmarkRow }) {
 
       <Flex vertical align='center' justify='space-between'>
         <Flex vertical align='center' gap={5}>
-          <HeaderText style={{ fontSize: 16 }}>Combo Rotation</HeaderText>
+          <HeaderText style={{ fontSize: 16 }}>{t('Combo')/* Combo Rotation */}</HeaderText>
           <ComboRotationSummary simMetadata={orchestrator.metadata}/>
         </Flex>
 
         <Flex vertical align='center' gap={5}>
-          <HeaderText style={{ fontSize: 16 }}>Ability Damage</HeaderText>
+          <HeaderText style={{ fontSize: 16 }}>{t('Damage')/* Ability Damage */}</HeaderText>
           <AbilityDamageSummary simResult={simulation.result!}/>
         </Flex>
       </Flex>
@@ -243,13 +252,13 @@ function ExpandedRow({ row }: { row: BenchmarkRow }) {
 }
 
 function renderStat() {
-  const t = i18next.getFixedT(null, 'common')
+  const t = i18next.getFixedT(null, 'common', 'ReadableStats')
 
-  return (stat: string) => (
+  return (stat: SubStats) => (
     <Flex align='center' justify='center' gap={2}>
       <img src={Assets.getStatIcon(stat)} style={{ width: ICON_SIZE }}/>
       <span>
-        {t(`ReadableStats.${stat as SubStats}`)}
+        {t(stat)}
       </span>
     </Flex>
   )

--- a/src/lib/tabs/tabBenchmarks/BenchmarkSettings.tsx
+++ b/src/lib/tabs/tabBenchmarks/BenchmarkSettings.tsx
@@ -1,17 +1,19 @@
 import { Flex, Form as AntDForm } from 'antd'
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import { ReactElement } from 'types/components'
 
 interface BenchmarkSettingProps {
-  label: string
+  label: 'SPD' | 'ERR' | 'SubDPS'
   itemName: string
   children: ReactElement
 }
 
 export function BenchmarkSetting({ label, itemName, children }: BenchmarkSettingProps) {
+  const { t } = useTranslation('benchmarksTab', { keyPrefix: 'RightPanel.Settings' })
   return (
     <Flex align='center' gap={10} justify='space-between'>
-      {label}
+      {t(label)}
       <AntDForm.Item name={itemName} noStyle>
         {children}
       </AntDForm.Item>

--- a/src/lib/tabs/tabBenchmarks/BenchmarksTab.tsx
+++ b/src/lib/tabs/tabBenchmarks/BenchmarksTab.tsx
@@ -1,5 +1,5 @@
 import { CheckOutlined, CloseOutlined, DeleteOutlined, SettingOutlined, ThunderboltFilled } from '@ant-design/icons'
-import { Form as AntDForm, Button, Card, Flex, InputNumber, Radio, Select } from 'antd'
+import { Button, Card, Flex, Form as AntDForm, InputNumber, Radio, Select } from 'antd'
 import { OverlayText, showcaseOutline } from 'lib/characterPreview/CharacterPreviewComponents'
 import { Sets } from 'lib/constants/constants'
 import { OpenCloseIDs, setOpen } from 'lib/hooks/useOpenClose'
@@ -23,7 +23,6 @@ import { CenteredImage } from 'lib/ui/CenteredImage'
 import { ColorizedTitleWithInfo } from 'lib/ui/ColorizedLink'
 import { CustomHorizontalDivider } from 'lib/ui/Dividers'
 import { HeaderText } from 'lib/ui/HeaderText'
-import { TsUtils } from 'lib/utils/TsUtils'
 import { useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Character, CharacterId } from 'types/character'
@@ -66,6 +65,7 @@ const defaultForm: Partial<BenchmarkForm> = {
 }
 
 export default function BenchmarksTab(): ReactElement {
+  const { t } = useTranslation('benchmarksTab')
   const [benchmarkForm] = AntDForm.useForm<BenchmarkForm>()
   const {
     isCharacterModalOpen,
@@ -90,7 +90,7 @@ export default function BenchmarksTab(): ReactElement {
   return (
     <Flex vertical style={{ minHeight: 1500, width: 1200, marginBottom: 200 }} align='center'>
       <ColorizedTitleWithInfo
-        text='Benchmark Generator'
+        text={t('Title')/* 'Benchmark Generator' */}
         url='https://github.com/fribbels/hsr-optimizer/blob/main/docs/guides/en/benchmark-generator.md'
       />
 
@@ -117,8 +117,6 @@ export default function BenchmarksTab(): ReactElement {
 }
 
 function BenchmarkInputs() {
-  const benchmarkForm = AntDForm.useFormInstance<BenchmarkForm>()
-
   return (
     <Flex vertical align='center'>
       <Flex gap={GAP * 3} style={{ width: '100%' }} justify='space-between'>
@@ -131,6 +129,7 @@ function BenchmarkInputs() {
 }
 
 function LeftPanel() {
+  const { t } = useTranslation('benchmarksTab', { keyPrefix: 'LeftPanel' })
   const form = AntDForm.useFormInstance<BenchmarkForm>()
   const characterId = AntDForm.useWatch('characterId', form) ?? ''
   const lightCone = AntDForm.useWatch('lightCone', form) ?? ''
@@ -141,7 +140,7 @@ function LeftPanel() {
   return (
     <Flex vertical gap={GAP}>
       <Flex vertical gap={GAP}>
-        <HeaderText>Benchmark</HeaderText>
+        <HeaderText>{t('Header')/* Benchmark */}</HeaderText>
         <CenteredImage
           src={Assets.getCharacterPreviewById(characterId)}
           containerW={250}
@@ -161,13 +160,14 @@ function LeftPanel() {
 }
 
 function MiddlePanel() {
+  const { t } = useTranslation('benchmarksTab', { keyPrefix: 'MiddlePanel' })
   const form = AntDForm.useFormInstance<BenchmarkForm>()
   const characterId = AntDForm.useWatch('characterId', form) ?? ''
 
   return (
     <Flex vertical gap={GAP} style={{ width: MID_PANEL_WIDTH }} justify='space-between'>
       <Flex vertical gap={GAP}>
-        <HeaderText>Character</HeaderText>
+        <HeaderText>{t('CharacterHeader')/* Character */}</HeaderText>
         <AntDForm.Item name='characterId' noStyle>
           <CharacterSelect
             value={null}
@@ -178,7 +178,7 @@ function MiddlePanel() {
       </Flex>
 
       <Flex vertical gap={GAP}>
-        <HeaderText>Light Cone</HeaderText>
+        <HeaderText>{t('LCHeader')/* Light Cone */}</HeaderText>
         <AntDForm.Item name='lightCone' noStyle>
           <LightConeSelect value={null} characterId={characterId}/>
         </AntDForm.Item>
@@ -198,22 +198,22 @@ function RightPanel() {
     resetCache,
   } = useBenchmarksTabStore()
   const benchmarkForm = AntDForm.useFormInstance<BenchmarkForm>()
-  const { t: tCommon } = useTranslation(['optimizerTab', 'common'])
-  const characterId = AntDForm.useWatch('characterId', benchmarkForm) ?? ''
+  const { t } = useTranslation('benchmarksTab', { keyPrefix: 'RightPanel' })
+  const { t: tOptimizerTab } = useTranslation('optimizerTab')
 
   return (
     <Flex vertical style={{ width: RIGHT_PANEL_WIDTH }} justify='space-between'>
       <Flex vertical gap={GAP}>
-        <HeaderText>Settings</HeaderText>
+        <HeaderText>{t('Settings.Header')/* Settings */}</HeaderText>
 
         <SpdBenchmarkSetting/>
-        <BenchmarkSetting label='Energy regen rope' itemName='errRope'>
+        <BenchmarkSetting label='ERR' itemName='errRope'>
           <Radio.Group buttonStyle='solid' size='small' block style={{ width: INPUT_WIDTH }}>
             <Radio.Button value={true}><CheckOutlined/></Radio.Button>
             <Radio.Button value={false}><CloseOutlined/></Radio.Button>
           </Radio.Group>
         </BenchmarkSetting>
-        <BenchmarkSetting label='Sub DPS' itemName='subDps'>
+        <BenchmarkSetting label='SubDPS' itemName='subDps'>
           <Radio.Group buttonStyle='solid' size='small' block style={{ width: INPUT_WIDTH }}>
             <Radio.Button value={true}><CheckOutlined/></Radio.Button>
             <Radio.Button value={false}><CloseOutlined/></Radio.Button>
@@ -222,7 +222,7 @@ function RightPanel() {
 
         <CustomHorizontalDivider height={8}/>
 
-        <HeaderText>Benchmark sets</HeaderText>
+        <HeaderText>{t('SetsHeader')/* Benchmark sets */}</HeaderText>
 
         <Flex vertical gap={HEADER_GAP}>
           <SetsSection simType={StatSimTypes.Benchmarks}/>
@@ -231,7 +231,7 @@ function RightPanel() {
             icon={<SettingOutlined/>}
             type='dashed'
           >
-            {tCommon('SetConditionals.Title')/* Conditional set effects */}
+            {tOptimizerTab('SetConditionals.Title')/* Conditional set effects */}
           </Button>
 
         </Flex>
@@ -251,7 +251,7 @@ function RightPanel() {
           style={{ width: '100%', height: 40 }}
           type='primary'
         >
-          Generate benchmarks
+          {t('ButtonText.Generate')/* Generate benchmarks */}
         </Button>
         <Button
           onClick={() => {
@@ -261,7 +261,7 @@ function RightPanel() {
           type='default'
           icon={<DeleteOutlined/>}
         >
-          Clear
+          {t('ButtonText.Clear')/* Clear */}
         </Button>
       </Flex>
     </Flex>
@@ -269,16 +269,16 @@ function RightPanel() {
 }
 
 function SpdBenchmarkSetting() {
-  const { t } = useTranslation('optimizerTab', { keyPrefix: 'Presets' })
+  const { t: tOptimizerTab } = useTranslation('optimizerTab', { keyPrefix: 'Presets' })
   const { t: tCharacterTab } = useTranslation('charactersTab', { keyPrefix: 'CharacterPreview.ScoringSidebar.BenchmarkSpd' })
   const benchmarkForm = AntDForm.useFormInstance<BenchmarkForm>()
 
   const presetOptions = useMemo(() => {
     // Optimizer has SPD0 as undefined for filters, we want to set it to 0
-    const presets = TsUtils.clone(generateSpdPresets(t))
+    const presets = generateSpdPresets(tOptimizerTab)
     presets.SPD0.value = 0
     return Object.values(presets)
-  }, [])
+  }, [tOptimizerTab])
 
   const options = [
     {
@@ -288,7 +288,7 @@ function SpdBenchmarkSetting() {
   ]
 
   return (
-    <BenchmarkSetting label='Benchmark basic SPD' itemName='basicSpd'>
+    <BenchmarkSetting label='SPD' itemName='basicSpd'>
       <InputNumber
         size='small'
         controls={false}
@@ -311,9 +311,10 @@ function SpdBenchmarkSetting() {
 }
 
 function TeammatesSection() {
+  const { t } = useTranslation('benchmarksTab', { keyPrefix: 'MiddlePanel' })
   return (
     <Flex vertical>
-      <HeaderText>Teammates</HeaderText>
+      <HeaderText>{t('TeammatesHeader')/* Teammates */}</HeaderText>
       <Flex justify='space-around'>
         <Teammate index={0}/>
         <Teammate index={1}/>
@@ -326,7 +327,7 @@ function TeammatesSection() {
 const iconSize = 64
 
 function Teammate({ index }: { index: number }) {
-  const { t } = useTranslation(['charactersTab', 'modals', 'common'])
+  const { t } = useTranslation('common')
   const {
     setCharacterModalOpen,
     setCharacterModalInitialCharacter,
@@ -371,7 +372,7 @@ function Teammate({ index }: { index: number }) {
         />
 
         <OverlayText
-          text={t('common:EidolonNShort', { eidolon: characterEidolon })}
+          text={t('EidolonNShort', { eidolon: characterEidolon })}
           top={-12}
         />
 
@@ -381,7 +382,7 @@ function Teammate({ index }: { index: number }) {
         />
 
         <OverlayText
-          text={t('common:SuperimpositionNShort', { superimposition: lightConeSuperimposition })}
+          text={t('SuperimpositionNShort', { superimposition: lightConeSuperimposition })}
           top={-18}
         />
       </Flex>

--- a/src/lib/tabs/tabMetadata/MetadataTab.tsx
+++ b/src/lib/tabs/tabMetadata/MetadataTab.tsx
@@ -163,7 +163,7 @@ function generateTeamGrid(characters: DBMetadataCharacter[]) {
 
 function SimulationComboDashboard() {
   const characters = Object.values(DB.getMetadata().characters)
-  const { t } = useTranslation('optimizerTab', { keyPrefix: 'ComboFilter.ComboOptions' })
+  const { t } = useTranslation('optimizerTab', { keyPrefix: 'ComboFilter' })
   return (
     <Flex vertical gap={40}>
       <GridDisplay grid={generateComboGrid(filterByPath(characters, PathNames.Destruction), t)}/>
@@ -178,7 +178,7 @@ function SimulationComboDashboard() {
   )
 }
 
-function generateComboGrid(characters: DBMetadataCharacter[], t: TFunction<'optimizerTab', 'ComboFilter.ComboOptions'>) {
+function generateComboGrid(characters: DBMetadataCharacter[], t: TFunction<'optimizerTab', 'ComboFilter'>) {
   let i = 0
   const comboByCharacter = [
     Array<ReactElement>(2)
@@ -196,7 +196,10 @@ function generateComboGrid(characters: DBMetadataCharacter[], t: TFunction<'opti
     i = 0
     const row: ReactElement[] = Array(2).fill(<Icon key={i++} src={Assets.getBlank()}/>)
     row[0] = <Icon key={0} src={Assets.getCharacterAvatarById(character.id)}/>
-    const text = combo.filter((x) => x != NULL_TURN_ABILITY_NAME).map(formatComboAction).join(' - ')
+    const text = combo
+      .filter((x) => x != NULL_TURN_ABILITY_NAME)
+      .map((action) => formatComboAction(action, t))
+      .join(' - ')
 
     row[1] = <Flex style={{ whiteSpace: 'nowrap', justifyContent: 'flex-start', marginRight: 10, marginLeft: 10, width: 600 }}>{text}</Flex>
     comboByCharacter.push(row)
@@ -204,8 +207,8 @@ function generateComboGrid(characters: DBMetadataCharacter[], t: TFunction<'opti
   return comboByCharacter
 }
 
-function formatComboAction(action: TurnAbilityName) {
-  return toI18NVisual(toTurnAbility(action))
+function formatComboAction(action: TurnAbilityName, t: TFunction<'optimizerTab', 'ComboFilter'>) {
+  return toI18NVisual(toTurnAbility(action), t)
 }
 
 // =========================================== ConditionalSetsPresetsDashboard ===========================================

--- a/src/lib/tabs/tabOptimizer/optimizerForm/components/TurnAbilitySelector.tsx
+++ b/src/lib/tabs/tabOptimizer/optimizerForm/components/TurnAbilitySelector.tsx
@@ -1,8 +1,9 @@
 import { Cascader, ConfigProvider, Form } from 'antd'
-import i18next from 'i18next'
+import { TFunction } from 'i18next'
 import { AbilityKind, ALL_ABILITIES, ComboOptionsLabelMapping, createAbility, NULL_TURN_ABILITY, NULL_TURN_ABILITY_NAME, toTurnAbility, TurnAbility, TurnAbilityName, TurnMarker } from 'lib/optimization/rotation/turnAbilityConfig'
 import { updateAbilityRotation } from 'lib/tabs/tabOptimizer/combo/comboDrawerController'
 import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
 import { OptimizerForm } from 'types/form'
 
 const { SHOW_CHILD } = Cascader
@@ -34,10 +35,9 @@ interface Option {
 const start = '['
 const end = ']'
 
-export function toI18NVisual(ability: TurnAbility): string {
+export function toI18NVisual(ability: TurnAbility, t: TFunction<'optimizerTab', 'ComboFilter'>): string {
   if (!ability || ability == NULL_TURN_ABILITY) return ''
-  const t = i18next.getFixedT(null, 'optimizerTab', 'ComboFilter')
-  const abilityKindVisual: string = t(`ComboOptions.${ComboOptionsLabelMapping[ability.kind]}` as never)
+  const abilityKindVisual: string = t(`ComboOptions.${ComboOptionsLabelMapping[ability.kind]}`)
 
   switch (ability.marker) {
     case TurnMarker.START:
@@ -51,17 +51,17 @@ export function toI18NVisual(ability: TurnAbility): string {
   }
 }
 
-function generateOptions(): Option[] {
-  const t = i18next.getFixedT(null, 'optimizerTab', 'ComboFilter')
+function generateOptions(t: TFunction<'optimizerTab', 'ComboFilter'>): Option[] {
+  // const t = i18next.getFixedT(null, 'optimizerTab', 'ComboFilter')
   return ALL_ABILITIES.map((kind) => ({
     value: `${kind}`,
-    label: t(`ComboOptions.${ComboOptionsLabelMapping[kind]}` as never),
+    label: t(`ComboOptions.${ComboOptionsLabelMapping[kind]}`),
     children: Object.values(TurnMarker)
       .map((marker) => {
         const turnAbility = createAbility(kind, marker)
         return {
           value: turnAbility.name,
-          label: toI18NVisual(turnAbility),
+          label: toI18NVisual(turnAbility, t),
           children: [],
         }
       }),
@@ -69,8 +69,9 @@ function generateOptions(): Option[] {
 }
 
 export function TurnAbilitySelector({ formName, disabled }: { formName: (string | number)[]; disabled: boolean }) {
+  const { t } = useTranslation('optimizerTab', { keyPrefix: 'ComboFilter' })
   const form = Form.useFormInstance<OptimizerForm>()
-  const options = useMemo(() => generateOptions(), [])
+  const options = useMemo(() => generateOptions(t), [t])
 
   return (
     <ConfigProvider theme={cascaderTheme}>
@@ -113,7 +114,8 @@ export function TurnAbilitySelector({ formName, disabled }: { formName: (string 
 }
 
 export function TurnAbilitySelectorSimple({ value, index }: { value: TurnAbilityName; index: number }) {
-  const options = useMemo(() => generateOptions(), [])
+  const { t } = useTranslation('optimizerTab', { keyPrefix: 'ComboFilter' })
+  const options = useMemo(() => generateOptions(t), [t])
 
   if (value == null) {
     return <></>
@@ -129,7 +131,7 @@ export function TurnAbilitySelectorSimple({ value, index }: { value: TurnAbility
         displayRender={(labels: string[]) => {
           const turnAbility = toTurnAbility(value)
 
-          return `${index}. ${toI18NVisual(turnAbility)}`
+          return `${index}. ${toI18NVisual(turnAbility, t)}`
         }}
         expandTrigger='hover'
         placeholder='Ability'
@@ -152,7 +154,8 @@ export function ControlledTurnAbilitySelector({
   value: TurnAbilityName
   style?: React.CSSProperties
 }) {
-  const options = useMemo(() => generateOptions(), [])
+  const { t } = useTranslation('optimizerTab', { keyPrefix: 'ComboFilter' })
+  const options = useMemo(() => generateOptions(t), [t])
 
   return (
     <ConfigProvider theme={cascaderTheme}>
@@ -164,7 +167,7 @@ export function ControlledTurnAbilitySelector({
           const turnAbilityName = labels[0] as TurnAbilityName
           const turnAbility = toTurnAbility(turnAbilityName)
 
-          return toI18NVisual(turnAbility)
+          return toI18NVisual(turnAbility, t)
         }}
         expandTrigger='hover'
         placeholder='Ability'

--- a/src/types/resources.d.ts
+++ b/src/types/resources.d.ts
@@ -1,4 +1,50 @@
 interface Resources {
+  "benchmarksTab": {
+    "Title": "Benchmark Generator",
+    "LeftPanel": {
+      "Header": "Benchmark"
+    },
+    "MiddlePanel": {
+      "CharacterHeader": "Character",
+      "LCHeader": "Light Cone",
+      "TeammatesHeader": "Teammates"
+    },
+    "RightPanel": {
+      "Settings": {
+        "Header": "Settings",
+        "SPD": "Benchmark basic SPD",
+        "ERR": "Energy regen rope",
+        "SubDPS": "Sub DPS"
+      },
+      "SetsHeader": "Benchmark sets",
+      "ButtonText": {
+        "Generate": "Generate benchmarks",
+        "Clear": "Clear"
+      }
+    },
+    "ResultsTabs": {
+      "WithSpeed": {
+        "100": "100% Benchmark Builds ({{Speed}} SPD)",
+        "200": "200% Benchmark Builds ({{Speed}} SPD)"
+      },
+      "WithoutSpeed": {
+        "100": "100% Benchmark Builds",
+        "200": "200% Benchmark Builds"
+      }
+    },
+    "ResultsGrid": {
+      "Combo": "Combo DMG",
+      "Delta": "Delta",
+      "Sets": "Sets"
+    },
+    "ResultsPanel": {
+      "BasicStats": "Basic Stats",
+      "CombatStats": "Combat Stats",
+      "Rolls": "Substat Rolls",
+      "Combo": "Combo Rotation",
+      "Damage": "Ability Damage"
+    }
+  },
   "charactersTab": {
     "ScreenshotMessages": {
       "ScreenshotSuccess": "Copied screenshot to clipboard",


### PR DESCRIPTION
fix nonreactive translations in combo filter/drawer

# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description
<!-- Please provide a brief description of the changes made in this pull request. 
List out: Added, Changed, Fixed, etc as appropriate -->

* Added translation support for benchmarks tab
* Fixed non reactive translation in combo filter and drawer

## Related Issue
<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

* 

## Checklist
<!-- Please check all the boxes below by replacing the space with an x. -->
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

