### PR TITLE
fix: ugly alignment of bucket panel icons at low char count

### DIFF
--- a/src/lib/tabs/tabRelics/relicInsightsPanel/Top10Panel.tsx
+++ b/src/lib/tabs/tabRelics/relicInsightsPanel/Top10Panel.tsx
@@ -9,12 +9,7 @@ import {
 import { Assets } from 'lib/rendering/assets'
 import { PanelProps } from 'lib/tabs/tabRelics/relicInsightsPanel/RelicInsightsPanel'
 import { TsUtils } from 'lib/utils/TsUtils'
-import React, {
-  useCallback,
-  useMemo,
-  useRef,
-  useState,
-} from 'react'
+import React, { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
   CartesianGrid,
@@ -28,7 +23,6 @@ import {
   XAxis,
   YAxis,
 } from 'recharts'
-import { CategoricalChartState } from 'recharts/types/chart/types'
 import {
   NameType,
   ValueType,


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

- Fixed relics tab buckets panel poorly alighning icons when character count was low

## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
