### PR TITLE
fix: ehr roll cap was not accounting for diminishing returns on 100% …

### DIFF
--- a/src/lib/simulations/orchestrator/benchmarkSimulationOrchestrator.ts
+++ b/src/lib/simulations/orchestrator/benchmarkSimulationOrchestrator.ts
@@ -464,7 +464,7 @@ export class BenchmarkSimulationOrchestrator {
     const perfectionSim = candidates[0]
 
     this.perfectionSimCandidates = candidates
-    this.perfectionSimResult = perfectionSim.result!
+    this.perfectionSimResult = cloneWorkerResult(perfectionSim.result!)
     this.perfectionSimRequest = perfectionSim.request
   }
 


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

- Hysilens specific bug where diminishing returns on 100% benchmark would cause the ehr roll cap to force her below 120% ehr, losing one stack of conversion

## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
