### PR TITLE
feat: benchmark set matching for dhpt + banana set

### DIFF
--- a/src/lib/simulations/orchestrator/benchmarkSimulationOrchestrator.ts
+++ b/src/lib/simulations/orchestrator/benchmarkSimulationOrchestrator.ts
@@ -48,7 +48,10 @@ import {
   SimulationRequest,
   StatSimTypes,
 } from 'lib/simulations/statSimulationTypes'
-import { KAFKA_B1 } from 'lib/simulations/tests/testMetadataConstants'
+import {
+  KAFKA_B1,
+  PERMANSOR_TERRAE,
+} from 'lib/simulations/tests/testMetadataConstants'
 import { generateFullDefaultForm } from 'lib/simulations/utils/benchmarkForm'
 import { applyBasicSpeedTargetFlag } from 'lib/simulations/utils/benchmarkSpeedTargets'
 import { runComputeOptimalSimulationWorker } from 'lib/simulations/workerPool'
@@ -143,6 +146,11 @@ export class BenchmarkSimulationOrchestrator {
     }
     if (addBreakEffect && !metadata.ornamentSets.find((set) => set == Sets.ForgeOfTheKalpagniLantern)) {
       metadata.ornamentSets.push(Sets.ForgeOfTheKalpagniLantern)
+    }
+
+    // Add banana if DH PT is on the team
+    if (!metadata.ornamentSets.find((set) => set == Sets.TheWondrousBananAmusementPark) && metadata.teammates.find((x) => x.characterId == PERMANSOR_TERRAE)) {
+      metadata.ornamentSets.push(Sets.TheWondrousBananAmusementPark)
     }
 
     // Add ehr if kafka is on the team

--- a/src/lib/tabs/tabChangelog/ChangelogTab.tsx
+++ b/src/lib/tabs/tabChangelog/ChangelogTab.tsx
@@ -125,6 +125,7 @@ function getChangelogContent() {
         `Fix: Hoyolab imports now automatically detect buffed characters`,
         `Balance: Hysilens' DPS score with a non-EHR light cone now has special diminishing returns scaling due to the 100% benchmark being unable to reach the EHR breakpoint`,
         `Balance: Changed Archer's default set from Genius of Brilliant Stars to Wavestrider Captain because of DEF PEN overcapping. Genius of Brilliant Stars is still matched`,
+        `Balance: Benchmarks with Dan Heng • Permansor Terrae as a teammate will match The Wondrous BananAmusement Park set`,
       ],
     },
     {


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

- With DHPT on the team, benchmarks should match banana set

## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [ ] I have added commit messages that are descriptive and meaningful.
- [ ] I have tested the changes locally.
- [ ] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
