### PR TITLE
fix: hoyolab import doesn't equip bufffed characters relics

### DIFF
--- a/src/lib/importer/hoyoLabFormatParser.tsx
+++ b/src/lib/importer/hoyoLabFormatParser.tsx
@@ -170,7 +170,7 @@ export function hoyolabParser(json: HoyolabData) {
       }
       output.relics.push({
         enhance: relic.level,
-        equippedBy: String(character.id) as CharacterId,
+        equippedBy: characterId as CharacterId,
         grade: relic.rarity,
         id: Utils.randomId(),
         part: getSlot(relic.pos),
@@ -187,7 +187,7 @@ export function hoyolabParser(json: HoyolabData) {
     const trailblazerMetadata: TrailblazerMetadata = getTrailblazerMetadata(character.id)
     if (trailblazerMetadata) output.metadata = trailblazerMetadata
   }
-  output.relics.map((relic) => RelicAugmenter.augment(relic))
+  output.relics.forEach(RelicAugmenter.augment)
   return output
 }
 


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

- Fixed hoyolab import not correcting relic equippedBy id when importing buffed characters

## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
