### PR TITLE
fix: make sidebar scrollable on small height screens

### DIFF
--- a/src/lib/layout/LayoutSider.tsx
+++ b/src/lib/layout/LayoutSider.tsx
@@ -21,6 +21,10 @@ export function LayoutSider() {
       width={170}
       style={{
         background: token.colorBgContainer,
+        height: '100vh',
+        position: 'sticky',
+        top: 0,
+        overflow: 'hidden',
       }}
       collapsible
       collapsedWidth={48}
@@ -29,9 +33,12 @@ export function LayoutSider() {
     >
       <div
         style={{
-          position: 'sticky',
-          top: 0,
+          height: '100%',
+          overflowY: 'auto',
+          scrollbarWidth: 'none', // Firefox
+          msOverflowStyle: 'none', // IE/Edge
         }}
+        className="layout-sider-scroll"
       >
         <MenuDrawer />
       </div>

--- a/src/style/style.css
+++ b/src/style/style.css
@@ -577,6 +577,11 @@ a {
     border-radius: 4px !important;
 }
 
+/* Hidden scroll for a sidebar */
+.layout-sider-scroll::-webkit-scrollbar {
+    display: none;
+}
+
 .homeCard {
     /*backdrop-filter: blur(12px) saturate(200%);*/
     /*-webkit-backdrop-filter: blur(12px) saturate(200%);*/


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

- fix the problem with the non scrollable sidebar when the height of the screen is to small to fit all the context of the sidebar. Also removed the scrollbar from the sidebar.

## Related Issue

- Closes #1077 

## Checklist

- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
