### PR TITLE
fix: Demiurge is included in Arcadia team aware default

### DIFF
--- a/src/lib/conditionals/evaluation/applyPresets.ts
+++ b/src/lib/conditionals/evaluation/applyPresets.ts
@@ -137,6 +137,8 @@ export function applyTeamAwareSetConditionalPresets(form: Form | BenchmarkForm, 
     ),
   ]
 
+  // Arcadia depends on the number of ally targets
+  // Demiurge is out-of-bounds and therefore not a target
   const targetableMemosprites = allyIds.filter((id) => (
     id
     && id != CYRENE


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

- Changed Arcadia's team aware default to not include Demiurge for its default value

## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x ] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
