### PR TITLE
fix: cache relic scores to prevent edit relic lag

### DIFF
--- a/src/lib/relics/scoreRelics.ts
+++ b/src/lib/relics/scoreRelics.ts
@@ -25,74 +25,109 @@ type PotentialWeights = {
   averagePct: number,
 }
 
+// Simple cache: WeakMap keyed by relic reference, auto-clears when params change
+let scoreCache: WeakMap<Relic, ScoredRelic> = new WeakMap()
+let cacheParams: { focusCharacter: Nullable<CharacterId>; excludedIds: string; metadataRef: unknown } | null = null
+
 export function scoreRelics(
   relics: Array<Relic>,
   excludedRelicPotentialCharacters: Array<CharacterId>,
   focusCharacter: Nullable<CharacterId>,
+  scoringMetadataOverrides?: unknown,
 ): Array<ScoredRelic> {
   const characterIds = Object.values(DB.getMetadata().characters).map((x) => x.id)
   const relicScorer = new RelicScorer()
-  return relics
-    .map((relic) => {
-      let weights: RelicScoringWeights = {
-        current: 0,
-        average: 0,
-        best: 0,
-        potentialSelected: {
-          bestPct: 0,
-          averagePct: 0,
-          rerollAvgPct: 0,
-        },
-        potentialAllAll: {
-          bestPct: 0,
-          averagePct: 0,
-        },
-        potentialAllCustom: {
-          bestPct: 0,
-          averagePct: 0,
-        },
-        rerollAllAll: 0,
-        rerollAllCustom: 0,
-        rerollAvgSelected: 0,
-        rerollAvgSelectedDelta: 0,
-        rerollAvgSelectedEquippedDelta: 0,
-      }
-      if (focusCharacter) {
-        const potentialSelected = relicScorer.scoreRelicPotential(relic, focusCharacter)
-        const rerollAvgSelected = Math.max(0, potentialSelected.rerollAvgPct)
-        const rerollAvgSelectedDelta = rerollAvgSelected == 0 ? 0 : (rerollAvgSelected - potentialSelected.averagePct)
-        weights = {
-          ...weights,
-          ...relicScorer.getFutureRelicScore(relic, focusCharacter),
-          potentialSelected,
-          rerollAvgSelected,
-          rerollAvgSelectedDelta,
-        }
-        const equippedRelic = DB.getRelicById(DB.getCharacterById(focusCharacter)?.equipped?.[relic.part])
-        if (equippedRelic) {
-          weights.rerollAvgSelectedEquippedDelta = weights.rerollAvgSelected - relicScorer.scoreRelicPotential(equippedRelic, focusCharacter).averagePct
-        }
-      }
 
-      for (const id of characterIds) {
-        const pct = relicScorer.scoreRelicPotential(relic, id)
-        weights.potentialAllAll = {
-          bestPct: Math.max(pct.bestPct, weights.potentialAllAll.bestPct),
-          averagePct: Math.max(pct.averagePct, weights.potentialAllAll.averagePct),
-        }
-        weights.rerollAllAll = Math.max(pct.rerollAvgPct, weights.rerollAllAll)
+  // Check if params changed - if so, clear cache
+  const excludedIds = excludedRelicPotentialCharacters.join(',')
+  if (
+    !cacheParams
+    || cacheParams.focusCharacter !== focusCharacter
+    || cacheParams.excludedIds !== excludedIds
+    || cacheParams.metadataRef !== scoringMetadataOverrides
+  ) {
+    scoreCache = new WeakMap()
+    cacheParams = { focusCharacter, excludedIds, metadataRef: scoringMetadataOverrides }
+  }
 
-        if (excludedRelicPotentialCharacters.includes(id)) continue
+  // Score relics, using cache when available
+  const scored = relics.map((relic) => {
+    const cached = scoreCache.get(relic)
+    if (cached) return cached
 
-        weights.potentialAllCustom = {
-          bestPct: Math.max(pct.bestPct, weights.potentialAllCustom.bestPct),
-          averagePct: Math.max(pct.averagePct, weights.potentialAllCustom.averagePct),
-        }
-        weights.rerollAllCustom = Math.max(pct.rerollAvgPct, weights.rerollAllCustom)
-      }
+    const result = scoreSingleRelic(relic, characterIds, excludedRelicPotentialCharacters, focusCharacter, relicScorer)
+    scoreCache.set(relic, result)
+    return result
+  })
 
-      weights.rerollAvgSelected = Math.max(0, weights.potentialSelected.rerollAvgPct)
-      return { ...relic, weights }
-    })
-    .reverse()
+  return scored.reverse()
+}
+
+function scoreSingleRelic(
+  relic: Relic,
+  characterIds: Array<CharacterId>,
+  excludedRelicPotentialCharacters: Array<CharacterId>,
+  focusCharacter: Nullable<CharacterId>,
+  relicScorer: RelicScorer,
+): ScoredRelic {
+  let weights: RelicScoringWeights = {
+    current: 0,
+    average: 0,
+    best: 0,
+    potentialSelected: {
+      bestPct: 0,
+      averagePct: 0,
+      rerollAvgPct: 0,
+    },
+    potentialAllAll: {
+      bestPct: 0,
+      averagePct: 0,
+    },
+    potentialAllCustom: {
+      bestPct: 0,
+      averagePct: 0,
+    },
+    rerollAllAll: 0,
+    rerollAllCustom: 0,
+    rerollAvgSelected: 0,
+    rerollAvgSelectedDelta: 0,
+    rerollAvgSelectedEquippedDelta: 0,
+  }
+
+  if (focusCharacter) {
+    const potentialSelected = relicScorer.scoreRelicPotential(relic, focusCharacter)
+    const rerollAvgSelected = Math.max(0, potentialSelected.rerollAvgPct)
+    const rerollAvgSelectedDelta = rerollAvgSelected == 0 ? 0 : (rerollAvgSelected - potentialSelected.averagePct)
+    weights = {
+      ...weights,
+      ...relicScorer.getFutureRelicScore(relic, focusCharacter),
+      potentialSelected,
+      rerollAvgSelected,
+      rerollAvgSelectedDelta,
+    }
+    const equippedRelic = DB.getRelicById(DB.getCharacterById(focusCharacter)?.equipped?.[relic.part])
+    if (equippedRelic) {
+      weights.rerollAvgSelectedEquippedDelta = weights.rerollAvgSelected - relicScorer.scoreRelicPotential(equippedRelic, focusCharacter).averagePct
+    }
+  }
+
+  for (const id of characterIds) {
+    const pct = relicScorer.scoreRelicPotential(relic, id)
+    weights.potentialAllAll = {
+      bestPct: Math.max(pct.bestPct, weights.potentialAllAll.bestPct),
+      averagePct: Math.max(pct.averagePct, weights.potentialAllAll.averagePct),
+    }
+    weights.rerollAllAll = Math.max(pct.rerollAvgPct, weights.rerollAllAll)
+
+    if (excludedRelicPotentialCharacters.includes(id)) continue
+
+    weights.potentialAllCustom = {
+      bestPct: Math.max(pct.bestPct, weights.potentialAllCustom.bestPct),
+      averagePct: Math.max(pct.averagePct, weights.potentialAllCustom.averagePct),
+    }
+    weights.rerollAllCustom = Math.max(pct.rerollAvgPct, weights.rerollAllCustom)
+  }
+
+  weights.rerollAvgSelected = Math.max(0, weights.potentialSelected.rerollAvgPct)
+  return { ...relic, weights }
 }

--- a/src/lib/tabs/tabRelics/RelicsGrid.tsx
+++ b/src/lib/tabs/tabRelics/RelicsGrid.tsx
@@ -66,10 +66,7 @@ export function RelicsGrid() {
   window.relicsGrid = gridRef
 
   const scoredRelics = useMemo(() => {
-    return scoreRelics(relics, excludedRelicPotentialCharacters, focusCharacter)
-    // relic scores have sn implicit dependency on scoringMetadataOverrides
-    // settings only relevant on first load so doesn't need to be in array
-    // eslint-disable-next-line exhaustive-deps
+    return scoreRelics(relics, excludedRelicPotentialCharacters, focusCharacter, scoringMetadataOverrides)
   }, [relics, scoringMetadataOverrides, focusCharacter, excludedRelicPotentialCharacters])
 
   const { filters, valueColumns } = useRelicsTabStore()


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

- Relic scores were being fully recalculated on a single relic edit, use a cache

## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [ ] I have added commit messages that are descriptive and meaningful.
- [ ] I have tested the changes locally.
- [ ] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
