### PR TITLE
fix: change screenshot download filename

### DIFF
--- a/src/lib/utils/utils.js
+++ b/src/lib/utils/utils.js
@@ -124,9 +124,8 @@ export const Utils = {
 
     function handleBlob(blob) {
       const prefix = characterName || 'Hsr-optimizer'
-      const date = new Date().toLocaleDateString(currentLocale()).replace(/[^apm\d]+/gi, '-')
-      const time = new Date().toLocaleTimeString(currentLocale()).replace(/[^apm\d]+/gi, '-')
-      const filename = `${prefix}_${date}_${time}.png`
+      const dateTime = new Date().toISOString()
+      const filename = `${prefix}_${dateTime}.png`
 
       if (action == 'clipboard') {
         if (isMobileOrSafari) {


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

- Changed downloaded screenshots to use ISOString format for date/time

## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

- Closes #1449 
- Closes unnoted issue where korean users would end up with a mangled date-time string
    ```'HSR-optimizer_' + new Date().toLocaleDateString('ko-KR').replace(/[^apm\d]+/gi, '-') + '_' + new Date().toLocaleTimeString('ko-KR').replace(/[^apm\d]+/gi, '-') ==> "HSR-optimizer_2026-1-13-_-2-43-57" ```

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
