### PR TITLE
fix: typo in ThusBurnsTheDawn.ts buff description

### DIFF
--- a/src/lib/conditionals/lightcone/5star/ThusBurnsTheDawn.ts
+++ b/src/lib/conditionals/lightcone/5star/ThusBurnsTheDawn.ts
@@ -37,7 +37,7 @@ export default (s: SuperImpositionLevel, withContent: boolean): LightConeConditi
       id: 'dmgBuff',
       formItem: 'switch',
       text: t('dmgBuff.text'),
-      content: t('dmgBuff.content', { DmgBuff: TsUtils.precisionRound(100 * sValuesDefPen[s]) }),
+      content: t('dmgBuff.content', { DmgBuff: TsUtils.precisionRound(100 * sValuesDmgBuff[s]) }),
     },
   }
 


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

- Fixed ThusBurnsTheDawn using the wrong value in the dmg buff conditional description
## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
