### PR TITLE
hotfix: hometab github link broken

### DIFF
--- a/public/locales/en_US/hometab.yaml
+++ b/public/locales/en_US/hometab.yaml
@@ -35,7 +35,7 @@ FeatureCards:
 Welcome: Welcome to the<1/>Fribbels Star Rail Optimizer
 SearchBar:
   Placeholder: UID
-  Label: "Enter your UID to view your showcase characters"
-  Api: "Uses Enka.Network"
+  Label: 'Enter your UID to view your showcase characters'
+  Api: 'Uses Enka.Network'
   Message: Invalid input - This should be your 9 digit ingame UUID
   Search: Search

--- a/src/lib/tabs/tabHome/HomeTab.tsx
+++ b/src/lib/tabs/tabHome/HomeTab.tsx
@@ -93,8 +93,9 @@ function CommunityCollapse() {
           </span>
 
           <span>
-            Come be a part of our Star Rail community! Join the <ColorizedLinkWithIcon url='https://discord.gg/rDmB4Un7qg' />{' '}
-            server to hang out, or check out the <ColorizedLinkWithIcon url='https://github.com/fribbels/hsr-optimizer' /> repo if you'd like to contribute.
+            Come be a part of our Star Rail community! Join the <ColorizedLinkWithIcon url='https://discord.gg/rDmB4Un7qg' />
+            {' server to hang out, or check out the '}
+            <ColorizedLinkWithIcon url='https://github.com/fribbels/hsr-optimizer' /> repo if you'd like to contribute.
           </span>
         </Trans>
       </Flex>


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

- Fixed broken github link in home tab community section

## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

This bug was caused by the dprint pass.
Adding a `{' '}` to accomodate the newline changed the index of the second `<ColourizedLink/>` from 3 to 4, translations were not updated and thus kept attempting to insert into index 3 which was just plain text, leading to the link not having any text and therefore vanishing.

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
