### PR TITLE
fix: prefer imported id when relic is verified

### DIFF
--- a/src/lib/state/db.ts
+++ b/src/lib/state/db.ts
@@ -899,6 +899,7 @@ export const DB = {
           // Inherit the new verified speed stats
           found = {
             ...found,
+            id: newRelic.id,
             verified: true,
             substats: newRelic.substats,
             augmentedStats: newRelic.augmentedStats,


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

- When merging new relics into the DB, prefer the id of the new relic if it is verified. This allows old optimizer saves with generated uuids to be replaced by the authoritative id from the game when using live import.

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [X] I have added commit messages that are descriptive and meaningful.
- [X] I have tested the changes locally.
- [X] I have reviewed the code changes.
