### PR TITLE
fix: light cone dimensions

### DIFF
--- a/src/lib/constants/constantsUi.ts
+++ b/src/lib/constants/constantsUi.ts
@@ -8,8 +8,8 @@ export const parentW = 198 * 2 + defaultGap // 2x relic cards + 1x gap
 export const innerW = 1024
 export const lcParentW = 240
 export const lcParentH = 280
-export const lcInnerW = 250
-export const lcInnerH = 1260 / 902 * lcInnerW
+export const lcInnerW = 260
+export const lcInnerH = 1260 / 904 * lcInnerW
 export const middleColumnWidth = 240
 
 export const newLcMargin = 8


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

- Light cones are 1260x904, but the code had 902.
- Slightly zooming in the LC to hide white borders

## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
