### PR TITLE
feat: scale dps score custom portraits by lc height difference

### DIFF
--- a/src/lib/characterPreview/CharacterCustomPortrait.tsx
+++ b/src/lib/characterPreview/CharacterCustomPortrait.tsx
@@ -1,3 +1,9 @@
+import {
+  newLcHeight,
+  newLcMargin,
+  parentH,
+} from 'lib/constants/constantsUi'
+import { ScoringType } from 'lib/scoring/simScoringUtils'
 import { LoadingBlurredImage } from 'lib/ui/LoadingBlurredImage'
 import React from 'react'
 import { CustomImageConfig } from 'types/customImage'
@@ -5,15 +11,38 @@ import { CustomImageConfig } from 'types/customImage'
 interface CharacterCustomPortraitProps {
   customPortrait: CustomImageConfig
   parentW: number
+  scoringType: ScoringType
   onPortraitLoad?: (img: string) => void
 }
 
 const CharacterCustomPortrait: React.FC<CharacterCustomPortraitProps> = ({
   customPortrait,
   parentW,
+  scoringType,
   onPortraitLoad,
 }) => {
+  // Scale by height so that the light cone in combat scoring doesn't cut off part of the image
+  const totalLcHeight = newLcHeight + newLcMargin
+  const scaleHeight = scoringType == ScoringType.COMBAT_SCORE ? (parentH - totalLcHeight) / parentH : 1
   const scaleWidth = parentW / customPortrait.customImageParams.croppedAreaPixels.width
+
+  // When we shrink the scale by height, this is aligned left so the right side shrinks left.
+  // To balance that, we horizontally offset back towards the center, proportionally to the light cone height
+  // That also means we have to set left limits so that this doesnt cause the image to underflow on the left & right
+  const horizontalOffset = scoringType == ScoringType.COMBAT_SCORE
+    ? totalLcHeight / parentH * parentW / 2
+    : 0
+
+  const height = customPortrait.originalDimensions.height * scaleWidth * scaleHeight
+  const width = customPortrait.originalDimensions.width * scaleWidth * scaleHeight
+  const top = -customPortrait.customImageParams.croppedAreaPixels.y * scaleWidth * scaleHeight
+  const left = Math.min(
+    0,
+    Math.max(
+      -customPortrait.customImageParams.croppedAreaPixels.x * scaleWidth * scaleHeight + horizontalOffset,
+      -width + parentW,
+    ),
+  )
 
   return (
     <div
@@ -25,10 +54,10 @@ const CharacterCustomPortrait: React.FC<CharacterCustomPortraitProps> = ({
         src={customPortrait.imageUrl}
         style={{
           position: 'relative',
-          left: `-${customPortrait.customImageParams.croppedAreaPixels.x * scaleWidth}px`,
-          top: `-${customPortrait.customImageParams.croppedAreaPixels.y * scaleWidth}px`,
-          width: `${customPortrait.originalDimensions.width * scaleWidth}px`,
-          height: `${customPortrait.originalDimensions.height * scaleWidth}px`,
+          height: `${height}px`,
+          width: `${width}px`,
+          top: `${top}px`,
+          left: `${left}px`,
           objectFit: 'cover',
         }}
         callback={onPortraitLoad}

--- a/src/lib/characterPreview/CharacterPreview.tsx
+++ b/src/lib/characterPreview/CharacterPreview.tsx
@@ -309,6 +309,7 @@ export function CharacterPreview(props: {
               <ShowcasePortrait
                 source={source}
                 character={character}
+                scoringType={scoringType}
                 displayDimensions={displayDimensions}
                 customPortrait={portraitToUse}
                 editPortraitModalOpen={editPortraitModalOpen}

--- a/src/lib/characterPreview/ShowcasePortrait.tsx
+++ b/src/lib/characterPreview/ShowcasePortrait.tsx
@@ -21,6 +21,7 @@ import {
 } from 'lib/constants/constantsUi'
 import EditImageModal from 'lib/overlays/modals/EditImageModal'
 import { Assets } from 'lib/rendering/assets'
+import { ScoringType } from 'lib/scoring/simScoringUtils'
 import { useShowcaseTabStore } from 'lib/tabs/tabShowcase/useShowcaseTabStore'
 import { LoadingBlurredImage } from 'lib/ui/LoadingBlurredImage'
 import { useTranslation } from 'react-i18next'
@@ -30,11 +31,10 @@ import {
   CustomImagePayload,
 } from 'types/customImage'
 
-const { Text } = Typography
-
 export function ShowcasePortrait(props: {
   source: ShowcaseSource,
   character: Character,
+  scoringType: ScoringType,
   displayDimensions: ShowcaseDisplayDimensions,
   customPortrait: CustomImageConfig | undefined,
   editPortraitModalOpen: boolean,
@@ -55,6 +55,7 @@ export function ShowcasePortrait(props: {
   const {
     source,
     character,
+    scoringType,
     displayDimensions,
     customPortrait,
     editPortraitModalOpen,
@@ -96,6 +97,7 @@ export function ShowcasePortrait(props: {
           <CharacterCustomPortrait
             customPortrait={customPortrait ?? character.portrait!}
             parentW={parentW}
+            scoringType={scoringType}
             onPortraitLoad={onPortraitLoad}
           />
         )

--- a/src/lib/characterPreview/characterPreviewController.tsx
+++ b/src/lib/characterPreview/characterPreviewController.tsx
@@ -13,6 +13,8 @@ import {
   lcInnerW,
   lcParentH,
   lcParentW,
+  newLcHeight,
+  newLcMargin,
   parentH,
   parentW,
 } from 'lib/constants/constantsUi'
@@ -146,9 +148,6 @@ export function getArtistName(character: Character) {
 }
 
 export function getShowcaseDisplayDimensions(character: Character, simScore: boolean): ShowcaseDisplayDimensions {
-  const newLcMargin = 8
-  const newLcHeight = 128
-
   const charCenter = DB.getMetadata().characters[character.id].imageCenter
   // @ts-ignore Some APIs return empty light cone as '0'
   const lcCenter = (character.form.lightCone && character.form.lightCone != '0' && DB.getMetadata().lightCones[character.form.lightCone])

--- a/src/lib/constants/constantsUi.ts
+++ b/src/lib/constants/constantsUi.ts
@@ -11,3 +11,6 @@ export const lcParentH = 280
 export const lcInnerW = 250
 export const lcInnerH = 1260 / 902 * lcInnerW
 export const middleColumnWidth = 240
+
+export const newLcMargin = 8
+export const newLcHeight = 128


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

- Added some math to scale dps score portraits by height, since the LC covered some of the image before

## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

- Closes https://github.com/fribbels/hsr-optimizer/issues/1251

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
