### PR TITLE
fix: workaround for int32 overflow GPU limitation

### DIFF
--- a/src/lib/gpu/wgsl/computeShader.wgsl
+++ b/src/lib/gpu/wgsl/computeShader.wgsl
@@ -57,7 +57,7 @@ fn main(
     workgroup_id.z * num_workgroups.x * num_workgroups.y;
   let indexGlobal = i32(workgroup_index * WORKGROUP_SIZE + local_invocation_index);
 
-  // Load params
+  // Load offset params
   let xl = i32(params.xl);
   let xp = i32(params.xp);
   let xf = i32(params.xf);
@@ -77,14 +77,15 @@ fn main(
 
     let index = cycleIndex + i;
 
-    // Calculate relic index per slot
+    // Calculate relic index per slot based on the index (global index + invocation index)
 
-    let l = (index % lSize);
-    let p = (((index - l) / lSize) % pSize);
-    let f = (((index - p * lSize - l) / (lSize * pSize)) % fSize);
-    let b = (((index - f * pSize * lSize - p * lSize - l) / (lSize * pSize * fSize)) % bSize);
-    let g = (((index - b * fSize * pSize * lSize - f * pSize * lSize - p * lSize - l) / (lSize * pSize * fSize * bSize)) % gSize);
-    let h = (((index - g * bSize * fSize * pSize * lSize - b * fSize * pSize * lSize - f * pSize * lSize - p * lSize - l) / (lSize * pSize * fSize * bSize * gSize)) % hSize);
+    // START RELIC SLOT INDEX STRATEGY
+    // ═════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗
+    /* INJECT RELIC SLOT INDEX STRATEGY */
+    // ═════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝
+    // START RELIC SLOT INDEX STRATEGY
+
+    // Sum this invocation slots with the block offset
 
     let finalL = (l + xl) % lSize;
     let carryL = (l + xl) / lSize;

--- a/src/lib/optimization/optimizer.ts
+++ b/src/lib/optimization/optimizer.ts
@@ -100,11 +100,6 @@ export const Optimizer = {
       lSize: relics.LinkRope.length,
     }
 
-    if (sizes.gSize * sizes.bSize * sizes.fSize * sizes.pSize * sizes.lSize > 2147483647) {
-      Message.warning(`Too many permutations, please apply stricter filters or set minimum enhance to at least +3.`, 15)
-      return
-    }
-
     const permutations = sizes.hSize * sizes.gSize * sizes.bSize * sizes.fSize * sizes.pSize * sizes.lSize
     OptimizerTabController.setMetadata(sizes, relics)
 


### PR DESCRIPTION
# Pull Request
<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

Added a workaround for the gpu permutation limit, which was previously capped because of int32 overflows. Consequently, I also removed the permutation limit warning.

## Related Issue

Closes #1083 

## Checklist
- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots
<!-- If the changes include any visual updates, please provide screenshots here. -->

