### PR TITLE
hotfix: custom diminishing returns formula on non-ehr light cone hysilens

### DIFF
--- a/src/lib/scoring/simScoringUtils.ts
+++ b/src/lib/scoring/simScoringUtils.ts
@@ -141,6 +141,7 @@ export function substatRollsModifier(
   rolls: number,
   stat: string,
   sim: Simulation,
+  customDiminishingReturnsFormula?: (mainsCount: number, rolls: number) => number,
 ) {
   const mainsCount = [
     sim.request.simBody,
@@ -149,7 +150,13 @@ export function substatRollsModifier(
     sim.request.simLinkRope,
   ].filter((x) => x == stat).length
 
-  return stat == Stats.SPD ? spdDiminishingReturnsFormula(mainsCount, rolls) : diminishingReturnsFormula(mainsCount, rolls)
+  return stat == Stats.SPD
+    ? spdDiminishingReturnsFormula(mainsCount, rolls)
+    : (
+      customDiminishingReturnsFormula
+        ? customDiminishingReturnsFormula(mainsCount, rolls)
+        : diminishingReturnsFormula(mainsCount, rolls)
+    )
 }
 
 export function diminishingReturnsFormula(mainsCount: number, rolls: number) {


### PR DESCRIPTION
…lens

# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

  // Manual adjustment for Hysilens scoring - Using non-EHR light cones forces the benchmark to be unable to hit 120%
  // EHR due to diminishing returns. To fix, relax diminishing returns on non-EHR LC builds

See: https://www.reddit.com/r/HysilensMainsHSR_/comments/1mua165/first_time_getting_such_rating/

## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
