### PR TITLE
hotfix: Anaxa and Everight E6S5 as teammates

### DIFF
--- a/src/lib/state/metadata.ts
+++ b/src/lib/state/metadata.ts
@@ -7859,8 +7859,8 @@ function getScoringMetadata(): Record<string, ScoringMetadata> {
           {
             characterId: ANAXA,
             lightCone: LIFE_SHOULD_BE_CAST_TO_FLAMES,
-            characterEidolon: 6,
-            lightConeSuperimposition: 5,
+            characterEidolon: 0,
+            lightConeSuperimposition: 1,
           },
           {
             characterId: PERMANSOR_TERRAE,
@@ -8211,8 +8211,8 @@ function getScoringMetadata(): Record<string, ScoringMetadata> {
           {
             characterId: EVERNIGHT,
             lightCone: TO_EVERNIGHTS_STARS,
-            characterEidolon: 6,
-            lightConeSuperimposition: 5,
+            characterEidolon: 0,
+            lightConeSuperimposition: 1,
           },
           {
             characterId: HYACINE,


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

- Fixes Anaxa / Evernight being E6S5 in default team for Therta / Castorice

## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
