### PR TITLE
hotfix: hit-scoped ATK_P buffs not applied correctly, refactor to remove _P from hit stats

### DIFF
--- a/public/locales/aa_ER/optimizerTab.yaml
+++ b/public/locales/aa_ER/optimizerTab.yaml
@@ -24,6 +24,7 @@ NoTeamConditionals: crwdns42666:0crwdne42666:0
 ResultLimitN: 'crwdns42668:0{{limit}}crwdne42668:0'
 MainStats: crwdns42670:0crwdne42670:0
 Sets: crwdns42672:0crwdne42672:0
+UnreleasedDisclaimer: crwdns46524:0{{nameList}}crwdne46524:0
 RelicSetSelector:
   Placeholder: crwdns42674:0crwdne42674:0
   4pcLabel: crwdns42676:0crwdne42676:0

--- a/public/locales/en_US/optimizerTab.yaml
+++ b/public/locales/en_US/optimizerTab.yaml
@@ -24,6 +24,7 @@ NoTeamConditionals: No conditional team passives
 ResultLimitN: 'Find top {{limit}} results'
 MainStats: Main stats
 Sets: Sets
+UnreleasedDisclaimer: Calculations for {{nameList}} are not complete yet, optimizer results will not be accurate
 RelicSetSelector:
   Placeholder: Relic set
   4pcLabel: 4 Piece

--- a/public/locales/hu_HU/modals.yaml
+++ b/public/locales/hu_HU/modals.yaml
@@ -1,0 +1,4 @@
+Relic:
+  Messages:
+    Error:
+      GradeMissing: A Part mező hiányzik

--- a/src/lib/conditionals/character/1000/Archer.ts
+++ b/src/lib/conditionals/character/1000/Archer.ts
@@ -352,7 +352,6 @@ const display = {
 
 export const Archer: CharacterConfig = {
   id: '1015',
-  info: {},
   display,
   conditionals,
   get scoring() {

--- a/src/lib/conditionals/character/1000/Arlan.ts
+++ b/src/lib/conditionals/character/1000/Arlan.ts
@@ -278,7 +278,6 @@ const display = {
 
 export const Arlan: CharacterConfig = {
   id: '1008',
-  info: {},
   display,
   conditionals,
   get scoring() {

--- a/src/lib/conditionals/character/1000/Asta.ts
+++ b/src/lib/conditionals/character/1000/Asta.ts
@@ -236,7 +236,6 @@ const display = {
 
 export const Asta: CharacterConfig = {
   id: '1009',
-  info: {},
   display,
   conditionals,
   get scoring() {

--- a/src/lib/conditionals/character/1000/DanHeng.ts
+++ b/src/lib/conditionals/character/1000/DanHeng.ts
@@ -306,7 +306,6 @@ const display = {
 
 export const DanHeng: CharacterConfig = {
   id: '1002',
-  info: {},
   display,
   conditionals,
   get scoring() {

--- a/src/lib/conditionals/character/1000/Herta.ts
+++ b/src/lib/conditionals/character/1000/Herta.ts
@@ -418,7 +418,6 @@ const display = {
 
 export const Herta: CharacterConfig = {
   id: '1013',
-  info: {},
   display,
   conditionals,
   get scoring() {

--- a/src/lib/conditionals/character/1000/Himeko.ts
+++ b/src/lib/conditionals/character/1000/Himeko.ts
@@ -1,43 +1,62 @@
-import { ASHBLAZING_ATK_STACK, } from 'lib/conditionals/conditionalConstants'
-import { boostAshblazingAtkContainer, gpuBoostAshblazingAtkContainer, } from 'lib/conditionals/conditionalFinalizers'
-import { AbilityEidolon, Conditionals, ContentDefinition, createEnum, } from 'lib/conditionals/conditionalUtils'
-import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { Parts, Sets, Stats } from 'lib/constants/constants'
-import { Source } from 'lib/optimization/buffSource'
-import { StatKey } from 'lib/optimization/engine/config/keys'
-import { DamageTag, ElementTag, } from 'lib/optimization/engine/config/tag'
-import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
-import { SortOption } from 'lib/optimization/sortOptions'
-import {
-  AbilityKind,
-  NULL_TURN_ABILITY_NAME,
-  START_ULT,
-  DEFAULT_FUA,
-  END_SKILL,
-  START_SKILL,
-  END_BREAK,
-} from 'lib/optimization/rotation/turnAbilityConfig'
-import {
-  SPREAD_RELICS_2P_ATK_CRIT_WEIGHTS,
-  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
-  SPREAD_ORNAMENTS_2P_FUA,
-  SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
-
-} from 'lib/scoring/scoringConstants'
-import { PresetEffects } from 'lib/scoring/presetEffects'
-import { Lingsha } from 'lib/conditionals/character/1200/Lingsha'
 import { Fugue } from 'lib/conditionals/character/1200/Fugue'
+import { Lingsha } from 'lib/conditionals/character/1200/Lingsha'
 import { TheDahlia } from 'lib/conditionals/character/1300/TheDahlia'
+import { ASHBLAZING_ATK_STACK } from 'lib/conditionals/conditionalConstants'
+import {
+  boostAshblazingAtkContainer,
+  gpuBoostAshblazingAtkContainer,
+} from 'lib/conditionals/conditionalFinalizers'
+import {
+  AbilityEidolon,
+  Conditionals,
+  ContentDefinition,
+  createEnum,
+} from 'lib/conditionals/conditionalUtils'
+import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
 import { LongRoadLeadsHome } from 'lib/conditionals/lightcone/5star/LongRoadLeadsHome'
 import { NeverForgetHerFlame } from 'lib/conditionals/lightcone/5star/NeverForgetHerFlame'
 import { ScentAloneStaysTrue } from 'lib/conditionals/lightcone/5star/ScentAloneStaysTrue'
+import {
+  Parts,
+  Sets,
+  Stats,
+} from 'lib/constants/constants'
+import { Source } from 'lib/optimization/buffSource'
+import { StatKey } from 'lib/optimization/engine/config/keys'
+import {
+  DamageTag,
+  ElementTag,
+} from 'lib/optimization/engine/config/tag'
+import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
+import {
+  AbilityKind,
+  DEFAULT_FUA,
+  END_BREAK,
+  END_SKILL,
+  NULL_TURN_ABILITY_NAME,
+  START_SKILL,
+  START_ULT,
+} from 'lib/optimization/rotation/turnAbilityConfig'
+import { SortOption } from 'lib/optimization/sortOptions'
+import { PresetEffects } from 'lib/scoring/presetEffects'
+import {
+  SPREAD_ORNAMENTS_2P_FUA,
+  SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
+  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+} from 'lib/scoring/scoringConstants'
 import { TsUtils } from 'lib/utils/TsUtils'
 import { Eidolon } from 'types/character'
-import { NumberToNumberMap } from 'types/common'
 import { CharacterConfig } from 'types/characterConfig'
+import { NumberToNumberMap } from 'types/common'
 import { CharacterConditionalsController } from 'types/conditionals'
-import { SimulationMetadata, ScoringMetadata } from 'types/metadata'
-import { OptimizerAction, OptimizerContext, } from 'types/optimizer'
+import {
+  ScoringMetadata,
+  SimulationMetadata,
+} from 'types/metadata'
+import {
+  OptimizerAction,
+  OptimizerContext,
+} from 'types/optimizer'
 
 export const HimekoEntities = createEnum('Himeko')
 export const HimekoAbilities: AbilityKind[] = [
@@ -217,7 +236,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   }
 }
 
-
 const simulation = (): SimulationMetadata => ({
   parts: {
     [Parts.Body]: [
@@ -338,8 +356,9 @@ const display = {
 
 export const Himeko: CharacterConfig = {
   id: '1003',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1000/Kafka.ts
+++ b/src/lib/conditionals/character/1000/Kafka.ts
@@ -1,42 +1,60 @@
-import { ASHBLAZING_ATK_STACK, } from 'lib/conditionals/conditionalConstants'
-import { boostAshblazingAtkContainer, gpuBoostAshblazingAtkContainer, } from 'lib/conditionals/conditionalFinalizers'
-import { AbilityEidolon, Conditionals, ContentDefinition, createEnum, } from 'lib/conditionals/conditionalUtils'
-import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { Parts, Sets, Stats } from 'lib/constants/constants'
-import { Source } from 'lib/optimization/buffSource'
-import { StatKey } from 'lib/optimization/engine/config/keys'
-import { DamageTag, ElementTag, TargetTag, } from 'lib/optimization/engine/config/tag'
-import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
-import { SortOption } from 'lib/optimization/sortOptions'
-import {
-  AbilityKind,
-  NULL_TURN_ABILITY_NAME,
-  START_ULT,
-  DEFAULT_DOT,
-  DEFAULT_SKILL,
-  END_DOT,
-  DEFAULT_FUA,
-  START_SKILL,
-} from 'lib/optimization/rotation/turnAbilityConfig'
-import {
-  SPREAD_RELICS_2P_ATK_WEIGHTS,
-  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
-
-} from 'lib/scoring/scoringConstants'
-import { PresetEffects } from 'lib/scoring/presetEffects'
 import { BlackSwanB1 } from 'lib/conditionals/character/1300/BlackSwanB1'
 import { Hysilens } from 'lib/conditionals/character/1400/Hysilens'
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
+import { ASHBLAZING_ATK_STACK } from 'lib/conditionals/conditionalConstants'
+import {
+  boostAshblazingAtkContainer,
+  gpuBoostAshblazingAtkContainer,
+} from 'lib/conditionals/conditionalFinalizers'
+import {
+  AbilityEidolon,
+  Conditionals,
+  ContentDefinition,
+  createEnum,
+} from 'lib/conditionals/conditionalUtils'
+import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
 import { ReforgedRemembrance } from 'lib/conditionals/lightcone/5star/ReforgedRemembrance'
 import { ThoughWorldsApart } from 'lib/conditionals/lightcone/5star/ThoughWorldsApart'
 import { WhyDoesTheOceanSing } from 'lib/conditionals/lightcone/5star/WhyDoesTheOceanSing'
+import {
+  Parts,
+  Sets,
+  Stats,
+} from 'lib/constants/constants'
+import { Source } from 'lib/optimization/buffSource'
+import { StatKey } from 'lib/optimization/engine/config/keys'
+import {
+  DamageTag,
+  ElementTag,
+  TargetTag,
+} from 'lib/optimization/engine/config/tag'
+import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
+import {
+  AbilityKind,
+  DEFAULT_DOT,
+  DEFAULT_FUA,
+  DEFAULT_SKILL,
+  END_DOT,
+  NULL_TURN_ABILITY_NAME,
+  START_SKILL,
+  START_ULT,
+} from 'lib/optimization/rotation/turnAbilityConfig'
+import { SortOption } from 'lib/optimization/sortOptions'
+import { PresetEffects } from 'lib/scoring/presetEffects'
+import { SPREAD_RELICS_4P_GENERAL_CONDITIONALS } from 'lib/scoring/scoringConstants'
 import { TsUtils } from 'lib/utils/TsUtils'
 
 import { Eidolon } from 'types/character'
 import { CharacterConfig } from 'types/characterConfig'
 import { CharacterConditionalsController } from 'types/conditionals'
-import { SimulationMetadata, ScoringMetadata } from 'types/metadata'
-import { OptimizerAction, OptimizerContext, } from 'types/optimizer'
+import {
+  ScoringMetadata,
+  SimulationMetadata,
+} from 'types/metadata'
+import {
+  OptimizerAction,
+  OptimizerContext,
+} from 'types/optimizer'
 
 export const KafkaEntities = createEnum('Kafka')
 export const KafkaAbilities: AbilityKind[] = [
@@ -197,7 +215,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   }
 }
 
-
 const simulation = (): SimulationMetadata => ({
   parts: {
     [Parts.Body]: [
@@ -323,8 +340,9 @@ const display = {
 
 export const Kafka: CharacterConfig = {
   id: '1005',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1000/KafkaB1.ts
+++ b/src/lib/conditionals/character/1000/KafkaB1.ts
@@ -1,48 +1,78 @@
-import { ASHBLAZING_ATK_STACK, } from 'lib/conditionals/conditionalConstants'
-import { boostAshblazingAtkContainer, gpuBoostAshblazingAtkContainer, } from 'lib/conditionals/conditionalFinalizers'
-import { AbilityEidolon, Conditionals, ContentDefinition, createEnum, } from 'lib/conditionals/conditionalUtils'
-import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { ConditionalActivation, ConditionalType, Parts, Sets, Stats, } from 'lib/constants/constants'
-import { newConditionalWgslWrapper } from 'lib/gpu/conditionals/dynamicConditionals'
-import { containerActionVal } from 'lib/gpu/injection/injectUtils'
-import { wgsl, wgslFalse, wgslTrue, } from 'lib/gpu/injection/wgslUtils'
-import { Source } from 'lib/optimization/buffSource'
-import { AKey, StatKey, } from 'lib/optimization/engine/config/keys'
-import { DamageTag, ElementTag, SELF_ENTITY_INDEX, TargetTag, } from 'lib/optimization/engine/config/tag'
-import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
-import { buff } from 'lib/optimization/engine/container/gpuBuffBuilder'
-import { SortOption } from 'lib/optimization/sortOptions'
-import {
-  AbilityKind,
-  NULL_TURN_ABILITY_NAME,
-  START_ULT,
-  DEFAULT_DOT,
-  DEFAULT_SKILL,
-  END_DOT,
-  DEFAULT_FUA,
-  START_SKILL,
-} from 'lib/optimization/rotation/turnAbilityConfig'
-import {
-  SPREAD_RELICS_2P_ATK_WEIGHTS,
-  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
-  RELICS_2P_SPEED,
-  SPREAD_ORNAMENTS_2P_SUPPORT,
-  SPREAD_ORNAMENTS_2P_ENERGY_REGEN,
-
-} from 'lib/scoring/scoringConstants'
-import { PresetEffects } from 'lib/scoring/presetEffects'
 import { BlackSwanB1 } from 'lib/conditionals/character/1300/BlackSwanB1'
 import { Hysilens } from 'lib/conditionals/character/1400/Hysilens'
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
+import { ASHBLAZING_ATK_STACK } from 'lib/conditionals/conditionalConstants'
+import {
+  boostAshblazingAtkContainer,
+  gpuBoostAshblazingAtkContainer,
+} from 'lib/conditionals/conditionalFinalizers'
+import {
+  AbilityEidolon,
+  Conditionals,
+  ContentDefinition,
+  createEnum,
+} from 'lib/conditionals/conditionalUtils'
+import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
 import { ReforgedRemembrance } from 'lib/conditionals/lightcone/5star/ReforgedRemembrance'
 import { ThoughWorldsApart } from 'lib/conditionals/lightcone/5star/ThoughWorldsApart'
 import { WhyDoesTheOceanSing } from 'lib/conditionals/lightcone/5star/WhyDoesTheOceanSing'
+import {
+  ConditionalActivation,
+  ConditionalType,
+  Parts,
+  Sets,
+  Stats,
+} from 'lib/constants/constants'
+import { newConditionalWgslWrapper } from 'lib/gpu/conditionals/dynamicConditionals'
+import { containerActionVal } from 'lib/gpu/injection/injectUtils'
+import {
+  wgsl,
+  wgslFalse,
+  wgslTrue,
+} from 'lib/gpu/injection/wgslUtils'
+import { Source } from 'lib/optimization/buffSource'
+import {
+  AKey,
+  StatKey,
+} from 'lib/optimization/engine/config/keys'
+import {
+  DamageTag,
+  ElementTag,
+  SELF_ENTITY_INDEX,
+  TargetTag,
+} from 'lib/optimization/engine/config/tag'
+import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
+import { buff } from 'lib/optimization/engine/container/gpuBuffBuilder'
+import {
+  AbilityKind,
+  DEFAULT_DOT,
+  DEFAULT_FUA,
+  DEFAULT_SKILL,
+  END_DOT,
+  NULL_TURN_ABILITY_NAME,
+  START_SKILL,
+  START_ULT,
+} from 'lib/optimization/rotation/turnAbilityConfig'
+import { SortOption } from 'lib/optimization/sortOptions'
+import { PresetEffects } from 'lib/scoring/presetEffects'
+import {
+  RELICS_2P_SPEED,
+  SPREAD_ORNAMENTS_2P_ENERGY_REGEN,
+  SPREAD_ORNAMENTS_2P_SUPPORT,
+  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+} from 'lib/scoring/scoringConstants'
 import { TsUtils } from 'lib/utils/TsUtils'
 import { Eidolon } from 'types/character'
 import { CharacterConfig } from 'types/characterConfig'
 import { CharacterConditionalsController } from 'types/conditionals'
-import { SimulationMetadata, ScoringMetadata } from 'types/metadata'
-import { OptimizerAction, OptimizerContext, } from 'types/optimizer'
+import {
+  ScoringMetadata,
+  SimulationMetadata,
+} from 'types/metadata'
+import {
+  OptimizerAction,
+  OptimizerContext,
+} from 'types/optimizer'
 
 export const KafkaB1Entities = createEnum('KafkaB1')
 export const KafkaB1Abilities: AbilityKind[] = [
@@ -279,7 +309,6 @@ if (ehrValue >= 0.75 && stateValue == 0) {
   }
 }
 
-
 const simulation = (): SimulationMetadata => ({
   parts: {
     [Parts.Body]: [
@@ -412,8 +441,9 @@ const display = {
 
 export const KafkaB1: CharacterConfig = {
   id: '1005b1',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1000/March7th.ts
+++ b/src/lib/conditionals/character/1000/March7th.ts
@@ -1,23 +1,31 @@
-import { ASHBLAZING_ATK_STACK, } from 'lib/conditionals/conditionalConstants'
-import { boostAshblazingAtkContainer, gpuBoostAshblazingAtkContainer, } from 'lib/conditionals/conditionalFinalizers'
-import { AbilityEidolon, createEnum, } from 'lib/conditionals/conditionalUtils'
-import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { Parts, Sets, Stats } from 'lib/constants/constants'
-import { Source } from 'lib/optimization/buffSource'
-import { SortOption } from 'lib/optimization/sortOptions'
-import { ElementTag } from 'lib/optimization/engine/config/tag'
-import { AbilityKind } from 'lib/optimization/rotation/turnAbilityConfig'
-import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
+import { ASHBLAZING_ATK_STACK } from 'lib/conditionals/conditionalConstants'
 import {
-  SPREAD_ORNAMENTS_2P_SUPPORT_WEIGHTS,
-  SPREAD_RELICS_2P_SPEED_WEIGHTS,
-} from 'lib/scoring/scoringConstants'
+  boostAshblazingAtkContainer,
+  gpuBoostAshblazingAtkContainer,
+} from 'lib/conditionals/conditionalFinalizers'
+import {
+  AbilityEidolon,
+  createEnum,
+} from 'lib/conditionals/conditionalUtils'
+import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
+import {
+  Parts,
+  Stats,
+} from 'lib/constants/constants'
+import { Source } from 'lib/optimization/buffSource'
+import { ElementTag } from 'lib/optimization/engine/config/tag'
+import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
+import { AbilityKind } from 'lib/optimization/rotation/turnAbilityConfig'
+import { SortOption } from 'lib/optimization/sortOptions'
 import { PresetEffects } from 'lib/scoring/presetEffects'
 import { Eidolon } from 'types/character'
 import { CharacterConfig } from 'types/characterConfig'
-import { ScoringMetadata } from 'types/metadata'
 import { CharacterConditionalsController } from 'types/conditionals'
-import { OptimizerAction, OptimizerContext, } from 'types/optimizer'
+import { ScoringMetadata } from 'types/metadata'
+import {
+  OptimizerAction,
+  OptimizerContext,
+} from 'types/optimizer'
 
 export const March7thEntities = createEnum('March7th')
 export const March7thAbilities: AbilityKind[] = [
@@ -182,8 +190,9 @@ const display = {
 
 export const March7th: CharacterConfig = {
   id: '1001',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1000/Saber.ts
+++ b/src/lib/conditionals/character/1000/Saber.ts
@@ -1,36 +1,52 @@
-import { AbilityEidolon, Conditionals, ContentDefinition, createEnum, } from 'lib/conditionals/conditionalUtils'
-import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { Parts, Sets, Stats } from 'lib/constants/constants'
-import { Source } from 'lib/optimization/buffSource'
-import { StatKey } from 'lib/optimization/engine/config/keys'
-import { DamageTag, ElementTag, } from 'lib/optimization/engine/config/tag'
-import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
-import { SortOption } from 'lib/optimization/sortOptions'
-import {
-  AbilityKind,
-  NULL_TURN_ABILITY_NAME,
-  START_ULT,
-  END_BASIC,
-  WHOLE_SKILL,
-} from 'lib/optimization/rotation/turnAbilityConfig'
-import {
-  SPREAD_RELICS_2P_ATK_CRIT_WEIGHTS,
-  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
-  SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
-
-} from 'lib/scoring/scoringConstants'
 import { Huohuo } from 'lib/conditionals/character/1200/Huohuo'
 import { Tingyun } from 'lib/conditionals/character/1200/Tingyun'
 import { Sunday } from 'lib/conditionals/character/1300/Sunday'
+import {
+  AbilityEidolon,
+  Conditionals,
+  ContentDefinition,
+  createEnum,
+} from 'lib/conditionals/conditionalUtils'
+import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
+import { DanceDanceDance } from 'lib/conditionals/lightcone/4star/DanceDanceDance'
 import { AGroundedAscent } from 'lib/conditionals/lightcone/5star/AGroundedAscent'
 import { NightOfFright } from 'lib/conditionals/lightcone/5star/NightOfFright'
-import { DanceDanceDance } from 'lib/conditionals/lightcone/4star/DanceDanceDance'
+import {
+  Parts,
+  Sets,
+  Stats,
+} from 'lib/constants/constants'
+import { Source } from 'lib/optimization/buffSource'
+import { StatKey } from 'lib/optimization/engine/config/keys'
+import {
+  DamageTag,
+  ElementTag,
+} from 'lib/optimization/engine/config/tag'
+import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
+import {
+  AbilityKind,
+  END_BASIC,
+  NULL_TURN_ABILITY_NAME,
+  START_ULT,
+  WHOLE_SKILL,
+} from 'lib/optimization/rotation/turnAbilityConfig'
+import { SortOption } from 'lib/optimization/sortOptions'
+import {
+  SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
+  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+} from 'lib/scoring/scoringConstants'
 import { TsUtils } from 'lib/utils/TsUtils'
 import { Eidolon } from 'types/character'
 import { CharacterConfig } from 'types/characterConfig'
 import { CharacterConditionalsController } from 'types/conditionals'
-import { SimulationMetadata, ScoringMetadata } from 'types/metadata'
-import { OptimizerAction, OptimizerContext, } from 'types/optimizer'
+import {
+  ScoringMetadata,
+  SimulationMetadata,
+} from 'types/metadata'
+import {
+  OptimizerAction,
+  OptimizerContext,
+} from 'types/optimizer'
 
 export const SaberEntities = createEnum('Saber')
 export const SaberAbilities: AbilityKind[] = [
@@ -264,7 +280,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   }
 }
 
-
 const simulation = (): SimulationMetadata => ({
   parts: {
     [Parts.Body]: [
@@ -385,8 +400,9 @@ const display = {
 
 export const Saber: CharacterConfig = {
   id: '1014',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1000/SilverWolf.ts
+++ b/src/lib/conditionals/character/1000/SilverWolf.ts
@@ -1,15 +1,23 @@
-import { AbilityEidolon, Conditionals, ContentDefinition, createEnum, } from 'lib/conditionals/conditionalUtils'
+import {
+  AbilityEidolon,
+  Conditionals,
+  ContentDefinition,
+  createEnum,
+} from 'lib/conditionals/conditionalUtils'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { Parts, Sets, Stats } from 'lib/constants/constants'
+import {
+  Parts,
+  Stats,
+} from 'lib/constants/constants'
 import { Source } from 'lib/optimization/buffSource'
 import { StatKey } from 'lib/optimization/engine/config/keys'
-import { ElementTag, TargetTag, } from 'lib/optimization/engine/config/tag'
-import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
-import { SortOption } from 'lib/optimization/sortOptions'
-import { AbilityKind } from 'lib/optimization/rotation/turnAbilityConfig'
 import {
-  SPREAD_ORNAMENTS_2P_SUPPORT_WEIGHTS,
-} from 'lib/scoring/scoringConstants'
+  ElementTag,
+  TargetTag,
+} from 'lib/optimization/engine/config/tag'
+import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
+import { AbilityKind } from 'lib/optimization/rotation/turnAbilityConfig'
+import { SortOption } from 'lib/optimization/sortOptions'
 import { PresetEffects } from 'lib/scoring/presetEffects'
 import { TsUtils } from 'lib/utils/TsUtils'
 
@@ -17,7 +25,10 @@ import { Eidolon } from 'types/character'
 import { CharacterConfig } from 'types/characterConfig'
 import { CharacterConditionalsController } from 'types/conditionals'
 import { ScoringMetadata } from 'types/metadata'
-import { OptimizerAction, OptimizerContext, } from 'types/optimizer'
+import {
+  OptimizerAction,
+  OptimizerContext,
+} from 'types/optimizer'
 
 export const SilverWolfEntities = createEnum('SilverWolf')
 export const SilverWolfAbilities: AbilityKind[] = [
@@ -201,7 +212,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   }
 }
 
-
 const scoring = (): ScoringMetadata => ({
   stats: {
     [Stats.ATK]: 0,
@@ -259,8 +269,9 @@ const display = {
 
 export const SilverWolf: CharacterConfig = {
   id: '1006',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1000/SilverWolfB1.ts
+++ b/src/lib/conditionals/character/1000/SilverWolfB1.ts
@@ -1,46 +1,64 @@
-import { AbilityEidolon, Conditionals, ContentDefinition, createEnum, } from 'lib/conditionals/conditionalUtils'
-import { dynamicStatConversionContainer, gpuDynamicStatConversion, } from 'lib/conditionals/evaluation/statConversion'
-import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { ConditionalActivation, ConditionalType, Parts, Sets, Stats, } from 'lib/constants/constants'
-import { wgslTrue } from 'lib/gpu/injection/wgslUtils'
-import { Source } from 'lib/optimization/buffSource'
-import { StatKey } from 'lib/optimization/engine/config/keys'
-import { ElementTag, TargetTag, } from 'lib/optimization/engine/config/tag'
-import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
-import { SortOption } from 'lib/optimization/sortOptions'
-import {
-  AbilityKind,
-  NULL_TURN_ABILITY_NAME,
-  START_ULT,
-  END_SKILL,
-  WHOLE_BASIC,
-} from 'lib/optimization/rotation/turnAbilityConfig'
-import {
-  SPREAD_RELICS_2P_SPEED_WEIGHTS,
-  SPREAD_RELICS_2P_ATK_CRIT_WEIGHTS,
-  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
-  RELICS_2P_SPEED,
-  SPREAD_ORNAMENTS_2P_SUPPORT_WEIGHTS,
-  SPREAD_ORNAMENTS_2P_ENERGY_REGEN_WEIGHTS,
-  SPREAD_ORNAMENTS_2P_SUPPORT,
-  SPREAD_ORNAMENTS_2P_ENERGY_REGEN,
-  SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
-
-} from 'lib/scoring/scoringConstants'
-import { PresetEffects } from 'lib/scoring/presetEffects'
 import { Acheron } from 'lib/conditionals/character/1300/Acheron'
 import { Cipher } from 'lib/conditionals/character/1400/Cipher'
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
+import {
+  AbilityEidolon,
+  Conditionals,
+  ContentDefinition,
+  createEnum,
+} from 'lib/conditionals/conditionalUtils'
+import {
+  dynamicStatConversionContainer,
+  gpuDynamicStatConversion,
+} from 'lib/conditionals/evaluation/statConversion'
+import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
 import { AlongThePassingShore } from 'lib/conditionals/lightcone/5star/AlongThePassingShore'
 import { LiesAflutterInTheWind } from 'lib/conditionals/lightcone/5star/LiesAflutterInTheWind'
 import { ThoughWorldsApart } from 'lib/conditionals/lightcone/5star/ThoughWorldsApart'
+import {
+  ConditionalActivation,
+  ConditionalType,
+  Parts,
+  Sets,
+  Stats,
+} from 'lib/constants/constants'
+import { wgslTrue } from 'lib/gpu/injection/wgslUtils'
+import { Source } from 'lib/optimization/buffSource'
+import { StatKey } from 'lib/optimization/engine/config/keys'
+import {
+  ElementTag,
+  TargetTag,
+} from 'lib/optimization/engine/config/tag'
+import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
+import {
+  AbilityKind,
+  END_SKILL,
+  NULL_TURN_ABILITY_NAME,
+  START_ULT,
+  WHOLE_BASIC,
+} from 'lib/optimization/rotation/turnAbilityConfig'
+import { SortOption } from 'lib/optimization/sortOptions'
+import { PresetEffects } from 'lib/scoring/presetEffects'
+import {
+  RELICS_2P_SPEED,
+  SPREAD_ORNAMENTS_2P_ENERGY_REGEN,
+  SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
+  SPREAD_ORNAMENTS_2P_SUPPORT,
+  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+} from 'lib/scoring/scoringConstants'
 import { TsUtils } from 'lib/utils/TsUtils'
 
 import { Eidolon } from 'types/character'
 import { CharacterConfig } from 'types/characterConfig'
 import { CharacterConditionalsController } from 'types/conditionals'
-import { SimulationMetadata, ScoringMetadata } from 'types/metadata'
-import { OptimizerAction, OptimizerContext, } from 'types/optimizer'
+import {
+  ScoringMetadata,
+  SimulationMetadata,
+} from 'types/metadata'
+import {
+  OptimizerAction,
+  OptimizerContext,
+} from 'types/optimizer'
 
 export const SilverWolfB1Entities = createEnum('SilverWolfB1')
 export const SilverWolfB1Abilities: AbilityKind[] = [
@@ -293,7 +311,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   }
 }
 
-
 const simulation = (): SimulationMetadata => ({
   parts: {
     [Parts.Body]: [
@@ -429,8 +446,9 @@ const display = {
 
 export const SilverWolfB1: CharacterConfig = {
   id: '1006b1',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1000/Welt.ts
+++ b/src/lib/conditionals/character/1000/Welt.ts
@@ -1,37 +1,54 @@
-import { AbilityEidolon, Conditionals, ContentDefinition, createEnum, } from 'lib/conditionals/conditionalUtils'
-import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { Parts, Sets, Stats } from 'lib/constants/constants'
-import { Source } from 'lib/optimization/buffSource'
-import { StatKey } from 'lib/optimization/engine/config/keys'
-import { ElementTag, TargetTag, } from 'lib/optimization/engine/config/tag'
-import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
-import { SortOption } from 'lib/optimization/sortOptions'
-import {
-  AbilityKind,
-  NULL_TURN_ABILITY_NAME,
-  START_ULT,
-  END_SKILL,
-  WHOLE_SKILL,
-} from 'lib/optimization/rotation/turnAbilityConfig'
-import {
-  SPREAD_RELICS_2P_ATK_WEIGHTS,
-  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
-  SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
-} from 'lib/scoring/scoringConstants'
-import { PresetEffects } from 'lib/scoring/presetEffects'
 import { Jiaoqiu } from 'lib/conditionals/character/1200/Jiaoqiu'
 import { Acheron } from 'lib/conditionals/character/1300/Acheron'
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
+import {
+  AbilityEidolon,
+  Conditionals,
+  ContentDefinition,
+  createEnum,
+} from 'lib/conditionals/conditionalUtils'
+import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
 import { AlongThePassingShore } from 'lib/conditionals/lightcone/5star/AlongThePassingShore'
 import { ThoseManySprings } from 'lib/conditionals/lightcone/5star/ThoseManySprings'
 import { ThoughWorldsApart } from 'lib/conditionals/lightcone/5star/ThoughWorldsApart'
+import {
+  Parts,
+  Sets,
+  Stats,
+} from 'lib/constants/constants'
+import { Source } from 'lib/optimization/buffSource'
+import { StatKey } from 'lib/optimization/engine/config/keys'
+import {
+  ElementTag,
+  TargetTag,
+} from 'lib/optimization/engine/config/tag'
+import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
+import {
+  AbilityKind,
+  END_SKILL,
+  NULL_TURN_ABILITY_NAME,
+  START_ULT,
+  WHOLE_SKILL,
+} from 'lib/optimization/rotation/turnAbilityConfig'
+import { SortOption } from 'lib/optimization/sortOptions'
+import { PresetEffects } from 'lib/scoring/presetEffects'
+import {
+  SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
+  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+} from 'lib/scoring/scoringConstants'
 import { TsUtils } from 'lib/utils/TsUtils'
 
 import { Eidolon } from 'types/character'
 import { CharacterConfig } from 'types/characterConfig'
 import { CharacterConditionalsController } from 'types/conditionals'
-import { SimulationMetadata, ScoringMetadata } from 'types/metadata'
-import { OptimizerAction, OptimizerContext, } from 'types/optimizer'
+import {
+  ScoringMetadata,
+  SimulationMetadata,
+} from 'types/metadata'
+import {
+  OptimizerAction,
+  OptimizerContext,
+} from 'types/optimizer'
 
 export const WeltEntities = createEnum('Welt')
 export const WeltAbilities: AbilityKind[] = [
@@ -221,7 +238,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   }
 }
 
-
 const simulation = (): SimulationMetadata => ({
   parts: {
     [Parts.Body]: [
@@ -345,8 +361,9 @@ const display = {
 
 export const Welt: CharacterConfig = {
   id: '1004',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1100/Bronya.ts
+++ b/src/lib/conditionals/character/1100/Bronya.ts
@@ -24,7 +24,6 @@ import {
   Stats,
 } from 'lib/constants/constants'
 import { wgslTrue } from 'lib/gpu/injection/wgslUtils'
-import { AbilityKind } from 'lib/optimization/rotation/turnAbilityConfig'
 import { Source } from 'lib/optimization/buffSource'
 import { StatKey } from 'lib/optimization/engine/config/keys'
 import {
@@ -33,6 +32,7 @@ import {
   TargetTag,
 } from 'lib/optimization/engine/config/tag'
 import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
+import { AbilityKind } from 'lib/optimization/rotation/turnAbilityConfig'
 import { SortOption } from 'lib/optimization/sortOptions'
 import { TsUtils } from 'lib/utils/TsUtils'
 
@@ -40,7 +40,6 @@ import { Eidolon } from 'types/character'
 import { CharacterConfig } from 'types/characterConfig'
 
 import { CharacterConditionalsController } from 'types/conditionals'
-import { AbilityDefinition } from 'types/hitConditionalTypes'
 import { ScoringMetadata } from 'types/metadata'
 import {
   OptimizerAction,
@@ -271,7 +270,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   }
 }
 
-
 const scoring = (): ScoringMetadata => ({
   stats: {
     [Stats.ATK]: 0,
@@ -319,8 +317,9 @@ const display = {
 
 export const Bronya: CharacterConfig = {
   id: '1101',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1100/Clara.ts
+++ b/src/lib/conditionals/character/1100/Clara.ts
@@ -1,3 +1,6 @@
+import { SparkleB1 } from 'lib/conditionals/character/1300/SparkleB1'
+import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
+import { Tribbie } from 'lib/conditionals/character/1400/Tribbie'
 import {
   ASHBLAZING_ATK_STACK,
 } from 'lib/conditionals/conditionalConstants'
@@ -12,7 +15,14 @@ import {
   createEnum,
 } from 'lib/conditionals/conditionalUtils'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { Parts, Sets, Stats } from 'lib/constants/constants'
+import { DanceDanceDance } from 'lib/conditionals/lightcone/4star/DanceDanceDance'
+import { IfTimeWereAFlower } from 'lib/conditionals/lightcone/5star/IfTimeWereAFlower'
+import { ThoughWorldsApart } from 'lib/conditionals/lightcone/5star/ThoughWorldsApart'
+import {
+  Parts,
+  Sets,
+  Stats,
+} from 'lib/constants/constants'
 import { Source } from 'lib/optimization/buffSource'
 import { StatKey } from 'lib/optimization/engine/config/keys'
 import {
@@ -20,34 +30,31 @@ import {
   ElementTag,
 } from 'lib/optimization/engine/config/tag'
 import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
-import { SortOption } from 'lib/optimization/sortOptions'
 import {
   AbilityKind,
-  NULL_TURN_ABILITY_NAME,
   DEFAULT_FUA,
   END_SKILL,
+  NULL_TURN_ABILITY_NAME,
   START_ULT,
   WHOLE_SKILL,
 } from 'lib/optimization/rotation/turnAbilityConfig'
+import { SortOption } from 'lib/optimization/sortOptions'
+import { PresetEffects } from 'lib/scoring/presetEffects'
 import {
   SPREAD_ORNAMENTS_2P_FUA,
   SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
   SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
 } from 'lib/scoring/scoringConstants'
-import { PresetEffects } from 'lib/scoring/presetEffects'
-import { SparkleB1 } from 'lib/conditionals/character/1300/SparkleB1'
-import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
-import { Tribbie } from 'lib/conditionals/character/1400/Tribbie'
-import { DanceDanceDance } from 'lib/conditionals/lightcone/4star/DanceDanceDance'
-import { IfTimeWereAFlower } from 'lib/conditionals/lightcone/5star/IfTimeWereAFlower'
-import { ThoughWorldsApart } from 'lib/conditionals/lightcone/5star/ThoughWorldsApart'
 import { TsUtils } from 'lib/utils/TsUtils'
 
 import { Eidolon } from 'types/character'
 import { CharacterConfig } from 'types/characterConfig'
 import { NumberToNumberMap } from 'types/common'
 import { CharacterConditionalsController } from 'types/conditionals'
-import { SimulationMetadata, ScoringMetadata } from 'types/metadata'
+import {
+  ScoringMetadata,
+  SimulationMetadata,
+} from 'types/metadata'
 import {
   OptimizerAction,
   OptimizerContext,
@@ -211,7 +218,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   }
 }
 
-
 const simulation = (): SimulationMetadata => ({
   parts: {
     [Parts.Body]: [
@@ -334,8 +340,9 @@ const display = {
 
 export const Clara: CharacterConfig = {
   id: '1107',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1100/Gepard.ts
+++ b/src/lib/conditionals/character/1100/Gepard.ts
@@ -16,7 +16,6 @@ import {
   Sets,
   Stats,
 } from 'lib/constants/constants'
-import { AbilityKind } from 'lib/optimization/rotation/turnAbilityConfig'
 import { Source } from 'lib/optimization/buffSource'
 import { StatKey } from 'lib/optimization/engine/config/keys'
 import {
@@ -24,6 +23,7 @@ import {
   TargetTag,
 } from 'lib/optimization/engine/config/tag'
 import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
+import { AbilityKind } from 'lib/optimization/rotation/turnAbilityConfig'
 import { SortOption } from 'lib/optimization/sortOptions'
 import { TsUtils } from 'lib/utils/TsUtils'
 import { Eidolon } from 'types/character'
@@ -173,7 +173,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   }
 }
 
-
 const scoring = (): ScoringMetadata => ({
   stats: {
     [Stats.ATK]: 0,
@@ -226,8 +225,9 @@ const display = {
 
 export const Gepard: CharacterConfig = {
   id: '1104',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1100/Hook.ts
+++ b/src/lib/conditionals/character/1100/Hook.ts
@@ -1,3 +1,6 @@
+import { SparkleB1 } from 'lib/conditionals/character/1300/SparkleB1'
+import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
+import { Tribbie } from 'lib/conditionals/character/1400/Tribbie'
 import {
   AbilityEidolon,
   Conditionals,
@@ -5,7 +8,14 @@ import {
   createEnum,
 } from 'lib/conditionals/conditionalUtils'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { Parts, Sets, Stats } from 'lib/constants/constants'
+import { ButTheBattleIsntOver } from 'lib/conditionals/lightcone/5star/ButTheBattleIsntOver'
+import { IfTimeWereAFlower } from 'lib/conditionals/lightcone/5star/IfTimeWereAFlower'
+import { ThoughWorldsApart } from 'lib/conditionals/lightcone/5star/ThoughWorldsApart'
+import {
+  Parts,
+  Sets,
+  Stats,
+} from 'lib/constants/constants'
 import { Source } from 'lib/optimization/buffSource'
 import { StatKey } from 'lib/optimization/engine/config/keys'
 import {
@@ -13,32 +23,29 @@ import {
   ElementTag,
 } from 'lib/optimization/engine/config/tag'
 import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
-import { SortOption } from 'lib/optimization/sortOptions'
 import {
   AbilityKind,
-  NULL_TURN_ABILITY_NAME,
   END_SKILL,
+  NULL_TURN_ABILITY_NAME,
   START_ULT,
   WHOLE_SKILL,
 } from 'lib/optimization/rotation/turnAbilityConfig'
+import { SortOption } from 'lib/optimization/sortOptions'
+import { PresetEffects } from 'lib/scoring/presetEffects'
 import {
   SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
   SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
 } from 'lib/scoring/scoringConstants'
-import { PresetEffects } from 'lib/scoring/presetEffects'
-import { SparkleB1 } from 'lib/conditionals/character/1300/SparkleB1'
-import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
-import { Tribbie } from 'lib/conditionals/character/1400/Tribbie'
-import { ButTheBattleIsntOver } from 'lib/conditionals/lightcone/5star/ButTheBattleIsntOver'
-import { IfTimeWereAFlower } from 'lib/conditionals/lightcone/5star/IfTimeWereAFlower'
-import { ThoughWorldsApart } from 'lib/conditionals/lightcone/5star/ThoughWorldsApart'
 import { TsUtils } from 'lib/utils/TsUtils'
 
 import { Eidolon } from 'types/character'
 import { CharacterConfig } from 'types/characterConfig'
 
 import { CharacterConditionalsController } from 'types/conditionals'
-import { SimulationMetadata, ScoringMetadata } from 'types/metadata'
+import {
+  ScoringMetadata,
+  SimulationMetadata,
+} from 'types/metadata'
 import {
   OptimizerAction,
   OptimizerContext,
@@ -198,7 +205,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   }
 }
 
-
 const simulation = (): SimulationMetadata => ({
   parts: {
     [Parts.Body]: [
@@ -318,8 +324,9 @@ const display = {
 
 export const Hook: CharacterConfig = {
   id: '1109',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1100/Luka.ts
+++ b/src/lib/conditionals/character/1100/Luka.ts
@@ -1,3 +1,6 @@
+import { Fugue } from 'lib/conditionals/character/1200/Fugue'
+import { Lingsha } from 'lib/conditionals/character/1200/Lingsha'
+import { RuanMei } from 'lib/conditionals/character/1300/RuanMei'
 import {
   AbilityEidolon,
   Conditionals,
@@ -5,7 +8,14 @@ import {
   createEnum,
 } from 'lib/conditionals/conditionalUtils'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { Parts, Sets, Stats } from 'lib/constants/constants'
+import { LongRoadLeadsHome } from 'lib/conditionals/lightcone/5star/LongRoadLeadsHome'
+import { PastSelfInTheMirror } from 'lib/conditionals/lightcone/5star/PastSelfInTheMirror'
+import { ScentAloneStaysTrue } from 'lib/conditionals/lightcone/5star/ScentAloneStaysTrue'
+import {
+  Parts,
+  Sets,
+  Stats,
+} from 'lib/constants/constants'
 import { Source } from 'lib/optimization/buffSource'
 import { StatKey } from 'lib/optimization/engine/config/keys'
 import {
@@ -13,35 +23,32 @@ import {
   TargetTag,
 } from 'lib/optimization/engine/config/tag'
 import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
-import { SortOption } from 'lib/optimization/sortOptions'
 import {
   AbilityKind,
-  NULL_TURN_ABILITY_NAME,
   DEFAULT_DOT,
   DEFAULT_SKILL,
   END_BREAK,
   END_DOT,
+  NULL_TURN_ABILITY_NAME,
   START_BASIC,
   START_ULT,
 } from 'lib/optimization/rotation/turnAbilityConfig'
+import { SortOption } from 'lib/optimization/sortOptions'
+import { PresetEffects } from 'lib/scoring/presetEffects'
 import {
   RELICS_2P_BREAK_EFFECT_SPEED,
   SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
 } from 'lib/scoring/scoringConstants'
-import { PresetEffects } from 'lib/scoring/presetEffects'
-import { Fugue } from 'lib/conditionals/character/1200/Fugue'
-import { Lingsha } from 'lib/conditionals/character/1200/Lingsha'
-import { RuanMei } from 'lib/conditionals/character/1300/RuanMei'
-import { LongRoadLeadsHome } from 'lib/conditionals/lightcone/5star/LongRoadLeadsHome'
-import { PastSelfInTheMirror } from 'lib/conditionals/lightcone/5star/PastSelfInTheMirror'
-import { ScentAloneStaysTrue } from 'lib/conditionals/lightcone/5star/ScentAloneStaysTrue'
 import { TsUtils } from 'lib/utils/TsUtils'
 
 import { Eidolon } from 'types/character'
 import { CharacterConfig } from 'types/characterConfig'
 
 import { CharacterConditionalsController } from 'types/conditionals'
-import { SimulationMetadata, ScoringMetadata } from 'types/metadata'
+import {
+  ScoringMetadata,
+  SimulationMetadata,
+} from 'types/metadata'
 import {
   OptimizerAction,
   OptimizerContext,
@@ -225,7 +232,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   }
 }
 
-
 const simulation = (): SimulationMetadata => ({
   parts: {
     [Parts.Body]: [
@@ -351,8 +357,9 @@ const display = {
 
 export const Luka: CharacterConfig = {
   id: '1111',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1100/Lynx.ts
+++ b/src/lib/conditionals/character/1100/Lynx.ts
@@ -18,11 +18,9 @@ import {
   ConditionalActivation,
   ConditionalType,
   Parts,
-  Sets,
   Stats,
 } from 'lib/constants/constants'
 import { wgslTrue } from 'lib/gpu/injection/wgslUtils'
-import { AbilityKind } from 'lib/optimization/rotation/turnAbilityConfig'
 import { Source } from 'lib/optimization/buffSource'
 import { StatKey } from 'lib/optimization/engine/config/keys'
 import {
@@ -30,6 +28,7 @@ import {
   TargetTag,
 } from 'lib/optimization/engine/config/tag'
 import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
+import { AbilityKind } from 'lib/optimization/rotation/turnAbilityConfig'
 import { SortOption } from 'lib/optimization/sortOptions'
 import { PresetEffects } from 'lib/scoring/presetEffects'
 import { TsUtils } from 'lib/utils/TsUtils'
@@ -273,7 +272,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   }
 }
 
-
 const scoring = (): ScoringMetadata => ({
   stats: {
     [Stats.ATK]: 0,
@@ -332,8 +330,9 @@ const display = {
 
 export const Lynx: CharacterConfig = {
   id: '1110',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1100/Natasha.ts
+++ b/src/lib/conditionals/character/1100/Natasha.ts
@@ -1,19 +1,18 @@
 import {
-  SKILL_DMG_TYPE,
-  ULT_DMG_TYPE,
-} from 'lib/conditionals/conditionalConstants'
-import {
   AbilityEidolon,
   ContentDefinition,
   createEnum,
 } from 'lib/conditionals/conditionalUtils'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { Parts, Sets, Stats } from 'lib/constants/constants'
-import { AbilityKind } from 'lib/optimization/rotation/turnAbilityConfig'
+import {
+  Parts,
+  Stats,
+} from 'lib/constants/constants'
 import { Source } from 'lib/optimization/buffSource'
 import { StatKey } from 'lib/optimization/engine/config/keys'
 import { ElementTag } from 'lib/optimization/engine/config/tag'
 import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
+import { AbilityKind } from 'lib/optimization/rotation/turnAbilityConfig'
 import { SortOption } from 'lib/optimization/sortOptions'
 import { PresetEffects } from 'lib/scoring/presetEffects'
 import { TsUtils } from 'lib/utils/TsUtils'
@@ -54,11 +53,9 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   // E6: Basic attack gains HP scaling
   const e6BasicHpScaling = e >= 6 ? 0.40 : 0
 
-  const defaults = {
-  }
+  const defaults = {}
 
-  const content: ContentDefinition<typeof defaults> = {
-  }
+  const content: ContentDefinition<typeof defaults> = {}
 
   return {
     content: () => Object.values(content),
@@ -120,7 +117,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   }
 }
 
-
 const scoring = (): ScoringMetadata => ({
   stats: {
     [Stats.ATK]: 0,
@@ -179,8 +175,9 @@ const display = {
 
 export const Natasha: CharacterConfig = {
   id: '1105',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1100/Pela.ts
+++ b/src/lib/conditionals/character/1100/Pela.ts
@@ -5,8 +5,10 @@ import {
   createEnum,
 } from 'lib/conditionals/conditionalUtils'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { Parts, Sets, Stats } from 'lib/constants/constants'
-import { AbilityKind } from 'lib/optimization/rotation/turnAbilityConfig'
+import {
+  Parts,
+  Stats,
+} from 'lib/constants/constants'
 import { Source } from 'lib/optimization/buffSource'
 import { StatKey } from 'lib/optimization/engine/config/keys'
 import {
@@ -15,6 +17,7 @@ import {
   TargetTag,
 } from 'lib/optimization/engine/config/tag'
 import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
+import { AbilityKind } from 'lib/optimization/rotation/turnAbilityConfig'
 import { SortOption } from 'lib/optimization/sortOptions'
 import { PresetEffects } from 'lib/scoring/presetEffects'
 import { TsUtils } from 'lib/utils/TsUtils'
@@ -140,10 +143,12 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
               .toughnessDmg(10)
               .build(),
             ...(e6Active
-              ? [HitDefinitionBuilder.standardAdditional()
+              ? [
+                HitDefinitionBuilder.standardAdditional()
                   .damageElement(ElementTag.Ice)
                   .atkScaling(e6AdditionalDmgScaling)
-                  .build()]
+                  .build(),
+              ]
               : []),
           ],
         },
@@ -155,10 +160,12 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
               .toughnessDmg(20)
               .build(),
             ...(e6Active
-              ? [HitDefinitionBuilder.standardAdditional()
+              ? [
+                HitDefinitionBuilder.standardAdditional()
                   .damageElement(ElementTag.Ice)
                   .atkScaling(e6AdditionalDmgScaling)
-                  .build()]
+                  .build(),
+              ]
               : []),
           ],
         },
@@ -170,10 +177,12 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
               .toughnessDmg(20)
               .build(),
             ...(e6Active
-              ? [HitDefinitionBuilder.standardAdditional()
+              ? [
+                HitDefinitionBuilder.standardAdditional()
                   .damageElement(ElementTag.Ice)
                   .atkScaling(e6AdditionalDmgScaling)
-                  .build()]
+                  .build(),
+              ]
               : []),
           ],
         },
@@ -192,8 +201,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
       x.buff(StatKey.SPD_P, (e >= 2 && r.skillRemovedBuff) ? 0.10 : 0, x.source(SOURCE_E2))
 
       // DMG boost for Basic/Skill/Ult when buff removed
-      x.buff(StatKey.DMG_BOOST, (r.skillRemovedBuff) ? 0.20 : 0,
-        x.damageType(DamageTag.BASIC | DamageTag.SKILL | DamageTag.ULT).source(SOURCE_TRACE))
+      x.buff(StatKey.DMG_BOOST, (r.skillRemovedBuff) ? 0.20 : 0, x.damageType(DamageTag.BASIC | DamageTag.SKILL | DamageTag.ULT).source(SOURCE_TRACE))
 
       // DMG boost when enemy debuffed
       x.buff(StatKey.DMG_BOOST, (r.enemyDebuffed) ? 0.20 : 0, x.source(SOURCE_TRACE))
@@ -205,15 +213,13 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
       x.buff(StatKey.EHR, (m.teamEhrBuff) ? 0.10 : 0, x.targets(TargetTag.FullTeam).source(SOURCE_TRACE))
 
       x.buff(StatKey.DEF_PEN, (m.ultDefPenDebuff) ? ultDefPenValue : 0, x.targets(TargetTag.FullTeam).source(SOURCE_ULT))
-      x.buff(StatKey.RES_PEN, (e >= 4 && m.e4SkillResShred) ? 0.12 : 0,
-        x.elements(ElementTag.Ice).targets(TargetTag.FullTeam).source(SOURCE_E4))
+      x.buff(StatKey.RES_PEN, (e >= 4 && m.e4SkillResShred) ? 0.12 : 0, x.elements(ElementTag.Ice).targets(TargetTag.FullTeam).source(SOURCE_E4))
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {},
     newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => '',
   }
 }
-
 
 const scoring = (): ScoringMetadata => ({
   stats: {
@@ -269,8 +275,9 @@ const display = {
 
 export const Pela: CharacterConfig = {
   id: '1106',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1100/Sampo.ts
+++ b/src/lib/conditionals/character/1100/Sampo.ts
@@ -1,3 +1,6 @@
+import { KafkaB1 } from 'lib/conditionals/character/1000/KafkaB1'
+import { Hysilens } from 'lib/conditionals/character/1400/Hysilens'
+import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
 import {
   AbilityEidolon,
   Conditionals,
@@ -5,7 +8,14 @@ import {
   createEnum,
 } from 'lib/conditionals/conditionalUtils'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { Parts, Sets, Stats } from 'lib/constants/constants'
+import { PatienceIsAllYouNeed } from 'lib/conditionals/lightcone/5star/PatienceIsAllYouNeed'
+import { ThoughWorldsApart } from 'lib/conditionals/lightcone/5star/ThoughWorldsApart'
+import { WhyDoesTheOceanSing } from 'lib/conditionals/lightcone/5star/WhyDoesTheOceanSing'
+import {
+  Parts,
+  Sets,
+  Stats,
+} from 'lib/constants/constants'
 import { Source } from 'lib/optimization/buffSource'
 import { StatKey } from 'lib/optimization/engine/config/keys'
 import {
@@ -14,32 +24,29 @@ import {
   TargetTag,
 } from 'lib/optimization/engine/config/tag'
 import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
-import { SortOption } from 'lib/optimization/sortOptions'
 import {
   AbilityKind,
-  NULL_TURN_ABILITY_NAME,
   DEFAULT_DOT,
   END_SKILL,
+  NULL_TURN_ABILITY_NAME,
   START_ULT,
   WHOLE_SKILL,
 } from 'lib/optimization/rotation/turnAbilityConfig'
+import { SortOption } from 'lib/optimization/sortOptions'
+import { PresetEffects } from 'lib/scoring/presetEffects'
 import {
   SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
 } from 'lib/scoring/scoringConstants'
-import { PresetEffects } from 'lib/scoring/presetEffects'
-import { KafkaB1 } from 'lib/conditionals/character/1000/KafkaB1'
-import { Hysilens } from 'lib/conditionals/character/1400/Hysilens'
-import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
-import { PatienceIsAllYouNeed } from 'lib/conditionals/lightcone/5star/PatienceIsAllYouNeed'
-import { ThoughWorldsApart } from 'lib/conditionals/lightcone/5star/ThoughWorldsApart'
-import { WhyDoesTheOceanSing } from 'lib/conditionals/lightcone/5star/WhyDoesTheOceanSing'
 import { TsUtils } from 'lib/utils/TsUtils'
 
 import { Eidolon } from 'types/character'
 import { CharacterConfig } from 'types/characterConfig'
 
 import { CharacterConditionalsController } from 'types/conditionals'
-import { SimulationMetadata, ScoringMetadata } from 'types/metadata'
+import {
+  ScoringMetadata,
+  SimulationMetadata,
+} from 'types/metadata'
 import {
   OptimizerAction,
   OptimizerContext,
@@ -200,7 +207,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   }
 }
 
-
 const simulation = (): SimulationMetadata => ({
   parts: {
     [Parts.Body]: [
@@ -321,8 +327,9 @@ const display = {
 
 export const Sampo: CharacterConfig = {
   id: '1108',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1100/Seele.ts
+++ b/src/lib/conditionals/character/1100/Seele.ts
@@ -1,3 +1,6 @@
+import { SilverWolfB1 } from 'lib/conditionals/character/1000/SilverWolfB1'
+import { SparkleB1 } from 'lib/conditionals/character/1300/SparkleB1'
+import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
 import {
   AbilityEidolon,
   Conditionals,
@@ -5,37 +8,41 @@ import {
   createEnum,
 } from 'lib/conditionals/conditionalUtils'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { Parts, Sets, Stats } from 'lib/constants/constants'
+import { ButTheBattleIsntOver } from 'lib/conditionals/lightcone/5star/ButTheBattleIsntOver'
+import { LiesAflutterInTheWind } from 'lib/conditionals/lightcone/5star/LiesAflutterInTheWind'
+import { ThoughWorldsApart } from 'lib/conditionals/lightcone/5star/ThoughWorldsApart'
+import {
+  Parts,
+  Sets,
+  Stats,
+} from 'lib/constants/constants'
 import { Source } from 'lib/optimization/buffSource'
 import { StatKey } from 'lib/optimization/engine/config/keys'
 import { ElementTag } from 'lib/optimization/engine/config/tag'
 import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
-import { SortOption } from 'lib/optimization/sortOptions'
 import {
   AbilityKind,
-  NULL_TURN_ABILITY_NAME,
   DEFAULT_SKILL,
   END_SKILL,
+  NULL_TURN_ABILITY_NAME,
   START_ULT,
 } from 'lib/optimization/rotation/turnAbilityConfig'
+import { SortOption } from 'lib/optimization/sortOptions'
+import { PresetEffects } from 'lib/scoring/presetEffects'
 import {
   SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
   SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
 } from 'lib/scoring/scoringConstants'
-import { PresetEffects } from 'lib/scoring/presetEffects'
-import { SilverWolfB1 } from 'lib/conditionals/character/1000/SilverWolfB1'
-import { SparkleB1 } from 'lib/conditionals/character/1300/SparkleB1'
-import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
-import { ButTheBattleIsntOver } from 'lib/conditionals/lightcone/5star/ButTheBattleIsntOver'
-import { LiesAflutterInTheWind } from 'lib/conditionals/lightcone/5star/LiesAflutterInTheWind'
-import { ThoughWorldsApart } from 'lib/conditionals/lightcone/5star/ThoughWorldsApart'
 import { TsUtils } from 'lib/utils/TsUtils'
 
 import { Eidolon } from 'types/character'
 import { CharacterConfig } from 'types/characterConfig'
 
 import { CharacterConditionalsController } from 'types/conditionals'
-import { SimulationMetadata, ScoringMetadata } from 'types/metadata'
+import {
+  ScoringMetadata,
+  SimulationMetadata,
+} from 'types/metadata'
 import {
   OptimizerAction,
   OptimizerContext,
@@ -135,10 +142,12 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
               .toughnessDmg(10)
               .build(),
             ...(e6Active
-              ? [HitDefinitionBuilder.standardAdditional()
+              ? [
+                HitDefinitionBuilder.standardAdditional()
                   .damageElement(ElementTag.Quantum)
                   .atkScaling(e6AdditionalDmgScaling)
-                  .build()]
+                  .build(),
+              ]
               : []),
           ],
         },
@@ -150,10 +159,12 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
               .toughnessDmg(20)
               .build(),
             ...(e6Active
-              ? [HitDefinitionBuilder.standardAdditional()
+              ? [
+                HitDefinitionBuilder.standardAdditional()
                   .damageElement(ElementTag.Quantum)
                   .atkScaling(e6AdditionalDmgScaling)
-                  .build()]
+                  .build(),
+              ]
               : []),
           ],
         },
@@ -165,10 +176,12 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
               .toughnessDmg(30)
               .build(),
             ...(e6Active
-              ? [HitDefinitionBuilder.standardAdditional()
+              ? [
+                HitDefinitionBuilder.standardAdditional()
                   .damageElement(ElementTag.Quantum)
                   .atkScaling(e6AdditionalDmgScaling)
-                  .build()]
+                  .build(),
+              ]
               : []),
           ],
         },
@@ -199,7 +212,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => '',
   }
 }
-
 
 const simulation = (): SimulationMetadata => ({
   parts: {
@@ -321,8 +333,9 @@ const display = {
 
 export const Seele: CharacterConfig = {
   id: '1102',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1100/Serval.ts
+++ b/src/lib/conditionals/character/1100/Serval.ts
@@ -1,3 +1,6 @@
+import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
+import { TheHerta } from 'lib/conditionals/character/1400/TheHerta'
+import { Tribbie } from 'lib/conditionals/character/1400/Tribbie'
 import {
   AbilityEidolon,
   Conditionals,
@@ -5,39 +8,43 @@ import {
   createEnum,
 } from 'lib/conditionals/conditionalUtils'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { Parts, Sets, Stats } from 'lib/constants/constants'
+import { IfTimeWereAFlower } from 'lib/conditionals/lightcone/5star/IfTimeWereAFlower'
+import { IntotheUnreachableVeil } from 'lib/conditionals/lightcone/5star/IntotheUnreachableVeil'
+import { ThoughWorldsApart } from 'lib/conditionals/lightcone/5star/ThoughWorldsApart'
+import {
+  Parts,
+  Sets,
+  Stats,
+} from 'lib/constants/constants'
 import { Source } from 'lib/optimization/buffSource'
 import { StatKey } from 'lib/optimization/engine/config/keys'
 import { ElementTag } from 'lib/optimization/engine/config/tag'
 import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
-import { SortOption } from 'lib/optimization/sortOptions'
 import {
   AbilityKind,
-  NULL_TURN_ABILITY_NAME,
   END_SKILL,
+  NULL_TURN_ABILITY_NAME,
   START_ULT,
   WHOLE_SKILL,
 } from 'lib/optimization/rotation/turnAbilityConfig'
+import { SortOption } from 'lib/optimization/sortOptions'
+import { PresetEffects } from 'lib/scoring/presetEffects'
 import {
   SPREAD_ORNAMENTS_2P_ENERGY_REGEN,
   SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
   SPREAD_ORNAMENTS_2P_SUPPORT,
   SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
 } from 'lib/scoring/scoringConstants'
-import { PresetEffects } from 'lib/scoring/presetEffects'
-import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
-import { TheHerta } from 'lib/conditionals/character/1400/TheHerta'
-import { Tribbie } from 'lib/conditionals/character/1400/Tribbie'
-import { IfTimeWereAFlower } from 'lib/conditionals/lightcone/5star/IfTimeWereAFlower'
-import { IntotheUnreachableVeil } from 'lib/conditionals/lightcone/5star/IntotheUnreachableVeil'
-import { ThoughWorldsApart } from 'lib/conditionals/lightcone/5star/ThoughWorldsApart'
 import { TsUtils } from 'lib/utils/TsUtils'
 
 import { Eidolon } from 'types/character'
 import { CharacterConfig } from 'types/characterConfig'
 
 import { CharacterConditionalsController } from 'types/conditionals'
-import { SimulationMetadata, ScoringMetadata } from 'types/metadata'
+import {
+  ScoringMetadata,
+  SimulationMetadata,
+} from 'types/metadata'
 import {
   OptimizerAction,
   OptimizerContext,
@@ -190,7 +197,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   }
 }
 
-
 const simulation = (): SimulationMetadata => ({
   parts: {
     [Parts.Body]: [
@@ -316,8 +322,9 @@ const display = {
 
 export const Serval: CharacterConfig = {
   id: '1103',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1100/Topaz.ts
+++ b/src/lib/conditionals/character/1100/Topaz.ts
@@ -22,7 +22,7 @@ import { ThoughWorldsApart } from 'lib/conditionals/lightcone/5star/ThoughWorlds
 import {
   Parts,
   Sets,
-  Stats
+  Stats,
 } from 'lib/constants/constants'
 import { Source } from 'lib/optimization/buffSource'
 import { StatKey } from 'lib/optimization/engine/config/keys'
@@ -56,7 +56,7 @@ import { CharacterConfig } from 'types/characterConfig'
 import { CharacterConditionalsController } from 'types/conditionals'
 import {
   ScoringMetadata,
-  SimulationMetadata
+  SimulationMetadata,
 } from 'types/metadata'
 import {
   OptimizerAction,
@@ -70,7 +70,6 @@ export const TopazAbilities: AbilityKind[] = [
   AbilityKind.FUA,
   AbilityKind.BREAK,
 ]
-
 
 const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsController => {
   const t = TsUtils.wrappedFixedT(withContent).get(null, 'conditionals', 'Characters.Topaz')
@@ -250,19 +249,22 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
       const r = action.characterConditionals as Conditionals<typeof content>
       const hitMulti = action.actionType === AbilityKind.BASIC
         ? basicHitCountMulti
-        : (r.numbyEnhancedState) ? fuaEnhancedHitCountMulti : fuaHitCountMulti
+        : (r.numbyEnhancedState)
+        ? fuaEnhancedHitCountMulti
+        : fuaHitCountMulti
       boostAshblazingAtkContainer(x, action, hitMulti)
     },
     newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
       const r = action.characterConditionals as Conditionals<typeof content>
       const hitMulti = action.actionType === AbilityKind.BASIC
         ? basicHitCountMulti
-        : (r.numbyEnhancedState) ? fuaEnhancedHitCountMulti : fuaHitCountMulti
+        : (r.numbyEnhancedState)
+        ? fuaEnhancedHitCountMulti
+        : fuaHitCountMulti
       return gpuBoostAshblazingAtkContainer(hitMulti, action)
     },
   }
 }
-
 
 const simulation = (): SimulationMetadata => ({
   parts: {
@@ -396,8 +398,9 @@ const display = {
 
 export const Topaz: CharacterConfig = {
   id: '1112',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1200/Bailu.ts
+++ b/src/lib/conditionals/character/1200/Bailu.ts
@@ -5,16 +5,18 @@ import {
   createEnum,
 } from 'lib/conditionals/conditionalUtils'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { Parts, Sets, Stats } from 'lib/constants/constants'
-import { SortOption } from 'lib/optimization/sortOptions'
+import {
+  Parts,
+  Stats,
+} from 'lib/constants/constants'
 import { Source } from 'lib/optimization/buffSource'
 import { StatKey } from 'lib/optimization/engine/config/keys'
-import { ElementTag, TargetTag } from 'lib/optimization/engine/config/tag'
-import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
 import {
-  MATCH_2P_WEIGHT,
-  SPREAD_ORNAMENTS_2P_SUPPORT_WEIGHTS,
-} from 'lib/scoring/scoringConstants'
+  ElementTag,
+  TargetTag,
+} from 'lib/optimization/engine/config/tag'
+import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
+import { SortOption } from 'lib/optimization/sortOptions'
 import { PresetEffects } from 'lib/scoring/presetEffects'
 import { TsUtils } from 'lib/utils/TsUtils'
 
@@ -198,7 +200,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   }
 }
 
-
 const scoring = (): ScoringMetadata => ({
   stats: {
     [Stats.ATK]: 0,
@@ -254,8 +255,9 @@ const display = {
 
 export const Bailu: CharacterConfig = {
   id: '1211',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1200/Blade.ts
+++ b/src/lib/conditionals/character/1200/Blade.ts
@@ -1,7 +1,13 @@
+import { Castorice } from 'lib/conditionals/character/1400/Castorice'
+import { Hyacine } from 'lib/conditionals/character/1400/Hyacine'
+import { Tribbie } from 'lib/conditionals/character/1400/Tribbie'
 import {
   ASHBLAZING_ATK_STACK,
 } from 'lib/conditionals/conditionalConstants'
-import { boostAshblazingAtkContainer, gpuBoostAshblazingAtkContainer } from 'lib/conditionals/conditionalFinalizers'
+import {
+  boostAshblazingAtkContainer,
+  gpuBoostAshblazingAtkContainer,
+} from 'lib/conditionals/conditionalFinalizers'
 import {
   AbilityEidolon,
   Conditionals,
@@ -9,41 +15,46 @@ import {
   createEnum,
 } from 'lib/conditionals/conditionalUtils'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { Parts, Sets, Stats } from 'lib/constants/constants'
-import { SortOption } from 'lib/optimization/sortOptions'
-import { Source } from 'lib/optimization/buffSource'
-import { StatKey } from 'lib/optimization/engine/config/keys'
-import { DamageTag, ElementTag } from 'lib/optimization/engine/config/tag'
-import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
-import {
-  MATCH_2P_WEIGHT,
-  SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
-  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
-  T2_WEIGHT,
-} from 'lib/scoring/scoringConstants'
-import { PresetEffects } from 'lib/scoring/presetEffects'
-import {
-  NULL_TURN_ABILITY_NAME,
-  START_SKILL,
-  DEFAULT_ULT,
-  END_BASIC,
-  DEFAULT_FUA,
-  WHOLE_BASIC,
-  AbilityKind,
-} from 'lib/optimization/rotation/turnAbilityConfig'
-import { Castorice } from 'lib/conditionals/character/1400/Castorice'
-import { Hyacine } from 'lib/conditionals/character/1400/Hyacine'
-import { Tribbie } from 'lib/conditionals/character/1400/Tribbie'
 import { IfTimeWereAFlower } from 'lib/conditionals/lightcone/5star/IfTimeWereAFlower'
 import { MakeFarewellsMoreBeautiful } from 'lib/conditionals/lightcone/5star/MakeFarewellsMoreBeautiful'
 import { MayRainbowsRemainInTheSky } from 'lib/conditionals/lightcone/5star/MayRainbowsRemainInTheSky'
+import {
+  Parts,
+  Sets,
+  Stats,
+} from 'lib/constants/constants'
+import { Source } from 'lib/optimization/buffSource'
+import { StatKey } from 'lib/optimization/engine/config/keys'
+import {
+  DamageTag,
+  ElementTag,
+} from 'lib/optimization/engine/config/tag'
+import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
+import {
+  AbilityKind,
+  DEFAULT_FUA,
+  DEFAULT_ULT,
+  END_BASIC,
+  NULL_TURN_ABILITY_NAME,
+  START_SKILL,
+  WHOLE_BASIC,
+} from 'lib/optimization/rotation/turnAbilityConfig'
+import { SortOption } from 'lib/optimization/sortOptions'
+import { PresetEffects } from 'lib/scoring/presetEffects'
+import {
+  SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
+  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+} from 'lib/scoring/scoringConstants'
 import { TsUtils } from 'lib/utils/TsUtils'
 
 import { Eidolon } from 'types/character'
 import { CharacterConfig } from 'types/characterConfig'
-import { SimulationMetadata, ScoringMetadata } from 'types/metadata'
 import { NumberToNumberMap } from 'types/common'
 import { CharacterConditionalsController } from 'types/conditionals'
+import {
+  ScoringMetadata,
+  SimulationMetadata,
+} from 'types/metadata'
 import {
   OptimizerAction,
   OptimizerContext,
@@ -213,7 +224,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   }
 }
 
-
 const simulation = (): SimulationMetadata => ({
   parts: {
     [Parts.Body]: [
@@ -338,8 +348,9 @@ const display = {
 
 export const Blade: CharacterConfig = {
   id: '1205',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1200/BladeB1.ts
+++ b/src/lib/conditionals/character/1200/BladeB1.ts
@@ -1,3 +1,6 @@
+import { Sunday } from 'lib/conditionals/character/1300/Sunday'
+import { Hyacine } from 'lib/conditionals/character/1400/Hyacine'
+import { Tribbie } from 'lib/conditionals/character/1400/Tribbie'
 import {
   AbilityEidolon,
   Conditionals,
@@ -5,39 +8,44 @@ import {
   createEnum,
 } from 'lib/conditionals/conditionalUtils'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { Parts, Sets, Stats } from 'lib/constants/constants'
-import { SortOption } from 'lib/optimization/sortOptions'
-import { Source } from 'lib/optimization/buffSource'
-import { StatKey } from 'lib/optimization/engine/config/keys'
-import { DamageTag, ElementTag } from 'lib/optimization/engine/config/tag'
-import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
-import {
-  MATCH_2P_WEIGHT,
-  SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
-  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
-  T2_WEIGHT,
-} from 'lib/scoring/scoringConstants'
-import { PresetEffects } from 'lib/scoring/presetEffects'
-import {
-  NULL_TURN_ABILITY_NAME,
-  START_SKILL,
-  DEFAULT_ULT,
-  END_BASIC,
-  DEFAULT_FUA,
-  WHOLE_BASIC,
-  AbilityKind,
-} from 'lib/optimization/rotation/turnAbilityConfig'
-import { Hyacine } from 'lib/conditionals/character/1400/Hyacine'
-import { Tribbie } from 'lib/conditionals/character/1400/Tribbie'
-import { Sunday } from 'lib/conditionals/character/1300/Sunday'
 import { AGroundedAscent } from 'lib/conditionals/lightcone/5star/AGroundedAscent'
 import { IfTimeWereAFlower } from 'lib/conditionals/lightcone/5star/IfTimeWereAFlower'
 import { MayRainbowsRemainInTheSky } from 'lib/conditionals/lightcone/5star/MayRainbowsRemainInTheSky'
+import {
+  Parts,
+  Sets,
+  Stats,
+} from 'lib/constants/constants'
+import { Source } from 'lib/optimization/buffSource'
+import { StatKey } from 'lib/optimization/engine/config/keys'
+import {
+  DamageTag,
+  ElementTag,
+} from 'lib/optimization/engine/config/tag'
+import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
+import {
+  AbilityKind,
+  DEFAULT_FUA,
+  DEFAULT_ULT,
+  END_BASIC,
+  NULL_TURN_ABILITY_NAME,
+  START_SKILL,
+  WHOLE_BASIC,
+} from 'lib/optimization/rotation/turnAbilityConfig'
+import { SortOption } from 'lib/optimization/sortOptions'
+import { PresetEffects } from 'lib/scoring/presetEffects'
+import {
+  SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
+  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+} from 'lib/scoring/scoringConstants'
 import { TsUtils } from 'lib/utils/TsUtils'
 import { Eidolon } from 'types/character'
 import { CharacterConfig } from 'types/characterConfig'
-import { SimulationMetadata, ScoringMetadata } from 'types/metadata'
 import { CharacterConditionalsController } from 'types/conditionals'
+import {
+  ScoringMetadata,
+  SimulationMetadata,
+} from 'types/metadata'
 import {
   OptimizerAction,
   OptimizerContext,
@@ -214,7 +222,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   }
 }
 
-
 const simulation = (): SimulationMetadata => ({
   parts: {
     [Parts.Body]: [
@@ -339,8 +346,9 @@ const display = {
 
 export const BladeB1: CharacterConfig = {
   id: '1205b1',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1200/Feixiao.ts
+++ b/src/lib/conditionals/character/1200/Feixiao.ts
@@ -1,3 +1,6 @@
+import { Robin } from 'lib/conditionals/character/1300/Robin'
+import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
+import { Tribbie } from 'lib/conditionals/character/1400/Tribbie'
 import {
   ASHBLAZING_ATK_STACK,
 } from 'lib/conditionals/conditionalConstants'
@@ -12,8 +15,14 @@ import {
   createEnum,
 } from 'lib/conditionals/conditionalUtils'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { Parts, Sets, Stats } from 'lib/constants/constants'
-import { SortOption } from 'lib/optimization/sortOptions'
+import { FlowingNightglow } from 'lib/conditionals/lightcone/5star/FlowingNightglow'
+import { IfTimeWereAFlower } from 'lib/conditionals/lightcone/5star/IfTimeWereAFlower'
+import { ThoughWorldsApart } from 'lib/conditionals/lightcone/5star/ThoughWorldsApart'
+import {
+  Parts,
+  Sets,
+  Stats,
+} from 'lib/constants/constants'
 import { Source } from 'lib/optimization/buffSource'
 import { StatKey } from 'lib/optimization/engine/config/keys'
 import {
@@ -22,33 +31,28 @@ import {
 } from 'lib/optimization/engine/config/tag'
 import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
 import {
-  MATCH_2P_WEIGHT,
-  SPREAD_ORNAMENTS_2P_FUA,
-  SPREAD_ORNAMENTS_2P_FUA_WEIGHTS,
-  SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
-  SPREAD_RELICS_2P_ATK_CRIT_WEIGHTS,
-  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
-} from 'lib/scoring/scoringConstants'
-import { PresetEffects } from 'lib/scoring/presetEffects'
-import {
-  NULL_TURN_ABILITY_NAME,
-  START_ULT,
+  AbilityKind,
+  DEFAULT_FUA,
   DEFAULT_SKILL,
   END_FUA,
-  DEFAULT_FUA,
-  AbilityKind,
+  NULL_TURN_ABILITY_NAME,
+  START_ULT,
 } from 'lib/optimization/rotation/turnAbilityConfig'
-import { Robin } from 'lib/conditionals/character/1300/Robin'
-import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
-import { Tribbie } from 'lib/conditionals/character/1400/Tribbie'
-import { FlowingNightglow } from 'lib/conditionals/lightcone/5star/FlowingNightglow'
-import { IfTimeWereAFlower } from 'lib/conditionals/lightcone/5star/IfTimeWereAFlower'
-import { ThoughWorldsApart } from 'lib/conditionals/lightcone/5star/ThoughWorldsApart'
+import { SortOption } from 'lib/optimization/sortOptions'
+import { PresetEffects } from 'lib/scoring/presetEffects'
+import {
+  SPREAD_ORNAMENTS_2P_FUA,
+  SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
+  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+} from 'lib/scoring/scoringConstants'
 import { TsUtils } from 'lib/utils/TsUtils'
 
 import { Eidolon } from 'types/character'
 import { CharacterConfig } from 'types/characterConfig'
-import { SimulationMetadata, ScoringMetadata } from 'types/metadata'
+import {
+  ScoringMetadata,
+  SimulationMetadata,
+} from 'types/metadata'
 
 import { CharacterConditionalsController } from 'types/conditionals'
 import {
@@ -276,7 +280,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   }
 }
 
-
 const simulation = (): SimulationMetadata => ({
   parts: {
     [Parts.Body]: [
@@ -401,8 +404,9 @@ const display = {
 
 export const Feixiao: CharacterConfig = {
   id: '1220',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1200/FuXuan.ts
+++ b/src/lib/conditionals/character/1200/FuXuan.ts
@@ -4,20 +4,26 @@ import {
   ContentDefinition,
   createEnum,
 } from 'lib/conditionals/conditionalUtils'
-import { dynamicStatConversionContainer, gpuDynamicStatConversion, } from 'lib/conditionals/evaluation/statConversion'
+import {
+  dynamicStatConversionContainer,
+  gpuDynamicStatConversion,
+} from 'lib/conditionals/evaluation/statConversion'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { ConditionalActivation, ConditionalType, Parts, Sets, Stats, } from 'lib/constants/constants'
+import {
+  ConditionalActivation,
+  ConditionalType,
+  Parts,
+  Stats,
+} from 'lib/constants/constants'
 import { wgslTrue } from 'lib/gpu/injection/wgslUtils'
-import { SortOption } from 'lib/optimization/sortOptions'
 import { Source } from 'lib/optimization/buffSource'
 import { StatKey } from 'lib/optimization/engine/config/keys'
-import { ElementTag, TargetTag, } from 'lib/optimization/engine/config/tag'
-import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
 import {
-  MATCH_2P_WEIGHT,
-  SPREAD_ORNAMENTS_2P_SUPPORT_WEIGHTS,
-  SPREAD_RELICS_2P_SPEED_WEIGHTS,
-} from 'lib/scoring/scoringConstants'
+  ElementTag,
+  TargetTag,
+} from 'lib/optimization/engine/config/tag'
+import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
+import { SortOption } from 'lib/optimization/sortOptions'
 import { PresetEffects } from 'lib/scoring/presetEffects'
 import { TsUtils } from 'lib/utils/TsUtils'
 
@@ -26,7 +32,10 @@ import { CharacterConfig } from 'types/characterConfig'
 import { ScoringMetadata } from 'types/metadata'
 
 import { CharacterConditionalsController } from 'types/conditionals'
-import { OptimizerAction, OptimizerContext, } from 'types/optimizer'
+import {
+  OptimizerAction,
+  OptimizerContext,
+} from 'types/optimizer'
 
 import { AbilityKind } from 'lib/optimization/rotation/turnAbilityConfig'
 export const FuXuanEntities = createEnum('FuXuan')
@@ -248,7 +257,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   }
 }
 
-
 const scoring = (): ScoringMetadata => ({
   stats: {
     [Stats.ATK]: 0,
@@ -307,8 +315,9 @@ const display = {
 
 export const FuXuan: CharacterConfig = {
   id: '1208',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1200/Fugue.ts
+++ b/src/lib/conditionals/character/1200/Fugue.ts
@@ -1,3 +1,6 @@
+import { Lingsha } from 'lib/conditionals/character/1200/Lingsha'
+import { Firefly } from 'lib/conditionals/character/1300/Firefly'
+import { TheDahlia } from 'lib/conditionals/character/1300/TheDahlia'
 import {
   AbilityEidolon,
   addSuperBreakHits,
@@ -6,10 +9,16 @@ import {
   createEnum,
 } from 'lib/conditionals/conditionalUtils'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { Parts, Sets, Stats } from 'lib/constants/constants'
-import { ModifierContext } from 'lib/optimization/context/calculateActions'
-import { SortOption } from 'lib/optimization/sortOptions'
+import { NeverForgetHerFlame } from 'lib/conditionals/lightcone/5star/NeverForgetHerFlame'
+import { ScentAloneStaysTrue } from 'lib/conditionals/lightcone/5star/ScentAloneStaysTrue'
+import { WhereaboutsShouldDreamsRest } from 'lib/conditionals/lightcone/5star/WhereaboutsShouldDreamsRest'
+import {
+  Parts,
+  Sets,
+  Stats,
+} from 'lib/constants/constants'
 import { Source } from 'lib/optimization/buffSource'
+import { ModifierContext } from 'lib/optimization/context/calculateActions'
 import { StatKey } from 'lib/optimization/engine/config/keys'
 import {
   DamageTag,
@@ -18,34 +27,30 @@ import {
 } from 'lib/optimization/engine/config/tag'
 import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
 import {
+  AbilityKind,
+  DEFAULT_BASIC,
+  END_BREAK,
+  NULL_TURN_ABILITY_NAME,
+  START_BASIC,
+  START_ULT,
+} from 'lib/optimization/rotation/turnAbilityConfig'
+import { SortOption } from 'lib/optimization/sortOptions'
+import {
   RELICS_2P_BREAK_EFFECT_SPEED,
   SPREAD_ORNAMENTS_2P_ENERGY_REGEN,
   SPREAD_ORNAMENTS_2P_SUPPORT,
-  SPREAD_RELICS_2P_BREAK_WEIGHTS,
-  SPREAD_RELICS_2P_SPEED_WEIGHTS,
   SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
 } from 'lib/scoring/scoringConstants'
-import {
-  NULL_TURN_ABILITY_NAME,
-  START_ULT,
-  DEFAULT_BASIC,
-  END_BREAK,
-  START_BASIC,
-  AbilityKind,
-} from 'lib/optimization/rotation/turnAbilityConfig'
-import { Firefly } from 'lib/conditionals/character/1300/Firefly'
-import { TheDahlia } from 'lib/conditionals/character/1300/TheDahlia'
-import { Lingsha } from 'lib/conditionals/character/1200/Lingsha'
-import { NeverForgetHerFlame } from 'lib/conditionals/lightcone/5star/NeverForgetHerFlame'
-import { ScentAloneStaysTrue } from 'lib/conditionals/lightcone/5star/ScentAloneStaysTrue'
-import { WhereaboutsShouldDreamsRest } from 'lib/conditionals/lightcone/5star/WhereaboutsShouldDreamsRest'
 import { TsUtils } from 'lib/utils/TsUtils'
 
 import { Eidolon } from 'types/character'
 import { CharacterConfig } from 'types/characterConfig'
-import { SimulationMetadata, ScoringMetadata } from 'types/metadata'
 import { CharacterConditionalsController } from 'types/conditionals'
 import { HitDefinition } from 'types/hitConditionalTypes'
+import {
+  ScoringMetadata,
+  SimulationMetadata,
+} from 'types/metadata'
 import {
   OptimizerAction,
   OptimizerContext,
@@ -240,7 +245,11 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 
       x.buff(StatKey.SUPER_BREAK_MODIFIER, (m.superBreakDmg) ? superBreakScaling : 0, x.targets(TargetTag.FullTeam).source(SOURCE_TALENT))
       x.buff(StatKey.DEF_PEN, (m.defReduction) ? skillDefPenValue : 0, x.targets(TargetTag.FullTeam).source(SOURCE_SKILL))
-      x.buff(StatKey.DMG_BOOST, (e >= 4 && m.foxianPrayer && m.e4BreakDmg) ? 0.20 : 0, x.damageType(DamageTag.BREAK).targets(TargetTag.SingleTarget).source(SOURCE_E4))
+      x.buff(
+        StatKey.DMG_BOOST,
+        (e >= 4 && m.foxianPrayer && m.e4BreakDmg) ? 0.20 : 0,
+        x.damageType(DamageTag.BREAK).targets(TargetTag.SingleTarget).source(SOURCE_E4),
+      )
     },
 
     precomputeTeammateEffectsContainer: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
@@ -252,7 +261,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {},
   }
 }
-
 
 const simulation = (): SimulationMetadata => ({
   parts: {
@@ -377,8 +385,9 @@ const display = {
 
 export const Fugue: CharacterConfig = {
   id: '1225',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1200/Guinaifen.ts
+++ b/src/lib/conditionals/character/1200/Guinaifen.ts
@@ -5,8 +5,10 @@ import {
   createEnum,
 } from 'lib/conditionals/conditionalUtils'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { Parts, Sets, Stats } from 'lib/constants/constants'
-import { SortOption } from 'lib/optimization/sortOptions'
+import {
+  Parts,
+  Stats,
+} from 'lib/constants/constants'
 import { Source } from 'lib/optimization/buffSource'
 import { StatKey } from 'lib/optimization/engine/config/keys'
 import {
@@ -14,12 +16,7 @@ import {
   TargetTag,
 } from 'lib/optimization/engine/config/tag'
 import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
-import {
-  MATCH_2P_WEIGHT,
-  SPREAD_ORNAMENTS_2P_SUPPORT_WEIGHTS,
-  SPREAD_RELICS_2P_ATK_WEIGHTS,
-  SPREAD_RELICS_2P_SPEED_WEIGHTS,
-} from 'lib/scoring/scoringConstants'
+import { SortOption } from 'lib/optimization/sortOptions'
 import { PresetEffects } from 'lib/scoring/presetEffects'
 import { TsUtils } from 'lib/utils/TsUtils'
 
@@ -219,7 +216,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   }
 }
 
-
 const scoring = (): ScoringMetadata => ({
   stats: {
     [Stats.ATK]: 0.5,
@@ -272,8 +268,9 @@ const display = {
 
 export const Guinaifen: CharacterConfig = {
   id: '1210',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1200/Hanya.ts
+++ b/src/lib/conditionals/character/1200/Hanya.ts
@@ -4,19 +4,27 @@ import {
   ContentDefinition,
   createEnum,
 } from 'lib/conditionals/conditionalUtils'
-import { dynamicStatConversionContainer, gpuDynamicStatConversion, } from 'lib/conditionals/evaluation/statConversion'
+import {
+  dynamicStatConversionContainer,
+  gpuDynamicStatConversion,
+} from 'lib/conditionals/evaluation/statConversion'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { ConditionalActivation, ConditionalType, Parts, Sets, Stats, } from 'lib/constants/constants'
+import {
+  ConditionalActivation,
+  ConditionalType,
+  Parts,
+  Stats,
+} from 'lib/constants/constants'
 import { wgslTrue } from 'lib/gpu/injection/wgslUtils'
-import { SortOption } from 'lib/optimization/sortOptions'
 import { Source } from 'lib/optimization/buffSource'
 import { StatKey } from 'lib/optimization/engine/config/keys'
-import { DamageTag, ElementTag, TargetTag, } from 'lib/optimization/engine/config/tag'
-import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
 import {
-  SPREAD_ORNAMENTS_2P_SUPPORT_WEIGHTS,
-  SPREAD_RELICS_2P_SPEED_WEIGHTS,
-} from 'lib/scoring/scoringConstants'
+  DamageTag,
+  ElementTag,
+  TargetTag,
+} from 'lib/optimization/engine/config/tag'
+import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
+import { SortOption } from 'lib/optimization/sortOptions'
 import { TsUtils } from 'lib/utils/TsUtils'
 
 import { Eidolon } from 'types/character'
@@ -24,7 +32,10 @@ import { CharacterConfig } from 'types/characterConfig'
 import { ScoringMetadata } from 'types/metadata'
 
 import { CharacterConditionalsController } from 'types/conditionals'
-import { OptimizerAction, OptimizerContext, } from 'types/optimizer'
+import {
+  OptimizerAction,
+  OptimizerContext,
+} from 'types/optimizer'
 
 import { AbilityKind } from 'lib/optimization/rotation/turnAbilityConfig'
 export const HanyaEntities = createEnum('Hanya')
@@ -224,7 +235,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   }
 }
 
-
 const scoring = (): ScoringMetadata => ({
   stats: {
     [Stats.ATK]: 0,
@@ -270,8 +280,9 @@ const display = {
 
 export const Hanya: CharacterConfig = {
   id: '1215',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1200/Huohuo.ts
+++ b/src/lib/conditionals/character/1200/Huohuo.ts
@@ -5,23 +5,28 @@ import {
   createEnum,
 } from 'lib/conditionals/conditionalUtils'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { Parts, Sets, Stats } from 'lib/constants/constants'
-import { SortOption } from 'lib/optimization/sortOptions'
+import {
+  Parts,
+  Stats,
+} from 'lib/constants/constants'
 import { Source } from 'lib/optimization/buffSource'
 import { StatKey } from 'lib/optimization/engine/config/keys'
-import { ElementTag, TargetTag, } from 'lib/optimization/engine/config/tag'
-import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
 import {
-  SPREAD_ORNAMENTS_2P_SUPPORT_WEIGHTS,
-  SPREAD_RELICS_2P_SPEED_WEIGHTS,
-} from 'lib/scoring/scoringConstants'
+  ElementTag,
+  TargetTag,
+} from 'lib/optimization/engine/config/tag'
+import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
+import { SortOption } from 'lib/optimization/sortOptions'
 import { PresetEffects } from 'lib/scoring/presetEffects'
 import { TsUtils } from 'lib/utils/TsUtils'
 import { Eidolon } from 'types/character'
 import { CharacterConfig } from 'types/characterConfig'
-import { ScoringMetadata } from 'types/metadata'
 import { CharacterConditionalsController } from 'types/conditionals'
-import { OptimizerAction, OptimizerContext, } from 'types/optimizer'
+import { ScoringMetadata } from 'types/metadata'
+import {
+  OptimizerAction,
+  OptimizerContext,
+} from 'types/optimizer'
 
 import { AbilityKind } from 'lib/optimization/rotation/turnAbilityConfig'
 export const HuohuoEntities = createEnum('Huohuo')
@@ -168,7 +173,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   }
 }
 
-
 const scoring = (): ScoringMetadata => ({
   stats: {
     [Stats.ATK]: 0,
@@ -225,8 +229,9 @@ const display = {
 
 export const Huohuo: CharacterConfig = {
   id: '1217',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1200/ImbibitorLunae.ts
+++ b/src/lib/conditionals/character/1200/ImbibitorLunae.ts
@@ -1,3 +1,6 @@
+import { SparkleB1 } from 'lib/conditionals/character/1300/SparkleB1'
+import { Cipher } from 'lib/conditionals/character/1400/Cipher'
+import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
 import {
   AbilityEidolon,
   Conditionals,
@@ -5,36 +8,42 @@ import {
   createEnum,
 } from 'lib/conditionals/conditionalUtils'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { Parts, Sets, Stats } from 'lib/constants/constants'
-import { SortOption } from 'lib/optimization/sortOptions'
-import { Source } from 'lib/optimization/buffSource'
-import { StatKey } from 'lib/optimization/engine/config/keys'
-import { DamageTag, ElementTag } from 'lib/optimization/engine/config/tag'
-import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
-import {
-  SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
-  SPREAD_RELICS_2P_ATK_CRIT_WEIGHTS,
-  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
-} from 'lib/scoring/scoringConstants'
-import { PresetEffects } from 'lib/scoring/presetEffects'
-import {
-  NULL_TURN_ABILITY_NAME,
-  START_ULT,
-  END_BASIC,
-  WHOLE_BASIC,
-  AbilityKind,
-} from 'lib/optimization/rotation/turnAbilityConfig'
-import { SparkleB1 } from 'lib/conditionals/character/1300/SparkleB1'
-import { Cipher } from 'lib/conditionals/character/1400/Cipher'
-import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
 import { AGroundedAscent } from 'lib/conditionals/lightcone/5star/AGroundedAscent'
 import { LiesAflutterInTheWind } from 'lib/conditionals/lightcone/5star/LiesAflutterInTheWind'
 import { ThoughWorldsApart } from 'lib/conditionals/lightcone/5star/ThoughWorldsApart'
+import {
+  Parts,
+  Sets,
+  Stats,
+} from 'lib/constants/constants'
+import { Source } from 'lib/optimization/buffSource'
+import { StatKey } from 'lib/optimization/engine/config/keys'
+import {
+  DamageTag,
+  ElementTag,
+} from 'lib/optimization/engine/config/tag'
+import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
+import {
+  AbilityKind,
+  END_BASIC,
+  NULL_TURN_ABILITY_NAME,
+  START_ULT,
+  WHOLE_BASIC,
+} from 'lib/optimization/rotation/turnAbilityConfig'
+import { SortOption } from 'lib/optimization/sortOptions'
+import { PresetEffects } from 'lib/scoring/presetEffects'
+import {
+  SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
+  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+} from 'lib/scoring/scoringConstants'
 import { TsUtils } from 'lib/utils/TsUtils'
 
 import { Eidolon } from 'types/character'
 import { CharacterConfig } from 'types/characterConfig'
-import { SimulationMetadata, ScoringMetadata } from 'types/metadata'
+import {
+  ScoringMetadata,
+  SimulationMetadata,
+} from 'types/metadata'
 
 import { CharacterConditionalsController } from 'types/conditionals'
 import {
@@ -193,8 +202,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
       x.buff(StatKey.DMG_BOOST, r.talentRighteousHeartStacks * righteousHeartDmgValue, x.source(SOURCE_TALENT))
 
       // E6 - RES PEN for enhanced basic 3
-      x.buff(StatKey.RES_PEN, (e >= 6 && r.basicEnhanced == 3) ? 0.20 * r.e6ResPenStacks : 0,
-        x.damageType(DamageTag.BASIC).source(SOURCE_E6))
+      x.buff(StatKey.RES_PEN, (e >= 6 && r.basicEnhanced == 3) ? 0.20 * r.e6ResPenStacks : 0, x.damageType(DamageTag.BASIC).source(SOURCE_E6))
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
@@ -202,7 +210,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => '',
   }
 }
-
 
 const simulation = (): SimulationMetadata => ({
   parts: {
@@ -325,8 +332,9 @@ const display = {
 
 export const ImbibitorLunae: CharacterConfig = {
   id: '1213',
-  info: { displayName: 'Imbibitor Lunae' },
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1200/Jiaoqiu.ts
+++ b/src/lib/conditionals/character/1200/Jiaoqiu.ts
@@ -18,7 +18,6 @@ import {
 } from 'lib/constants/constants'
 import { containerActionVal } from 'lib/gpu/injection/injectUtils'
 import { wgslTrue } from 'lib/gpu/injection/wgslUtils'
-import { SortOption } from 'lib/optimization/sortOptions'
 import { Source } from 'lib/optimization/buffSource'
 import { StatKey } from 'lib/optimization/engine/config/keys'
 import {
@@ -28,11 +27,7 @@ import {
   TargetTag,
 } from 'lib/optimization/engine/config/tag'
 import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
-import {
-  MATCH_2P_WEIGHT,
-  SPREAD_ORNAMENTS_2P_SUPPORT_WEIGHTS,
-  SPREAD_RELICS_2P_SPEED_WEIGHTS,
-} from 'lib/scoring/scoringConstants'
+import { SortOption } from 'lib/optimization/sortOptions'
 import { PresetEffects } from 'lib/scoring/presetEffects'
 import { TsUtils } from 'lib/utils/TsUtils'
 
@@ -299,7 +294,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   }
 }
 
-
 const scoring = (): ScoringMetadata => ({
   stats: {
     [Stats.ATK]: 0.5,
@@ -348,8 +342,9 @@ const display = {
 
 export const Jiaoqiu: CharacterConfig = {
   id: '1218',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1200/JingYuan.ts
+++ b/src/lib/conditionals/character/1200/JingYuan.ts
@@ -12,8 +12,11 @@ import {
   createEnum,
 } from 'lib/conditionals/conditionalUtils'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { Parts, Sets, Stats } from 'lib/constants/constants'
-import { SortOption } from 'lib/optimization/sortOptions'
+import {
+  Parts,
+  Sets,
+  Stats,
+} from 'lib/constants/constants'
 import { Source } from 'lib/optimization/buffSource'
 import { StatKey } from 'lib/optimization/engine/config/keys'
 import {
@@ -21,40 +24,41 @@ import {
   ElementTag,
 } from 'lib/optimization/engine/config/tag'
 import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
+import { SortOption } from 'lib/optimization/sortOptions'
+import { PresetEffects } from 'lib/scoring/presetEffects'
 import {
   SPREAD_ORNAMENTS_2P_FUA,
-  SPREAD_ORNAMENTS_2P_FUA_WEIGHTS,
   SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
-  SPREAD_RELICS_2P_ATK_CRIT_WEIGHTS,
   SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
-  T2_WEIGHT,
 } from 'lib/scoring/scoringConstants'
-import { PresetEffects } from 'lib/scoring/presetEffects'
 import { TsUtils } from 'lib/utils/TsUtils'
 
 import { Eidolon } from 'types/character'
 import { CharacterConfig } from 'types/characterConfig'
-import { ScoringMetadata, SimulationMetadata } from 'types/metadata'
+import {
+  ScoringMetadata,
+  SimulationMetadata,
+} from 'types/metadata'
 
-import { CharacterConditionalsController } from 'types/conditionals'
-import {
-  OptimizerAction,
-  OptimizerContext,
-} from 'types/optimizer'
-import {
-  DEFAULT_FUA,
-  END_SKILL,
-  NULL_TURN_ABILITY_NAME,
-  START_ULT,
-  WHOLE_SKILL,
-  AbilityKind,
-} from 'lib/optimization/rotation/turnAbilityConfig'
 import { Robin } from 'lib/conditionals/character/1300/Robin'
 import { Sunday } from 'lib/conditionals/character/1300/Sunday'
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
 import { AGroundedAscent } from 'lib/conditionals/lightcone/5star/AGroundedAscent'
 import { FlowingNightglow } from 'lib/conditionals/lightcone/5star/FlowingNightglow'
 import { ThoughWorldsApart } from 'lib/conditionals/lightcone/5star/ThoughWorldsApart'
+import {
+  AbilityKind,
+  DEFAULT_FUA,
+  END_SKILL,
+  NULL_TURN_ABILITY_NAME,
+  START_ULT,
+  WHOLE_SKILL,
+} from 'lib/optimization/rotation/turnAbilityConfig'
+import { CharacterConditionalsController } from 'types/conditionals'
+import {
+  OptimizerAction,
+  OptimizerContext,
+} from 'types/optimizer'
 
 export const JingYuanEntities = createEnum('JingYuan', 'LightningLord')
 export const JingYuanAbilities: AbilityKind[] = [
@@ -266,7 +270,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   }
 }
 
-
 const simulation = (): SimulationMetadata => ({
   parts: {
     [Parts.Body]: [
@@ -392,8 +395,9 @@ const display = {
 
 export const JingYuan: CharacterConfig = {
   id: '1204',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1200/Jingliu.ts
+++ b/src/lib/conditionals/character/1200/Jingliu.ts
@@ -5,43 +5,50 @@ import {
   createEnum,
 } from 'lib/conditionals/conditionalUtils'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { Parts, Sets, Stats } from 'lib/constants/constants'
-import { SortOption } from 'lib/optimization/sortOptions'
+import {
+  Parts,
+  Sets,
+  Stats,
+} from 'lib/constants/constants'
 import { Source } from 'lib/optimization/buffSource'
 import { StatKey } from 'lib/optimization/engine/config/keys'
-import { DamageTag, ElementTag } from 'lib/optimization/engine/config/tag'
-import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
 import {
-  MATCH_2P_WEIGHT,
+  DamageTag,
+  ElementTag,
+} from 'lib/optimization/engine/config/tag'
+import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
+import { SortOption } from 'lib/optimization/sortOptions'
+import {
   SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
-  SPREAD_RELICS_2P_ATK_CRIT_WEIGHTS,
   SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
-  T2_WEIGHT,
 } from 'lib/scoring/scoringConstants'
 import { TsUtils } from 'lib/utils/TsUtils'
 import { Eidolon } from 'types/character'
 import { CharacterConfig } from 'types/characterConfig'
-import { ScoringMetadata, SimulationMetadata } from 'types/metadata'
+import {
+  ScoringMetadata,
+  SimulationMetadata,
+} from 'types/metadata'
 
-import { CharacterConditionalsController } from 'types/conditionals'
-import {
-  OptimizerAction,
-  OptimizerContext,
-} from 'types/optimizer'
-import {
-  DEFAULT_ULT,
-  END_ULT,
-  NULL_TURN_ABILITY_NAME,
-  START_SKILL,
-  WHOLE_SKILL,
-  AbilityKind,
-} from 'lib/optimization/rotation/turnAbilityConfig'
 import { Bronya } from 'lib/conditionals/character/1100/Bronya'
 import { Huohuo } from 'lib/conditionals/character/1200/Huohuo'
 import { RuanMei } from 'lib/conditionals/character/1300/RuanMei'
 import { ButTheBattleIsntOver } from 'lib/conditionals/lightcone/5star/ButTheBattleIsntOver'
 import { NightOfFright } from 'lib/conditionals/lightcone/5star/NightOfFright'
 import { PastSelfInTheMirror } from 'lib/conditionals/lightcone/5star/PastSelfInTheMirror'
+import {
+  AbilityKind,
+  DEFAULT_ULT,
+  END_ULT,
+  NULL_TURN_ABILITY_NAME,
+  START_SKILL,
+  WHOLE_SKILL,
+} from 'lib/optimization/rotation/turnAbilityConfig'
+import { CharacterConditionalsController } from 'types/conditionals'
+import {
+  OptimizerAction,
+  OptimizerContext,
+} from 'types/optimizer'
 
 export const JingliuEntities = createEnum('Jingliu')
 export const JingliuAbilities: AbilityKind[] = [
@@ -201,7 +208,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   }
 }
 
-
 const simulation = (): SimulationMetadata => ({
   parts: {
     [Parts.Body]: [
@@ -318,8 +324,9 @@ const display = {
 
 export const Jingliu: CharacterConfig = {
   id: '1212',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1200/JingliuB1.ts
+++ b/src/lib/conditionals/character/1200/JingliuB1.ts
@@ -1,3 +1,6 @@
+import { Bronya } from 'lib/conditionals/character/1100/Bronya'
+import { Hyacine } from 'lib/conditionals/character/1400/Hyacine'
+import { Tribbie } from 'lib/conditionals/character/1400/Tribbie'
 import {
   AbilityEidolon,
   Conditionals,
@@ -5,8 +8,14 @@ import {
   createEnum,
 } from 'lib/conditionals/conditionalUtils'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { Parts, Sets, Stats } from 'lib/constants/constants'
-import { SortOption } from 'lib/optimization/sortOptions'
+import { ButTheBattleIsntOver } from 'lib/conditionals/lightcone/5star/ButTheBattleIsntOver'
+import { IfTimeWereAFlower } from 'lib/conditionals/lightcone/5star/IfTimeWereAFlower'
+import { MayRainbowsRemainInTheSky } from 'lib/conditionals/lightcone/5star/MayRainbowsRemainInTheSky'
+import {
+  Parts,
+  Sets,
+  Stats,
+} from 'lib/constants/constants'
 import { Source } from 'lib/optimization/buffSource'
 import { StatKey } from 'lib/optimization/engine/config/keys'
 import {
@@ -15,35 +24,30 @@ import {
 } from 'lib/optimization/engine/config/tag'
 import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
 import {
-  MATCH_2P_WEIGHT,
-  SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
-  SPREAD_RELICS_2P_ATK_CRIT_WEIGHTS,
-  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
-  T2_WEIGHT,
-} from 'lib/scoring/scoringConstants'
-import { TsUtils } from 'lib/utils/TsUtils'
-import { Eidolon } from 'types/character'
-import { CharacterConfig } from 'types/characterConfig'
-import { ScoringMetadata, SimulationMetadata } from 'types/metadata'
-import { CharacterConditionalsController } from 'types/conditionals'
-import {
-  OptimizerAction,
-  OptimizerContext,
-} from 'types/optimizer'
-import {
+  AbilityKind,
   DEFAULT_ULT,
   END_ULT,
   NULL_TURN_ABILITY_NAME,
   START_SKILL,
   WHOLE_SKILL,
-  AbilityKind,
 } from 'lib/optimization/rotation/turnAbilityConfig'
-import { Bronya } from 'lib/conditionals/character/1100/Bronya'
-import { Hyacine } from 'lib/conditionals/character/1400/Hyacine'
-import { Tribbie } from 'lib/conditionals/character/1400/Tribbie'
-import { ButTheBattleIsntOver } from 'lib/conditionals/lightcone/5star/ButTheBattleIsntOver'
-import { IfTimeWereAFlower } from 'lib/conditionals/lightcone/5star/IfTimeWereAFlower'
-import { MayRainbowsRemainInTheSky } from 'lib/conditionals/lightcone/5star/MayRainbowsRemainInTheSky'
+import { SortOption } from 'lib/optimization/sortOptions'
+import {
+  SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
+  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+} from 'lib/scoring/scoringConstants'
+import { TsUtils } from 'lib/utils/TsUtils'
+import { Eidolon } from 'types/character'
+import { CharacterConfig } from 'types/characterConfig'
+import { CharacterConditionalsController } from 'types/conditionals'
+import {
+  ScoringMetadata,
+  SimulationMetadata,
+} from 'types/metadata'
+import {
+  OptimizerAction,
+  OptimizerContext,
+} from 'types/optimizer'
 
 export const JingliuB1Entities = createEnum('JingliuB1')
 export const JingliuB1Abilities: AbilityKind[] = [
@@ -234,7 +238,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   }
 }
 
-
 const simulation = (): SimulationMetadata => ({
   parts: {
     [Parts.Body]: [
@@ -354,8 +357,9 @@ const display = {
 
 export const JingliuB1: CharacterConfig = {
   id: '1212b1',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1200/Lingsha.ts
+++ b/src/lib/conditionals/character/1200/Lingsha.ts
@@ -1,7 +1,4 @@
-import {
-  ASHBLAZING_ATK_STACK,
-  BREAK_DMG_TYPE,
-} from 'lib/conditionals/conditionalConstants'
+import { ASHBLAZING_ATK_STACK } from 'lib/conditionals/conditionalConstants'
 import {
   boostAshblazingAtkContainer,
   gpuBoostAshblazingAtkContainer,
@@ -21,11 +18,9 @@ import {
   ConditionalActivation,
   ConditionalType,
   Parts,
-  Sets,
   Stats,
 } from 'lib/constants/constants'
 import { wgslTrue } from 'lib/gpu/injection/wgslUtils'
-import { SortOption } from 'lib/optimization/sortOptions'
 import { Source } from 'lib/optimization/buffSource'
 import { StatKey } from 'lib/optimization/engine/config/keys'
 import {
@@ -34,21 +29,15 @@ import {
   TargetTag,
 } from 'lib/optimization/engine/config/tag'
 import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
-import { buff } from 'lib/optimization/engine/container/gpuBuffBuilder'
-import {
-  MATCH_2P_WEIGHT,
-  SPREAD_ORNAMENTS_2P_SUPPORT_WEIGHTS,
-  SPREAD_RELICS_2P_BREAK_WEIGHTS,
-  SPREAD_RELICS_2P_SPEED_WEIGHTS,
-} from 'lib/scoring/scoringConstants'
+import { SortOption } from 'lib/optimization/sortOptions'
 import { PresetEffects } from 'lib/scoring/presetEffects'
 import { TsUtils } from 'lib/utils/TsUtils'
 
 import { Eidolon } from 'types/character'
 import { CharacterConfig } from 'types/characterConfig'
-import { ScoringMetadata } from 'types/metadata'
 import { NumberToNumberMap } from 'types/common'
 import { CharacterConditionalsController } from 'types/conditionals'
+import { ScoringMetadata } from 'types/metadata'
 import {
   OptimizerAction,
   OptimizerContext,
@@ -365,7 +354,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   }
 }
 
-
 const scoring = (): ScoringMetadata => ({
   stats: {
     [Stats.ATK]: 1.00,
@@ -426,8 +414,9 @@ const display = {
 
 export const Lingsha: CharacterConfig = {
   id: '1222',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1200/Luocha.ts
+++ b/src/lib/conditionals/character/1200/Luocha.ts
@@ -5,8 +5,10 @@ import {
   createEnum,
 } from 'lib/conditionals/conditionalUtils'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { Parts, Sets, Stats } from 'lib/constants/constants'
-import { SortOption } from 'lib/optimization/sortOptions'
+import {
+  Parts,
+  Stats,
+} from 'lib/constants/constants'
 import { Source } from 'lib/optimization/buffSource'
 import { StatKey } from 'lib/optimization/engine/config/keys'
 import {
@@ -14,17 +16,13 @@ import {
   TargetTag,
 } from 'lib/optimization/engine/config/tag'
 import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
-import {
-  SPREAD_ORNAMENTS_2P_SUPPORT_WEIGHTS,
-  SPREAD_RELICS_2P_ATK_WEIGHTS,
-  SPREAD_RELICS_2P_SPEED_WEIGHTS,
-} from 'lib/scoring/scoringConstants'
+import { SortOption } from 'lib/optimization/sortOptions'
 import { PresetEffects } from 'lib/scoring/presetEffects'
 import { TsUtils } from 'lib/utils/TsUtils'
 import { Eidolon } from 'types/character'
 import { CharacterConfig } from 'types/characterConfig'
-import { ScoringMetadata } from 'types/metadata'
 import { CharacterConditionalsController } from 'types/conditionals'
+import { ScoringMetadata } from 'types/metadata'
 import {
   OptimizerAction,
   OptimizerContext,
@@ -175,7 +173,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   }
 }
 
-
 const scoring = (): ScoringMetadata => ({
   stats: {
     [Stats.ATK]: 1,
@@ -231,8 +228,9 @@ const display = {
 
 export const Luocha: CharacterConfig = {
   id: '1203',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1200/March7thImaginary.ts
+++ b/src/lib/conditionals/character/1200/March7thImaginary.ts
@@ -12,44 +12,55 @@ import {
   createEnum,
 } from 'lib/conditionals/conditionalUtils'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { Parts, Sets, Stats } from 'lib/constants/constants'
-import { SortOption } from 'lib/optimization/sortOptions'
+import {
+  Parts,
+  Sets,
+  Stats,
+} from 'lib/constants/constants'
 import { Source } from 'lib/optimization/buffSource'
 import { StatKey } from 'lib/optimization/engine/config/keys'
-import { DamageTag, ElementTag, TargetTag } from 'lib/optimization/engine/config/tag'
+import {
+  DamageTag,
+  ElementTag,
+  TargetTag,
+} from 'lib/optimization/engine/config/tag'
 import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
+import { SortOption } from 'lib/optimization/sortOptions'
+import { PresetEffects } from 'lib/scoring/presetEffects'
 import {
   SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
   SPREAD_ORNAMENTS_2P_SUPPORT,
   SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
 } from 'lib/scoring/scoringConstants'
-import { PresetEffects } from 'lib/scoring/presetEffects'
 import { TsUtils } from 'lib/utils/TsUtils'
 
 import { Eidolon } from 'types/character'
 import { CharacterConfig } from 'types/characterConfig'
-import { ScoringMetadata, SimulationMetadata } from 'types/metadata'
+import {
+  ScoringMetadata,
+  SimulationMetadata,
+} from 'types/metadata'
 
-import { CharacterConditionalsController } from 'types/conditionals'
-import {
-  OptimizerAction,
-  OptimizerContext,
-} from 'types/optimizer'
-import {
-  DEFAULT_BREAK,
-  DEFAULT_FUA,
-  END_BASIC,
-  NULL_TURN_ABILITY_NAME,
-  START_ULT,
-  WHOLE_BASIC,
-  AbilityKind,
-} from 'lib/optimization/rotation/turnAbilityConfig'
 import { Fugue } from 'lib/conditionals/character/1200/Fugue'
 import { Lingsha } from 'lib/conditionals/character/1200/Lingsha'
 import { TheDahlia } from 'lib/conditionals/character/1300/TheDahlia'
 import { LongRoadLeadsHome } from 'lib/conditionals/lightcone/5star/LongRoadLeadsHome'
 import { NeverForgetHerFlame } from 'lib/conditionals/lightcone/5star/NeverForgetHerFlame'
 import { ScentAloneStaysTrue } from 'lib/conditionals/lightcone/5star/ScentAloneStaysTrue'
+import {
+  AbilityKind,
+  DEFAULT_BREAK,
+  DEFAULT_FUA,
+  END_BASIC,
+  NULL_TURN_ABILITY_NAME,
+  START_ULT,
+  WHOLE_BASIC,
+} from 'lib/optimization/rotation/turnAbilityConfig'
+import { CharacterConditionalsController } from 'types/conditionals'
+import {
+  OptimizerAction,
+  OptimizerContext,
+} from 'types/optimizer'
 
 export const March7thImaginaryEntities = createEnum('March7thImaginary')
 export const March7thImaginaryAbilities: AbilityKind[] = [
@@ -210,11 +221,11 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
             ...(
               (basicAdditionalScaling > 0)
                 ? [
-                    HitDefinitionBuilder.standardAdditional()
-                      .damageElement(ElementTag.Imaginary)
-                      .atkScaling(basicAdditionalScaling)
-                      .build(),
-                  ]
+                  HitDefinitionBuilder.standardAdditional()
+                    .damageElement(ElementTag.Imaginary)
+                    .atkScaling(basicAdditionalScaling)
+                    .build(),
+                ]
                 : []
             ),
           ],
@@ -229,19 +240,17 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
           ],
         },
         [AbilityKind.FUA]: {
-          hits: [
-            ...(
-              (e >= 2)
-                ? [
-                    HitDefinitionBuilder.standardFua()
-                      .damageElement(ElementTag.Imaginary)
-                      .atkScaling(0.60)
-                      .toughnessDmg(10)
-                      .build(),
-                  ]
-                : []
-            ),
-          ],
+          hits: (
+            (e >= 2)
+              ? [
+                HitDefinitionBuilder.standardFua()
+                  .damageElement(ElementTag.Imaginary)
+                  .atkScaling(0.60)
+                  .toughnessDmg(10)
+                  .build(),
+              ]
+              : []
+          ),
         },
         [AbilityKind.BREAK]: {
           hits: [
@@ -280,7 +289,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
   }
 }
-
 
 const simulation = (): SimulationMetadata => ({
   parts: {
@@ -404,8 +412,9 @@ const display = {
 
 export const March7thImaginary: CharacterConfig = {
   id: '1224',
-  info: { displayName: 'March 7th (Hunt)' },
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1200/Moze.ts
+++ b/src/lib/conditionals/character/1200/Moze.ts
@@ -12,46 +12,54 @@ import {
   createEnum,
 } from 'lib/conditionals/conditionalUtils'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { Parts, Sets, Stats } from 'lib/constants/constants'
-import { SortOption } from 'lib/optimization/sortOptions'
+import {
+  Parts,
+  Sets,
+  Stats,
+} from 'lib/constants/constants'
 import { Source } from 'lib/optimization/buffSource'
 import { StatKey } from 'lib/optimization/engine/config/keys'
-import { DamageTag, ElementTag, TargetTag } from 'lib/optimization/engine/config/tag'
+import {
+  DamageTag,
+  ElementTag,
+  TargetTag,
+} from 'lib/optimization/engine/config/tag'
 import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
+import { SortOption } from 'lib/optimization/sortOptions'
+import { PresetEffects } from 'lib/scoring/presetEffects'
 import {
   SPREAD_ORNAMENTS_2P_FUA,
-  SPREAD_ORNAMENTS_2P_FUA_WEIGHTS,
   SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
   SPREAD_ORNAMENTS_2P_SUPPORT,
-  SPREAD_RELICS_2P_ATK_CRIT_WEIGHTS,
   SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
-  T2_WEIGHT,
 } from 'lib/scoring/scoringConstants'
-import { PresetEffects } from 'lib/scoring/presetEffects'
 import { TsUtils } from 'lib/utils/TsUtils'
 
 import { Eidolon } from 'types/character'
 import { CharacterConfig } from 'types/characterConfig'
-import { ScoringMetadata, SimulationMetadata } from 'types/metadata'
+import {
+  ScoringMetadata,
+  SimulationMetadata,
+} from 'types/metadata'
 
+import { Feixiao } from 'lib/conditionals/character/1200/Feixiao'
+import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
+import { Tribbie } from 'lib/conditionals/character/1400/Tribbie'
+import { IfTimeWereAFlower } from 'lib/conditionals/lightcone/5star/IfTimeWereAFlower'
+import { IVentureForthToHunt } from 'lib/conditionals/lightcone/5star/IVentureForthToHunt'
+import { ThoughWorldsApart } from 'lib/conditionals/lightcone/5star/ThoughWorldsApart'
+import {
+  AbilityKind,
+  DEFAULT_FUA,
+  DEFAULT_ULT,
+  NULL_TURN_ABILITY_NAME,
+  WHOLE_SKILL,
+} from 'lib/optimization/rotation/turnAbilityConfig'
 import { CharacterConditionalsController } from 'types/conditionals'
 import {
   OptimizerAction,
   OptimizerContext,
 } from 'types/optimizer'
-import {
-  DEFAULT_FUA,
-  DEFAULT_ULT,
-  NULL_TURN_ABILITY_NAME,
-  WHOLE_SKILL,
-  AbilityKind,
-} from 'lib/optimization/rotation/turnAbilityConfig'
-import { Feixiao } from 'lib/conditionals/character/1200/Feixiao'
-import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
-import { Tribbie } from 'lib/conditionals/character/1400/Tribbie'
-import { IVentureForthToHunt } from 'lib/conditionals/lightcone/5star/IVentureForthToHunt'
-import { IfTimeWereAFlower } from 'lib/conditionals/lightcone/5star/IfTimeWereAFlower'
-import { ThoughWorldsApart } from 'lib/conditionals/lightcone/5star/ThoughWorldsApart'
 
 export const MozeEntities = createEnum('Moze')
 export const MozeAbilities: AbilityKind[] = [
@@ -170,11 +178,11 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
             ...(
               (r.preyMark)
                 ? [
-                    HitDefinitionBuilder.standardAdditional()
-                      .damageElement(ElementTag.Lightning)
-                      .atkScaling(additionalDmgScaling)
-                      .build(),
-                  ]
+                  HitDefinitionBuilder.standardAdditional()
+                    .damageElement(ElementTag.Lightning)
+                    .atkScaling(additionalDmgScaling)
+                    .build(),
+                ]
                 : []
             ),
           ],
@@ -189,11 +197,11 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
             ...(
               (r.preyMark)
                 ? [
-                    HitDefinitionBuilder.standardAdditional()
-                      .damageElement(ElementTag.Lightning)
-                      .atkScaling(additionalDmgScaling)
-                      .build(),
-                  ]
+                  HitDefinitionBuilder.standardAdditional()
+                    .damageElement(ElementTag.Lightning)
+                    .atkScaling(additionalDmgScaling)
+                    .build(),
+                ]
                 : []
             ),
           ],
@@ -209,11 +217,11 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
             ...(
               (r.preyMark)
                 ? [
-                    HitDefinitionBuilder.standardAdditional()
-                      .damageElement(ElementTag.Lightning)
-                      .atkScaling(additionalDmgScaling)
-                      .build(),
-                  ]
+                  HitDefinitionBuilder.standardAdditional()
+                    .damageElement(ElementTag.Lightning)
+                    .atkScaling(additionalDmgScaling)
+                    .build(),
+                ]
                 : []
             ),
           ],
@@ -228,11 +236,11 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
             ...(
               (r.preyMark)
                 ? [
-                    HitDefinitionBuilder.standardAdditional()
-                      .damageElement(ElementTag.Lightning)
-                      .atkScaling(additionalDmgScaling)
-                      .build(),
-                  ]
+                  HitDefinitionBuilder.standardAdditional()
+                    .damageElement(ElementTag.Lightning)
+                    .atkScaling(additionalDmgScaling)
+                    .build(),
+                ]
                 : []
             ),
           ],
@@ -267,7 +275,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
   }
 }
-
 
 const simulation = (): SimulationMetadata => ({
   parts: {
@@ -393,8 +400,9 @@ const display = {
 
 export const Moze: CharacterConfig = {
   id: '1223',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1200/Qingque.ts
+++ b/src/lib/conditionals/character/1200/Qingque.ts
@@ -12,45 +12,53 @@ import {
   createEnum,
 } from 'lib/conditionals/conditionalUtils'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { Parts, Sets, Stats } from 'lib/constants/constants'
-import { SortOption } from 'lib/optimization/sortOptions'
+import {
+  Parts,
+  Sets,
+  Stats,
+} from 'lib/constants/constants'
 import { Source } from 'lib/optimization/buffSource'
 import { StatKey } from 'lib/optimization/engine/config/keys'
-import { DamageTag, ElementTag } from 'lib/optimization/engine/config/tag'
+import {
+  DamageTag,
+  ElementTag,
+} from 'lib/optimization/engine/config/tag'
 import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
+import { SortOption } from 'lib/optimization/sortOptions'
+import { PresetEffects } from 'lib/scoring/presetEffects'
 import {
   SPREAD_ORNAMENTS_2P_FUA,
-  SPREAD_ORNAMENTS_2P_FUA_WEIGHTS,
   SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
-  SPREAD_RELICS_2P_ATK_CRIT_WEIGHTS,
   SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
 } from 'lib/scoring/scoringConstants'
-import { PresetEffects } from 'lib/scoring/presetEffects'
 import { TsUtils } from 'lib/utils/TsUtils'
 
-import { Eidolon } from 'types/character'
-import { CharacterConfig } from 'types/characterConfig'
-import { ScoringMetadata, SimulationMetadata } from 'types/metadata'
-import { NumberToNumberMap } from 'types/common'
-import { CharacterConditionalsController } from 'types/conditionals'
-import {
-  OptimizerAction,
-  OptimizerContext,
-} from 'types/optimizer'
-import {
-  DEFAULT_FUA,
-  DEFAULT_ULT,
-  END_BASIC,
-  NULL_TURN_ABILITY_NAME,
-  START_SKILL,
-  AbilityKind,
-} from 'lib/optimization/rotation/turnAbilityConfig'
 import { SparkleB1 } from 'lib/conditionals/character/1300/SparkleB1'
 import { Cipher } from 'lib/conditionals/character/1400/Cipher'
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
 import { AGroundedAscent } from 'lib/conditionals/lightcone/5star/AGroundedAscent'
 import { LiesAflutterInTheWind } from 'lib/conditionals/lightcone/5star/LiesAflutterInTheWind'
 import { ThoughWorldsApart } from 'lib/conditionals/lightcone/5star/ThoughWorldsApart'
+import {
+  AbilityKind,
+  DEFAULT_FUA,
+  DEFAULT_ULT,
+  END_BASIC,
+  NULL_TURN_ABILITY_NAME,
+  START_SKILL,
+} from 'lib/optimization/rotation/turnAbilityConfig'
+import { Eidolon } from 'types/character'
+import { CharacterConfig } from 'types/characterConfig'
+import { NumberToNumberMap } from 'types/common'
+import { CharacterConditionalsController } from 'types/conditionals'
+import {
+  ScoringMetadata,
+  SimulationMetadata,
+} from 'types/metadata'
+import {
+  OptimizerAction,
+  OptimizerContext,
+} from 'types/optimizer'
 
 export const QingqueEntities = createEnum('Qingque')
 export const QingqueAbilities: AbilityKind[] = [
@@ -168,19 +176,17 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
           ],
         },
         [AbilityKind.FUA]: {
-          hits: [
-            ...(
-              (e >= 4)
-                ? [
-                    HitDefinitionBuilder.standardFua()
-                      .damageElement(ElementTag.Quantum)
-                      .atkScaling(basicAtkScaling)
-                      .toughnessDmg((r.basicEnhanced) ? 20 : 10)
-                      .build(),
-                  ]
-                : []
-            ),
-          ],
+          hits: (
+            (e >= 4)
+              ? [
+                HitDefinitionBuilder.standardFua()
+                  .damageElement(ElementTag.Quantum)
+                  .atkScaling(basicAtkScaling)
+                  .toughnessDmg((r.basicEnhanced) ? 20 : 10)
+                  .build(),
+              ]
+              : []
+          ),
         },
         [AbilityKind.BREAK]: {
           hits: [
@@ -211,7 +217,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
   }
 }
-
 
 const simulation = (): SimulationMetadata => ({
   parts: {
@@ -337,8 +342,9 @@ const display = {
 
 export const Qingque: CharacterConfig = {
   id: '1201',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1200/Sushang.ts
+++ b/src/lib/conditionals/character/1200/Sushang.ts
@@ -5,40 +5,51 @@ import {
   createEnum,
 } from 'lib/conditionals/conditionalUtils'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { Parts, Sets, Stats } from 'lib/constants/constants'
-import { SortOption } from 'lib/optimization/sortOptions'
+import {
+  Parts,
+  Sets,
+  Stats,
+} from 'lib/constants/constants'
 import { Source } from 'lib/optimization/buffSource'
 import { StatKey } from 'lib/optimization/engine/config/keys'
-import { DamageTag, ElementTag, } from 'lib/optimization/engine/config/tag'
-import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
 import {
-  MATCH_2P_WEIGHT,
+  DamageTag,
+  ElementTag,
+} from 'lib/optimization/engine/config/tag'
+import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
+import { SortOption } from 'lib/optimization/sortOptions'
+import {
   SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
-  SPREAD_RELICS_2P_ATK_WEIGHTS,
   SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
 } from 'lib/scoring/scoringConstants'
 import { TsUtils } from 'lib/utils/TsUtils'
 
 import { Eidolon } from 'types/character'
 import { CharacterConfig } from 'types/characterConfig'
-import { ScoringMetadata, SimulationMetadata } from 'types/metadata'
-
-import { CharacterConditionalsController } from 'types/conditionals'
-import { OptimizerAction, OptimizerContext, } from 'types/optimizer'
 import {
+  ScoringMetadata,
+  SimulationMetadata,
+} from 'types/metadata'
+
+import { Fugue } from 'lib/conditionals/character/1200/Fugue'
+import { Lingsha } from 'lib/conditionals/character/1200/Lingsha'
+import { TheDahlia } from 'lib/conditionals/character/1300/TheDahlia'
+import { LongRoadLeadsHome } from 'lib/conditionals/lightcone/5star/LongRoadLeadsHome'
+import { NeverForgetHerFlame } from 'lib/conditionals/lightcone/5star/NeverForgetHerFlame'
+import { ScentAloneStaysTrue } from 'lib/conditionals/lightcone/5star/ScentAloneStaysTrue'
+import {
+  AbilityKind,
   DEFAULT_ULT,
   END_BREAK,
   NULL_TURN_ABILITY_NAME,
   START_SKILL,
   WHOLE_SKILL,
-  AbilityKind,
 } from 'lib/optimization/rotation/turnAbilityConfig'
-import { Lingsha } from 'lib/conditionals/character/1200/Lingsha'
-import { Fugue } from 'lib/conditionals/character/1200/Fugue'
-import { TheDahlia } from 'lib/conditionals/character/1300/TheDahlia'
-import { LongRoadLeadsHome } from 'lib/conditionals/lightcone/5star/LongRoadLeadsHome'
-import { NeverForgetHerFlame } from 'lib/conditionals/lightcone/5star/NeverForgetHerFlame'
-import { ScentAloneStaysTrue } from 'lib/conditionals/lightcone/5star/ScentAloneStaysTrue'
+import { CharacterConditionalsController } from 'types/conditionals'
+import {
+  OptimizerAction,
+  OptimizerContext,
+} from 'types/optimizer'
 
 export const SushangEntities = createEnum('Sushang')
 export const SushangAbilities: AbilityKind[] = [
@@ -217,7 +228,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   }
 }
 
-
 const simulation = (): SimulationMetadata => ({
   parts: {
     [Parts.Body]: [
@@ -338,8 +348,9 @@ const display = {
 
 export const Sushang: CharacterConfig = {
   id: '1206',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1200/Tingyun.ts
+++ b/src/lib/conditionals/character/1200/Tingyun.ts
@@ -17,16 +17,15 @@ import {
   Stats,
 } from 'lib/constants/constants'
 import { wgslTrue } from 'lib/gpu/injection/wgslUtils'
-import { SortOption } from 'lib/optimization/sortOptions'
 import { Source } from 'lib/optimization/buffSource'
 import { StatKey } from 'lib/optimization/engine/config/keys'
-import { DamageTag, ElementTag, TargetTag } from 'lib/optimization/engine/config/tag'
-import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
 import {
-  SPREAD_ORNAMENTS_2P_SUPPORT_WEIGHTS,
-  SPREAD_RELICS_2P_ATK_WEIGHTS,
-  SPREAD_RELICS_2P_SPEED_WEIGHTS,
-} from 'lib/scoring/scoringConstants'
+  DamageTag,
+  ElementTag,
+  TargetTag,
+} from 'lib/optimization/engine/config/tag'
+import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
+import { SortOption } from 'lib/optimization/sortOptions'
 import { TsUtils } from 'lib/utils/TsUtils'
 import { Eidolon } from 'types/character'
 import { CharacterConfig } from 'types/characterConfig'
@@ -165,11 +164,11 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
             ...(
               (r.benedictionBuff)
                 ? [
-                    HitDefinitionBuilder.standardAdditional()
-                      .damageElement(ElementTag.Lightning)
-                      .atkScaling(skillLightningDmgBoostScaling + talentScaling)
-                      .build(),
-                  ]
+                  HitDefinitionBuilder.standardAdditional()
+                    .damageElement(ElementTag.Lightning)
+                    .atkScaling(skillLightningDmgBoostScaling + talentScaling)
+                    .build(),
+                ]
                 : []
             ),
           ],
@@ -223,7 +222,16 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
           return r.benedictionBuff
         },
         effect: function(x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) {
-          dynamicStatConversionContainer(Stats.ATK, Stats.ATK, this, x, action, context, SOURCE_TRACE, (convertibleValue) => convertibleValue * skillAtkBoostMax)
+          dynamicStatConversionContainer(
+            Stats.ATK,
+            Stats.ATK,
+            this,
+            x,
+            action,
+            context,
+            SOURCE_TRACE,
+            (convertibleValue) => convertibleValue * skillAtkBoostMax,
+          )
         },
         gpu: function(action: OptimizerAction, context: OptimizerContext) {
           const r = action.characterConditionals as Conditionals<typeof content>
@@ -242,7 +250,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     ],
   }
 }
-
 
 const scoring = (): ScoringMetadata => ({
   stats: {
@@ -294,8 +301,9 @@ const display = {
 
 export const Tingyun: CharacterConfig = {
   id: '1202',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1200/Xueyi.ts
+++ b/src/lib/conditionals/character/1200/Xueyi.ts
@@ -12,12 +12,18 @@ import {
   createEnum,
 } from 'lib/conditionals/conditionalUtils'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { Parts, Sets, Stats } from 'lib/constants/constants'
+import {
+  Parts,
+  Sets,
+  Stats,
+} from 'lib/constants/constants'
 import { containerActionVal } from 'lib/gpu/injection/injectUtils'
 import { wgslTrue } from 'lib/gpu/injection/wgslUtils'
-import { SortOption } from 'lib/optimization/sortOptions'
 import { Source } from 'lib/optimization/buffSource'
-import { AKey, StatKey } from 'lib/optimization/engine/config/keys'
+import {
+  AKey,
+  StatKey,
+} from 'lib/optimization/engine/config/keys'
 import {
   DamageTag,
   ElementTag,
@@ -25,41 +31,42 @@ import {
 } from 'lib/optimization/engine/config/tag'
 import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
 import { buff } from 'lib/optimization/engine/container/gpuBuffBuilder'
+import { SortOption } from 'lib/optimization/sortOptions'
+import { PresetEffects } from 'lib/scoring/presetEffects'
 import {
-  MATCH_2P_WEIGHT,
   SPREAD_ORNAMENTS_2P_FUA,
   SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
-  SPREAD_RELICS_2P_ATK_WEIGHTS,
   SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
-  T2_WEIGHT,
 } from 'lib/scoring/scoringConstants'
-import { PresetEffects } from 'lib/scoring/presetEffects'
 import { TsUtils } from 'lib/utils/TsUtils'
 
-import { Eidolon } from 'types/character'
-import { CharacterConfig } from 'types/characterConfig'
-import { ScoringMetadata, SimulationMetadata } from 'types/metadata'
-import { NumberToNumberMap } from 'types/common'
-import { CharacterConditionalsController } from 'types/conditionals'
-import {
-  OptimizerAction,
-  OptimizerContext,
-} from 'types/optimizer'
-import {
-  DEFAULT_BREAK,
-  DEFAULT_FUA,
-  END_SKILL,
-  NULL_TURN_ABILITY_NAME,
-  START_ULT,
-  WHOLE_SKILL,
-  AbilityKind,
-} from 'lib/optimization/rotation/turnAbilityConfig'
 import { Fugue } from 'lib/conditionals/character/1200/Fugue'
 import { Lingsha } from 'lib/conditionals/character/1200/Lingsha'
 import { TheDahlia } from 'lib/conditionals/character/1300/TheDahlia'
 import { LongRoadLeadsHome } from 'lib/conditionals/lightcone/5star/LongRoadLeadsHome'
 import { NeverForgetHerFlame } from 'lib/conditionals/lightcone/5star/NeverForgetHerFlame'
 import { ScentAloneStaysTrue } from 'lib/conditionals/lightcone/5star/ScentAloneStaysTrue'
+import {
+  AbilityKind,
+  DEFAULT_BREAK,
+  DEFAULT_FUA,
+  END_SKILL,
+  NULL_TURN_ABILITY_NAME,
+  START_ULT,
+  WHOLE_SKILL,
+} from 'lib/optimization/rotation/turnAbilityConfig'
+import { Eidolon } from 'types/character'
+import { CharacterConfig } from 'types/characterConfig'
+import { NumberToNumberMap } from 'types/common'
+import { CharacterConditionalsController } from 'types/conditionals'
+import {
+  ScoringMetadata,
+  SimulationMetadata,
+} from 'types/metadata'
+import {
+  OptimizerAction,
+  OptimizerContext,
+} from 'types/optimizer'
 
 export const XueyiEntities = createEnum('Xueyi')
 export const XueyiAbilities: AbilityKind[] = [
@@ -249,7 +256,6 @@ if (${wgslTrue(r.beToDmgBoost)}) {
   }
 }
 
-
 const simulation = (): SimulationMetadata => ({
   parts: {
     [Parts.Body]: [
@@ -377,8 +383,9 @@ const display = {
 
 export const Xueyi: CharacterConfig = {
   id: '1214',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1200/Yanqing.ts
+++ b/src/lib/conditionals/character/1200/Yanqing.ts
@@ -12,44 +12,49 @@ import {
   createEnum,
 } from 'lib/conditionals/conditionalUtils'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { Parts, Sets, Stats } from 'lib/constants/constants'
-import { SortOption } from 'lib/optimization/sortOptions'
+import {
+  Parts,
+  Sets,
+  Stats,
+} from 'lib/constants/constants'
 import { Source } from 'lib/optimization/buffSource'
 import { StatKey } from 'lib/optimization/engine/config/keys'
 import { ElementTag } from 'lib/optimization/engine/config/tag'
 import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
+import { SortOption } from 'lib/optimization/sortOptions'
+import { PresetEffects } from 'lib/scoring/presetEffects'
 import {
-  MATCH_2P_WEIGHT,
   SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
-  SPREAD_RELICS_2P_ATK_CRIT_WEIGHTS,
   SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
 } from 'lib/scoring/scoringConstants'
-import { PresetEffects } from 'lib/scoring/presetEffects'
 import { TsUtils } from 'lib/utils/TsUtils'
 import { Eidolon } from 'types/character'
 import { CharacterConfig } from 'types/characterConfig'
-import { ScoringMetadata, SimulationMetadata } from 'types/metadata'
+import {
+  ScoringMetadata,
+  SimulationMetadata,
+} from 'types/metadata'
 
-import { CharacterConditionalsController } from 'types/conditionals'
-import {
-  OptimizerAction,
-  OptimizerContext,
-} from 'types/optimizer'
-import {
-  DEFAULT_SKILL,
-  END_FUA,
-  NULL_TURN_ABILITY_NAME,
-  START_SKILL,
-  START_ULT,
-  WHOLE_SKILL,
-  AbilityKind,
-} from 'lib/optimization/rotation/turnAbilityConfig'
 import { Bronya } from 'lib/conditionals/character/1100/Bronya'
 import { Robin } from 'lib/conditionals/character/1300/Robin'
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
 import { ButTheBattleIsntOver } from 'lib/conditionals/lightcone/5star/ButTheBattleIsntOver'
 import { FlowingNightglow } from 'lib/conditionals/lightcone/5star/FlowingNightglow'
 import { ThoughWorldsApart } from 'lib/conditionals/lightcone/5star/ThoughWorldsApart'
+import {
+  AbilityKind,
+  DEFAULT_SKILL,
+  END_FUA,
+  NULL_TURN_ABILITY_NAME,
+  START_SKILL,
+  START_ULT,
+  WHOLE_SKILL,
+} from 'lib/optimization/rotation/turnAbilityConfig'
+import { CharacterConditionalsController } from 'types/conditionals'
+import {
+  OptimizerAction,
+  OptimizerContext,
+} from 'types/optimizer'
 
 export const YanqingEntities = createEnum('Yanqing')
 export const YanqingAbilities: AbilityKind[] = [
@@ -274,7 +279,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   }
 }
 
-
 const simulation = (): SimulationMetadata => ({
   parts: {
     [Parts.Body]: [
@@ -394,8 +398,9 @@ const display = {
 
 export const Yanqing: CharacterConfig = {
   id: '1209',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1200/Yukong.ts
+++ b/src/lib/conditionals/character/1200/Yukong.ts
@@ -5,8 +5,10 @@ import {
   createEnum,
 } from 'lib/conditionals/conditionalUtils'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { Parts, Sets, Stats } from 'lib/constants/constants'
-import { SortOption } from 'lib/optimization/sortOptions'
+import {
+  Parts,
+  Stats,
+} from 'lib/constants/constants'
 import { Source } from 'lib/optimization/buffSource'
 import { StatKey } from 'lib/optimization/engine/config/keys'
 import {
@@ -14,9 +16,7 @@ import {
   TargetTag,
 } from 'lib/optimization/engine/config/tag'
 import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
-import {
-  SPREAD_ORNAMENTS_2P_SUPPORT_WEIGHTS,
-} from 'lib/scoring/scoringConstants'
+import { SortOption } from 'lib/optimization/sortOptions'
 import { PresetEffects } from 'lib/scoring/presetEffects'
 import { TsUtils } from 'lib/utils/TsUtils'
 import { Eidolon } from 'types/character'
@@ -191,7 +191,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   }
 }
 
-
 const scoring = (): ScoringMetadata => ({
   stats: {
     [Stats.ATK]: 0.75,
@@ -244,8 +243,9 @@ const display = {
 
 export const Yukong: CharacterConfig = {
   id: '1207',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1200/Yunli.ts
+++ b/src/lib/conditionals/character/1200/Yunli.ts
@@ -12,8 +12,11 @@ import {
   createEnum,
 } from 'lib/conditionals/conditionalUtils'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { Parts, Sets, Stats } from 'lib/constants/constants'
-import { SortOption } from 'lib/optimization/sortOptions'
+import {
+  Parts,
+  Sets,
+  Stats,
+} from 'lib/constants/constants'
 import { Source } from 'lib/optimization/buffSource'
 import { StatKey } from 'lib/optimization/engine/config/keys'
 import {
@@ -21,39 +24,40 @@ import {
   ElementTag,
 } from 'lib/optimization/engine/config/tag'
 import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
+import { SortOption } from 'lib/optimization/sortOptions'
+import { PresetEffects } from 'lib/scoring/presetEffects'
 import {
-  MATCH_2P_WEIGHT,
   SPREAD_ORNAMENTS_2P_FUA,
-  SPREAD_ORNAMENTS_2P_FUA_WEIGHTS,
   SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
-  SPREAD_RELICS_2P_ATK_CRIT_WEIGHTS,
   SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
 } from 'lib/scoring/scoringConstants'
-import { PresetEffects } from 'lib/scoring/presetEffects'
 import { TsUtils } from 'lib/utils/TsUtils'
 
-import { Eidolon } from 'types/character'
-import { CharacterConfig } from 'types/characterConfig'
-import { ScoringMetadata, SimulationMetadata } from 'types/metadata'
-import { NumberToNumberMap } from 'types/common'
-import { CharacterConditionalsController } from 'types/conditionals'
-import {
-  OptimizerAction,
-  OptimizerContext,
-} from 'types/optimizer'
-import {
-  DEFAULT_FUA,
-  END_SKILL,
-  NULL_TURN_ABILITY_NAME,
-  START_ULT,
-  AbilityKind,
-} from 'lib/optimization/rotation/turnAbilityConfig'
 import { Huohuo } from 'lib/conditionals/character/1200/Huohuo'
 import { Tingyun } from 'lib/conditionals/character/1200/Tingyun'
 import { SparkleB1 } from 'lib/conditionals/character/1300/SparkleB1'
 import { DanceDanceDance } from 'lib/conditionals/lightcone/4star/DanceDanceDance'
 import { MemoriesOfThePast } from 'lib/conditionals/lightcone/4star/MemoriesOfThePast'
 import { NightOfFright } from 'lib/conditionals/lightcone/5star/NightOfFright'
+import {
+  AbilityKind,
+  DEFAULT_FUA,
+  END_SKILL,
+  NULL_TURN_ABILITY_NAME,
+  START_ULT,
+} from 'lib/optimization/rotation/turnAbilityConfig'
+import { Eidolon } from 'types/character'
+import { CharacterConfig } from 'types/characterConfig'
+import { NumberToNumberMap } from 'types/common'
+import { CharacterConditionalsController } from 'types/conditionals'
+import {
+  ScoringMetadata,
+  SimulationMetadata,
+} from 'types/metadata'
+import {
+  OptimizerAction,
+  OptimizerContext,
+} from 'types/optimizer'
 
 export const YunliEntities = createEnum('Yunli')
 export const YunliAbilities: AbilityKind[] = [
@@ -302,7 +306,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   }
 }
 
-
 const simulation = (): SimulationMetadata => ({
   parts: {
     [Parts.Body]: [
@@ -422,8 +425,9 @@ const display = {
 
 export const Yunli: CharacterConfig = {
   id: '1221',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1300/Acheron.ts
+++ b/src/lib/conditionals/character/1300/Acheron.ts
@@ -1,3 +1,6 @@
+import { SilverWolfB1 } from 'lib/conditionals/character/1000/SilverWolfB1'
+import { Cipher } from 'lib/conditionals/character/1400/Cipher'
+import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
 import {
   AbilityEidolon,
   Conditionals,
@@ -6,9 +9,16 @@ import {
   createEnum,
 } from 'lib/conditionals/conditionalUtils'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { Parts, PathNames, Sets, Stats } from 'lib/constants/constants'
+import { BeforeTheTutorialMissionStarts } from 'lib/conditionals/lightcone/4star/BeforeTheTutorialMissionStarts'
+import { LiesAflutterInTheWind } from 'lib/conditionals/lightcone/5star/LiesAflutterInTheWind'
+import { ThoughWorldsApart } from 'lib/conditionals/lightcone/5star/ThoughWorldsApart'
+import {
+  Parts,
+  PathNames,
+  Sets,
+  Stats,
+} from 'lib/constants/constants'
 import { Source } from 'lib/optimization/buffSource'
-import { SortOption } from 'lib/optimization/sortOptions'
 import { StatKey } from 'lib/optimization/engine/config/keys'
 import {
   DamageTag,
@@ -18,28 +28,25 @@ import {
 import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
 import {
   AbilityKind,
+  END_SKILL,
   NULL_TURN_ABILITY_NAME,
   START_ULT,
-  END_SKILL,
   WHOLE_SKILL,
 } from 'lib/optimization/rotation/turnAbilityConfig'
+import { SortOption } from 'lib/optimization/sortOptions'
+import { PresetEffects } from 'lib/scoring/presetEffects'
 import {
-  SPREAD_RELICS_2P_ATK_CRIT_WEIGHTS,
   SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
   SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
 } from 'lib/scoring/scoringConstants'
-import { PresetEffects } from 'lib/scoring/presetEffects'
-import { SilverWolfB1 } from 'lib/conditionals/character/1000/SilverWolfB1'
-import { Cipher } from 'lib/conditionals/character/1400/Cipher'
-import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
-import { BeforeTheTutorialMissionStarts } from 'lib/conditionals/lightcone/4star/BeforeTheTutorialMissionStarts'
-import { LiesAflutterInTheWind } from 'lib/conditionals/lightcone/5star/LiesAflutterInTheWind'
-import { ThoughWorldsApart } from 'lib/conditionals/lightcone/5star/ThoughWorldsApart'
 import { TsUtils } from 'lib/utils/TsUtils'
 import { Eidolon } from 'types/character'
 import { CharacterConfig } from 'types/characterConfig'
 import { CharacterConditionalsController } from 'types/conditionals'
-import { SimulationMetadata, ScoringMetadata } from 'types/metadata'
+import {
+  ScoringMetadata,
+  SimulationMetadata,
+} from 'types/metadata'
 import {
   OptimizerAction,
   OptimizerContext,
@@ -260,7 +267,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   }
 }
 
-
 const simulation = (): SimulationMetadata => ({
   parts: {
     [Parts.Body]: [
@@ -379,8 +385,9 @@ const display = {
 
 export const Acheron: CharacterConfig = {
   id: '1308',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1300/Argenti.ts
+++ b/src/lib/conditionals/character/1300/Argenti.ts
@@ -1,3 +1,6 @@
+import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
+import { TheHerta } from 'lib/conditionals/character/1400/TheHerta'
+import { Tribbie } from 'lib/conditionals/character/1400/Tribbie'
 import {
   AbilityEidolon,
   Conditionals,
@@ -5,9 +8,15 @@ import {
   createEnum,
 } from 'lib/conditionals/conditionalUtils'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { Parts, Sets, Stats } from 'lib/constants/constants'
+import { IfTimeWereAFlower } from 'lib/conditionals/lightcone/5star/IfTimeWereAFlower'
+import { IntotheUnreachableVeil } from 'lib/conditionals/lightcone/5star/IntotheUnreachableVeil'
+import { ThoughWorldsApart } from 'lib/conditionals/lightcone/5star/ThoughWorldsApart'
+import {
+  Parts,
+  Sets,
+  Stats,
+} from 'lib/constants/constants'
 import { Source } from 'lib/optimization/buffSource'
-import { SortOption } from 'lib/optimization/sortOptions'
 import { StatKey } from 'lib/optimization/engine/config/keys'
 import {
   DamageTag,
@@ -16,27 +25,25 @@ import {
 import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
 import {
   AbilityKind,
+  DEFAULT_ULT,
+  END_SKILL,
   NULL_TURN_ABILITY_NAME,
   START_ULT,
-  END_SKILL,
-  DEFAULT_ULT,
 } from 'lib/optimization/rotation/turnAbilityConfig'
+import { SortOption } from 'lib/optimization/sortOptions'
 import {
   SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
   SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
 } from 'lib/scoring/scoringConstants'
-import { TheHerta } from 'lib/conditionals/character/1400/TheHerta'
-import { Tribbie } from 'lib/conditionals/character/1400/Tribbie'
-import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
-import { IfTimeWereAFlower } from 'lib/conditionals/lightcone/5star/IfTimeWereAFlower'
-import { IntotheUnreachableVeil } from 'lib/conditionals/lightcone/5star/IntotheUnreachableVeil'
-import { ThoughWorldsApart } from 'lib/conditionals/lightcone/5star/ThoughWorldsApart'
 import { TsUtils } from 'lib/utils/TsUtils'
 
 import { Eidolon } from 'types/character'
 import { CharacterConfig } from 'types/characterConfig'
 import { CharacterConditionalsController } from 'types/conditionals'
-import { SimulationMetadata, ScoringMetadata } from 'types/metadata'
+import {
+  ScoringMetadata,
+  SimulationMetadata,
+} from 'types/metadata'
 import {
   OptimizerAction,
   OptimizerContext,
@@ -213,7 +220,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   }
 }
 
-
 const simulation = (): SimulationMetadata => ({
   parts: {
     [Parts.Body]: [
@@ -336,8 +342,9 @@ const display = {
 
 export const Argenti: CharacterConfig = {
   id: '1302',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1300/Aventurine.ts
+++ b/src/lib/conditionals/character/1300/Aventurine.ts
@@ -1,44 +1,65 @@
-import { AbilityEidolon, Conditionals, ContentDefinition, createEnum, } from 'lib/conditionals/conditionalUtils'
-import { dynamicStatConversionContainer, gpuDynamicStatConversion, } from 'lib/conditionals/evaluation/statConversion'
+import { Topaz } from 'lib/conditionals/character/1100/Topaz'
+import { Feixiao } from 'lib/conditionals/character/1200/Feixiao'
+import { Robin } from 'lib/conditionals/character/1300/Robin'
+import {
+  AbilityEidolon,
+  Conditionals,
+  ContentDefinition,
+  createEnum,
+} from 'lib/conditionals/conditionalUtils'
+import {
+  dynamicStatConversionContainer,
+  gpuDynamicStatConversion,
+} from 'lib/conditionals/evaluation/statConversion'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { ConditionalActivation, ConditionalType, Parts, Sets, Stats, } from 'lib/constants/constants'
+import { FlowingNightglow } from 'lib/conditionals/lightcone/5star/FlowingNightglow'
+import { IVentureForthToHunt } from 'lib/conditionals/lightcone/5star/IVentureForthToHunt'
+import { WorrisomeBlissful } from 'lib/conditionals/lightcone/5star/WorrisomeBlissful'
+import {
+  ConditionalActivation,
+  ConditionalType,
+  Parts,
+  Sets,
+  Stats,
+} from 'lib/constants/constants'
 import { containerActionVal } from 'lib/gpu/injection/injectUtils'
 import { wgslTrue } from 'lib/gpu/injection/wgslUtils'
 import { Source } from 'lib/optimization/buffSource'
-import { SortOption } from 'lib/optimization/sortOptions'
 import { StatKey } from 'lib/optimization/engine/config/keys'
-import { ElementTag, SELF_ENTITY_INDEX, TargetTag, } from 'lib/optimization/engine/config/tag'
+import {
+  ElementTag,
+  SELF_ENTITY_INDEX,
+  TargetTag,
+} from 'lib/optimization/engine/config/tag'
 import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
 import {
   AbilityKind,
-  NULL_TURN_ABILITY_NAME,
-  START_ULT,
   DEFAULT_FUA,
   END_BASIC,
+  NULL_TURN_ABILITY_NAME,
+  START_ULT,
   WHOLE_BASIC,
 } from 'lib/optimization/rotation/turnAbilityConfig'
+import { SortOption } from 'lib/optimization/sortOptions'
+import { PresetEffects } from 'lib/scoring/presetEffects'
 import {
-  SPREAD_RELICS_2P_SPEED_WEIGHTS,
-  SPREAD_ORNAMENTS_2P_SUPPORT_WEIGHTS,
-  SPREAD_ORNAMENTS_2P_FUA_WEIGHTS,
   SPREAD_ORNAMENTS_2P_FUA,
   SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
   SPREAD_ORNAMENTS_2P_SUPPORT,
   SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
 } from 'lib/scoring/scoringConstants'
-import { PresetEffects } from 'lib/scoring/presetEffects'
-import { Topaz } from 'lib/conditionals/character/1100/Topaz'
-import { Feixiao } from 'lib/conditionals/character/1200/Feixiao'
-import { Robin } from 'lib/conditionals/character/1300/Robin'
-import { FlowingNightglow } from 'lib/conditionals/lightcone/5star/FlowingNightglow'
-import { IVentureForthToHunt } from 'lib/conditionals/lightcone/5star/IVentureForthToHunt'
-import { WorrisomeBlissful } from 'lib/conditionals/lightcone/5star/WorrisomeBlissful'
 import { TsUtils } from 'lib/utils/TsUtils'
 import { Eidolon } from 'types/character'
 import { CharacterConfig } from 'types/characterConfig'
 import { CharacterConditionalsController } from 'types/conditionals'
-import { SimulationMetadata, ScoringMetadata } from 'types/metadata'
-import { OptimizerAction, OptimizerContext, } from 'types/optimizer'
+import {
+  ScoringMetadata,
+  SimulationMetadata,
+} from 'types/metadata'
+import {
+  OptimizerAction,
+  OptimizerContext,
+} from 'types/optimizer'
 
 export const AventurineEntities = createEnum('Aventurine')
 export const AventurineAbilities: AbilityKind[] = [
@@ -285,7 +306,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   }
 }
 
-
 const simulation = (): SimulationMetadata => ({
   parts: {
     [Parts.Body]: [
@@ -421,8 +441,9 @@ const display = {
 
 export const Aventurine: CharacterConfig = {
   id: '1304',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1300/BlackSwan.ts
+++ b/src/lib/conditionals/character/1300/BlackSwan.ts
@@ -1,3 +1,6 @@
+import { KafkaB1 } from 'lib/conditionals/character/1000/KafkaB1'
+import { Hysilens } from 'lib/conditionals/character/1400/Hysilens'
+import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
 import {
   AbilityEidolon,
   Conditionals,
@@ -5,14 +8,20 @@ import {
   createEnum,
 } from 'lib/conditionals/conditionalUtils'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { Parts, Sets, Stats } from 'lib/constants/constants'
+import { PatienceIsAllYouNeed } from 'lib/conditionals/lightcone/5star/PatienceIsAllYouNeed'
+import { ThoughWorldsApart } from 'lib/conditionals/lightcone/5star/ThoughWorldsApart'
+import { WhyDoesTheOceanSing } from 'lib/conditionals/lightcone/5star/WhyDoesTheOceanSing'
+import {
+  Parts,
+  Sets,
+  Stats,
+} from 'lib/constants/constants'
 import { containerActionVal } from 'lib/gpu/injection/injectUtils'
 import {
   wgsl,
   wgslTrue,
 } from 'lib/gpu/injection/wgslUtils'
 import { Source } from 'lib/optimization/buffSource'
-import { SortOption } from 'lib/optimization/sortOptions'
 import {
   AKey,
   StatKey,
@@ -27,29 +36,27 @@ import { ComputedStatsContainer } from 'lib/optimization/engine/container/comput
 import { buff } from 'lib/optimization/engine/container/gpuBuffBuilder'
 import {
   AbilityKind,
+  DEFAULT_DOT,
+  END_SKILL,
   NULL_TURN_ABILITY_NAME,
   START_ULT,
-  END_SKILL,
-  DEFAULT_DOT,
   WHOLE_BASIC,
   WHOLE_SKILL,
 } from 'lib/optimization/rotation/turnAbilityConfig'
+import { SortOption } from 'lib/optimization/sortOptions'
+import { PresetEffects } from 'lib/scoring/presetEffects'
 import {
   SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
 } from 'lib/scoring/scoringConstants'
-import { PresetEffects } from 'lib/scoring/presetEffects'
-import { KafkaB1 } from 'lib/conditionals/character/1000/KafkaB1'
-import { Hysilens } from 'lib/conditionals/character/1400/Hysilens'
-import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
-import { PatienceIsAllYouNeed } from 'lib/conditionals/lightcone/5star/PatienceIsAllYouNeed'
-import { ThoughWorldsApart } from 'lib/conditionals/lightcone/5star/ThoughWorldsApart'
-import { WhyDoesTheOceanSing } from 'lib/conditionals/lightcone/5star/WhyDoesTheOceanSing'
 import { TsUtils } from 'lib/utils/TsUtils'
 
 import { Eidolon } from 'types/character'
 import { CharacterConfig } from 'types/characterConfig'
 import { CharacterConditionalsController } from 'types/conditionals'
-import { SimulationMetadata, ScoringMetadata } from 'types/metadata'
+import {
+  ScoringMetadata,
+  SimulationMetadata,
+} from 'types/metadata'
 import {
   OptimizerAction,
   OptimizerContext,
@@ -267,7 +274,6 @@ if (${wgslTrue(r.ehrToDmgBoost)}) {
   }
 }
 
-
 const simulation = (): SimulationMetadata => ({
   parts: {
     [Parts.Body]: [
@@ -393,8 +399,9 @@ const display = {
 
 export const BlackSwan: CharacterConfig = {
   id: '1307',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1300/BlackSwanB1.ts
+++ b/src/lib/conditionals/character/1300/BlackSwanB1.ts
@@ -1,3 +1,6 @@
+import { KafkaB1 } from 'lib/conditionals/character/1000/KafkaB1'
+import { Hysilens } from 'lib/conditionals/character/1400/Hysilens'
+import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
 import {
   AbilityEidolon,
   Conditionals,
@@ -5,14 +8,20 @@ import {
   createEnum,
 } from 'lib/conditionals/conditionalUtils'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { Parts, Sets, Stats } from 'lib/constants/constants'
+import { PatienceIsAllYouNeed } from 'lib/conditionals/lightcone/5star/PatienceIsAllYouNeed'
+import { ThoughWorldsApart } from 'lib/conditionals/lightcone/5star/ThoughWorldsApart'
+import { WhyDoesTheOceanSing } from 'lib/conditionals/lightcone/5star/WhyDoesTheOceanSing'
+import {
+  Parts,
+  Sets,
+  Stats,
+} from 'lib/constants/constants'
 import { containerActionVal } from 'lib/gpu/injection/injectUtils'
 import {
   wgsl,
   wgslTrue,
 } from 'lib/gpu/injection/wgslUtils'
 import { Source } from 'lib/optimization/buffSource'
-import { SortOption } from 'lib/optimization/sortOptions'
 import {
   AKey,
   StatKey,
@@ -27,29 +36,27 @@ import { ComputedStatsContainer } from 'lib/optimization/engine/container/comput
 import { buff } from 'lib/optimization/engine/container/gpuBuffBuilder'
 import {
   AbilityKind,
+  DEFAULT_DOT,
+  END_SKILL,
   NULL_TURN_ABILITY_NAME,
   START_ULT,
-  END_SKILL,
-  DEFAULT_DOT,
   WHOLE_BASIC,
   WHOLE_SKILL,
 } from 'lib/optimization/rotation/turnAbilityConfig'
+import { SortOption } from 'lib/optimization/sortOptions'
+import { PresetEffects } from 'lib/scoring/presetEffects'
 import {
   SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
 } from 'lib/scoring/scoringConstants'
-import { PresetEffects } from 'lib/scoring/presetEffects'
-import { KafkaB1 } from 'lib/conditionals/character/1000/KafkaB1'
-import { Hysilens } from 'lib/conditionals/character/1400/Hysilens'
-import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
-import { PatienceIsAllYouNeed } from 'lib/conditionals/lightcone/5star/PatienceIsAllYouNeed'
-import { ThoughWorldsApart } from 'lib/conditionals/lightcone/5star/ThoughWorldsApart'
-import { WhyDoesTheOceanSing } from 'lib/conditionals/lightcone/5star/WhyDoesTheOceanSing'
 import { TsUtils } from 'lib/utils/TsUtils'
 
 import { Eidolon } from 'types/character'
 import { CharacterConfig } from 'types/characterConfig'
 import { CharacterConditionalsController } from 'types/conditionals'
-import { SimulationMetadata, ScoringMetadata } from 'types/metadata'
+import {
+  ScoringMetadata,
+  SimulationMetadata,
+} from 'types/metadata'
 import {
   OptimizerAction,
   OptimizerContext,
@@ -288,7 +295,6 @@ if (${wgslTrue(r.ehrToDmgBoost)}) {
   }
 }
 
-
 const simulation = (): SimulationMetadata => ({
   parts: {
     [Parts.Body]: [
@@ -414,8 +420,9 @@ const display = {
 
 export const BlackSwanB1: CharacterConfig = {
   id: '1307b1',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1300/Boothill.ts
+++ b/src/lib/conditionals/character/1300/Boothill.ts
@@ -1,3 +1,6 @@
+import { Fugue } from 'lib/conditionals/character/1200/Fugue'
+import { Lingsha } from 'lib/conditionals/character/1200/Lingsha'
+import { TheDahlia } from 'lib/conditionals/character/1300/TheDahlia'
 import {
   AbilityEidolon,
   Conditionals,
@@ -5,6 +8,9 @@ import {
   createEnum,
 } from 'lib/conditionals/conditionalUtils'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
+import { LongRoadLeadsHome } from 'lib/conditionals/lightcone/5star/LongRoadLeadsHome'
+import { NeverForgetHerFlame } from 'lib/conditionals/lightcone/5star/NeverForgetHerFlame'
+import { ScentAloneStaysTrue } from 'lib/conditionals/lightcone/5star/ScentAloneStaysTrue'
 import {
   ConditionalActivation,
   ConditionalType,
@@ -28,38 +34,32 @@ import {
   SELF_ENTITY_INDEX,
 } from 'lib/optimization/engine/config/tag'
 import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
-import { SortOption } from 'lib/optimization/sortOptions'
 import {
   AbilityKind,
-  NULL_TURN_ABILITY_NAME,
-  START_SKILL,
-  DEFAULT_ULT,
   DEFAULT_BASIC,
+  DEFAULT_ULT,
   END_BREAK,
-  WHOLE_BASIC,
+  NULL_TURN_ABILITY_NAME,
   START_BASIC,
+  START_SKILL,
+  WHOLE_BASIC,
 } from 'lib/optimization/rotation/turnAbilityConfig'
+import { SortOption } from 'lib/optimization/sortOptions'
 import {
-  SPREAD_RELICS_2P_SPEED_WEIGHTS,
-  SPREAD_RELICS_2P_BREAK_WEIGHTS,
   RELICS_2P_BREAK_EFFECT_SPEED,
   SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
 } from 'lib/scoring/scoringConstants'
-import { Fugue } from 'lib/conditionals/character/1200/Fugue'
-import { Lingsha } from 'lib/conditionals/character/1200/Lingsha'
-import { TheDahlia } from 'lib/conditionals/character/1300/TheDahlia'
-import { LongRoadLeadsHome } from 'lib/conditionals/lightcone/5star/LongRoadLeadsHome'
-import { NeverForgetHerFlame } from 'lib/conditionals/lightcone/5star/NeverForgetHerFlame'
-import { ScentAloneStaysTrue } from 'lib/conditionals/lightcone/5star/ScentAloneStaysTrue'
 import { TsUtils } from 'lib/utils/TsUtils'
 
-import { DamageFunctionType } from 'lib/optimization/engine/damage/damageCalculator'
 import { Eidolon } from 'types/character'
 import { CharacterConfig } from 'types/characterConfig'
 import { NumberToNumberMap } from 'types/common'
 import { CharacterConditionalsController } from 'types/conditionals'
 import { HitDefinition } from 'types/hitConditionalTypes'
-import { SimulationMetadata, ScoringMetadata } from 'types/metadata'
+import {
+  ScoringMetadata,
+  SimulationMetadata,
+} from 'types/metadata'
 import {
   OptimizerAction,
   OptimizerContext,
@@ -348,7 +348,6 @@ ${p_containerActionVal(SELF_ENTITY_INDEX, StatKey.UNCONVERTIBLE_CD_BUFF, action.
   }
 }
 
-
 const simulation = (): SimulationMetadata => ({
   parts: {
     [Parts.Body]: [
@@ -461,8 +460,9 @@ const display = {
 
 export const Boothill: CharacterConfig = {
   id: '1315',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1300/DrRatio.ts
+++ b/src/lib/conditionals/character/1300/DrRatio.ts
@@ -1,3 +1,6 @@
+import { Aventurine } from 'lib/conditionals/character/1300/Aventurine'
+import { Robin } from 'lib/conditionals/character/1300/Robin'
+import { Cipher } from 'lib/conditionals/character/1400/Cipher'
 import {
   ASHBLAZING_ATK_STACK,
 } from 'lib/conditionals/conditionalConstants'
@@ -12,9 +15,15 @@ import {
   createEnum,
 } from 'lib/conditionals/conditionalUtils'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { Parts, Sets, Stats } from 'lib/constants/constants'
+import { FlowingNightglow } from 'lib/conditionals/lightcone/5star/FlowingNightglow'
+import { InherentlyUnjustDestiny } from 'lib/conditionals/lightcone/5star/InherentlyUnjustDestiny'
+import { LiesAflutterInTheWind } from 'lib/conditionals/lightcone/5star/LiesAflutterInTheWind'
+import {
+  Parts,
+  Sets,
+  Stats,
+} from 'lib/constants/constants'
 import { Source } from 'lib/optimization/buffSource'
-import { SortOption } from 'lib/optimization/sortOptions'
 import { StatKey } from 'lib/optimization/engine/config/keys'
 import {
   DamageTag,
@@ -23,33 +32,29 @@ import {
 import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
 import {
   AbilityKind,
-  NULL_TURN_ABILITY_NAME,
-  START_ULT,
+  DEFAULT_FUA,
   DEFAULT_SKILL,
   END_FUA,
-  DEFAULT_FUA,
+  NULL_TURN_ABILITY_NAME,
   START_SKILL,
+  START_ULT,
 } from 'lib/optimization/rotation/turnAbilityConfig'
+import { SortOption } from 'lib/optimization/sortOptions'
+import { PresetEffects } from 'lib/scoring/presetEffects'
 import {
-  SPREAD_RELICS_2P_ATK_CRIT_WEIGHTS,
-  SPREAD_ORNAMENTS_2P_FUA_WEIGHTS,
   SPREAD_ORNAMENTS_2P_FUA,
   SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
   SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
 } from 'lib/scoring/scoringConstants'
-import { PresetEffects } from 'lib/scoring/presetEffects'
-import { Aventurine } from 'lib/conditionals/character/1300/Aventurine'
-import { Robin } from 'lib/conditionals/character/1300/Robin'
-import { Cipher } from 'lib/conditionals/character/1400/Cipher'
-import { FlowingNightglow } from 'lib/conditionals/lightcone/5star/FlowingNightglow'
-import { InherentlyUnjustDestiny } from 'lib/conditionals/lightcone/5star/InherentlyUnjustDestiny'
-import { LiesAflutterInTheWind } from 'lib/conditionals/lightcone/5star/LiesAflutterInTheWind'
 import { TsUtils } from 'lib/utils/TsUtils'
 
 import { Eidolon } from 'types/character'
 import { CharacterConfig } from 'types/characterConfig'
 import { CharacterConditionalsController } from 'types/conditionals'
-import { SimulationMetadata, ScoringMetadata } from 'types/metadata'
+import {
+  ScoringMetadata,
+  SimulationMetadata,
+} from 'types/metadata'
 import {
   OptimizerAction,
   OptimizerContext,
@@ -197,8 +202,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
                   .atkScaling(e2AdditionalScaling)
                   .build(),
               ]
-              : []
-            ),
+              : []),
           ],
         },
         [AbilityKind.BREAK]: {
@@ -230,7 +234,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
   }
 }
-
 
 const simulation = (): SimulationMetadata => ({
   parts: {
@@ -358,8 +361,9 @@ const display = {
 
 export const DrRatio: CharacterConfig = {
   id: '1305',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1300/Firefly.ts
+++ b/src/lib/conditionals/character/1300/Firefly.ts
@@ -1,3 +1,6 @@
+import { Fugue } from 'lib/conditionals/character/1200/Fugue'
+import { Lingsha } from 'lib/conditionals/character/1200/Lingsha'
+import { TheDahlia } from 'lib/conditionals/character/1300/TheDahlia'
 import {
   AbilityEidolon,
   Conditionals,
@@ -5,42 +8,64 @@ import {
   createEnum,
   teammateMatchesId,
 } from 'lib/conditionals/conditionalUtils'
-import { dynamicStatConversionContainer, gpuDynamicStatConversion, } from 'lib/conditionals/evaluation/statConversion'
+import {
+  dynamicStatConversionContainer,
+  gpuDynamicStatConversion,
+} from 'lib/conditionals/evaluation/statConversion'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { ConditionalActivation, ConditionalType, Parts, Sets, Stats, } from 'lib/constants/constants'
+import { LongRoadLeadsHome } from 'lib/conditionals/lightcone/5star/LongRoadLeadsHome'
+import { NeverForgetHerFlame } from 'lib/conditionals/lightcone/5star/NeverForgetHerFlame'
+import { ScentAloneStaysTrue } from 'lib/conditionals/lightcone/5star/ScentAloneStaysTrue'
+import {
+  ConditionalActivation,
+  ConditionalType,
+  Parts,
+  Sets,
+  Stats,
+} from 'lib/constants/constants'
 import { containerActionVal } from 'lib/gpu/injection/injectUtils'
-import { wgsl, wgslTrue, } from 'lib/gpu/injection/wgslUtils'
+import {
+  wgsl,
+  wgslTrue,
+} from 'lib/gpu/injection/wgslUtils'
 import { Source } from 'lib/optimization/buffSource'
-import { SortOption } from 'lib/optimization/sortOptions'
-import { AKey, StatKey, } from 'lib/optimization/engine/config/keys'
-import { DamageTag, ElementTag, SELF_ENTITY_INDEX, } from 'lib/optimization/engine/config/tag'
+import {
+  AKey,
+  StatKey,
+} from 'lib/optimization/engine/config/keys'
+import {
+  DamageTag,
+  ElementTag,
+  SELF_ENTITY_INDEX,
+} from 'lib/optimization/engine/config/tag'
 import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
 import { buff } from 'lib/optimization/engine/container/gpuBuffBuilder'
 import {
   AbilityKind,
-  NULL_TURN_ABILITY_NAME,
-  START_ULT,
   DEFAULT_SKILL,
   END_BREAK,
+  NULL_TURN_ABILITY_NAME,
+  START_ULT,
   WHOLE_SKILL,
 } from 'lib/optimization/rotation/turnAbilityConfig'
+import { SortOption } from 'lib/optimization/sortOptions'
 import {
   SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
 } from 'lib/scoring/scoringConstants'
-import { Fugue } from 'lib/conditionals/character/1200/Fugue'
-import { Lingsha } from 'lib/conditionals/character/1200/Lingsha'
-import { TheDahlia } from 'lib/conditionals/character/1300/TheDahlia'
-import { LongRoadLeadsHome } from 'lib/conditionals/lightcone/5star/LongRoadLeadsHome'
-import { NeverForgetHerFlame } from 'lib/conditionals/lightcone/5star/NeverForgetHerFlame'
-import { ScentAloneStaysTrue } from 'lib/conditionals/lightcone/5star/ScentAloneStaysTrue'
 import { TsUtils } from 'lib/utils/TsUtils'
 
 import { Eidolon } from 'types/character'
 import { CharacterConfig } from 'types/characterConfig'
 import { CharacterConditionalsController } from 'types/conditionals'
 import { Hit } from 'types/hitConditionalTypes'
-import { SimulationMetadata, ScoringMetadata } from 'types/metadata'
-import { OptimizerAction, OptimizerContext, } from 'types/optimizer'
+import {
+  ScoringMetadata,
+  SimulationMetadata,
+} from 'types/metadata'
+import {
+  OptimizerAction,
+  OptimizerContext,
+} from 'types/optimizer'
 
 export const FireflyEntities = createEnum('Firefly')
 export const FireflyAbilities: AbilityKind[] = [
@@ -317,7 +342,6 @@ if (${wgslTrue(r.superBreakDmg && r.enhancedStateActive)} && be >= 3.60) {
   }
 }
 
-
 const simulation = (): SimulationMetadata => ({
   parts: {
     [Parts.Body]: [
@@ -432,8 +456,9 @@ const display = {
 
 export const Firefly: CharacterConfig = {
   id: '1310',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1300/Gallagher.ts
+++ b/src/lib/conditionals/character/1300/Gallagher.ts
@@ -17,11 +17,9 @@ import {
   ConditionalActivation,
   ConditionalType,
   Parts,
-  Sets,
   Stats,
 } from 'lib/constants/constants'
 import { wgslTrue } from 'lib/gpu/injection/wgslUtils'
-import { AbilityKind } from 'lib/optimization/rotation/turnAbilityConfig'
 import { Source } from 'lib/optimization/buffSource'
 import { StatKey } from 'lib/optimization/engine/config/keys'
 import {
@@ -30,12 +28,8 @@ import {
   TargetTag,
 } from 'lib/optimization/engine/config/tag'
 import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
+import { AbilityKind } from 'lib/optimization/rotation/turnAbilityConfig'
 import { SortOption } from 'lib/optimization/sortOptions'
-import {
-  SPREAD_RELICS_2P_SPEED_WEIGHTS,
-  SPREAD_RELICS_2P_BREAK_WEIGHTS,
-  SPREAD_ORNAMENTS_2P_SUPPORT_WEIGHTS,
-} from 'lib/scoring/scoringConstants'
 import { PresetEffects } from 'lib/scoring/presetEffects'
 import { TsUtils } from 'lib/utils/TsUtils'
 import { Eidolon } from 'types/character'
@@ -228,7 +222,11 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
       const m = action.characterConditionals as Conditionals<typeof teammateContent>
 
       x.buff(StatKey.RES, (e >= 2 && m.e2ResBuff) ? 0.30 : 0, x.targets(TargetTag.SingleTarget).source(SOURCE_E2))
-      x.buff(StatKey.VULNERABILITY, (m.targetBesotted) ? talentBesottedScaling : 0, x.damageType(DamageTag.BREAK).targets(TargetTag.FullTeam).source(SOURCE_TALENT))
+      x.buff(
+        StatKey.VULNERABILITY,
+        (m.targetBesotted) ? talentBesottedScaling : 0,
+        x.damageType(DamageTag.BREAK).targets(TargetTag.FullTeam).source(SOURCE_TALENT),
+      )
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
@@ -277,7 +275,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     ],
   }
 }
-
 
 const scoring = (): ScoringMetadata => ({
   stats: {
@@ -332,8 +329,9 @@ const display = {
 
 export const Gallagher: CharacterConfig = {
   id: '1301',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1300/Jade.ts
+++ b/src/lib/conditionals/character/1300/Jade.ts
@@ -1,3 +1,6 @@
+import { Lingsha } from 'lib/conditionals/character/1200/Lingsha'
+import { TheHerta } from 'lib/conditionals/character/1400/TheHerta'
+import { Tribbie } from 'lib/conditionals/character/1400/Tribbie'
 import {
   ASHBLAZING_ATK_STACK,
 } from 'lib/conditionals/conditionalConstants'
@@ -12,9 +15,15 @@ import {
   createEnum,
 } from 'lib/conditionals/conditionalUtils'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { Parts, Sets, Stats } from 'lib/constants/constants'
+import { IfTimeWereAFlower } from 'lib/conditionals/lightcone/5star/IfTimeWereAFlower'
+import { IntotheUnreachableVeil } from 'lib/conditionals/lightcone/5star/IntotheUnreachableVeil'
+import { ScentAloneStaysTrue } from 'lib/conditionals/lightcone/5star/ScentAloneStaysTrue'
+import {
+  Parts,
+  Sets,
+  Stats,
+} from 'lib/constants/constants'
 import { Source } from 'lib/optimization/buffSource'
-import { SortOption } from 'lib/optimization/sortOptions'
 import { StatKey } from 'lib/optimization/engine/config/keys'
 import {
   DamageTag,
@@ -24,32 +33,28 @@ import {
 import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
 import {
   AbilityKind,
-  NULL_TURN_ABILITY_NAME,
-  WHOLE_SKILL,
-  DEFAULT_ULT,
   DEFAULT_FUA,
+  DEFAULT_ULT,
+  NULL_TURN_ABILITY_NAME,
   WHOLE_BASIC,
+  WHOLE_SKILL,
 } from 'lib/optimization/rotation/turnAbilityConfig'
+import { SortOption } from 'lib/optimization/sortOptions'
+import { PresetEffects } from 'lib/scoring/presetEffects'
 import {
-  SPREAD_RELICS_2P_ATK_CRIT_WEIGHTS,
-  SPREAD_ORNAMENTS_2P_FUA_WEIGHTS,
   SPREAD_ORNAMENTS_2P_FUA,
   SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
   SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
 } from 'lib/scoring/scoringConstants'
-import { PresetEffects } from 'lib/scoring/presetEffects'
-import { Lingsha } from 'lib/conditionals/character/1200/Lingsha'
-import { TheHerta } from 'lib/conditionals/character/1400/TheHerta'
-import { Tribbie } from 'lib/conditionals/character/1400/Tribbie'
-import { IfTimeWereAFlower } from 'lib/conditionals/lightcone/5star/IfTimeWereAFlower'
-import { IntotheUnreachableVeil } from 'lib/conditionals/lightcone/5star/IntotheUnreachableVeil'
-import { ScentAloneStaysTrue } from 'lib/conditionals/lightcone/5star/ScentAloneStaysTrue'
 import { TsUtils } from 'lib/utils/TsUtils'
 
 import { Eidolon } from 'types/character'
 import { CharacterConfig } from 'types/characterConfig'
 import { CharacterConditionalsController } from 'types/conditionals'
-import { SimulationMetadata, ScoringMetadata } from 'types/metadata'
+import {
+  ScoringMetadata,
+  SimulationMetadata,
+} from 'types/metadata'
 import {
   OptimizerAction,
   OptimizerContext,
@@ -258,7 +263,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   }
 }
 
-
 const simulation = (): SimulationMetadata => ({
   parts: {
     [Parts.Body]: [
@@ -386,8 +390,9 @@ const display = {
 
 export const Jade: CharacterConfig = {
   id: '1314',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1300/Misha.ts
+++ b/src/lib/conditionals/character/1300/Misha.ts
@@ -1,3 +1,6 @@
+import { Huohuo } from 'lib/conditionals/character/1200/Huohuo'
+import { RuanMei } from 'lib/conditionals/character/1300/RuanMei'
+import { SparkleB1 } from 'lib/conditionals/character/1300/SparkleB1'
 import {
   AbilityEidolon,
   Conditionals,
@@ -5,10 +8,19 @@ import {
   createEnum,
 } from 'lib/conditionals/conditionalUtils'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { Parts, Sets, Stats } from 'lib/constants/constants'
+import { ButTheBattleIsntOver } from 'lib/conditionals/lightcone/5star/ButTheBattleIsntOver'
+import { NightOfFright } from 'lib/conditionals/lightcone/5star/NightOfFright'
+import { PastSelfInTheMirror } from 'lib/conditionals/lightcone/5star/PastSelfInTheMirror'
+import {
+  Parts,
+  Sets,
+  Stats,
+} from 'lib/constants/constants'
 import { Source } from 'lib/optimization/buffSource'
-import { SortOption } from 'lib/optimization/sortOptions'
-import { AKey, StatKey } from 'lib/optimization/engine/config/keys'
+import {
+  AKey,
+  StatKey,
+} from 'lib/optimization/engine/config/keys'
 import {
   ElementTag,
   TargetTag,
@@ -16,29 +28,26 @@ import {
 import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
 import {
   AbilityKind,
+  END_SKILL,
   NULL_TURN_ABILITY_NAME,
   START_ULT,
-  END_SKILL,
   WHOLE_SKILL,
 } from 'lib/optimization/rotation/turnAbilityConfig'
+import { SortOption } from 'lib/optimization/sortOptions'
+import { PresetEffects } from 'lib/scoring/presetEffects'
 import {
-  SPREAD_RELICS_2P_ATK_CRIT_WEIGHTS,
   SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
   SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
 } from 'lib/scoring/scoringConstants'
-import { PresetEffects } from 'lib/scoring/presetEffects'
-import { Huohuo } from 'lib/conditionals/character/1200/Huohuo'
-import { RuanMei } from 'lib/conditionals/character/1300/RuanMei'
-import { SparkleB1 } from 'lib/conditionals/character/1300/SparkleB1'
-import { ButTheBattleIsntOver } from 'lib/conditionals/lightcone/5star/ButTheBattleIsntOver'
-import { NightOfFright } from 'lib/conditionals/lightcone/5star/NightOfFright'
-import { PastSelfInTheMirror } from 'lib/conditionals/lightcone/5star/PastSelfInTheMirror'
 import { TsUtils } from 'lib/utils/TsUtils'
 
 import { Eidolon } from 'types/character'
 import { CharacterConfig } from 'types/characterConfig'
 import { CharacterConditionalsController } from 'types/conditionals'
-import { SimulationMetadata, ScoringMetadata } from 'types/metadata'
+import {
+  ScoringMetadata,
+  SimulationMetadata,
+} from 'types/metadata'
 import {
   OptimizerAction,
   OptimizerContext,
@@ -214,7 +223,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   }
 }
 
-
 const simulation = (): SimulationMetadata => ({
   parts: {
     [Parts.Body]: [
@@ -335,8 +343,9 @@ const display = {
 
 export const Misha: CharacterConfig = {
   id: '1312',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1300/Rappa.ts
+++ b/src/lib/conditionals/character/1300/Rappa.ts
@@ -1,3 +1,6 @@
+import { Fugue } from 'lib/conditionals/character/1200/Fugue'
+import { Lingsha } from 'lib/conditionals/character/1200/Lingsha'
+import { RuanMei } from 'lib/conditionals/character/1300/RuanMei'
 import {
   AbilityEidolon,
   Conditionals,
@@ -5,12 +8,24 @@ import {
   createEnum,
 } from 'lib/conditionals/conditionalUtils'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { Parts, Sets, Stats } from 'lib/constants/constants'
+import { LongRoadLeadsHome } from 'lib/conditionals/lightcone/5star/LongRoadLeadsHome'
+import { PastSelfInTheMirror } from 'lib/conditionals/lightcone/5star/PastSelfInTheMirror'
+import { ScentAloneStaysTrue } from 'lib/conditionals/lightcone/5star/ScentAloneStaysTrue'
+import {
+  Parts,
+  Sets,
+  Stats,
+} from 'lib/constants/constants'
 import { containerActionVal } from 'lib/gpu/injection/injectUtils'
-import { wgsl, wgslTrue } from 'lib/gpu/injection/wgslUtils'
+import {
+  wgsl,
+  wgslTrue,
+} from 'lib/gpu/injection/wgslUtils'
 import { Source } from 'lib/optimization/buffSource'
-import { SortOption } from 'lib/optimization/sortOptions'
-import { AKey, HKey, StatKey } from 'lib/optimization/engine/config/keys'
+import {
+  HKey,
+  StatKey,
+} from 'lib/optimization/engine/config/keys'
 import {
   DamageTag,
   ElementTag,
@@ -21,31 +36,29 @@ import { ComputedStatsContainer } from 'lib/optimization/engine/container/comput
 import { buff } from 'lib/optimization/engine/container/gpuBuffBuilder'
 import {
   AbilityKind,
-  NULL_TURN_ABILITY_NAME,
-  START_ULT,
   END_BASIC,
-  WHOLE_BASIC,
-  START_BASIC,
   END_BREAK,
+  NULL_TURN_ABILITY_NAME,
+  START_BASIC,
+  START_ULT,
+  WHOLE_BASIC,
   WHOLE_SKILL,
 } from 'lib/optimization/rotation/turnAbilityConfig'
+import { SortOption } from 'lib/optimization/sortOptions'
+import { PresetEffects } from 'lib/scoring/presetEffects'
 import {
   SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
 } from 'lib/scoring/scoringConstants'
-import { PresetEffects } from 'lib/scoring/presetEffects'
-import { Fugue } from 'lib/conditionals/character/1200/Fugue'
-import { Lingsha } from 'lib/conditionals/character/1200/Lingsha'
-import { RuanMei } from 'lib/conditionals/character/1300/RuanMei'
-import { LongRoadLeadsHome } from 'lib/conditionals/lightcone/5star/LongRoadLeadsHome'
-import { PastSelfInTheMirror } from 'lib/conditionals/lightcone/5star/PastSelfInTheMirror'
-import { ScentAloneStaysTrue } from 'lib/conditionals/lightcone/5star/ScentAloneStaysTrue'
 import { TsUtils } from 'lib/utils/TsUtils'
 
 import { Eidolon } from 'types/character'
 import { CharacterConfig } from 'types/characterConfig'
 import { CharacterConditionalsController } from 'types/conditionals'
 import { Hit } from 'types/hitConditionalTypes'
-import { SimulationMetadata, ScoringMetadata } from 'types/metadata'
+import {
+  ScoringMetadata,
+  SimulationMetadata,
+} from 'types/metadata'
 import {
   OptimizerAction,
   OptimizerContext,
@@ -311,7 +324,6 @@ if (${wgslTrue(r.atkToBreakVulnerability)}) {
   }
 }
 
-
 const simulation = (): SimulationMetadata => ({
   parts: {
     [Parts.Body]: [
@@ -426,8 +438,9 @@ const display = {
 
 export const Rappa: CharacterConfig = {
   id: '1317',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1300/Robin.ts
+++ b/src/lib/conditionals/character/1300/Robin.ts
@@ -1,26 +1,42 @@
-import { AbilityEidolon, Conditionals, ContentDefinition, createEnum, } from 'lib/conditionals/conditionalUtils'
-import { dynamicStatConversionContainer, gpuDynamicStatConversion, } from 'lib/conditionals/evaluation/statConversion'
-import { AbilityKind } from 'lib/optimization/rotation/turnAbilityConfig'
+import {
+  AbilityEidolon,
+  Conditionals,
+  ContentDefinition,
+  createEnum,
+} from 'lib/conditionals/conditionalUtils'
+import {
+  dynamicStatConversionContainer,
+  gpuDynamicStatConversion,
+} from 'lib/conditionals/evaluation/statConversion'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { ConditionalActivation, ConditionalType, Parts, Sets, Stats, } from 'lib/constants/constants'
+import {
+  ConditionalActivation,
+  ConditionalType,
+  Parts,
+  Sets,
+  Stats,
+} from 'lib/constants/constants'
 import { wgslTrue } from 'lib/gpu/injection/wgslUtils'
 import { Source } from 'lib/optimization/buffSource'
-import { SortOption } from 'lib/optimization/sortOptions'
 import { StatKey } from 'lib/optimization/engine/config/keys'
-import { DamageTag, ElementTag, TargetTag, } from 'lib/optimization/engine/config/tag'
-import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
 import {
-  SPREAD_RELICS_2P_ATK_WEIGHTS,
-  SPREAD_RELICS_2P_SPEED_WEIGHTS,
-  SPREAD_ORNAMENTS_2P_SUPPORT_WEIGHTS,
-} from 'lib/scoring/scoringConstants'
+  DamageTag,
+  ElementTag,
+  TargetTag,
+} from 'lib/optimization/engine/config/tag'
+import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
+import { AbilityKind } from 'lib/optimization/rotation/turnAbilityConfig'
+import { SortOption } from 'lib/optimization/sortOptions'
 import { TsUtils } from 'lib/utils/TsUtils'
 
 import { Eidolon } from 'types/character'
 import { CharacterConfig } from 'types/characterConfig'
 import { CharacterConditionalsController } from 'types/conditionals'
 import { ScoringMetadata } from 'types/metadata'
-import { OptimizerAction, OptimizerContext, } from 'types/optimizer'
+import {
+  OptimizerAction,
+  OptimizerContext,
+} from 'types/optimizer'
 
 export const RobinEntities = createEnum('Robin')
 export const RobinAbilities: AbilityKind[] = [
@@ -291,7 +307,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   }
 }
 
-
 const scoring = (): ScoringMetadata => ({
   stats: {
     [Stats.ATK]: 1,
@@ -344,8 +359,9 @@ const display = {
 
 export const Robin: CharacterConfig = {
   id: '1309',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1300/RuanMei.ts
+++ b/src/lib/conditionals/character/1300/RuanMei.ts
@@ -5,21 +5,26 @@ import {
   createEnum,
 } from 'lib/conditionals/conditionalUtils'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { Parts, Sets, Stats } from 'lib/constants/constants'
+import {
+  Parts,
+  Stats,
+} from 'lib/constants/constants'
 import { containerActionVal } from 'lib/gpu/injection/injectUtils'
 import { wgsl } from 'lib/gpu/injection/wgslUtils'
-import { AbilityKind } from 'lib/optimization/rotation/turnAbilityConfig'
 import { Source } from 'lib/optimization/buffSource'
-import { SortOption } from 'lib/optimization/sortOptions'
-import { AKey, StatKey } from 'lib/optimization/engine/config/keys'
-import { ElementTag, SELF_ENTITY_INDEX, TargetTag } from 'lib/optimization/engine/config/tag'
+import {
+  AKey,
+  StatKey,
+} from 'lib/optimization/engine/config/keys'
+import {
+  ElementTag,
+  SELF_ENTITY_INDEX,
+  TargetTag,
+} from 'lib/optimization/engine/config/tag'
 import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
 import { buff } from 'lib/optimization/engine/container/gpuBuffBuilder'
-import {
-  SPREAD_RELICS_2P_SPEED_WEIGHTS,
-  SPREAD_RELICS_2P_BREAK_WEIGHTS,
-  SPREAD_ORNAMENTS_2P_SUPPORT_WEIGHTS,
-} from 'lib/scoring/scoringConstants'
+import { AbilityKind } from 'lib/optimization/rotation/turnAbilityConfig'
+import { SortOption } from 'lib/optimization/sortOptions'
 import { TsUtils } from 'lib/utils/TsUtils'
 import { Eidolon } from 'types/character'
 import { CharacterConfig } from 'types/characterConfig'
@@ -225,7 +230,6 @@ ${buff.action(AKey.DMG_BOOST, 'beDmgBuff').wgsl(action)}
   }
 }
 
-
 const scoring = (): ScoringMetadata => ({
   stats: {
     [Stats.ATK]: 0,
@@ -271,8 +275,9 @@ const display = {
 
 export const RuanMei: CharacterConfig = {
   id: '1303',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1300/Sparkle.ts
+++ b/src/lib/conditionals/character/1300/Sparkle.ts
@@ -15,19 +15,18 @@ import {
   ConditionalType,
   ElementNames,
   Parts,
-  Sets,
   Stats,
 } from 'lib/constants/constants'
 import { wgslTrue } from 'lib/gpu/injection/wgslUtils'
-import { AbilityKind } from 'lib/optimization/rotation/turnAbilityConfig'
 import { Source } from 'lib/optimization/buffSource'
-import { SortOption } from 'lib/optimization/sortOptions'
 import { StatKey } from 'lib/optimization/engine/config/keys'
-import { ElementTag, TargetTag } from 'lib/optimization/engine/config/tag'
-import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
 import {
-  SPREAD_ORNAMENTS_2P_SUPPORT_WEIGHTS,
-} from 'lib/scoring/scoringConstants'
+  ElementTag,
+  TargetTag,
+} from 'lib/optimization/engine/config/tag'
+import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
+import { AbilityKind } from 'lib/optimization/rotation/turnAbilityConfig'
+import { SortOption } from 'lib/optimization/sortOptions'
 import { TsUtils } from 'lib/utils/TsUtils'
 
 import { Eidolon } from 'types/character'
@@ -279,7 +278,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   }
 }
 
-
 const scoring = (): ScoringMetadata => ({
   stats: {
     [Stats.ATK]: 0,
@@ -328,8 +326,9 @@ const display = {
 
 export const Sparkle: CharacterConfig = {
   id: '1306',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1300/SparkleB1.ts
+++ b/src/lib/conditionals/character/1300/SparkleB1.ts
@@ -13,22 +13,18 @@ import {
   ConditionalActivation,
   ConditionalType,
   Parts,
-  Sets,
   Stats,
 } from 'lib/constants/constants'
 import { wgslTrue } from 'lib/gpu/injection/wgslUtils'
-import { AbilityKind } from 'lib/optimization/rotation/turnAbilityConfig'
 import { Source } from 'lib/optimization/buffSource'
-import { SortOption } from 'lib/optimization/sortOptions'
 import { StatKey } from 'lib/optimization/engine/config/keys'
 import {
   ElementTag,
   TargetTag,
 } from 'lib/optimization/engine/config/tag'
 import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
-import {
-  SPREAD_ORNAMENTS_2P_SUPPORT_WEIGHTS,
-} from 'lib/scoring/scoringConstants'
+import { AbilityKind } from 'lib/optimization/rotation/turnAbilityConfig'
+import { SortOption } from 'lib/optimization/sortOptions'
 import { TsUtils } from 'lib/utils/TsUtils'
 
 import { Eidolon } from 'types/character'
@@ -282,7 +278,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   }
 }
 
-
 const scoring = (): ScoringMetadata => ({
   stats: {
     [Stats.ATK]: 0,
@@ -331,8 +326,9 @@ const display = {
 
 export const SparkleB1: CharacterConfig = {
   id: '1306b1',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1300/Sunday.ts
+++ b/src/lib/conditionals/character/1300/Sunday.ts
@@ -6,26 +6,42 @@ import {
   findMemospriteIndex,
 } from 'lib/conditionals/conditionalUtils'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { ConditionalActivation, ConditionalType, Parts, Sets, Stats, } from 'lib/constants/constants'
-import { newConditionalWgslWrapper } from 'lib/gpu/conditionals/dynamicConditionals'
-import { containerActionVal, p_containerActionVal, } from 'lib/gpu/injection/injectUtils'
-import { wgslFalse, wgslTrue } from 'lib/gpu/injection/wgslUtils'
-import { AbilityKind } from 'lib/optimization/rotation/turnAbilityConfig'
-import { Source } from 'lib/optimization/buffSource'
-import { SortOption } from 'lib/optimization/sortOptions'
-import { StatKey } from 'lib/optimization/engine/config/keys'
-import { ElementTag, SELF_ENTITY_INDEX, TargetTag, } from 'lib/optimization/engine/config/tag'
-import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
 import {
-  SPREAD_ORNAMENTS_2P_SUPPORT_WEIGHTS,
-} from 'lib/scoring/scoringConstants'
+  ConditionalActivation,
+  ConditionalType,
+  Parts,
+  Sets,
+  Stats,
+} from 'lib/constants/constants'
+import { newConditionalWgslWrapper } from 'lib/gpu/conditionals/dynamicConditionals'
+import {
+  containerActionVal,
+  p_containerActionVal,
+} from 'lib/gpu/injection/injectUtils'
+import {
+  wgslFalse,
+  wgslTrue,
+} from 'lib/gpu/injection/wgslUtils'
+import { Source } from 'lib/optimization/buffSource'
+import { StatKey } from 'lib/optimization/engine/config/keys'
+import {
+  ElementTag,
+  SELF_ENTITY_INDEX,
+  TargetTag,
+} from 'lib/optimization/engine/config/tag'
+import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
+import { AbilityKind } from 'lib/optimization/rotation/turnAbilityConfig'
+import { SortOption } from 'lib/optimization/sortOptions'
 import { TsUtils } from 'lib/utils/TsUtils'
 
 import { Eidolon } from 'types/character'
 import { CharacterConfig } from 'types/characterConfig'
 import { CharacterConditionalsController } from 'types/conditionals'
 import { ScoringMetadata } from 'types/metadata'
-import { OptimizerAction, OptimizerContext, } from 'types/optimizer'
+import {
+  OptimizerAction,
+  OptimizerContext,
+} from 'types/optimizer'
 
 export const SundayEntities = createEnum('Sunday')
 export const SundayAbilities: AbilityKind[] = [
@@ -370,7 +386,6 @@ if (cr > 1.00) {
   }
 }
 
-
 const scoring = (): ScoringMetadata => ({
   stats: {
     [Stats.ATK]: 0,
@@ -417,8 +432,9 @@ const display = {
 
 export const Sunday: CharacterConfig = {
   id: '1313',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1300/TheDahlia.ts
+++ b/src/lib/conditionals/character/1300/TheDahlia.ts
@@ -1,3 +1,10 @@
+import { SilverWolf } from 'lib/conditionals/character/1000/SilverWolf'
+import { Fugue } from 'lib/conditionals/character/1200/Fugue'
+import { Lingsha } from 'lib/conditionals/character/1200/Lingsha'
+import { Boothill } from 'lib/conditionals/character/1300/Boothill'
+import { Firefly } from 'lib/conditionals/character/1300/Firefly'
+import { Anaxa } from 'lib/conditionals/character/1400/Anaxa'
+import { Phainon } from 'lib/conditionals/character/1400/Phainon'
 import {
   ASHBLAZING_ATK_STACK,
 } from 'lib/conditionals/conditionalConstants'
@@ -13,9 +20,15 @@ import {
   createEnum,
 } from 'lib/conditionals/conditionalUtils'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { Parts, Sets, Stats } from 'lib/constants/constants'
+import { LongRoadLeadsHome } from 'lib/conditionals/lightcone/5star/LongRoadLeadsHome'
+import { ScentAloneStaysTrue } from 'lib/conditionals/lightcone/5star/ScentAloneStaysTrue'
+import { WhereaboutsShouldDreamsRest } from 'lib/conditionals/lightcone/5star/WhereaboutsShouldDreamsRest'
+import {
+  Parts,
+  Sets,
+  Stats,
+} from 'lib/constants/constants'
 import { Source } from 'lib/optimization/buffSource'
-import { SortOption } from 'lib/optimization/sortOptions'
 import { ModifierContext } from 'lib/optimization/context/calculateActions'
 import { StatKey } from 'lib/optimization/engine/config/keys'
 import {
@@ -25,40 +38,31 @@ import {
 import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
 import {
   AbilityKind,
-  NULL_TURN_ABILITY_NAME,
-  START_ULT,
+  DEFAULT_FUA,
   DEFAULT_SKILL,
   END_BREAK,
-  DEFAULT_FUA,
+  NULL_TURN_ABILITY_NAME,
+  START_ULT,
   WHOLE_BASIC,
 } from 'lib/optimization/rotation/turnAbilityConfig'
+import { SortOption } from 'lib/optimization/sortOptions'
+import { PresetEffects } from 'lib/scoring/presetEffects'
 import {
-  SPREAD_RELICS_2P_SPEED_WEIGHTS,
-  SPREAD_RELICS_2P_BREAK_WEIGHTS,
   RELICS_2P_BREAK_EFFECT_SPEED,
-  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
   SPREAD_ORNAMENTS_2P_ENERGY_REGEN,
   SPREAD_ORNAMENTS_2P_SUPPORT,
+  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
 } from 'lib/scoring/scoringConstants'
-import { PresetEffects } from 'lib/scoring/presetEffects'
-import { SilverWolf } from 'lib/conditionals/character/1000/SilverWolf'
-import { Fugue } from 'lib/conditionals/character/1200/Fugue'
-import { Lingsha } from 'lib/conditionals/character/1200/Lingsha'
-import { Boothill } from 'lib/conditionals/character/1300/Boothill'
-import { Firefly } from 'lib/conditionals/character/1300/Firefly'
-import { Anaxa } from 'lib/conditionals/character/1400/Anaxa'
-import { Phainon } from 'lib/conditionals/character/1400/Phainon'
-import { LongRoadLeadsHome } from 'lib/conditionals/lightcone/5star/LongRoadLeadsHome'
-import { NeverForgetHerFlame } from 'lib/conditionals/lightcone/5star/NeverForgetHerFlame'
-import { ScentAloneStaysTrue } from 'lib/conditionals/lightcone/5star/ScentAloneStaysTrue'
-import { WhereaboutsShouldDreamsRest } from 'lib/conditionals/lightcone/5star/WhereaboutsShouldDreamsRest'
 import { TsUtils } from 'lib/utils/TsUtils'
 import { Eidolon } from 'types/character'
 import { CharacterConfig } from 'types/characterConfig'
 import { NumberToNumberMap } from 'types/common'
 import { CharacterConditionalsController } from 'types/conditionals'
 import { Hit } from 'types/hitConditionalTypes'
-import { SimulationMetadata, ScoringMetadata } from 'types/metadata'
+import {
+  ScoringMetadata,
+  SimulationMetadata,
+} from 'types/metadata'
 import {
   OptimizerAction,
   OptimizerContext,
@@ -407,7 +411,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   }
 }
 
-
 const simulation = (): SimulationMetadata => ({
   parts: {
     [Parts.Body]: [
@@ -528,8 +531,9 @@ const display = {
 
 export const TheDahlia: CharacterConfig = {
   id: '1321',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1400/Aglaea.ts
+++ b/src/lib/conditionals/character/1400/Aglaea.ts
@@ -8,7 +8,17 @@ import {
   createEnum,
 } from 'lib/conditionals/conditionalUtils'
 
+import { Sunday } from 'lib/conditionals/character/1300/Sunday'
+import {
+  Cyrene,
+  cyreneActionExists,
+  cyreneSpecialEffectEidolonUpgraded,
+} from 'lib/conditionals/character/1400/Cyrene'
+import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
+import { AGroundedAscent } from 'lib/conditionals/lightcone/5star/AGroundedAscent'
+import { ThisLoveForever } from 'lib/conditionals/lightcone/5star/ThisLoveForever'
+import { ThoughWorldsApart } from 'lib/conditionals/lightcone/5star/ThoughWorldsApart'
 import {
   ConditionalActivation,
   ConditionalType,
@@ -39,20 +49,6 @@ import {
 } from 'lib/optimization/engine/config/tag'
 import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
 import { buff } from 'lib/optimization/engine/container/gpuBuffBuilder'
-import { SortOption } from 'lib/optimization/sortOptions'
-import {
-  MATCH_2P_WEIGHT,
-  SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
-  SPREAD_RELICS_2P_ATK_CRIT_WEIGHTS,
-  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
-} from 'lib/scoring/scoringConstants'
-import { PresetEffects } from 'lib/scoring/presetEffects'
-import { Cyrene, cyreneActionExists, cyreneSpecialEffectEidolonUpgraded } from 'lib/conditionals/character/1400/Cyrene'
-import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
-import { Sunday } from 'lib/conditionals/character/1300/Sunday'
-import { AGroundedAscent } from 'lib/conditionals/lightcone/5star/AGroundedAscent'
-import { ThisLoveForever } from 'lib/conditionals/lightcone/5star/ThisLoveForever'
-import { ThoughWorldsApart } from 'lib/conditionals/lightcone/5star/ThoughWorldsApart'
 import {
   AbilityKind,
   DEFAULT_MEMO_SKILL,
@@ -61,12 +57,21 @@ import {
   START_ULT,
   WHOLE_BASIC,
 } from 'lib/optimization/rotation/turnAbilityConfig'
-import { CharacterConfig } from 'types/characterConfig'
-import { SimulationMetadata, ScoringMetadata } from 'types/metadata'
+import { SortOption } from 'lib/optimization/sortOptions'
+import { PresetEffects } from 'lib/scoring/presetEffects'
+import {
+  SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
+  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+} from 'lib/scoring/scoringConstants'
 import { TsUtils } from 'lib/utils/TsUtils'
 import { Eidolon } from 'types/character'
+import { CharacterConfig } from 'types/characterConfig'
 import { CharacterConditionalsController } from 'types/conditionals'
 import { AbilityDefinition } from 'types/hitConditionalTypes'
+import {
+  ScoringMetadata,
+  SimulationMetadata,
+} from 'types/metadata'
 import {
   OptimizerAction,
   OptimizerContext,
@@ -292,9 +297,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
     initializeConfigurationsContainer: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
       const r = action.characterConditionals as Conditionals<typeof content>
-
-
-
     },
     precomputeEffectsContainer: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
       const r = action.characterConditionals as Conditionals<typeof content>
@@ -444,7 +446,6 @@ ${p_containerActionVal(memoEntityIndex, StatKey.UNCONVERTIBLE_ATK_BUFF, config)}
   }
 }
 
-
 const simulation = (): SimulationMetadata => ({
   parts: {
     [Parts.Body]: [
@@ -571,8 +572,9 @@ const display = {
 
 export const Aglaea: CharacterConfig = {
   id: '1402',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1400/Anaxa.ts
+++ b/src/lib/conditionals/character/1400/Anaxa.ts
@@ -1,3 +1,10 @@
+import { Cerydra } from 'lib/conditionals/character/1400/Cerydra'
+import {
+  Cyrene,
+  cyreneActionExists,
+  cyreneSpecialEffectEidolonUpgraded,
+} from 'lib/conditionals/character/1400/Cyrene'
+import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
 import {
   AbilityEidolon,
   Conditionals,
@@ -6,16 +13,15 @@ import {
   createEnum,
 } from 'lib/conditionals/conditionalUtils'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { Parts, PathNames, Sets, Stats } from 'lib/constants/constants'
-import { SortOption } from 'lib/optimization/sortOptions'
+import { EpochEtchedInGoldenBlood } from 'lib/conditionals/lightcone/5star/EpochEtchedInGoldenBlood'
+import { ThisLoveForever } from 'lib/conditionals/lightcone/5star/ThisLoveForever'
+import { ThoughWorldsApart } from 'lib/conditionals/lightcone/5star/ThoughWorldsApart'
 import {
-  SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
-  SPREAD_ORNAMENTS_2P_SUPPORT,
-  SPREAD_RELICS_2P_ATK_WEIGHTS,
-  SPREAD_RELICS_2P_SPEED_WEIGHTS,
-  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
-} from 'lib/scoring/scoringConstants'
-import { PresetEffects } from 'lib/scoring/presetEffects'
+  Parts,
+  PathNames,
+  Sets,
+  Stats,
+} from 'lib/constants/constants'
 import { Source } from 'lib/optimization/buffSource'
 import { StatKey } from 'lib/optimization/engine/config/keys'
 import {
@@ -24,12 +30,6 @@ import {
   TargetTag,
 } from 'lib/optimization/engine/config/tag'
 import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
-import { Cerydra } from 'lib/conditionals/character/1400/Cerydra'
-import { Cyrene, cyreneActionExists, cyreneSpecialEffectEidolonUpgraded } from 'lib/conditionals/character/1400/Cyrene'
-import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
-import { EpochEtchedInGoldenBlood } from 'lib/conditionals/lightcone/5star/EpochEtchedInGoldenBlood'
-import { ThisLoveForever } from 'lib/conditionals/lightcone/5star/ThisLoveForever'
-import { ThoughWorldsApart } from 'lib/conditionals/lightcone/5star/ThoughWorldsApart'
 import {
   AbilityKind,
   DEFAULT_SKILL,
@@ -38,11 +38,21 @@ import {
   START_SKILL,
   START_ULT,
 } from 'lib/optimization/rotation/turnAbilityConfig'
-import { CharacterConfig } from 'types/characterConfig'
-import { SimulationMetadata, ScoringMetadata } from 'types/metadata'
+import { SortOption } from 'lib/optimization/sortOptions'
+import { PresetEffects } from 'lib/scoring/presetEffects'
+import {
+  SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
+  SPREAD_ORNAMENTS_2P_SUPPORT,
+  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+} from 'lib/scoring/scoringConstants'
 import { TsUtils } from 'lib/utils/TsUtils'
 import { Eidolon } from 'types/character'
+import { CharacterConfig } from 'types/characterConfig'
 import { CharacterConditionalsController } from 'types/conditionals'
+import {
+  ScoringMetadata,
+  SimulationMetadata,
+} from 'types/metadata'
 import {
   OptimizerAction,
   OptimizerContext,
@@ -264,12 +274,21 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
       x.buff(StatKey.CD, (r.eruditionTeammateBuffs && eruditionMembers == 1 || e >= 6 && r.e6Buffs) ? 1.40 : 0, x.source(SOURCE_TRACE))
     },
 
-    precomputeMutualEffectsContainer: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext, originalCharacterAction?: OptimizerAction) => {
+    precomputeMutualEffectsContainer: (
+      x: ComputedStatsContainer,
+      action: OptimizerAction,
+      context: OptimizerContext,
+      originalCharacterAction?: OptimizerAction,
+    ) => {
       const m = action.characterConditionals as Conditionals<typeof teammateContent>
 
       // Trace: DMG boost when 2+ Erudition members or E6 active
       const eruditionMembers = countTeamPath(context, PathNames.Erudition)
-      x.buff(StatKey.DMG_BOOST, (m.eruditionTeammateBuffs && eruditionMembers >= 2 || e >= 6 && m.e6Buffs) ? 0.50 : 0, x.targets(TargetTag.FullTeam).source(SOURCE_TRACE))
+      x.buff(
+        StatKey.DMG_BOOST,
+        (m.eruditionTeammateBuffs && eruditionMembers >= 2 || e >= 6 && m.e6Buffs) ? 0.50 : 0,
+        x.targets(TargetTag.FullTeam).source(SOURCE_TRACE),
+      )
 
       // E1: DEF PEN
       x.buff(StatKey.DEF_PEN, (e >= 1 && m.e1DefPen) ? 0.16 : 0, x.targets(TargetTag.FullTeam).source(SOURCE_E1))
@@ -283,7 +302,11 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
       const cyreneSkillDmgBuff = cyreneActionExists(action)
         ? (cyreneSpecialEffectEidolonUpgraded(action) ? 0.44 : 0.40)
         : 0
-      x.buff(StatKey.DMG_BOOST, cyreneBuffActive ? cyreneSkillDmgBuff : 0, x.damageType(DamageTag.SKILL).targets(TargetTag.SelfAndPet).source(Source.odeTo(Anaxa.id)))
+      x.buff(
+        StatKey.DMG_BOOST,
+        cyreneBuffActive ? cyreneSkillDmgBuff : 0,
+        x.damageType(DamageTag.SKILL).targets(TargetTag.SelfAndPet).source(Source.odeTo(Anaxa.id)),
+      )
 
       const cyreneAtkBuff = cyreneActionExists(originalCharacterAction!)
         ? (cyreneSpecialEffectEidolonUpgraded(originalCharacterAction!) ? 0.66 : 0.60)
@@ -299,7 +322,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => '',
   }
 }
-
 
 const simulation = (): SimulationMetadata => ({
   parts: {
@@ -429,8 +451,9 @@ const display = {
 
 export const Anaxa: CharacterConfig = {
   id: '1405',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1400/Castorice.ts
+++ b/src/lib/conditionals/character/1400/Castorice.ts
@@ -1,4 +1,11 @@
 import {
+  Cyrene,
+  cyreneActionExists,
+  cyreneSpecialEffectEidolonUpgraded,
+} from 'lib/conditionals/character/1400/Cyrene'
+import { Evernight } from 'lib/conditionals/character/1400/Evernight'
+import { Hyacine } from 'lib/conditionals/character/1400/Hyacine'
+import {
   BuffPriority,
 } from 'lib/conditionals/conditionalConstants'
 import {
@@ -8,15 +15,14 @@ import {
   createEnum,
 } from 'lib/conditionals/conditionalUtils'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { Parts, Sets, Stats } from 'lib/constants/constants'
-import { SortOption } from 'lib/optimization/sortOptions'
+import { MayRainbowsRemainInTheSky } from 'lib/conditionals/lightcone/5star/MayRainbowsRemainInTheSky'
+import { ThisLoveForever } from 'lib/conditionals/lightcone/5star/ThisLoveForever'
+import { ToEvernightsStars } from 'lib/conditionals/lightcone/5star/ToEvernightsStars'
 import {
-  MATCH_2P_WEIGHT,
-  SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
-  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
-  T2_WEIGHT,
-} from 'lib/scoring/scoringConstants'
-import { PresetEffects } from 'lib/scoring/presetEffects'
+  Parts,
+  Sets,
+  Stats,
+} from 'lib/constants/constants'
 import { Source } from 'lib/optimization/buffSource'
 import { StatKey } from 'lib/optimization/engine/config/keys'
 import {
@@ -25,13 +31,6 @@ import {
   TargetTag,
 } from 'lib/optimization/engine/config/tag'
 import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
-import { Cyrene, cyreneActionExists, cyreneSpecialEffectEidolonUpgraded } from 'lib/conditionals/character/1400/Cyrene'
-import { Evernight } from 'lib/conditionals/character/1400/Evernight'
-import { Hyacine } from 'lib/conditionals/character/1400/Hyacine'
-import { MakeFarewellsMoreBeautiful } from 'lib/conditionals/lightcone/5star/MakeFarewellsMoreBeautiful'
-import { MayRainbowsRemainInTheSky } from 'lib/conditionals/lightcone/5star/MayRainbowsRemainInTheSky'
-import { ThisLoveForever } from 'lib/conditionals/lightcone/5star/ThisLoveForever'
-import { ToEvernightsStars } from 'lib/conditionals/lightcone/5star/ToEvernightsStars'
 import {
   AbilityKind,
   DEFAULT_MEMO_SKILL,
@@ -40,9 +39,18 @@ import {
   NULL_TURN_ABILITY_NAME,
   WHOLE_SKILL,
 } from 'lib/optimization/rotation/turnAbilityConfig'
-import { CharacterConfig } from 'types/characterConfig'
-import { SimulationMetadata, ScoringMetadata } from 'types/metadata'
+import { SortOption } from 'lib/optimization/sortOptions'
+import { PresetEffects } from 'lib/scoring/presetEffects'
+import {
+  SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
+  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+} from 'lib/scoring/scoringConstants'
 import { TsUtils } from 'lib/utils/TsUtils'
+import { CharacterConfig } from 'types/characterConfig'
+import {
+  ScoringMetadata,
+  SimulationMetadata,
+} from 'types/metadata'
 
 import { Eidolon } from 'types/character'
 import { CharacterConditionalsController } from 'types/conditionals'
@@ -245,9 +253,11 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
       const r = action.characterConditionals as Conditionals<typeof content>
 
       // Compute memo skill scaling based on enhances
-      const memoSkillHpScaling = r.memoSkillEnhances === 1 ? memoSkillScaling1
-        : r.memoSkillEnhances === 2 ? memoSkillScaling2
-          : memoSkillScaling3
+      const memoSkillHpScaling = r.memoSkillEnhances === 1
+        ? memoSkillScaling1
+        : r.memoSkillEnhances === 2
+        ? memoSkillScaling2
+        : memoSkillScaling3
 
       // Compute memo talent total scaling (includes Cyrene buff)
       const cyreneOverflowPercentAssumption = 30 // Assumes 130% overflow
@@ -340,9 +350,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 
     initializeConfigurationsContainer: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
       const r = action.characterConditionals as Conditionals<typeof content>
-
-
-
     },
 
     precomputeEffectsContainer: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
@@ -383,7 +390,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => '',
   }
 }
-
 
 const simulation = (): SimulationMetadata => ({
   parts: {
@@ -505,8 +511,9 @@ const display = {
 
 export const Castorice: CharacterConfig = {
   id: '1407',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1400/Cerydra.ts
+++ b/src/lib/conditionals/character/1400/Cerydra.ts
@@ -1,11 +1,13 @@
 import {
+  cyreneActionExists,
+  cyreneSpecialEffectEidolonUpgraded,
+} from 'lib/conditionals/character/1400/Cyrene'
+import {
   AbilityEidolon,
   Conditionals,
   ContentDefinition,
   createEnum,
 } from 'lib/conditionals/conditionalUtils'
-import { AbilityKind } from 'lib/optimization/rotation/turnAbilityConfig'
-import { cyreneActionExists, cyreneSpecialEffectEidolonUpgraded } from 'lib/conditionals/character/1400/Cyrene'
 import {
   dynamicStatConversionContainer,
   gpuDynamicStatConversion,
@@ -15,7 +17,6 @@ import {
   ConditionalActivation,
   ConditionalType,
   Parts,
-  Sets,
   Stats,
 } from 'lib/constants/constants'
 import { containerActionVal } from 'lib/gpu/injection/injectUtils'
@@ -29,13 +30,8 @@ import {
   TargetTag,
 } from 'lib/optimization/engine/config/tag'
 import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
+import { AbilityKind } from 'lib/optimization/rotation/turnAbilityConfig'
 import { SortOption } from 'lib/optimization/sortOptions'
-import {
-  RELICS_2P_ATK,
-  RELICS_2P_SPEED,
-  SPREAD_ORNAMENTS_2P_SUPPORT_WEIGHTS,
-  weights,
-} from 'lib/scoring/scoringConstants'
 import { TsUtils } from 'lib/utils/TsUtils'
 import { Eidolon } from 'types/character'
 import { CharacterConfig } from 'types/characterConfig'
@@ -394,8 +390,9 @@ const display = {
 
 export const Cerydra: CharacterConfig = {
   id: '1412',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1400/Cipher.ts
+++ b/src/lib/conditionals/character/1400/Cipher.ts
@@ -1,3 +1,10 @@
+import { Feixiao } from 'lib/conditionals/character/1200/Feixiao'
+import { Robin } from 'lib/conditionals/character/1300/Robin'
+import {
+  cyreneActionExists,
+  cyreneSpecialEffectEidolonUpgraded,
+} from 'lib/conditionals/character/1400/Cyrene'
+import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
 import {
   ASHBLAZING_ATK_STACK,
 } from 'lib/conditionals/conditionalConstants'
@@ -11,8 +18,10 @@ import {
   ContentDefinition,
   createEnum,
 } from 'lib/conditionals/conditionalUtils'
-import { cyreneActionExists, cyreneSpecialEffectEidolonUpgraded } from 'lib/conditionals/character/1400/Cyrene'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
+import { FlowingNightglow } from 'lib/conditionals/lightcone/5star/FlowingNightglow'
+import { IVentureForthToHunt } from 'lib/conditionals/lightcone/5star/IVentureForthToHunt'
+import { ThoughWorldsApart } from 'lib/conditionals/lightcone/5star/ThoughWorldsApart'
 import {
   ConditionalActivation,
   ConditionalType,
@@ -34,36 +43,30 @@ import {
   TargetTag,
 } from 'lib/optimization/engine/config/tag'
 import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
+import {
+  AbilityKind,
+  DEFAULT_FUA,
+  DEFAULT_ULT,
+  NULL_TURN_ABILITY_NAME,
+  WHOLE_BASIC,
+  WHOLE_SKILL,
+} from 'lib/optimization/rotation/turnAbilityConfig'
 import { SortOption } from 'lib/optimization/sortOptions'
+import { PresetEffects } from 'lib/scoring/presetEffects'
 import {
   SPREAD_ORNAMENTS_2P_FUA,
   SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
   SPREAD_ORNAMENTS_2P_SUPPORT,
-  SPREAD_ORNAMENTS_2P_SUPPORT_WEIGHTS,
-  SPREAD_RELICS_2P_ATK_CRIT_WEIGHTS,
-  SPREAD_RELICS_2P_SPEED_WEIGHTS,
   SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
 } from 'lib/scoring/scoringConstants'
-import { PresetEffects } from 'lib/scoring/presetEffects'
-import { Feixiao } from 'lib/conditionals/character/1200/Feixiao'
-import { Robin } from 'lib/conditionals/character/1300/Robin'
-import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
-import { FlowingNightglow } from 'lib/conditionals/lightcone/5star/FlowingNightglow'
-import { IVentureForthToHunt } from 'lib/conditionals/lightcone/5star/IVentureForthToHunt'
-import { ThoughWorldsApart } from 'lib/conditionals/lightcone/5star/ThoughWorldsApart'
-import {
-  AbilityKind,
-  DEFAULT_FUA,
-  NULL_TURN_ABILITY_NAME,
-  DEFAULT_ULT,
-  WHOLE_BASIC,
-  WHOLE_SKILL,
-} from 'lib/optimization/rotation/turnAbilityConfig'
-import { CharacterConfig } from 'types/characterConfig'
-import { SimulationMetadata, ScoringMetadata } from 'types/metadata'
 import { TsUtils } from 'lib/utils/TsUtils'
 import { Eidolon } from 'types/character'
+import { CharacterConfig } from 'types/characterConfig'
 import { CharacterConditionalsController } from 'types/conditionals'
+import {
+  ScoringMetadata,
+  SimulationMetadata,
+} from 'types/metadata'
 import {
   OptimizerAction,
   OptimizerContext,
@@ -424,7 +427,6 @@ if (
   }
 }
 
-
 const simulation = (): SimulationMetadata => ({
   parts: {
     [Parts.Body]: [
@@ -556,8 +558,9 @@ const display = {
 
 export const Cipher: CharacterConfig = {
   id: '1406',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1400/Cyrene.ts
+++ b/src/lib/conditionals/character/1400/Cyrene.ts
@@ -3,9 +3,9 @@ import { Evernight } from 'lib/conditionals/character/1400/Evernight'
 import { Hyacine } from 'lib/conditionals/character/1400/Hyacine'
 import {
   TrailblazerRemembranceCaelus,
-  TrailblazerRemembranceStelle
+  TrailblazerRemembranceStelle,
 } from 'lib/conditionals/character/8000/TrailblazerRemembrance'
-import { BuffPriority, } from 'lib/conditionals/conditionalConstants'
+import { BuffPriority } from 'lib/conditionals/conditionalConstants'
 import {
   AbilityEidolon,
   Conditionals,
@@ -20,18 +20,18 @@ import { ToEvernightsStars } from 'lib/conditionals/lightcone/5star/ToEvernights
 import {
   Parts,
   Sets,
-  Stats
+  Stats,
 } from 'lib/constants/constants'
 import { containerActionVal } from 'lib/gpu/injection/injectUtils'
 import {
   wgsl,
-  wgslTrue
+  wgslTrue,
 } from 'lib/gpu/injection/wgslUtils'
 import { Source } from 'lib/optimization/buffSource'
 import {
   AKey,
   HKey,
-  StatKey
+  StatKey,
 } from 'lib/optimization/engine/config/keys'
 import {
   DamageTag,
@@ -58,13 +58,13 @@ import {
 import { TsUtils } from 'lib/utils/TsUtils'
 import {
   CharacterId,
-  Eidolon
+  Eidolon,
 } from 'types/character'
 import { CharacterConfig } from 'types/characterConfig'
 import { CharacterConditionalsController } from 'types/conditionals'
 import {
   ScoringMetadata,
-  SimulationMetadata
+  SimulationMetadata,
 } from 'types/metadata'
 import {
   OptimizerAction,
@@ -98,7 +98,6 @@ export const CyreneAbilities: AbilityKind[] = [
   AbilityKind.MEMO_SKILL,
   AbilityKind.BREAK,
 ]
-
 
 const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsController => {
   const t = TsUtils.wrappedFixedT(withContent).get(null, 'conditionals', 'Characters.Cyrene')
@@ -355,9 +354,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 
     initializeConfigurationsContainer: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
       const r = action.characterConditionals as Conditionals<typeof content>
-
-
-
     },
 
     precomputeEffectsContainer: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
@@ -386,7 +382,12 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
       x.buff(StatKey.DEF_PEN, (e >= 6 && m.e6DefPen) ? 0.20 : 0, x.targets(TargetTag.FullTeam).source(SOURCE_E6))
     },
 
-    precomputeTeammateEffectsContainer: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext, originalCharacterAction?: OptimizerAction) => {
+    precomputeTeammateEffectsContainer: (
+      x: ComputedStatsContainer,
+      action: OptimizerAction,
+      context: OptimizerContext,
+      originalCharacterAction?: OptimizerAction,
+    ) => {
       const t = action.characterConditionals as Conditionals<typeof teammateContent>
 
       // Trace SPD-based DMG buff
@@ -415,7 +416,11 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 
       if (spd >= 180 && r.traceSpdBasedBuff) {
         x.buff(StatKey.DMG_BOOST, 0.20, x.targets(TargetTag.SelfAndMemosprite).source(SOURCE_TRACE))
-        x.buff(StatKey.RES_PEN, Math.floor(Math.min(60, spd - 180)) * 0.02, x.elements(ElementTag.Ice).targets(TargetTag.SelfAndMemosprite).source(SOURCE_TRACE))
+        x.buff(
+          StatKey.RES_PEN,
+          Math.floor(Math.min(60, spd - 180)) * 0.02,
+          x.elements(ElementTag.Ice).targets(TargetTag.SelfAndMemosprite).source(SOURCE_TRACE),
+        )
       }
     },
     newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
@@ -575,10 +580,9 @@ export function cyreneSpecialEffectEidolonUpgraded(action: OptimizerAction) {
 
 export const Cyrene: CharacterConfig = {
   id: '1415',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }
-
-

--- a/src/lib/conditionals/character/1400/Evernight.ts
+++ b/src/lib/conditionals/character/1400/Evernight.ts
@@ -1,3 +1,10 @@
+import { Castorice } from 'lib/conditionals/character/1400/Castorice'
+import {
+  Cyrene,
+  cyreneActionExists,
+  cyreneSpecialEffectEidolonUpgraded,
+} from 'lib/conditionals/character/1400/Cyrene'
+import { Hyacine } from 'lib/conditionals/character/1400/Hyacine'
 import { BuffPriority } from 'lib/conditionals/conditionalConstants'
 import {
   AbilityEidolon,
@@ -7,6 +14,9 @@ import {
   createEnum,
 } from 'lib/conditionals/conditionalUtils'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
+import { MakeFarewellsMoreBeautiful } from 'lib/conditionals/lightcone/5star/MakeFarewellsMoreBeautiful'
+import { MayRainbowsRemainInTheSky } from 'lib/conditionals/lightcone/5star/MayRainbowsRemainInTheSky'
+import { ThisLoveForever } from 'lib/conditionals/lightcone/5star/ThisLoveForever'
 import {
   ConditionalActivation,
   ConditionalType,
@@ -41,17 +51,9 @@ import {
 import { SortOption } from 'lib/optimization/sortOptions'
 import { PresetEffects } from 'lib/scoring/presetEffects'
 import {
-  MATCH_2P_WEIGHT,
   SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
   SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
-  T2_WEIGHT,
 } from 'lib/scoring/scoringConstants'
-import { Castorice } from 'lib/conditionals/character/1400/Castorice'
-import { Cyrene, cyreneActionExists, cyreneSpecialEffectEidolonUpgraded } from 'lib/conditionals/character/1400/Cyrene'
-import { Hyacine } from 'lib/conditionals/character/1400/Hyacine'
-import { MakeFarewellsMoreBeautiful } from 'lib/conditionals/lightcone/5star/MakeFarewellsMoreBeautiful'
-import { MayRainbowsRemainInTheSky } from 'lib/conditionals/lightcone/5star/MayRainbowsRemainInTheSky'
-import { ThisLoveForever } from 'lib/conditionals/lightcone/5star/ThisLoveForever'
 import { TsUtils } from 'lib/utils/TsUtils'
 import { Eidolon } from 'types/character'
 import { CharacterConfig } from 'types/characterConfig'
@@ -390,7 +392,11 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
       x.buff(StatKey.VULNERABILITY, (m.enhancedState) ? ultVulnScaling : 0, x.targets(TargetTag.FullTeam).source(SOURCE_ULT))
 
       // E1 Final DMG boost (memosprites only, team-wide)
-      x.multiplicativeBoost(StatKey.FINAL_DMG_BOOST, (e >= 1 && m.e1FinalDmg) ? e1FinalDmgMap[context.enemyCount] : 0, x.targets(TargetTag.Memosprite).source(SOURCE_E1))
+      x.multiplicativeBoost(
+        StatKey.FINAL_DMG_BOOST,
+        (e >= 1 && m.e1FinalDmg) ? e1FinalDmgMap[context.enemyCount] : 0,
+        x.targets(TargetTag.Memosprite).source(SOURCE_E1),
+      )
 
       // E4 Break Efficiency (memosprites only, team-wide)
       x.buff(StatKey.BREAK_EFFICIENCY_BOOST, (e >= 4 && m.e4Buffs) ? 0.25 : 0, x.targets(TargetTag.Memosprite).source(SOURCE_E4))
@@ -654,8 +660,9 @@ const display = {
 
 export const Evernight: CharacterConfig = {
   id: '1413',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1400/Hyacine.ts
+++ b/src/lib/conditionals/character/1400/Hyacine.ts
@@ -3,31 +3,50 @@ import {
   SKILL_DMG_TYPE,
   ULT_DMG_TYPE,
 } from 'lib/conditionals/conditionalConstants'
-import { AbilityEidolon, Conditionals, ContentDefinition, createEnum } from 'lib/conditionals/conditionalUtils'
-import { AbilityKind } from 'lib/optimization/rotation/turnAbilityConfig'
+import {
+  AbilityEidolon,
+  Conditionals,
+  ContentDefinition,
+  createEnum,
+} from 'lib/conditionals/conditionalUtils'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { ConditionalActivation, ConditionalType, Parts, Sets, Stats, } from 'lib/constants/constants'
+import {
+  ConditionalActivation,
+  ConditionalType,
+  Parts,
+  Stats,
+} from 'lib/constants/constants'
 import { newConditionalWgslWrapper } from 'lib/gpu/conditionals/dynamicConditionals'
-import { containerActionVal, p_containerActionVal, } from 'lib/gpu/injection/injectUtils'
-import { wgslFalse, wgslTrue, } from 'lib/gpu/injection/wgslUtils'
+import {
+  containerActionVal,
+  p_containerActionVal,
+} from 'lib/gpu/injection/injectUtils'
+import {
+  wgslFalse,
+  wgslTrue,
+} from 'lib/gpu/injection/wgslUtils'
 import { Source } from 'lib/optimization/buffSource'
 import { StatKey } from 'lib/optimization/engine/config/keys'
-import { DamageTag, ElementTag, SELF_ENTITY_INDEX, TargetTag, } from 'lib/optimization/engine/config/tag'
-import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
-import { TsUtils } from 'lib/utils/TsUtils'
-import { SortOption } from 'lib/optimization/sortOptions'
 import {
-  SPREAD_ORNAMENTS_2P_SUPPORT_WEIGHTS,
-  SPREAD_RELICS_2P_SPEED_WEIGHTS,
-  T2_WEIGHT,
-} from 'lib/scoring/scoringConstants'
+  DamageTag,
+  ElementTag,
+  SELF_ENTITY_INDEX,
+  TargetTag,
+} from 'lib/optimization/engine/config/tag'
+import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
+import { AbilityKind } from 'lib/optimization/rotation/turnAbilityConfig'
+import { SortOption } from 'lib/optimization/sortOptions'
 import { PresetEffects } from 'lib/scoring/presetEffects'
+import { TsUtils } from 'lib/utils/TsUtils'
 import { CharacterConfig } from 'types/characterConfig'
 import { ScoringMetadata } from 'types/metadata'
 
 import { Eidolon } from 'types/character'
 import { CharacterConditionalsController } from 'types/conditionals'
-import { OptimizerAction, OptimizerContext, } from 'types/optimizer'
+import {
+  OptimizerAction,
+  OptimizerContext,
+} from 'types/optimizer'
 
 export const HyacineEntities = createEnum('Hyacine', 'Ica')
 export const HyacineAbilities: AbilityKind[] = [
@@ -297,9 +316,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     // Container methods
     initializeConfigurationsContainer: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
       const r = action.characterConditionals as Conditionals<typeof content>
-
-
-
     },
 
     precomputeEffectsContainer: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
@@ -466,7 +482,6 @@ if (${wgslTrue(e >= 4 && r.e4CdBuff)}) {
   }
 }
 
-
 const scoring = (): ScoringMetadata => ({
   stats: {
     [Stats.ATK]: 0,
@@ -518,8 +533,9 @@ const display = {
 
 export const Hyacine: CharacterConfig = {
   id: '1409',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1400/Hysilens.ts
+++ b/src/lib/conditionals/character/1400/Hysilens.ts
@@ -1,11 +1,20 @@
+import { KafkaB1 } from 'lib/conditionals/character/1000/KafkaB1'
+import { BlackSwanB1 } from 'lib/conditionals/character/1300/BlackSwanB1'
+import {
+  cyreneActionExists,
+  cyreneSpecialEffectEidolonUpgraded,
+} from 'lib/conditionals/character/1400/Cyrene'
+import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
 import {
   AbilityEidolon,
   Conditionals,
   ContentDefinition,
   createEnum,
 } from 'lib/conditionals/conditionalUtils'
-import { cyreneActionExists, cyreneSpecialEffectEidolonUpgraded } from 'lib/conditionals/character/1400/Cyrene'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
+import { PatienceIsAllYouNeed } from 'lib/conditionals/lightcone/5star/PatienceIsAllYouNeed'
+import { ReforgedRemembrance } from 'lib/conditionals/lightcone/5star/ReforgedRemembrance'
+import { ThoughWorldsApart } from 'lib/conditionals/lightcone/5star/ThoughWorldsApart'
 import {
   Parts,
   Sets,
@@ -37,17 +46,7 @@ import {
 } from 'lib/optimization/rotation/turnAbilityConfig'
 import { SortOption } from 'lib/optimization/sortOptions'
 import { PresetEffects } from 'lib/scoring/presetEffects'
-import {
-  SPREAD_RELICS_2P_ATK_WEIGHTS,
-  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
-  T2_WEIGHT,
-} from 'lib/scoring/scoringConstants'
-import { KafkaB1 } from 'lib/conditionals/character/1000/KafkaB1'
-import { BlackSwanB1 } from 'lib/conditionals/character/1300/BlackSwanB1'
-import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
-import { PatienceIsAllYouNeed } from 'lib/conditionals/lightcone/5star/PatienceIsAllYouNeed'
-import { ReforgedRemembrance } from 'lib/conditionals/lightcone/5star/ReforgedRemembrance'
-import { ThoughWorldsApart } from 'lib/conditionals/lightcone/5star/ThoughWorldsApart'
+import { SPREAD_RELICS_4P_GENERAL_CONDITIONALS } from 'lib/scoring/scoringConstants'
 import { TsUtils } from 'lib/utils/TsUtils'
 import { Eidolon } from 'types/character'
 import { CharacterConfig } from 'types/characterConfig'
@@ -330,7 +329,11 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     precomputeMutualEffectsContainer: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
       const m = action.characterConditionals as Conditionals<typeof content>
 
-      x.multiplicativeBoost(StatKey.FINAL_DMG_BOOST, (e >= 1 && m.e1Buffs) ? 0.16 : 0, x.targets(TargetTag.FullTeam).damageType(DamageTag.DOT).source(SOURCE_E1))
+      x.multiplicativeBoost(
+        StatKey.FINAL_DMG_BOOST,
+        (e >= 1 && m.e1Buffs) ? 0.16 : 0,
+        x.targets(TargetTag.FullTeam).damageType(DamageTag.DOT).source(SOURCE_E1),
+      )
       x.buff(StatKey.VULNERABILITY, (m.skillVulnerability) ? skillVulnScaling : 0, x.targets(TargetTag.FullTeam).source(SOURCE_SKILL))
       x.buff(StatKey.DEF_PEN, (m.ultZone) ? ultDefPenScaling : 0, x.targets(TargetTag.FullTeam).source(SOURCE_ULT))
       x.buff(StatKey.RES_PEN, (e >= 4 && m.e4ResPen) ? 0.20 : 0, x.targets(TargetTag.FullTeam).source(SOURCE_E4))
@@ -480,8 +483,9 @@ const display = {
 
 export const Hysilens: CharacterConfig = {
   id: '1410',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1400/Mydei.ts
+++ b/src/lib/conditionals/character/1400/Mydei.ts
@@ -1,4 +1,11 @@
 import {
+  Cyrene,
+  cyreneActionExists,
+  cyreneSpecialEffectEidolonUpgraded,
+} from 'lib/conditionals/character/1400/Cyrene'
+import { Hyacine } from 'lib/conditionals/character/1400/Hyacine'
+import { Tribbie } from 'lib/conditionals/character/1400/Tribbie'
+import {
   AbilityEidolon,
   Conditionals,
   ContentDefinition,
@@ -9,6 +16,9 @@ import {
   gpuDynamicStatConversion,
 } from 'lib/conditionals/evaluation/statConversion'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
+import { IfTimeWereAFlower } from 'lib/conditionals/lightcone/5star/IfTimeWereAFlower'
+import { MayRainbowsRemainInTheSky } from 'lib/conditionals/lightcone/5star/MayRainbowsRemainInTheSky'
+import { ThisLoveForever } from 'lib/conditionals/lightcone/5star/ThisLoveForever'
 import {
   ConditionalActivation,
   ConditionalType,
@@ -16,13 +26,9 @@ import {
   Sets,
   Stats,
 } from 'lib/constants/constants'
-import { containerActionVal } from 'lib/gpu/injection/injectUtils'
-import {
-  wgsl,
-  wgslTrue,
-} from 'lib/gpu/injection/wgslUtils'
-import { Source } from 'lib/optimization/buffSource'
+import { wgslTrue } from 'lib/gpu/injection/wgslUtils'
 import { BasicKey } from 'lib/optimization/basicStatsArray'
+import { Source } from 'lib/optimization/buffSource'
 import {
   AKey,
   StatKey,
@@ -30,24 +36,9 @@ import {
 import {
   DamageTag,
   ElementTag,
-  SELF_ENTITY_INDEX,
 } from 'lib/optimization/engine/config/tag'
 import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
 import { buff } from 'lib/optimization/engine/container/gpuBuffBuilder'
-import { SortOption } from 'lib/optimization/sortOptions'
-import {
-  MATCH_2P_WEIGHT,
-  SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
-  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
-  T2_WEIGHT,
-} from 'lib/scoring/scoringConstants'
-import { PresetEffects } from 'lib/scoring/presetEffects'
-import { Cyrene, cyreneActionExists, cyreneSpecialEffectEidolonUpgraded } from 'lib/conditionals/character/1400/Cyrene'
-import { Hyacine } from 'lib/conditionals/character/1400/Hyacine'
-import { Tribbie } from 'lib/conditionals/character/1400/Tribbie'
-import { IfTimeWereAFlower } from 'lib/conditionals/lightcone/5star/IfTimeWereAFlower'
-import { MayRainbowsRemainInTheSky } from 'lib/conditionals/lightcone/5star/MayRainbowsRemainInTheSky'
-import { ThisLoveForever } from 'lib/conditionals/lightcone/5star/ThisLoveForever'
 import {
   AbilityKind,
   END_SKILL,
@@ -55,9 +46,18 @@ import {
   START_ULT,
   WHOLE_SKILL,
 } from 'lib/optimization/rotation/turnAbilityConfig'
-import { CharacterConfig } from 'types/characterConfig'
-import { SimulationMetadata, ScoringMetadata } from 'types/metadata'
+import { SortOption } from 'lib/optimization/sortOptions'
+import { PresetEffects } from 'lib/scoring/presetEffects'
+import {
+  SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
+  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+} from 'lib/scoring/scoringConstants'
 import { TsUtils } from 'lib/utils/TsUtils'
+import { CharacterConfig } from 'types/characterConfig'
+import {
+  ScoringMetadata,
+  SimulationMetadata,
+} from 'types/metadata'
 
 import { Eidolon } from 'types/character'
 import { CharacterConditionalsController } from 'types/conditionals'
@@ -311,7 +311,6 @@ if (${wgslTrue(r.vendettaState)}) {
   }
 }
 
-
 const simulation = (): SimulationMetadata => ({
   parts: {
     [Parts.Body]: [
@@ -426,8 +425,9 @@ const display = {
 
 export const Mydei: CharacterConfig = {
   id: '1404',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1400/PermansorTerrae.ts
+++ b/src/lib/conditionals/character/1400/PermansorTerrae.ts
@@ -1,4 +1,8 @@
 import {
+  cyreneActionExists,
+  cyreneSpecialEffectEidolonUpgraded,
+} from 'lib/conditionals/character/1400/Cyrene'
+import {
   ASHBLAZING_ATK_STACK,
   NONE_TYPE,
   SKILL_DMG_TYPE,
@@ -14,12 +18,9 @@ import {
   ContentDefinition,
   createEnum,
 } from 'lib/conditionals/conditionalUtils'
-import { AbilityKind } from 'lib/optimization/rotation/turnAbilityConfig'
-import { cyreneActionExists, cyreneSpecialEffectEidolonUpgraded } from 'lib/conditionals/character/1400/Cyrene'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
 import {
   Parts,
-  Sets,
   Stats,
 } from 'lib/constants/constants'
 import { Source } from 'lib/optimization/buffSource'
@@ -29,13 +30,9 @@ import {
   TargetTag,
 } from 'lib/optimization/engine/config/tag'
 import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
+import { AbilityKind } from 'lib/optimization/rotation/turnAbilityConfig'
 import { SortOption } from 'lib/optimization/sortOptions'
 import { PresetEffects } from 'lib/scoring/presetEffects'
-import {
-  SPREAD_ORNAMENTS_2P_SUPPORT_WEIGHTS,
-  SPREAD_RELICS_2P_ATK_WEIGHTS,
-  SPREAD_RELICS_2P_SPEED_WEIGHTS,
-} from 'lib/scoring/scoringConstants'
 import { TsUtils } from 'lib/utils/TsUtils'
 import { Eidolon } from 'types/character'
 import { CharacterConfig } from 'types/characterConfig'
@@ -348,8 +345,9 @@ const display = {
 
 export const PermansorTerrae: CharacterConfig = {
   id: '1414',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1400/Phainon.ts
+++ b/src/lib/conditionals/character/1400/Phainon.ts
@@ -1,3 +1,11 @@
+import { Sunday } from 'lib/conditionals/character/1300/Sunday'
+import { Cerydra } from 'lib/conditionals/character/1400/Cerydra'
+import {
+  Cyrene,
+  cyreneActionExists,
+  cyreneSpecialEffectEidolonUpgraded,
+} from 'lib/conditionals/character/1400/Cyrene'
+import { Hyacine } from 'lib/conditionals/character/1400/Hyacine'
 import {
   AbilityEidolon,
   Conditionals,
@@ -7,16 +15,15 @@ import {
   teammateMatchesId,
 } from 'lib/conditionals/conditionalUtils'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { Parts, PathNames, Sets, Stats } from 'lib/constants/constants'
-import { SortOption } from 'lib/optimization/sortOptions'
+import { AGroundedAscent } from 'lib/conditionals/lightcone/5star/AGroundedAscent'
+import { EpochEtchedInGoldenBlood } from 'lib/conditionals/lightcone/5star/EpochEtchedInGoldenBlood'
+import { ThisLoveForever } from 'lib/conditionals/lightcone/5star/ThisLoveForever'
 import {
-  SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
-  SPREAD_RELICS_2P_ATK_CRIT_WEIGHTS,
-  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
-  T2_WEIGHT,
-} from 'lib/scoring/scoringConstants'
-import { CharacterConfig } from 'types/characterConfig'
-import { SimulationMetadata, ScoringMetadata } from 'types/metadata'
+  Parts,
+  PathNames,
+  Sets,
+  Stats,
+} from 'lib/constants/constants'
 import { Source } from 'lib/optimization/buffSource'
 import { StatKey } from 'lib/optimization/engine/config/keys'
 import {
@@ -25,13 +32,6 @@ import {
   TargetTag,
 } from 'lib/optimization/engine/config/tag'
 import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
-import { Sunday } from 'lib/conditionals/character/1300/Sunday'
-import { Cerydra } from 'lib/conditionals/character/1400/Cerydra'
-import { Cyrene, cyreneActionExists, cyreneSpecialEffectEidolonUpgraded } from 'lib/conditionals/character/1400/Cyrene'
-import { Hyacine } from 'lib/conditionals/character/1400/Hyacine'
-import { AGroundedAscent } from 'lib/conditionals/lightcone/5star/AGroundedAscent'
-import { EpochEtchedInGoldenBlood } from 'lib/conditionals/lightcone/5star/EpochEtchedInGoldenBlood'
-import { ThisLoveForever } from 'lib/conditionals/lightcone/5star/ThisLoveForever'
 import {
   AbilityKind,
   DEFAULT_BASIC,
@@ -40,9 +40,19 @@ import {
   NULL_TURN_ABILITY_NAME,
   START_ULT,
 } from 'lib/optimization/rotation/turnAbilityConfig'
+import { SortOption } from 'lib/optimization/sortOptions'
+import {
+  SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
+  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+} from 'lib/scoring/scoringConstants'
 import { TsUtils } from 'lib/utils/TsUtils'
 import { Eidolon } from 'types/character'
+import { CharacterConfig } from 'types/characterConfig'
 import { CharacterConditionalsController } from 'types/conditionals'
+import {
+  ScoringMetadata,
+  SimulationMetadata,
+} from 'types/metadata'
 import {
   OptimizerAction,
   OptimizerContext,
@@ -253,14 +263,14 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
           [AbilityKind.SKILL]: {
             hits: r.enhancedSkillType === PhainonEnhancedSkillType.FOUNDATION
               ? [
-                  HitDefinitionBuilder.standardSkill()
-                    .damageElement(ElementTag.Physical)
-                    .atkScaling(foundationSkillScaling)
-                    .toughnessDmg(foundationSkillToughness)
-                    .trueDmgModifier(e >= 6 && r.e6TrueDmg ? 0.36 : 0)
-                    .build(),
-                  ...(cyreneAdditionalScaling > 0 ? [createCyreneAdditionalHit()] : []),
-                ]
+                HitDefinitionBuilder.standardSkill()
+                  .damageElement(ElementTag.Physical)
+                  .atkScaling(foundationSkillScaling)
+                  .toughnessDmg(foundationSkillToughness)
+                  .trueDmgModifier(e >= 6 && r.e6TrueDmg ? 0.36 : 0)
+                  .build(),
+                ...(cyreneAdditionalScaling > 0 ? [createCyreneAdditionalHit()] : []),
+              ]
               : [], // Calamity mode has no skill damage
           },
           [AbilityKind.ULT]: {
@@ -314,10 +324,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
             ],
           },
           [AbilityKind.ULT]: {
-            hits: [
-              // Non-transformed ULT has no damage
-              ...(cyreneAdditionalScaling > 0 ? [createCyreneAdditionalHit()] : []),
-            ],
+            hits: (cyreneAdditionalScaling > 0 ? [createCyreneAdditionalHit()] : []),
           },
           [AbilityKind.FUA]: {
             hits: [
@@ -382,20 +389,17 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
       }
     },
 
-
     precomputeMutualEffectsContainer: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
       const m = action.characterConditionals as Conditionals<typeof teammateContent>
 
       x.buff(StatKey.SPD_P, m.spdBuff ? 0.15 : 0, x.targets(TargetTag.FullTeam).source(SOURCE_TALENT))
     },
 
-
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
     },
     newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => '',
   }
 }
-
 
 const simulation = (): SimulationMetadata => ({
   parts: {
@@ -516,8 +520,9 @@ const display = {
 
 export const Phainon: CharacterConfig = {
   id: '1408',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1400/TheHerta.ts
+++ b/src/lib/conditionals/character/1400/TheHerta.ts
@@ -1,3 +1,6 @@
+import { Jade } from 'lib/conditionals/character/1300/Jade'
+import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
+import { Tribbie } from 'lib/conditionals/character/1400/Tribbie'
 import {
   AbilityEidolon,
   Conditionals,
@@ -7,15 +10,23 @@ import {
   mainIsPath,
 } from 'lib/conditionals/conditionalUtils'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { Parts, PathNames, Sets, Stats } from 'lib/constants/constants'
+import { IfTimeWereAFlower } from 'lib/conditionals/lightcone/5star/IfTimeWereAFlower'
+import { ThoughWorldsApart } from 'lib/conditionals/lightcone/5star/ThoughWorldsApart'
+import { YetHopeIsPriceless } from 'lib/conditionals/lightcone/5star/YetHopeIsPriceless'
 import {
-  SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
-  SPREAD_RELICS_2P_ATK_CRIT_WEIGHTS,
-  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
-  T2_WEIGHT,
-} from 'lib/scoring/scoringConstants'
-import { SortOption } from 'lib/optimization/sortOptions'
-import { PresetEffects } from 'lib/scoring/presetEffects'
+  Parts,
+  PathNames,
+  Sets,
+  Stats,
+} from 'lib/constants/constants'
+import { Source } from 'lib/optimization/buffSource'
+import { StatKey } from 'lib/optimization/engine/config/keys'
+import {
+  DamageTag,
+  ElementTag,
+  TargetTag,
+} from 'lib/optimization/engine/config/tag'
+import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
 import {
   AbilityKind,
   END_ULT,
@@ -23,21 +34,19 @@ import {
   START_SKILL,
   WHOLE_SKILL,
 } from 'lib/optimization/rotation/turnAbilityConfig'
-import { Jade } from 'lib/conditionals/character/1300/Jade'
-import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
-import { Tribbie } from 'lib/conditionals/character/1400/Tribbie'
-import { IfTimeWereAFlower } from 'lib/conditionals/lightcone/5star/IfTimeWereAFlower'
-import { ThoughWorldsApart } from 'lib/conditionals/lightcone/5star/ThoughWorldsApart'
-import { YetHopeIsPriceless } from 'lib/conditionals/lightcone/5star/YetHopeIsPriceless'
-import { CharacterConfig } from 'types/characterConfig'
-import { SimulationMetadata, ScoringMetadata } from 'types/metadata'
-import { Source } from 'lib/optimization/buffSource'
-import { StatKey } from 'lib/optimization/engine/config/keys'
-import { DamageTag, ElementTag, TargetTag } from 'lib/optimization/engine/config/tag'
-import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
+import { SortOption } from 'lib/optimization/sortOptions'
+import {
+  SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
+  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+} from 'lib/scoring/scoringConstants'
 import { TsUtils } from 'lib/utils/TsUtils'
 import { Eidolon } from 'types/character'
+import { CharacterConfig } from 'types/characterConfig'
 import { CharacterConditionalsController } from 'types/conditionals'
+import {
+  ScoringMetadata,
+  SimulationMetadata,
+} from 'types/metadata'
 import {
   OptimizerAction,
   OptimizerContext,
@@ -249,9 +258,17 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     precomputeMutualEffectsContainer: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
       const m = action.characterConditionals as Conditionals<typeof teammateContent>
 
-      x.buff(StatKey.CD, (m.eruditionTeammate && countTeamPath(context, PathNames.Erudition) >= 2) ? 0.80 : 0, x.targets(TargetTag.FullTeam).source(SOURCE_TRACE))
+      x.buff(
+        StatKey.CD,
+        (m.eruditionTeammate && countTeamPath(context, PathNames.Erudition) >= 2) ? 0.80 : 0,
+        x.targets(TargetTag.FullTeam).source(SOURCE_TRACE),
+      )
 
-      x.buff(StatKey.SPD_P, (e >= 4 && m.e4EruditionSpdBuff && mainIsPath(context, PathNames.Erudition)) ? 0.12 : 0, x.targets(TargetTag.SelfAndPet).source(SOURCE_E4))
+      x.buff(
+        StatKey.SPD_P,
+        (e >= 4 && m.e4EruditionSpdBuff && mainIsPath(context, PathNames.Erudition)) ? 0.12 : 0,
+        x.targets(TargetTag.SelfAndPet).source(SOURCE_E4),
+      )
     },
     precomputeTeammateEffectsContainer: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
     },
@@ -376,8 +393,9 @@ const display = {
 
 export const TheHerta: CharacterConfig = {
   id: '1401',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1400/Tribbie.ts
+++ b/src/lib/conditionals/character/1400/Tribbie.ts
@@ -1,11 +1,20 @@
+import { Anaxa } from 'lib/conditionals/character/1400/Anaxa'
+import {
+  cyreneActionExists,
+  cyreneSpecialEffectEidolonUpgraded,
+} from 'lib/conditionals/character/1400/Cyrene'
+import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
+import { TheHerta } from 'lib/conditionals/character/1400/TheHerta'
 import {
   AbilityEidolon,
   Conditionals,
   ContentDefinition,
   createEnum,
 } from 'lib/conditionals/conditionalUtils'
-import { cyreneActionExists, cyreneSpecialEffectEidolonUpgraded } from 'lib/conditionals/character/1400/Cyrene'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
+import { IntotheUnreachableVeil } from 'lib/conditionals/lightcone/5star/IntotheUnreachableVeil'
+import { LifeShouldBeCastToFlames } from 'lib/conditionals/lightcone/5star/LifeShouldBeCastToFlames'
+import { ThoughWorldsApart } from 'lib/conditionals/lightcone/5star/ThoughWorldsApart'
 import {
   Parts,
   Sets,
@@ -32,21 +41,11 @@ import {
 import { SortOption } from 'lib/optimization/sortOptions'
 import { PresetEffects } from 'lib/scoring/presetEffects'
 import {
-  MATCH_2P_WEIGHT,
   SPREAD_ORNAMENTS_2P_FUA,
-  SPREAD_ORNAMENTS_2P_FUA_WEIGHTS,
   SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
   SPREAD_ORNAMENTS_2P_SUPPORT,
-  SPREAD_ORNAMENTS_2P_SUPPORT_WEIGHTS,
-  SPREAD_RELICS_2P_SPEED_WEIGHTS,
   SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
 } from 'lib/scoring/scoringConstants'
-import { Anaxa } from 'lib/conditionals/character/1400/Anaxa'
-import { TheHerta } from 'lib/conditionals/character/1400/TheHerta'
-import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
-import { IntotheUnreachableVeil } from 'lib/conditionals/lightcone/5star/IntotheUnreachableVeil'
-import { LifeShouldBeCastToFlames } from 'lib/conditionals/lightcone/5star/LifeShouldBeCastToFlames'
-import { ThoughWorldsApart } from 'lib/conditionals/lightcone/5star/ThoughWorldsApart'
 import { TsUtils } from 'lib/utils/TsUtils'
 
 import { Eidolon } from 'types/character'
@@ -465,8 +464,9 @@ const display = {
 
 export const Tribbie: CharacterConfig = {
   id: '1403',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1500/Ashveil.ts
+++ b/src/lib/conditionals/character/1500/Ashveil.ts
@@ -12,6 +12,7 @@ import {
   Conditionals,
   ContentDefinition,
   createEnum,
+  Mutual,
 } from 'lib/conditionals/conditionalUtils'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
 import { AGroundedAscent } from 'lib/conditionals/lightcone/5star/AGroundedAscent'
@@ -118,7 +119,9 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     e1TargetHpBelow50: true,
   }
 
-  const content: ContentDefinition<typeof defaults> = {
+  type Content = ContentDefinition<typeof defaults>
+
+  const content: Content = {
     baitActive: {
       id: 'baitActive',
       formItem: 'switch',
@@ -177,11 +180,15 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
   }
 
-  const teammateContent: ContentDefinition<typeof teammateDefaults> = {
+  type TeammateContent = ContentDefinition<typeof teammateDefaults>
+
+  const teammateContent: TeammateContent = {
     baitActive: content.baitActive,
     e1DmgVulnerability: content.e1DmgVulnerability,
     e1TargetHpBelow50: content.e1TargetHpBelow50,
   }
+
+  type MutualContent = Mutual<Content, TeammateContent>
 
   return {
     content: () => Object.values(content),
@@ -200,7 +207,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 
     actionDeclaration: () => [...AshveilAbilities],
     actionDefinition: (action: OptimizerAction, context: OptimizerContext) => {
-      const r = action.characterConditionals as Conditionals<typeof content>
+      const r = action.characterConditionals as Conditionals<Content>
 
       return {
         [AbilityKind.BASIC]: {
@@ -249,7 +256,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     actionModifiers: () => [],
 
     precomputeEffectsContainer: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
-      const r = action.characterConditionals as Conditionals<typeof content>
+      const r = action.characterConditionals as Conditionals<Content>
 
       // FUA DMG +80%
       x.buff(StatKey.DMG_BOOST, 0.80, x.damageType(DamageTag.FUA).source(SOURCE_TRACE))
@@ -265,7 +272,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     precomputeMutualEffectsContainer: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
-      const m = action.characterConditionals as Conditionals<typeof teammateContent>
+      const m = action.characterConditionals as Conditionals<MutualContent>
 
       // Team CRIT DMG +40%
       x.buff(StatKey.CD, 0.40, x.targets(TargetTag.FullTeam).source(SOURCE_TRACE))
@@ -404,7 +411,6 @@ const display = {
 
 export const Ashveil: CharacterConfig = {
   id: '1504',
-  info: {},
   display,
   conditionals,
   get scoring() {

--- a/src/lib/conditionals/character/1500/Sparxie.ts
+++ b/src/lib/conditionals/character/1500/Sparxie.ts
@@ -1,4 +1,10 @@
 import i18next from 'i18next'
+import { Huohuo } from 'lib/conditionals/character/1200/Huohuo'
+import { SparkleB1 } from 'lib/conditionals/character/1300/SparkleB1'
+import {
+  getYaoguangAhaPunchlineValue,
+  Yaoguang,
+} from 'lib/conditionals/character/1500/Yaoguang'
 import {
   AbilityEidolon,
   Conditionals,
@@ -10,6 +16,9 @@ import {
   gpuDynamicStatConversion,
 } from 'lib/conditionals/evaluation/statConversion'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
+import { ButTheBattleIsntOver } from 'lib/conditionals/lightcone/5star/ButTheBattleIsntOver'
+import { NightOfFright } from 'lib/conditionals/lightcone/5star/NightOfFright'
+import { WhenSheDecidedToSee } from 'lib/conditionals/lightcone/5star/WhenSheDecidedToSee'
 import {
   ConditionalActivation,
   ConditionalType,
@@ -41,12 +50,6 @@ import {
   SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
   SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
 } from 'lib/scoring/scoringConstants'
-import { Huohuo } from 'lib/conditionals/character/1200/Huohuo'
-import { SparkleB1 } from 'lib/conditionals/character/1300/SparkleB1'
-import { getYaoguangAhaPunchlineValue, Yaoguang } from 'lib/conditionals/character/1500/Yaoguang'
-import { ButTheBattleIsntOver } from 'lib/conditionals/lightcone/5star/ButTheBattleIsntOver'
-import { NightOfFright } from 'lib/conditionals/lightcone/5star/NightOfFright'
-import { WhenSheDecidedToSee } from 'lib/conditionals/lightcone/5star/WhenSheDecidedToSee'
 import { Eidolon } from 'types/character'
 import { CharacterConfig } from 'types/characterConfig'
 import { CharacterConditionalsController } from 'types/conditionals'
@@ -506,8 +509,9 @@ const display = {
 
 export const Sparxie: CharacterConfig = {
   id: '1501',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/1500/Yaoguang.ts
+++ b/src/lib/conditionals/character/1500/Yaoguang.ts
@@ -1,4 +1,7 @@
 import i18next from 'i18next'
+import { Huohuo } from 'lib/conditionals/character/1200/Huohuo'
+import { SparkleB1 } from 'lib/conditionals/character/1300/SparkleB1'
+import { Sparxie } from 'lib/conditionals/character/1500/Sparxie'
 import {
   AbilityEidolon,
   Conditionals,
@@ -12,6 +15,9 @@ import {
   gpuDynamicStatConversion,
 } from 'lib/conditionals/evaluation/statConversion'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
+import { ButTheBattleIsntOver } from 'lib/conditionals/lightcone/5star/ButTheBattleIsntOver'
+import { DazzledByAFloweryWorld } from 'lib/conditionals/lightcone/5star/DazzledByAFloweryWorld'
+import { NightOfFright } from 'lib/conditionals/lightcone/5star/NightOfFright'
 import {
   ConditionalActivation,
   ConditionalType,
@@ -46,12 +52,6 @@ import {
   SPREAD_ORNAMENTS_2P_SUPPORT,
   SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
 } from 'lib/scoring/scoringConstants'
-import { Huohuo } from 'lib/conditionals/character/1200/Huohuo'
-import { SparkleB1 } from 'lib/conditionals/character/1300/SparkleB1'
-import { Sparxie } from 'lib/conditionals/character/1500/Sparxie'
-import { ButTheBattleIsntOver } from 'lib/conditionals/lightcone/5star/ButTheBattleIsntOver'
-import { DazzledByAFloweryWorld } from 'lib/conditionals/lightcone/5star/DazzledByAFloweryWorld'
-import { NightOfFright } from 'lib/conditionals/lightcone/5star/NightOfFright'
 import { Eidolon } from 'types/character'
 import { CharacterConfig } from 'types/characterConfig'
 import { CharacterConditionalsController } from 'types/conditionals'
@@ -581,9 +581,9 @@ export function getYaoguangAhaPunchlineValue(action: OptimizerAction, context: O
 
 export const Yaoguang: CharacterConfig = {
   id: '1502',
-  info: {},
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }
-

--- a/src/lib/conditionals/character/8000/TrailblazerDestruction.ts
+++ b/src/lib/conditionals/character/8000/TrailblazerDestruction.ts
@@ -1,3 +1,6 @@
+import { Bronya } from 'lib/conditionals/character/1100/Bronya'
+import { Huohuo } from 'lib/conditionals/character/1200/Huohuo'
+import { RuanMei } from 'lib/conditionals/character/1300/RuanMei'
 import {
   AbilityEidolon,
   Conditionals,
@@ -5,18 +8,21 @@ import {
   createEnum,
 } from 'lib/conditionals/conditionalUtils'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { Parts, Sets, Stats } from 'lib/constants/constants'
-import { SortOption } from 'lib/optimization/sortOptions'
-import {
-  SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
-  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
-} from 'lib/scoring/scoringConstants'
-import { Bronya } from 'lib/conditionals/character/1100/Bronya'
-import { Huohuo } from 'lib/conditionals/character/1200/Huohuo'
-import { RuanMei } from 'lib/conditionals/character/1300/RuanMei'
 import { ButTheBattleIsntOver } from 'lib/conditionals/lightcone/5star/ButTheBattleIsntOver'
 import { NightOfFright } from 'lib/conditionals/lightcone/5star/NightOfFright'
 import { PastSelfInTheMirror } from 'lib/conditionals/lightcone/5star/PastSelfInTheMirror'
+import {
+  Parts,
+  Sets,
+  Stats,
+} from 'lib/constants/constants'
+import { Source } from 'lib/optimization/buffSource'
+import { StatKey } from 'lib/optimization/engine/config/keys'
+import {
+  DamageTag,
+  ElementTag,
+} from 'lib/optimization/engine/config/tag'
+import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
 import {
   AbilityKind,
   END_SKILL,
@@ -24,14 +30,18 @@ import {
   START_ULT,
   WHOLE_SKILL,
 } from 'lib/optimization/rotation/turnAbilityConfig'
-import { CharacterConfig } from 'types/characterConfig'
-import { SimulationMetadata, ScoringMetadata } from 'types/metadata'
-import { Source } from 'lib/optimization/buffSource'
-import { StatKey } from 'lib/optimization/engine/config/keys'
-import { DamageTag, ElementTag } from 'lib/optimization/engine/config/tag'
-import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
+import { SortOption } from 'lib/optimization/sortOptions'
+import {
+  SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
+  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+} from 'lib/scoring/scoringConstants'
 import { TsUtils } from 'lib/utils/TsUtils'
 import { Eidolon } from 'types/character'
+import { CharacterConfig } from 'types/characterConfig'
+import {
+  ScoringMetadata,
+  SimulationMetadata,
+} from 'types/metadata'
 
 import { CharacterConditionalsController } from 'types/conditionals'
 import {
@@ -169,7 +179,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   }
 }
 
-
 const simulation = (): SimulationMetadata => ({
   parts: {
     [Parts.Body]: [
@@ -294,16 +303,18 @@ const displayStelle = {
 
 export const TrailblazerDestructionCaelus: CharacterConfig = {
   id: '8001',
-  info: { displayName: 'Caelus (Destruction)' },
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
   display: displayCaelus,
 }
 
 export const TrailblazerDestructionStelle: CharacterConfig = {
   id: '8002',
-  info: { displayName: 'Stelle (Destruction)' },
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
   display: displayStelle,
 }

--- a/src/lib/conditionals/character/8000/TrailblazerHarmony.ts
+++ b/src/lib/conditionals/character/8000/TrailblazerHarmony.ts
@@ -6,27 +6,31 @@ import {
   createEnum,
 } from 'lib/conditionals/conditionalUtils'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { Parts, Sets, Stats } from 'lib/constants/constants'
-import { SortOption } from 'lib/optimization/sortOptions'
 import {
-  SPREAD_ORNAMENTS_2P_SUPPORT_WEIGHTS,
-  SPREAD_RELICS_2P_BREAK_WEIGHTS,
-  SPREAD_RELICS_2P_SPEED_WEIGHTS,
-} from 'lib/scoring/scoringConstants'
-import { CharacterConfig } from 'types/characterConfig'
-import { ScoringMetadata } from 'types/metadata'
+  Parts,
+  Stats,
+} from 'lib/constants/constants'
 import { Source } from 'lib/optimization/buffSource'
 import { ModifierContext } from 'lib/optimization/context/calculateActions'
 import { StatKey } from 'lib/optimization/engine/config/keys'
-import { ElementTag, TargetTag, } from 'lib/optimization/engine/config/tag'
+import {
+  ElementTag,
+  TargetTag,
+} from 'lib/optimization/engine/config/tag'
 import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
+import { SortOption } from 'lib/optimization/sortOptions'
 import { TsUtils } from 'lib/utils/TsUtils'
+import { CharacterConfig } from 'types/characterConfig'
+import { ScoringMetadata } from 'types/metadata'
 
 import { Eidolon } from 'types/character'
 
 import { AbilityKind } from 'lib/optimization/rotation/turnAbilityConfig'
 import { CharacterConditionalsController } from 'types/conditionals'
-import { OptimizerAction, OptimizerContext, } from 'types/optimizer'
+import {
+  OptimizerAction,
+  OptimizerContext,
+} from 'types/optimizer'
 
 export const TrailblazerHarmonyEntities = createEnum('TrailblazerHarmony')
 export const TrailblazerHarmonyAbilities: AbilityKind[] = [
@@ -218,7 +222,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   }
 }
 
-
 const scoring = (): ScoringMetadata => ({
   stats: {
     [Stats.ATK]: 0,
@@ -261,16 +264,18 @@ const display = {
 
 export const TrailblazerHarmonyCaelus: CharacterConfig = {
   id: '8005',
-  info: { displayName: 'Caelus (Harmony)' },
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }
 
 export const TrailblazerHarmonyStelle: CharacterConfig = {
   id: '8006',
-  info: { displayName: 'Stelle (Harmony)' },
   display,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/8000/TrailblazerPreservation.ts
+++ b/src/lib/conditionals/character/8000/TrailblazerPreservation.ts
@@ -1,23 +1,33 @@
-import { AbilityEidolon, Conditionals, ContentDefinition, createEnum, } from 'lib/conditionals/conditionalUtils'
-import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { Parts, Sets, Stats } from 'lib/constants/constants'
-import { SortOption } from 'lib/optimization/sortOptions'
 import {
-  SPREAD_ORNAMENTS_2P_SUPPORT_WEIGHTS,
-  SPREAD_RELICS_2P_SPEED_WEIGHTS,
-} from 'lib/scoring/scoringConstants'
-import { CharacterConfig } from 'types/characterConfig'
-import { ScoringMetadata } from 'types/metadata'
+  AbilityEidolon,
+  Conditionals,
+  ContentDefinition,
+  createEnum,
+} from 'lib/conditionals/conditionalUtils'
+import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
+import {
+  Parts,
+  Stats,
+} from 'lib/constants/constants'
 import { Source } from 'lib/optimization/buffSource'
 import { StatKey } from 'lib/optimization/engine/config/keys'
-import { ElementTag, TargetTag, } from 'lib/optimization/engine/config/tag'
+import {
+  ElementTag,
+  TargetTag,
+} from 'lib/optimization/engine/config/tag'
 import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
+import { SortOption } from 'lib/optimization/sortOptions'
 import { TsUtils } from 'lib/utils/TsUtils'
 import { Eidolon } from 'types/character'
+import { CharacterConfig } from 'types/characterConfig'
+import { ScoringMetadata } from 'types/metadata'
 
 import { AbilityKind } from 'lib/optimization/rotation/turnAbilityConfig'
 import { CharacterConditionalsController } from 'types/conditionals'
-import { OptimizerAction, OptimizerContext, } from 'types/optimizer'
+import {
+  OptimizerAction,
+  OptimizerContext,
+} from 'types/optimizer'
 
 export const TrailblazerPreservationEntities = createEnum('TrailblazerPreservation')
 export const TrailblazerPreservationAbilities: AbilityKind[] = [
@@ -188,7 +198,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   }
 }
 
-
 const scoring = (): ScoringMetadata => ({
   stats: {
     [Stats.ATK]: 0,
@@ -246,16 +255,18 @@ const displayStelle = {
 
 export const TrailblazerPreservationCaelus: CharacterConfig = {
   id: '8003',
-  info: { displayName: 'Caelus (Preservation)' },
   display: displayCaelus,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }
 
 export const TrailblazerPreservationStelle: CharacterConfig = {
   id: '8004',
-  info: { displayName: 'Stelle (Preservation)' },
   display: displayStelle,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/character/8000/TrailblazerRemembrance.ts
+++ b/src/lib/conditionals/character/8000/TrailblazerRemembrance.ts
@@ -1,26 +1,47 @@
-import { BuffPriority, } from 'lib/conditionals/conditionalConstants'
-import { AbilityEidolon, Conditionals, ContentDefinition, createEnum, } from 'lib/conditionals/conditionalUtils'
+import { BuffPriority } from 'lib/conditionals/conditionalConstants'
+import {
+  AbilityEidolon,
+  Conditionals,
+  ContentDefinition,
+  createEnum,
+} from 'lib/conditionals/conditionalUtils'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { ConditionalActivation, ConditionalType, Parts, Sets, Stats, } from 'lib/constants/constants'
+import {
+  ConditionalActivation,
+  ConditionalType,
+  Parts,
+  Stats,
+} from 'lib/constants/constants'
 import { newConditionalWgslWrapper } from 'lib/gpu/conditionals/dynamicConditionals'
-import { containerActionVal, p_containerActionVal, } from 'lib/gpu/injection/injectUtils'
-import { wgsl, wgslFalse, } from 'lib/gpu/injection/wgslUtils'
+import {
+  containerActionVal,
+  p_containerActionVal,
+} from 'lib/gpu/injection/injectUtils'
+import {
+  wgsl,
+  wgslFalse,
+} from 'lib/gpu/injection/wgslUtils'
 import { Source } from 'lib/optimization/buffSource'
 import { StatKey } from 'lib/optimization/engine/config/keys'
-import { DamageTag, ElementTag, SELF_ENTITY_INDEX, TargetTag, } from 'lib/optimization/engine/config/tag'
-import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
-import { TsUtils } from 'lib/utils/TsUtils'
-import { SortOption } from 'lib/optimization/sortOptions'
 import {
-  SPREAD_ORNAMENTS_2P_SUPPORT_WEIGHTS,
-} from 'lib/scoring/scoringConstants'
-import { PresetEffects } from 'lib/scoring/presetEffects'
-import { CharacterConfig } from 'types/characterConfig'
-import { ScoringMetadata } from 'types/metadata'
-import { Eidolon } from 'types/character'
+  DamageTag,
+  ElementTag,
+  SELF_ENTITY_INDEX,
+  TargetTag,
+} from 'lib/optimization/engine/config/tag'
+import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
 import { AbilityKind } from 'lib/optimization/rotation/turnAbilityConfig'
+import { SortOption } from 'lib/optimization/sortOptions'
+import { PresetEffects } from 'lib/scoring/presetEffects'
+import { TsUtils } from 'lib/utils/TsUtils'
+import { Eidolon } from 'types/character'
+import { CharacterConfig } from 'types/characterConfig'
 import { CharacterConditionalsController } from 'types/conditionals'
-import { OptimizerAction, OptimizerContext, } from 'types/optimizer'
+import { ScoringMetadata } from 'types/metadata'
+import {
+  OptimizerAction,
+  OptimizerContext,
+} from 'types/optimizer'
 
 export const TrailblazerRemembranceAbilities: AbilityKind[] = [
   AbilityKind.BASIC,
@@ -283,9 +304,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 
     initializeConfigurationsContainer: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
       const r = action.characterConditionals as Conditionals<typeof content>
-
-
-
     },
 
     precomputeEffectsContainer: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
@@ -399,7 +417,6 @@ ${p_containerActionVal(memoEntityIndex, StatKey.CD, config)} += finalBuffCd;
   }
 }
 
-
 const scoring = (): ScoringMetadata => ({
   stats: {
     [Stats.ATK]: 0,
@@ -459,16 +476,18 @@ const displayStelle = {
 
 export const TrailblazerRemembranceCaelus: CharacterConfig = {
   id: '8007',
-  info: { displayName: 'Caelus (Remembrance)' },
   display: displayCaelus,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }
 
 export const TrailblazerRemembranceStelle: CharacterConfig = {
   id: '8008',
-  info: { displayName: 'Stelle (Remembrance)' },
   display: displayStelle,
   conditionals,
-  get scoring() { return scoring() },
+  get scoring() {
+    return scoring()
+  },
 }

--- a/src/lib/conditionals/conditionalUtils.ts
+++ b/src/lib/conditionals/conditionalUtils.ts
@@ -15,6 +15,11 @@ import {
  * Helper methods used in conditional files
  */
 
+export type Mutual<S, T> = {
+  [K in keyof S]: K extends keyof T ? S[K] extends T[K] ? T[K] : never
+    : never
+}
+
 export type ContentDefinition<T extends Record<string, unknown>> = {
   [K in keyof T]:
     & ContentItem
@@ -193,7 +198,6 @@ export function teammateConditionalActive(action: OptimizerAction, teammateId: s
 
   return teammateAction.characterConditionals[conditionalId]
 }
-
 
 // Returns the entity index of the memosprite, or -1 if not found
 export function findMemospriteIndex(action: OptimizerAction): number {

--- a/src/lib/conditionals/lightcone/5star/AThanklessCoronation.ts
+++ b/src/lib/conditionals/lightcone/5star/AThanklessCoronation.ts
@@ -48,6 +48,7 @@ const conditionals = (s: SuperImpositionLevel, withContent: boolean): LightConeC
       const r = action.lightConeConditionals as Conditionals<typeof content>
 
       x.buff(StatKey.ATK_P, (r.ultAtkBoost) ? sValuesUltAtk[s] : 0, x.damageType(DamageTag.ULT).source(SOURCE_LC))
+      x.buff(StatKey.ATK, (r.ultAtkBoost) ? sValuesUltAtk[s] * context.baseATK : 0, x.damageType(DamageTag.ULT).source(SOURCE_LC))
       x.buff(StatKey.ATK_P, (r.energyAtkBuff && context.baseEnergy >= 300) ? sValuesEnergyAtk[s] : 0, x.source(SOURCE_LC))
     },
   }

--- a/src/lib/conditionals/lightcone/5star/AThanklessCoronation.ts
+++ b/src/lib/conditionals/lightcone/5star/AThanklessCoronation.ts
@@ -10,7 +10,10 @@ import { TsUtils } from 'lib/utils/TsUtils'
 import { LightConeConditionalsController } from 'types/conditionals'
 import { SuperImpositionLevel } from 'types/lightCone'
 import { LightConeConfig } from 'types/lightConeConfig'
-import { OptimizerAction, OptimizerContext } from 'types/optimizer'
+import {
+  OptimizerAction,
+  OptimizerContext,
+} from 'types/optimizer'
 
 const conditionals = (s: SuperImpositionLevel, withContent: boolean): LightConeConditionalsController => {
   const t = TsUtils.wrappedFixedT(withContent).get(null, 'conditionals', 'Lightcones.AThanklessCoronation.Content')
@@ -47,7 +50,6 @@ const conditionals = (s: SuperImpositionLevel, withContent: boolean): LightConeC
     precomputeEffectsContainer: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
       const r = action.lightConeConditionals as Conditionals<typeof content>
 
-      x.buff(StatKey.ATK_P, (r.ultAtkBoost) ? sValuesUltAtk[s] : 0, x.damageType(DamageTag.ULT).source(SOURCE_LC))
       x.buff(StatKey.ATK, (r.ultAtkBoost) ? sValuesUltAtk[s] * context.baseATK : 0, x.damageType(DamageTag.ULT).source(SOURCE_LC))
       x.buff(StatKey.ATK_P, (r.energyAtkBuff && context.baseEnergy >= 300) ? sValuesEnergyAtk[s] : 0, x.source(SOURCE_LC))
     },

--- a/src/lib/conditionals/lightcone/5star/InTheNameOfTheWorld.ts
+++ b/src/lib/conditionals/lightcone/5star/InTheNameOfTheWorld.ts
@@ -55,7 +55,7 @@ const conditionals = (s: SuperImpositionLevel, withContent: boolean): LightConeC
       const r = action.lightConeConditionals as Conditionals<typeof content>
 
       x.buff(StatKey.DMG_BOOST, (r.enemyDebuffedDmgBoost) ? sValuesDmg[s] : 0, x.source(SOURCE_LC))
-      x.buff(StatKey.ATK_P, (r.skillAtkBoost) ? sValuesAtk[s] : 0, x.damageType(DamageTag.SKILL).source(SOURCE_LC))
+      x.buff(StatKey.ATK, (r.skillAtkBoost) ? sValuesAtk[s] * context.baseATK : 0, x.damageType(DamageTag.SKILL).source(SOURCE_LC))
     },
   }
 }

--- a/src/lib/gpu/tests/webgpuTestGenerator.ts
+++ b/src/lib/gpu/tests/webgpuTestGenerator.ts
@@ -1,12 +1,3 @@
-
-import {
-  generateTestRelics,
-  StatDeltaAnalysis,
-  testWrapper,
-} from 'lib/gpu/tests/webgpuTestUtils'
-import { getWebgpuDevice } from 'lib/gpu/webgpuDevice'
-import { RelicsByPart } from 'lib/gpu/webgpuTypes'
-import { SortOption } from 'lib/optimization/sortOptions'
 import { Archer } from 'lib/conditionals/character/1000/Archer'
 import { Saber } from 'lib/conditionals/character/1000/Saber'
 import { Anaxa } from 'lib/conditionals/character/1400/Anaxa'
@@ -29,7 +20,20 @@ import { ThoughWorldsApart } from 'lib/conditionals/lightcone/5star/ThoughWorlds
 import { ThusBurnsTheDawn } from 'lib/conditionals/lightcone/5star/ThusBurnsTheDawn'
 import { ToEvernightsStars } from 'lib/conditionals/lightcone/5star/ToEvernightsStars'
 import { WhyDoesTheOceanSing } from 'lib/conditionals/lightcone/5star/WhyDoesTheOceanSing'
+import {
+  generateTestRelics,
+  StatDeltaAnalysis,
+  testWrapper,
+} from 'lib/gpu/tests/webgpuTestUtils'
+import { getWebgpuDevice } from 'lib/gpu/webgpuDevice'
+import { RelicsByPart } from 'lib/gpu/webgpuTypes'
+import { SortOption } from 'lib/optimization/sortOptions'
 
+import i18next from 'i18next'
+import {
+  SetsOrnamentsNames,
+  SetsRelicsNames,
+} from 'lib/sets/setConfigRegistry'
 import { generateFullDefaultForm } from 'lib/simulations/utils/benchmarkForm'
 import DB from 'lib/state/db'
 import { OptimizerTabController } from 'lib/tabs/tabOptimizer/optimizerTabController'
@@ -40,10 +44,6 @@ import {
   DBMetadata,
   DBMetadataLightCone,
 } from 'types/metadata'
-import {
-  SetsOrnamentsNames,
-  SetsRelicsNames,
-} from 'lib/sets/setConfigRegistry'
 
 export type WebgpuTest = {
   name: string,
@@ -246,7 +246,7 @@ export function generateE0S1CharacterTest(characterId: CharacterId, lightConeId:
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
   return testWrapper(
-    `E0S1 ${cache.metadata.characters[characterId].displayName} — ${cache.metadata.lightCones[lightConeId].displayName}`,
+    `E0S1 ${i18next.t(`gameData:Characters.${characterId}.LongName`)} — ${i18next.t(`gameData:Lightcones.${lightConeId}.Name`)}`,
     request,
     relics,
     device,
@@ -264,7 +264,7 @@ export function generateE6S5CharacterTest(characterId: CharacterId, lightConeId:
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
   return testWrapper(
-    `E6S5 ${cache.metadata.characters[characterId].displayName} — ${cache.metadata.lightCones[lightConeId].displayName}`,
+    `E6S5 ${i18next.t(`gameData:Characters.${characterId}.LongName`)} — ${i18next.t(`gameData:Lightcones.${lightConeId}.Name`)}`,
     request,
     relics,
     device,

--- a/src/lib/optimization/engine/config/keys.ts
+++ b/src/lib/optimization/engine/config/keys.ts
@@ -7,19 +7,28 @@ export type AKeyType = keyof typeof newStatsConfig
 // Branded types for type safety
 declare const AKeyBrand: unique symbol
 declare const HKeyBrand: unique symbol
+declare const HitAKeyBrand: unique symbol
 
 export type AKeyValue = number & { readonly [AKeyBrand]: true }
 export type HKeyValue = number & { readonly [HKeyBrand]: true }
 
+// HitAKeyValue extends AKeyValue: hit stat indices are a subtype of action stat indices
+export type HitAKeyValue = AKeyValue & { readonly [HitAKeyBrand]: true }
+
 // ============== AKey ==============
 
-export const AKey: Record<AKeyType, AKeyValue> = Object.keys(newStatsConfig).reduce(
+// Hit stats map to HitAKeyValue, action-only stats to AKeyValue
+export type AKeyRecord = {
+  [K in AKeyType]: typeof newStatsConfig[K] extends { hit: true } ? HitAKeyValue : AKeyValue
+}
+
+export const AKey = Object.keys(newStatsConfig).reduce(
   (acc, key, index) => {
     acc[key as AKeyType] = index as AKeyValue
     return acc
   },
   {} as Record<AKeyType, AKeyValue>,
-)
+) as AKeyRecord  // narrowing: AKeyRecord extends Record<AKeyType, AKeyValue> since HitAKeyValue extends AKeyValue
 
 const AKeyNames = Object.keys(newStatsConfig) as AKeyType[]
 
@@ -32,7 +41,6 @@ export function getAKeyName(key: AKeyValue): AKeyType {
 const hitStatEntries = Object.entries(newStatsConfig)
   .filter(([_, value]) => (value as { hit?: boolean }).hit)
 
-// HKeyType is the subset of AKeyType that has hit: true
 export type HKeyType = (typeof hitStatEntries)[number][0]
 
 export const HKey = hitStatEntries.reduce(

--- a/src/lib/optimization/engine/config/statsConfig.ts
+++ b/src/lib/optimization/engine/config/statsConfig.ts
@@ -34,10 +34,10 @@ const optimizerTabResPen = createI18nKey<keyof Resources['common']['Elements']>(
 export const newStatsConfig = {
   // ================ Hit Stats ================
 
-  HP_P: { hit: true, label: commonReadableStat('HP%') },
-  ATK_P: { hit: true, label: commonReadableStat('ATK%') },
-  DEF_P: { hit: true, label: commonReadableStat('DEF%') },
-  SPD_P: { hit: true, label: commonReadableStat('SPD%') },
+  HP_P: { label: commonReadableStat('HP%') },
+  ATK_P: { label: commonReadableStat('ATK%') },
+  DEF_P: { label: commonReadableStat('DEF%') },
+  SPD_P: { label: commonReadableStat('SPD%') },
   HP: { hit: true, flat: true, label: commonReadableStat('HP') },
   ATK: { hit: true, flat: true, label: commonReadableStat('ATK') },
   DEF: { hit: true, flat: true, label: commonReadableStat('DEF') },

--- a/src/lib/optimization/engine/container/buffBuilder.ts
+++ b/src/lib/optimization/engine/container/buffBuilder.ts
@@ -15,8 +15,9 @@ import {
 } from 'lib/optimization/engine/config/tag'
 import { ComputedStatsContainerConfig } from 'lib/optimization/engine/container/computedStatsContainer'
 
-export class BuffBuilder<_Completed extends boolean = false> {
+export class BuffBuilder<_Completed extends boolean = false, _HasHitFilter extends boolean = false> {
   private readonly _completionBrand!: _Completed
+  declare readonly _hitFilterBrand: _HasHitFilter
 
   _actionKind: string | undefined = undefined
   _elementTags = ALL_ELEMENT_TAGS
@@ -31,13 +32,11 @@ export class BuffBuilder<_Completed extends boolean = false> {
 
   private config!: ComputedStatsContainerConfig
 
-  constructor() {}
-
   setConfig(config: ComputedStatsContainerConfig): void {
     this.config = config
   }
 
-  reset(): IncompleteBuffBuilder {
+  reset(): IncompleteActionBuff {
     this._actionKind = undefined
     this._elementTags = ALL_ELEMENT_TAGS
     this._damageTags = ALL_DAMAGE_TAGS
@@ -48,63 +47,67 @@ export class BuffBuilder<_Completed extends boolean = false> {
     this._targetTags = TargetTag.SelfAndPet
     this._deferrable = false
     this._source = Source.NONE
-    return this as IncompleteBuffBuilder
+    return this as IncompleteActionBuff
   }
 
-  elements(e: ElementTag): IncompleteBuffBuilder {
+  // Hit-filter methods - mark _HasHitFilter as true
+  elements(e: ElementTag): IncompleteHitBuff {
     this._elementTags = e
-    return this as IncompleteBuffBuilder
+    return this as IncompleteHitBuff
   }
 
-  damageType(d: DamageTag): IncompleteBuffBuilder {
+  damageType(d: DamageTag): IncompleteHitBuff {
     // BREAK buffs should also affect SUPER_BREAK hits
     if (d & DamageTag.BREAK) d |= DamageTag.SUPER_BREAK
     this._damageTags = d
-    return this as IncompleteBuffBuilder
+    return this as IncompleteHitBuff
   }
 
-  outputType(o: OutputTag): IncompleteBuffBuilder {
+  outputType(o: OutputTag): IncompleteHitBuff {
     this._outputTags = o
-    return this as IncompleteBuffBuilder
+    return this as IncompleteHitBuff
   }
 
-  directness(d: DirectnessTag): IncompleteBuffBuilder {
+  directness(d: DirectnessTag): IncompleteHitBuff {
     this._directnessTag = d
-    return this as IncompleteBuffBuilder
+    return this as IncompleteHitBuff
   }
 
-  actionKind(k: string): IncompleteBuffBuilder {
+  // Non-filter methods - propagate _HasHitFilter
+  actionKind(k: string): BuffBuilder<false, _HasHitFilter> {
     this._actionKind = k
-    return this as IncompleteBuffBuilder
+    return this as BuffBuilder<false, _HasHitFilter>
   }
 
-  origin(e: string): IncompleteBuffBuilder {
+  origin(e: string): BuffBuilder<false, _HasHitFilter> {
     this._origin = this.config.entityRegistry.getIndex(e)
-    return this as IncompleteBuffBuilder
+    return this as BuffBuilder<false, _HasHitFilter>
   }
 
-  target(e: string): IncompleteBuffBuilder {
+  target(e: string): BuffBuilder<false, _HasHitFilter> {
     this._target = this.config.entityRegistry.getIndex(e)
     this._targetTags = TargetTag.None
-    return this as IncompleteBuffBuilder
+    return this as BuffBuilder<false, _HasHitFilter>
   }
 
-  targets(t: TargetTag): IncompleteBuffBuilder {
+  targets(t: TargetTag): BuffBuilder<false, _HasHitFilter> {
     this._targetTags = t
     if (t & TargetTag.SingleTarget) this._deferrable = true
-    return this as IncompleteBuffBuilder
+    return this as BuffBuilder<false, _HasHitFilter>
   }
 
-  deferrable(): IncompleteBuffBuilder {
+  deferrable(): BuffBuilder<false, _HasHitFilter> {
     this._deferrable = true
-    return this as IncompleteBuffBuilder
+    return this as BuffBuilder<false, _HasHitFilter>
   }
 
-  source(s: BuffSource): CompleteBuffBuilder {
+  source(s: BuffSource): BuffBuilder<true, _HasHitFilter> {
     this._source = s
-    return this as CompleteBuffBuilder
+    return this as BuffBuilder<true, _HasHitFilter>
   }
 }
 
-export type IncompleteBuffBuilder = BuffBuilder<false>
-export type CompleteBuffBuilder = BuffBuilder<true>
+export type IncompleteActionBuff = BuffBuilder<false, false>
+export type IncompleteHitBuff = BuffBuilder<false, true>
+export type CompleteActionBuff = BuffBuilder<true, false>
+export type CompleteHitBuff = BuffBuilder<true, true>

--- a/src/lib/optimization/engine/container/computedStatsContainer.ts
+++ b/src/lib/optimization/engine/container/computedStatsContainer.ts
@@ -1,6 +1,9 @@
 import { aKeyToConvertibleStat } from 'lib/conditionals/evaluation/statConversionConfig'
+import {
+  Stats,
+  StatsValues,
+} from 'lib/constants/constants'
 import { evaluateConditional } from 'lib/gpu/conditionals/dynamicConditionals'
-import { Stats, StatsValues } from 'lib/constants/constants'
 import {
   BasicStatsArray,
   BasicStatsArrayCore,
@@ -12,9 +15,10 @@ import {
   AKeyType,
   AKeyValue,
   AToHKey,
-  GLOBAL_REGISTERS_LENGTH,
   getAKeyName,
+  GLOBAL_REGISTERS_LENGTH,
   HIT_STATS_LENGTH,
+  HitAKeyValue,
   HKeyValue,
   StatKey,
 } from 'lib/optimization/engine/config/keys'
@@ -32,8 +36,10 @@ import {
 } from 'lib/optimization/engine/config/tag'
 import {
   BuffBuilder,
-  CompleteBuffBuilder,
-  IncompleteBuffBuilder,
+  CompleteActionBuff,
+  CompleteHitBuff,
+  IncompleteActionBuff,
+  IncompleteHitBuff,
 } from 'lib/optimization/engine/container/buffBuilder'
 import { NamedArray } from 'lib/optimization/engine/util/namedArray'
 import {
@@ -128,7 +134,7 @@ function buildActionBuffIndexCache(
 function buildEntityTargetCaches(
   entities: OptimizerEntity[],
   entityStride: number,
-): { indices: Record<number, number[]>; offsets: Record<number, number[]> } {
+): { indices: Record<number, number[]>, offsets: Record<number, number[]> } {
   const indices: Record<number, number[]> = {}
   const offsets: Record<number, number[]> = {}
   const allTargetTags = Object.values(TargetTag).filter((v): v is number => typeof v === 'number')
@@ -408,7 +414,9 @@ export class ComputedStatsContainer {
 
   // ============== Buffs ==============
 
-  set(key: AKeyValue, value: number, config: BuffBuilder<true>) {
+  set(key: HitAKeyValue, value: number, config: CompleteActionBuff | CompleteHitBuff): void
+  set(key: AKeyValue, value: number, config: CompleteActionBuff): void
+  set(key: AKeyValue, value: number, config: CompleteActionBuff | CompleteHitBuff) {
     this.internalBuff(
       key,
       value,
@@ -426,7 +434,9 @@ export class ComputedStatsContainer {
     )
   }
 
-  buff(key: AKeyValue, value: number, config: BuffBuilder<true>) {
+  buff(key: HitAKeyValue, value: number, config: CompleteActionBuff | CompleteHitBuff): void
+  buff(key: AKeyValue, value: number, config: CompleteActionBuff): void
+  buff(key: AKeyValue, value: number, config: CompleteActionBuff | CompleteHitBuff) {
     this.internalBuff(
       key,
       value,
@@ -444,7 +454,9 @@ export class ComputedStatsContainer {
     )
   }
 
-  multiply(key: AKeyValue, value: number, config: BuffBuilder<true>) {
+  multiply(key: HitAKeyValue, value: number, config: CompleteActionBuff | CompleteHitBuff): void
+  multiply(key: AKeyValue, value: number, config: CompleteActionBuff): void
+  multiply(key: AKeyValue, value: number, config: CompleteActionBuff | CompleteHitBuff) {
     this.internalBuff(
       key,
       value,
@@ -462,7 +474,9 @@ export class ComputedStatsContainer {
     )
   }
 
-  multiplicativeComplement(key: AKeyValue, value: number, config: BuffBuilder<true>) {
+  multiplicativeComplement(key: HitAKeyValue, value: number, config: CompleteActionBuff | CompleteHitBuff): void
+  multiplicativeComplement(key: AKeyValue, value: number, config: CompleteActionBuff): void
+  multiplicativeComplement(key: AKeyValue, value: number, config: CompleteActionBuff | CompleteHitBuff) {
     this.internalBuff(
       key,
       value,
@@ -480,7 +494,9 @@ export class ComputedStatsContainer {
     )
   }
 
-  multiplicativeBoost(key: AKeyValue, value: number, config: BuffBuilder<true>) {
+  multiplicativeBoost(key: HitAKeyValue, value: number, config: CompleteActionBuff | CompleteHitBuff): void
+  multiplicativeBoost(key: AKeyValue, value: number, config: CompleteActionBuff): void
+  multiplicativeBoost(key: AKeyValue, value: number, config: CompleteActionBuff | CompleteHitBuff) {
     this.internalBuff(
       key,
       value,
@@ -498,7 +514,9 @@ export class ComputedStatsContainer {
     )
   }
 
-  buffDynamic(key: AKeyValue, value: number, action: OptimizerAction, context: OptimizerContext, config: BuffBuilder<true>) {
+  buffDynamic(key: HitAKeyValue, value: number, action: OptimizerAction, context: OptimizerContext, config: CompleteActionBuff | CompleteHitBuff): void
+  buffDynamic(key: AKeyValue, value: number, action: OptimizerAction, context: OptimizerContext, config: CompleteActionBuff): void
+  buffDynamic(key: AKeyValue, value: number, action: OptimizerAction, context: OptimizerContext, config: CompleteActionBuff | CompleteHitBuff) {
     this.internalBuff(
       key,
       value,
@@ -781,43 +799,43 @@ export class ComputedStatsContainer {
 
   // ============== Buff Builder ==============
 
-  elements(e: ElementTag): IncompleteBuffBuilder {
+  elements(e: ElementTag): IncompleteHitBuff {
     return this.builder.reset().elements(e)
   }
 
-  damageType(d: DamageTag): IncompleteBuffBuilder {
+  damageType(d: DamageTag): IncompleteHitBuff {
     return this.builder.reset().damageType(d)
   }
 
-  origin(o: string): IncompleteBuffBuilder {
+  origin(o: string): IncompleteActionBuff {
     return this.builder.reset().origin(o)
   }
 
-  target(e: string): IncompleteBuffBuilder {
+  target(e: string): IncompleteActionBuff {
     return this.builder.reset().target(e)
   }
 
-  targets(t: TargetTag): IncompleteBuffBuilder {
+  targets(t: TargetTag): IncompleteActionBuff {
     return this.builder.reset().targets(t)
   }
 
-  outputType(o: OutputTag): IncompleteBuffBuilder {
+  outputType(o: OutputTag): IncompleteHitBuff {
     return this.builder.reset().outputType(o)
   }
 
-  directness(d: DirectnessTag): IncompleteBuffBuilder {
+  directness(d: DirectnessTag): IncompleteHitBuff {
     return this.builder.reset().directness(d)
   }
 
-  actionKind(k: string): IncompleteBuffBuilder {
+  actionKind(k: string): IncompleteActionBuff {
     return this.builder.reset().actionKind(k)
   }
 
-  deferrable(): IncompleteBuffBuilder {
+  deferrable(): IncompleteActionBuff {
     return this.builder.reset().deferrable()
   }
 
-  source(s: BuffSource): CompleteBuffBuilder {
+  source(s: BuffSource): CompleteActionBuff {
     return this.builder.reset().source(s)
   }
 
@@ -871,10 +889,10 @@ const ContainerKeyToExternal: Partial<Record<AKeyType, StatsValues>> = {
 }
 
 export type OptimizerEntity = EntityDefinition & {
-  name: string
-  targetMask: number
-  baseAtk: number
-  baseDef: number
-  baseHp: number
-  baseSpd: number
+  name: string,
+  targetMask: number,
+  baseAtk: number,
+  baseDef: number,
+  baseHp: number,
+  baseSpd: number,
 }

--- a/src/lib/overlays/modals/BuildsModal.tsx
+++ b/src/lib/overlays/modals/BuildsModal.tsx
@@ -295,6 +295,7 @@ export function BuildList(props: BuildListProps) {
         overflowY: 'auto',
         marginBottom: 20,
         width: '100%',
+        minWidth: 400,
         height: 840,
         ...style,
       }}
@@ -391,7 +392,19 @@ function BuildCard(props: BuildCardProps) {
       <Flex vertical gap={8}>
         <Flex justify='space-between' gap={8} align='center'>
           <Flex vertical align='flex-start'>
-            <HeaderText style={{ flex: 1, fontSize: 16, fontWeight: 600, maxWidth: preview ? 350 : 85, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{build.name}</HeaderText>
+            <HeaderText
+              style={{
+                flex: 1,
+                fontSize: 16,
+                fontWeight: 600,
+                maxWidth: preview ? 350 : 85,
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {build.name}
+            </HeaderText>
           </Flex>
           {!preview && (
             <Flex gap={5}>

--- a/src/lib/overlays/modals/SaveBuildModal.tsx
+++ b/src/lib/overlays/modals/SaveBuildModal.tsx
@@ -23,7 +23,6 @@ import { SaveState } from 'lib/state/saveState'
 import { CharacterTabController } from 'lib/tabs/tabCharacters/characterTabController'
 import {
   ReactNode,
-  useEffect,
   useMemo,
   useState,
 } from 'react'
@@ -162,8 +161,12 @@ export function SaveBuildModal(props: {
               superimposition: t.lightConeSuperimposition,
               relicSet: t.teamRelicSet,
               ornamentSet: t.teamOrnamentSet,
+              characterConditionals: t.characterConditionals,
+              lightConeConditionals: t.lightConeConditionals,
             })),
           equipped: window.store.getState().optimizerBuild ?? {},
+          characterConditionals: form.getFieldValue('characterConditionals'),
+          lightConeConditionals: form.getFieldValue('lightConeConditionals'),
         }
     }
   }, [selectedBuild, source, character])
@@ -180,7 +183,7 @@ export function SaveBuildModal(props: {
     >
       {contextHolder}
       <Flex gap={10} style={{ height: 856 }}>
-        <Flex vertical style={{ width: 400 }}>
+        <Flex vertical>
           <Form
             form={characterForm}
             preserve={false}

--- a/src/lib/rendering/assets.ts
+++ b/src/lib/rendering/assets.ts
@@ -9,6 +9,7 @@ import {
 import { setToId } from 'lib/sets/setConfigRegistry'
 import { BASE_PATH } from 'lib/state/db'
 import { Languages } from 'lib/utils/i18nUtils'
+import { Nullable } from 'types/common'
 
 // let baseUrl = process.env.PUBLIC_URL // Local testing;
 // const baseUrl = 'https://d28ecrnsw8u0fj.cloudfront.net'
@@ -77,12 +78,12 @@ export const Assets = {
     if (!lightCone) return Assets.getBlank()
     return getImageUrl(`/image/light_cone_portrait/${lightCone.id}.webp`)
   },
-  getLightConePortraitById: (lightConeId: string) => {
+  getLightConePortraitById: (lightConeId: Nullable<string>) => {
     if (!lightConeId) return Assets.getBlank()
     return getImageUrl(`/image/light_cone_portrait/${lightConeId}.webp`)
   },
 
-  getLightConeIconById: (lightConeId?: string) => {
+  getLightConeIconById: (lightConeId: Nullable<string>) => {
     if (!lightConeId) return Assets.getBlankLightCone()
     return getImageUrl(`/icon/light_cone/${lightConeId}.webp`)
   },

--- a/src/lib/scoring/scoringConstants.ts
+++ b/src/lib/scoring/scoringConstants.ts
@@ -1,15 +1,5 @@
 import { Sets } from 'lib/constants/constants'
 
-export const MATCH_2P_WEIGHT = 0.75
-export const T2_WEIGHT = 0.9
-
-export function weights<K extends string>(sets: K[], weight: number = 1) {
-  return sets.reduce((acc, set) => {
-    acc[set] = weight
-    return acc
-  }, {} as Record<K, number>)
-}
-
 export const RELICS_2P_BREAK_EFFECT_SPEED = [
   Sets.MessengerTraversingHackerspace,
   Sets.SacerdosRelivedOrdeal,
@@ -32,31 +22,6 @@ export const RELICS_2P_ATK = [
   Sets.HeroOfTriumphantSong,
 ]
 
-export const SPREAD_RELICS_2P_SPEED_WEIGHTS = {
-  [Sets.WarriorGoddessOfSunAndThunder]: MATCH_2P_WEIGHT,
-  [Sets.MessengerTraversingHackerspace]: MATCH_2P_WEIGHT,
-  [Sets.SacerdosRelivedOrdeal]: MATCH_2P_WEIGHT,
-}
-
-export const SPREAD_RELICS_2P_BREAK_WEIGHTS = {
-  [Sets.ThiefOfShootingMeteor]: MATCH_2P_WEIGHT,
-  [Sets.WatchmakerMasterOfDreamMachinations]: MATCH_2P_WEIGHT,
-  [Sets.IronCavalryAgainstTheScourge]: MATCH_2P_WEIGHT,
-}
-
-export const SPREAD_RELICS_2P_ATK_WEIGHTS = {
-  [Sets.MusketeerOfWildWheat]: MATCH_2P_WEIGHT,
-  [Sets.PrisonerInDeepConfinement]: MATCH_2P_WEIGHT,
-  [Sets.TheWindSoaringValorous]: MATCH_2P_WEIGHT,
-  [Sets.HeroOfTriumphantSong]: MATCH_2P_WEIGHT,
-}
-
-export const SPREAD_RELICS_2P_ATK_CRIT_WEIGHTS = {
-  ...SPREAD_RELICS_2P_ATK_WEIGHTS,
-  [Sets.ScholarLostInErudition]: MATCH_2P_WEIGHT,
-  [Sets.WorldRemakingDeliverer]: MATCH_2P_WEIGHT,
-}
-
 export const SPREAD_RELICS_4P_GENERAL_CONDITIONALS = [
   [Sets.WavestriderCaptain, Sets.WavestriderCaptain],
   [Sets.PoetOfMourningCollapse, Sets.PoetOfMourningCollapse],
@@ -70,8 +35,6 @@ export const SPREAD_ORNAMENTS_2P_FUA = [
   Sets.InertSalsotto,
 ]
 
-export const SPREAD_ORNAMENTS_2P_FUA_WEIGHTS = weights(SPREAD_ORNAMENTS_2P_FUA)
-
 export const SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS = [
   Sets.SigoniaTheUnclaimedDesolation,
   Sets.ArcadiaOfWovenDreams,
@@ -83,8 +46,6 @@ export const SPREAD_ORNAMENTS_2P_ENERGY_REGEN = [
   Sets.LushakaTheSunkenSeas,
 ]
 
-export const SPREAD_ORNAMENTS_2P_ENERGY_REGEN_WEIGHTS = weights(SPREAD_ORNAMENTS_2P_ENERGY_REGEN)
-
 export const SPREAD_ORNAMENTS_2P_SUPPORT = [
   Sets.SprightlyVonwacq,
   Sets.BrokenKeel,
@@ -94,5 +55,3 @@ export const SPREAD_ORNAMENTS_2P_SUPPORT = [
   Sets.ForgeOfTheKalpagniLantern,
   Sets.GiantTreeOfRaptBrooding,
 ]
-
-export const SPREAD_ORNAMENTS_2P_SUPPORT_WEIGHTS = weights(SPREAD_ORNAMENTS_2P_SUPPORT)

--- a/src/lib/simulations/tests/customBenchmark/benchmarkOrchestratorTestUtils.ts
+++ b/src/lib/simulations/tests/customBenchmark/benchmarkOrchestratorTestUtils.ts
@@ -1,3 +1,4 @@
+import i18next from 'i18next'
 import {
   applyScoringMetadataPresets,
   applySetConditionalPresets,
@@ -63,7 +64,7 @@ export async function expectBenchmarkResultsToMatch(
     // @ts-ignore
     const message = error.message
     throw new Error(`
-${DB.getMetadata().characters[input.character.characterId].displayName} BENCHMARK
+${i18next.t(`gameData:Characters.${input.character.characterId}.LongName`)} BENCHMARK
 ${message}
 ${JSON.stringify(input, null, 2)}
       `)

--- a/src/lib/simulations/tests/dpsScore/dpsScoreOrchestratorTestUtils.ts
+++ b/src/lib/simulations/tests/dpsScore/dpsScoreOrchestratorTestUtils.ts
@@ -1,3 +1,4 @@
+import i18next from 'i18next'
 import { runDpsScoreBenchmarkOrchestrator } from 'lib/simulations/orchestrator/runDpsScoreBenchmarkOrchestrator'
 import {
   generateTestSingleRelicsByPart,
@@ -45,7 +46,7 @@ export async function expectDpsScoreResultsToMatch(
     // @ts-ignore
     const message = error.message
     throw new Error(`
-${DB.getMetadata().characters[input.character.characterId].displayName} BENCHMARK
+${i18next.t(`gameData:Characters.${input.character.characterId}.LongName`)} BENCHMARK
 ${message}
 ${JSON.stringify(input, null, 2)}
       `)

--- a/src/lib/simulations/tests/statSim/statSimTestUtils.ts
+++ b/src/lib/simulations/tests/statSim/statSimTestUtils.ts
@@ -1,3 +1,4 @@
+import i18next from 'i18next'
 import {
   collectResults,
   TestInput,
@@ -27,7 +28,7 @@ function expectSingleResultsToMatch(actual: TestResultByName, expected: TestResu
       // @ts-ignore
       const message = error.message
       throw new Error(`
-${DB.getMetadata().characters[input.character.characterId].displayName} ${key} ${view}
+${i18next.t(`gameData:Characters.${input.character.characterId}.LongName`)} ${key} ${view}
 ${message}
 ${JSON.stringify(input, null, 2)}
       `)

--- a/src/lib/state/db.ts
+++ b/src/lib/state/db.ts
@@ -66,8 +66,10 @@ import {
   CharacterId,
   SavedBuild,
 } from 'types/character'
+import { ConditionalValueMap } from 'types/conditionals'
 import { CustomImageConfig } from 'types/customImage'
 import { Form } from 'types/form'
+import { LightConeId } from 'types/lightCone'
 import {
   DBMetadata,
   ScoringMetadata,
@@ -606,7 +608,24 @@ export const DB = {
       // TODO: Temporary migration from old to new format, remove once appropriate
       const scoringMetadata = DB.getScoringMetadata(character.id)
       character.builds = character.builds?.map((savedBuild) => {
-        if (savedBuild.optimizerMetadata !== undefined) return savedBuild
+        if (savedBuild.optimizerMetadata !== undefined) {
+          if (savedBuild.characterConditionals !== undefined) return savedBuild
+          // sub-migration to where conditionals are saved
+          // build format is otherwise correct, so relocate conditionals and return
+          const updatedBuild = { ...savedBuild }
+          // @ts-ignore
+          const oldConditionals: Record<CharacterId | LightConeId, ConditionalValueMap> | undefined = savedBuild.optimizerMetadata?.conditionals
+          updatedBuild.characterConditionals = oldConditionals?.[character.id]
+          updatedBuild.lightConeConditionals = oldConditionals?.[savedBuild.lightConeId!]
+          updatedBuild.team = savedBuild.team.map((x) => ({
+            ...x,
+            characterConditionals: oldConditionals?.[x.characterId],
+            lightConeConditionals: oldConditionals?.[x.lightConeId!],
+          }))
+          // @ts-ignore
+          if (updatedBuild.optimizerMetadata) delete updatedBuild.optimizerMetadata.conditionals
+          return updatedBuild
+        }
         const build = savedBuild as unknown as { build: string[], name: string, score: { score: string, rating: string } }
         const migratedBuild: SavedBuild = {
           characterId: character.id,
@@ -626,9 +645,13 @@ export const DB = {
             superimposition: x.lightConeSuperimposition,
             relicSet: x.teamRelicSet,
             ornamentSet: x.teamOrnamentSet,
+            characterConditionals: undefined,
+            lightConeConditionals: undefined,
           })) ?? [],
           optimizerMetadata: null,
           deprioritizeBuffs: scoringMetadata.simulation?.deprioritizeBuffs ?? false,
+          characterConditionals: undefined,
+          lightConeConditionals: undefined,
         }
         return migratedBuild
       }) ?? []
@@ -831,7 +854,6 @@ export const DB = {
       case SavedBuildSource.OPTIMIZER:
         const formData = OptimizerTabController.formToDisplay(OptimizerTabController.getForm())
         const optimizerMetadata: BuildOptimizerMetadata = {
-          conditionals: {},
           setFilters: {
             relics: TsUtils.clone(formData.relicSets),
             ornaments: TsUtils.clone(formData.ornamentSets),
@@ -841,8 +863,6 @@ export const DB = {
           setConditionals: TsUtils.clone(formData.setConditionals),
           presets: formData.comboPreprocessor,
         }
-        optimizerMetadata.conditionals[formData.characterId] = TsUtils.clone(formData.characterConditionals)
-        optimizerMetadata.conditionals[formData.lightCone] = TsUtils.clone(formData.lightConeConditionals)
         ;[formData.teammate0, formData.teammate1, formData.teammate2].forEach((teammate) => {
           team.push({
             characterId: teammate.characterId,
@@ -851,9 +871,9 @@ export const DB = {
             superimposition: teammate.lightConeSuperimposition,
             relicSet: teammate.teamRelicSet,
             ornamentSet: teammate.teamOrnamentSet,
+            characterConditionals: TsUtils.clone(teammate.characterConditionals),
+            lightConeConditionals: TsUtils.clone(teammate.lightConeConditionals),
           })
-          if (teammate.characterId) optimizerMetadata.conditionals[teammate.characterId] = TsUtils.clone(teammate.characterConditionals)
-          if (teammate.lightCone) optimizerMetadata.conditionals[teammate.lightCone] = TsUtils.clone(teammate.lightConeConditionals)
         })
 
         build = {
@@ -866,6 +886,8 @@ export const DB = {
           optimizerMetadata,
           team,
           deprioritizeBuffs: formData.deprioritizeBuffs ?? false,
+          characterConditionals: TsUtils.clone(formData.characterConditionals),
+          lightConeConditionals: TsUtils.clone(formData.lightConeConditionals),
         }
         break
       case SavedBuildSource.SHOWCASE:
@@ -881,6 +903,8 @@ export const DB = {
               superimposition: teammate.lightConeSuperimposition,
               relicSet: teammate.teamRelicSet,
               ornamentSet: teammate.teamOrnamentSet,
+              characterConditionals: undefined,
+              lightConeConditionals: undefined,
             })
           })
         }
@@ -894,6 +918,8 @@ export const DB = {
           optimizerMetadata: null,
           team,
           deprioritizeBuffs: simulation?.deprioritizeBuffs ?? false,
+          characterConditionals: undefined,
+          lightConeConditionals: undefined,
         }
         break
       default:
@@ -1460,6 +1486,8 @@ function loadCharacterBuildInOptimizer(arg1: CharacterId | SavedBuild, buildInde
   form.setFieldValue('characterEidolon', build.eidolon)
   form.setFieldValue('lightCone', build.lightConeId)
   form.setFieldValue('lightConeSuperimposition', build.superimposition)
+  form.setFieldValue('characterConditionals', TsUtils.clone(build.characterConditionals))
+  form.setFieldValue('lightConeConditionals', TsUtils.clone(build.lightConeConditionals))
 
   form.setFieldValue('deprioritizeBuffs', build.deprioritizeBuffs)
 
@@ -1477,6 +1505,8 @@ function loadCharacterBuildInOptimizer(arg1: CharacterId | SavedBuild, buildInde
       form.setFieldValue([key, 'lightConeSuperimposition'], teammate.superimposition)
       form.setFieldValue([key, 'teamOrnamentSet'], teammate.ornamentSet)
       form.setFieldValue([key, 'teamRelicSet'], teammate.relicSet)
+      form.setFieldValue([key, 'characterConditionals'], TsUtils.clone(teammate.characterConditionals))
+      form.setFieldValue([key, 'lightConeConditionals'], TsUtils.clone(teammate.lightConeConditionals))
     } else {
       form.setFieldsValue({ [key]: defaultTeammate() })
       continue
@@ -1492,7 +1522,6 @@ function loadCharacterBuildInOptimizer(arg1: CharacterId | SavedBuild, buildInde
         form.setFieldValue([key, 'lightConeConditionals'], matchingDbTeammate.lightConeConditionals)
       } else {
         // Otherwise set to defaults
-        const lightConePath = metadata.lightCones[teammate.lightConeId].path
         const path = metadata.characters[teammate.characterId].path
         const element = metadata.characters[teammate.characterId].element
 
@@ -1500,18 +1529,23 @@ function loadCharacterBuildInOptimizer(arg1: CharacterId | SavedBuild, buildInde
           .get({ characterId: teammate.characterId, characterEidolon: teammate.eidolon })
           .defaults()
 
-        const lightConeConditionals = LightConeConditionalsResolver
-          .get({
-            lightCone: teammate.lightConeId,
-            lightConeSuperimposition: teammate.superimposition,
-            lightConePath,
-            path,
-            element,
-            characterId: teammate.characterId,
-          })
-          .defaults()
+        if (teammate.lightConeId) {
+          const lightConePath = metadata.lightCones[teammate.lightConeId].path
+          const lightConeConditionals = LightConeConditionalsResolver
+            .get({
+              lightCone: teammate.lightConeId,
+              lightConeSuperimposition: teammate.superimposition,
+              lightConePath,
+              path,
+              element,
+              characterId: teammate.characterId,
+            })
+            .defaults()
+          form.setFieldValue([key, 'lightConeConditionals'], lightConeConditionals)
+        } else {
+          form.setFieldValue([key, 'lightConeConditionals'], defaultTeammate().lightConeConditionals)
+        }
         form.setFieldValue([key, 'characterConditionals'], characterConditionals)
-        form.setFieldValue([key, 'lightConeConditionals'], lightConeConditionals)
       }
     }
   }
@@ -1539,44 +1573,8 @@ function loadCharacterBuildInOptimizer(arg1: CharacterId | SavedBuild, buildInde
     form.setFieldValue('relicSets', TsUtils.clone(meta.setFilters.relics))
     form.setFieldValue('ornamentSets', TsUtils.clone(meta.setFilters.ornaments))
     form.setFieldValue('setConditionals', TsUtils.clone(meta.setConditionals))
-    definedEntries(meta.conditionals)
-      .forEach(([id, conditionalValueMap]) => {
-        if (id === build.characterId) {
-          form.setFieldValue('characterConditionals', TsUtils.clone(conditionalValueMap))
-          return
-        }
-        if (id === build.lightConeId) {
-          form.setFieldValue('lightConeConditionals', TsUtils.clone(conditionalValueMap))
-          return
-        }
-
-        let teammateIdx = build.team.findIndex((x) => x.characterId === id)
-        switch (teammateIdx) {
-          case 0:
-          case 1:
-          case 2:
-            form.setFieldValue([`teammate${teammateIdx}`, 'characterConditionals'], TsUtils.clone(conditionalValueMap))
-            return
-          default:
-            break
-        }
-
-        teammateIdx = build.team.findIndex((x) => x.lightConeId === id)
-        switch (teammateIdx) {
-          case 0:
-          case 1:
-          case 2:
-            form.setFieldValue([`teammate${teammateIdx}`, 'lightConeConditionals'], TsUtils.clone(conditionalValueMap))
-            return
-          default:
-            break
-        }
-
-        console.error('Found orphaned conditional while loading build')
-      })
   }
 
   window.store.getState().setActiveKey(AppPages.OPTIMIZER)
-  window.store.getState().setSavedSessionKey(SavedSessionKeys.optimizerCharacterId, characterId)
   SaveState.delayedSave()
 }

--- a/src/lib/state/metadataInitializer.ts
+++ b/src/lib/state/metadataInitializer.ts
@@ -89,7 +89,6 @@ export const Metadata = {
 
     for (const lightCone of Object.values(lightCones)) {
       lightCone.superimpositions = convertLcSuperimpositions(lightCone)
-      lightCone.displayName = lightCone.name
       applyLightConeDisplayConfig(lightConeConfigs, lightCone)
     }
 
@@ -160,13 +159,11 @@ function applyCharacterConfig(
 ) {
   const config = characterConfigs.get(characterId as CharacterId)
   const imageCenter = config?.display.imageCenter ?? DEFAULT_IMAGE_CENTER
-  const displayName = config?.info.displayName ?? characters[characterId].name
   const metadata = config?.scoring
 
   characters[characterId].traces = dbMetadataCharacter.traces
   characters[characterId].traceTree = dbMetadataCharacter.traceTree
   characters[characterId].imageCenter = imageCenter
-  characters[characterId].displayName = displayName
 
   if (metadata) {
     for (const part of [Parts.Body, Parts.Feet, Parts.PlanarSphere, Parts.LinkRope]) {

--- a/src/lib/tabs/tabOptimizer/UnreleasedCharacterDisclaimer.tsx
+++ b/src/lib/tabs/tabOptimizer/UnreleasedCharacterDisclaimer.tsx
@@ -4,41 +4,35 @@ import {
 } from 'antd'
 import DB from 'lib/state/db'
 import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
 import { CharacterId } from 'types/character'
-import { LightCone } from 'types/lightCone'
+import {
+  LightCone,
+  LightConeId,
+} from 'types/lightCone'
 
-const UNRELEASED_CHARACTER_IDS = new Set<string>([
-  // '1501', // Sparxie
-  // '1502', // Yao Guang
-])
+const UNRELEASED_CHARACTER_IDS = new Set<CharacterId>([])
 
-const UNRELEASED_LIGHT_CONE_IDS = new Set<string>([
-  // '23053', // Dazzled by a Flowery World
-  // '23054', // When She Decided to See
-  // // '24006', // Elation Brimming With Blessings
-  // '21064', // Mushy Shroomy's Adventures
-  // '21065', // Today's Good Luck
-  // '20023', // Sneering
-  // '20024', // Lingering Tear
-])
+const UNRELEASED_LIGHT_CONE_IDS = new Set<LightConeId>([])
 
 export function UnreleasedCharacterDisclaimer() {
-  const characterId: CharacterId = AntDForm.useWatch(['characterId'], window.optimizerForm)
-  const lightConeId: string = AntDForm.useWatch(['lightCone'], window.optimizerForm)
-  const teammate0CharId: CharacterId = AntDForm.useWatch(['teammate0', 'characterId'], window.optimizerForm)
-  const teammate1CharId: CharacterId = AntDForm.useWatch(['teammate1', 'characterId'], window.optimizerForm)
-  const teammate2CharId: CharacterId = AntDForm.useWatch(['teammate2', 'characterId'], window.optimizerForm)
-  const teammate0LcId: string = AntDForm.useWatch(['teammate0', 'lightCone'], window.optimizerForm)
-  const teammate1LcId: string = AntDForm.useWatch(['teammate1', 'lightCone'], window.optimizerForm)
-  const teammate2LcId: string = AntDForm.useWatch(['teammate2', 'lightCone'], window.optimizerForm)
+  const { t: tGameData } = useTranslation('gameData')
+  const { t } = useTranslation('optimizerTab')
+  const characterId = AntDForm.useWatch(['characterId'], window.optimizerForm)
+  const lightConeId = AntDForm.useWatch(['lightCone'], window.optimizerForm)
+  const teammate0CharId = AntDForm.useWatch(['teammate0', 'characterId'], window.optimizerForm)
+  const teammate1CharId = AntDForm.useWatch(['teammate1', 'characterId'], window.optimizerForm)
+  const teammate2CharId = AntDForm.useWatch(['teammate2', 'characterId'], window.optimizerForm)
+  const teammate0LcId = AntDForm.useWatch(['teammate0', 'lightCone'], window.optimizerForm)
+  const teammate1LcId = AntDForm.useWatch(['teammate1', 'lightCone'], window.optimizerForm)
+  const teammate2LcId = AntDForm.useWatch(['teammate2', 'lightCone'], window.optimizerForm)
 
   const unreleasedNames = useMemo(() => {
-    const metadata = DB.getMetadata()
     const names: string[] = []
 
     for (const id of [characterId, teammate0CharId, teammate1CharId, teammate2CharId]) {
       if (id && UNRELEASED_CHARACTER_IDS.has(id)) {
-        const name = metadata.characters[id]?.displayName ?? id
+        const name = tGameData(`Characters.${id}.LongName`)
         if (!names.includes(name)) {
           names.push(name)
         }
@@ -47,7 +41,7 @@ export function UnreleasedCharacterDisclaimer() {
 
     for (const id of [lightConeId, teammate0LcId, teammate1LcId, teammate2LcId]) {
       if (id && UNRELEASED_LIGHT_CONE_IDS.has(id)) {
-        const name = metadata.lightCones[id as LightCone['id']]?.displayName ?? id
+        const name = tGameData(`Lightcones.${id}.Name`)
         if (!names.includes(name)) {
           names.push(name)
         }
@@ -55,7 +49,7 @@ export function UnreleasedCharacterDisclaimer() {
     }
 
     return names
-  }, [characterId, lightConeId, teammate0CharId, teammate1CharId, teammate2CharId, teammate0LcId, teammate1LcId, teammate2LcId])
+  }, [characterId, lightConeId, teammate0CharId, teammate1CharId, teammate2CharId, teammate0LcId, teammate1LcId, teammate2LcId, tGameData])
 
   if (unreleasedNames.length === 0) {
     return null
@@ -63,7 +57,8 @@ export function UnreleasedCharacterDisclaimer() {
 
   return (
     <Alert
-      message={`Calculations for ${unreleasedNames.join(', ')} are not complete yet, optimizer results will not be accurate`}
+      message={t('UnreleasedDisclaimer', { nameList: unreleasedNames.join(', ') })}
+      // `Calculations for ${unreleasedNames.join(', ')} are not complete yet, optimizer results will not be accurate`
       type='warning'
       showIcon
     />

--- a/src/lib/tabs/tabOptimizer/optimizerForm/components/LightConeSelect.tsx
+++ b/src/lib/tabs/tabOptimizer/optimizerForm/components/LightConeSelect.tsx
@@ -1,7 +1,17 @@
-import { Card, Flex, Input, InputRef, Modal, Select, } from 'antd'
+import {
+  Card,
+  Flex,
+  Input,
+  InputRef,
+  Modal,
+  Select,
+} from 'antd'
 import { PathName } from 'lib/constants/constants'
 import { Assets } from 'lib/rendering/assets'
-import { generateLightConeOptions, LcOptions, } from 'lib/rendering/optionGenerator'
+import {
+  generateLightConeOptions,
+  LcOptions,
+} from 'lib/rendering/optionGenerator'
 import DB from 'lib/state/db'
 import {
   CardGridItemContent,
@@ -12,7 +22,14 @@ import {
 import { TsUtils } from 'lib/utils/TsUtils'
 import { Utils } from 'lib/utils/utils'
 import * as React from 'react'
-import { ChangeEvent, ReactNode, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  ChangeEvent,
+  ReactNode,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import { useTranslation } from 'react-i18next'
 import { CharacterId } from 'types/character'
 import { LightConeId } from 'types/lightCone'
@@ -109,7 +126,7 @@ const LightConeSelect: React.FC<LightConeSelectProps> = (
     if (currentFilters.path.length && !currentFilters.path.includes(x.path)) {
       return false
     }
-    return x.name.toLowerCase().includes(currentFilters.name)
+    return x.label.toLowerCase().includes(currentFilters.name)
   }
 
   const handleClick = (id: LightConeId) => {

--- a/src/types/character.ts
+++ b/src/types/character.ts
@@ -41,7 +41,6 @@ export type SavedBuild = Prettify<
 >
 
 export type BuildOptimizerMetadata = {
-  conditionals: Partial<Record<CharacterId | LightConeId, ConditionalValueMap>>,
   comboStateJson: string | null,
   statFilters: StatFilters | null,
   setFilters: {
@@ -59,4 +58,6 @@ export type BuildTeammate = {
   superimposition: number,
   relicSet?: string,
   ornamentSet?: string,
+  characterConditionals: ConditionalValueMap | undefined,
+  lightConeConditionals: ConditionalValueMap | undefined,
 }

--- a/src/types/characterConfig.ts
+++ b/src/types/characterConfig.ts
@@ -1,28 +1,23 @@
 import {
   CharacterId,
-  Eidolon
+  Eidolon,
 } from 'types/character'
 import { CharacterConditionalsController } from 'types/conditionals'
 import { ScoringMetadata } from 'types/metadata'
 
-export type CharacterInfo = {
-  displayName?: string
-}
-
 export type CharacterDisplay = {
   imageCenter?: {
-    x: number
-    y: number
-    z: number
-  }
-  showcaseColor?: string
+    x: number,
+    y: number,
+    z: number,
+  },
+  showcaseColor?: string,
 }
 
 export type CharacterConfig = {
-  id: CharacterId
-  info: CharacterInfo
-  display: CharacterDisplay
-  conditionals: (e: Eidolon, withContent: boolean) => CharacterConditionalsController
+  id: CharacterId,
+  display: CharacterDisplay,
+  conditionals: (e: Eidolon, withContent: boolean) => CharacterConditionalsController,
   /** Getter — defers evaluation to avoid circular imports between config files */
-  scoring: ScoringMetadata
+  scoring: ScoringMetadata,
 }

--- a/src/types/metadata.ts
+++ b/src/types/metadata.ts
@@ -9,14 +9,14 @@ import {
   StatsValues,
   SubStats,
 } from 'lib/constants/constants'
-import {
-  SetsOrnaments,
-  SetsRelics,
-} from 'lib/sets/setConfigRegistry'
 import { statConversion } from 'lib/importer/characterConverter'
 import { TurnAbilityName } from 'lib/optimization/rotation/turnAbilityConfig'
 import { SortOptionProperties } from 'lib/optimization/sortOptions'
 import { PresetDefinition } from 'lib/scoring/presetEffects'
+import {
+  SetsOrnaments,
+  SetsRelics,
+} from 'lib/sets/setConfigRegistry'
 import { CharacterId } from 'types/character'
 import { LightConeId } from 'types/lightCone'
 
@@ -110,19 +110,16 @@ export type DBMetadataCharacter = {
   traces: Record<string, number>,
   traceTree: TraceNode[],
   imageCenter: ImageCenter,
-  displayName: string,
   scoringMetadata: ScoringMetadata,
 }
 
 export type DBMetadataLightCone = {
   id: LightConeId,
-  name: string,
   rarity: 5 | 4 | 3,
   path: PathName,
   stats: Record<string, number>,
   unreleased: boolean,
   superimpositions: Record<number, Record<string, number>>,
-  displayName: string,
   imageOffset: { x: number, y: number, s: number },
 }
 

--- a/src/types/resources.d.ts
+++ b/src/types/resources.d.ts
@@ -6013,6 +6013,7 @@ interface Resources {
     "ResultLimitN": "Find top {{limit}} results",
     "MainStats": "Main stats",
     "Sets": "Sets",
+    "UnreleasedDisclaimer": "Calculations for {{nameList}} are not complete yet, optimizer results will not be accurate",
     "RelicSetSelector": {
       "Placeholder": "Relic set",
       "4pcLabel": "4 Piece",
@@ -6714,7 +6715,7 @@ interface Resources {
         }
       },
       "DamageSplits": {
-        "Title": "Damage Type Distribution",
+        "Title": "Combo Breakdown",
         "Legend": {
           "abilityDmg": "Ability",
           "breakDmg": "Break",


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->
                                                                                                                                                                                                                                                                                                                                                                                           
- Reclassified percentage ATK buffs (ATK_P) to flat ATK with base multiplier                                                                                                                                                                                                                                                    
- Removed hit: true flag from percentage stats 
- Fixed AThanklessCoronation and InTheNameOfTheWorld

## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [ ] I have added commit messages that are descriptive and meaningful.
- [ ] I have tested the changes locally.
- [ ] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
