### PR TITLE
fix: portrait scaling underflow check should account for vertical limit

### DIFF
--- a/src/lib/characterPreview/CharacterCustomPortrait.tsx
+++ b/src/lib/characterPreview/CharacterCustomPortrait.tsx
@@ -22,9 +22,12 @@ const CharacterCustomPortrait: React.FC<CharacterCustomPortraitProps> = ({
   onPortraitLoad,
 }) => {
   // Scale by height so that the light cone in combat scoring doesn't cut off part of the image
-  const totalLcHeight = newLcHeight + newLcMargin
-  const scaleHeight = scoringType == ScoringType.COMBAT_SCORE ? (parentH - totalLcHeight) / parentH : 1
   const scaleWidth = parentW / customPortrait.customImageParams.croppedAreaPixels.width
+  const totalLcHeight = newLcHeight + newLcMargin
+  const heightScaleLimit = customPortrait.customImageParams.croppedAreaPixels.width / customPortrait.originalDimensions.width
+  const scaleHeight = scoringType == ScoringType.COMBAT_SCORE
+    ? Math.max((parentH - totalLcHeight) / parentH, heightScaleLimit)
+    : 1
 
   // When we shrink the scale by height, this is aligned left so the right side shrinks left.
   // To balance that, we horizontally offset back towards the center, proportionally to the light cone height


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

- Forgot to add a vertical scaling limit

## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
