### PR TITLE
fix: hit-scoped ATK_P buffs not applied correctly, refactor to remove _P from hit stats

### DIFF
--- a/src/lib/conditionals/lightcone/5star/AThanklessCoronation.ts
+++ b/src/lib/conditionals/lightcone/5star/AThanklessCoronation.ts
@@ -48,6 +48,7 @@ const conditionals = (s: SuperImpositionLevel, withContent: boolean): LightConeC
       const r = action.lightConeConditionals as Conditionals<typeof content>
 
       x.buff(StatKey.ATK_P, (r.ultAtkBoost) ? sValuesUltAtk[s] : 0, x.damageType(DamageTag.ULT).source(SOURCE_LC))
+      x.buff(StatKey.ATK, (r.ultAtkBoost) ? sValuesUltAtk[s] * context.baseATK : 0, x.damageType(DamageTag.ULT).source(SOURCE_LC))
       x.buff(StatKey.ATK_P, (r.energyAtkBuff && context.baseEnergy >= 300) ? sValuesEnergyAtk[s] : 0, x.source(SOURCE_LC))
     },
   }

--- a/src/lib/conditionals/lightcone/5star/AThanklessCoronation.ts
+++ b/src/lib/conditionals/lightcone/5star/AThanklessCoronation.ts
@@ -10,7 +10,10 @@ import { TsUtils } from 'lib/utils/TsUtils'
 import { LightConeConditionalsController } from 'types/conditionals'
 import { SuperImpositionLevel } from 'types/lightCone'
 import { LightConeConfig } from 'types/lightConeConfig'
-import { OptimizerAction, OptimizerContext } from 'types/optimizer'
+import {
+  OptimizerAction,
+  OptimizerContext,
+} from 'types/optimizer'
 
 const conditionals = (s: SuperImpositionLevel, withContent: boolean): LightConeConditionalsController => {
   const t = TsUtils.wrappedFixedT(withContent).get(null, 'conditionals', 'Lightcones.AThanklessCoronation.Content')
@@ -47,7 +50,6 @@ const conditionals = (s: SuperImpositionLevel, withContent: boolean): LightConeC
     precomputeEffectsContainer: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
       const r = action.lightConeConditionals as Conditionals<typeof content>
 
-      x.buff(StatKey.ATK_P, (r.ultAtkBoost) ? sValuesUltAtk[s] : 0, x.damageType(DamageTag.ULT).source(SOURCE_LC))
       x.buff(StatKey.ATK, (r.ultAtkBoost) ? sValuesUltAtk[s] * context.baseATK : 0, x.damageType(DamageTag.ULT).source(SOURCE_LC))
       x.buff(StatKey.ATK_P, (r.energyAtkBuff && context.baseEnergy >= 300) ? sValuesEnergyAtk[s] : 0, x.source(SOURCE_LC))
     },

--- a/src/lib/conditionals/lightcone/5star/InTheNameOfTheWorld.ts
+++ b/src/lib/conditionals/lightcone/5star/InTheNameOfTheWorld.ts
@@ -55,7 +55,7 @@ const conditionals = (s: SuperImpositionLevel, withContent: boolean): LightConeC
       const r = action.lightConeConditionals as Conditionals<typeof content>
 
       x.buff(StatKey.DMG_BOOST, (r.enemyDebuffedDmgBoost) ? sValuesDmg[s] : 0, x.source(SOURCE_LC))
-      x.buff(StatKey.ATK_P, (r.skillAtkBoost) ? sValuesAtk[s] : 0, x.damageType(DamageTag.SKILL).source(SOURCE_LC))
+      x.buff(StatKey.ATK, (r.skillAtkBoost) ? sValuesAtk[s] * context.baseATK : 0, x.damageType(DamageTag.SKILL).source(SOURCE_LC))
     },
   }
 }

--- a/src/lib/optimization/engine/config/keys.ts
+++ b/src/lib/optimization/engine/config/keys.ts
@@ -7,19 +7,28 @@ export type AKeyType = keyof typeof newStatsConfig
 // Branded types for type safety
 declare const AKeyBrand: unique symbol
 declare const HKeyBrand: unique symbol
+declare const HitAKeyBrand: unique symbol
 
 export type AKeyValue = number & { readonly [AKeyBrand]: true }
 export type HKeyValue = number & { readonly [HKeyBrand]: true }
 
+// HitAKeyValue extends AKeyValue: hit stat indices are a subtype of action stat indices
+export type HitAKeyValue = AKeyValue & { readonly [HitAKeyBrand]: true }
+
 // ============== AKey ==============
 
-export const AKey: Record<AKeyType, AKeyValue> = Object.keys(newStatsConfig).reduce(
+// Hit stats map to HitAKeyValue, action-only stats to AKeyValue
+export type AKeyRecord = {
+  [K in AKeyType]: typeof newStatsConfig[K] extends { hit: true } ? HitAKeyValue : AKeyValue
+}
+
+export const AKey = Object.keys(newStatsConfig).reduce(
   (acc, key, index) => {
     acc[key as AKeyType] = index as AKeyValue
     return acc
   },
   {} as Record<AKeyType, AKeyValue>,
-)
+) as AKeyRecord  // narrowing: AKeyRecord extends Record<AKeyType, AKeyValue> since HitAKeyValue extends AKeyValue
 
 const AKeyNames = Object.keys(newStatsConfig) as AKeyType[]
 
@@ -32,7 +41,6 @@ export function getAKeyName(key: AKeyValue): AKeyType {
 const hitStatEntries = Object.entries(newStatsConfig)
   .filter(([_, value]) => (value as { hit?: boolean }).hit)
 
-// HKeyType is the subset of AKeyType that has hit: true
 export type HKeyType = (typeof hitStatEntries)[number][0]
 
 export const HKey = hitStatEntries.reduce(

--- a/src/lib/optimization/engine/config/statsConfig.ts
+++ b/src/lib/optimization/engine/config/statsConfig.ts
@@ -34,10 +34,10 @@ const optimizerTabResPen = createI18nKey<keyof Resources['common']['Elements']>(
 export const newStatsConfig = {
   // ================ Hit Stats ================
 
-  HP_P: { hit: true, label: commonReadableStat('HP%') },
-  ATK_P: { hit: true, label: commonReadableStat('ATK%') },
-  DEF_P: { hit: true, label: commonReadableStat('DEF%') },
-  SPD_P: { hit: true, label: commonReadableStat('SPD%') },
+  HP_P: { label: commonReadableStat('HP%') },
+  ATK_P: { label: commonReadableStat('ATK%') },
+  DEF_P: { label: commonReadableStat('DEF%') },
+  SPD_P: { label: commonReadableStat('SPD%') },
   HP: { hit: true, flat: true, label: commonReadableStat('HP') },
   ATK: { hit: true, flat: true, label: commonReadableStat('ATK') },
   DEF: { hit: true, flat: true, label: commonReadableStat('DEF') },

--- a/src/lib/optimization/engine/container/buffBuilder.ts
+++ b/src/lib/optimization/engine/container/buffBuilder.ts
@@ -15,8 +15,9 @@ import {
 } from 'lib/optimization/engine/config/tag'
 import { ComputedStatsContainerConfig } from 'lib/optimization/engine/container/computedStatsContainer'
 
-export class BuffBuilder<_Completed extends boolean = false> {
+export class BuffBuilder<_Completed extends boolean = false, _HasHitFilter extends boolean = false> {
   private readonly _completionBrand!: _Completed
+  declare readonly _hitFilterBrand: _HasHitFilter
 
   _actionKind: string | undefined = undefined
   _elementTags = ALL_ELEMENT_TAGS
@@ -31,13 +32,11 @@ export class BuffBuilder<_Completed extends boolean = false> {
 
   private config!: ComputedStatsContainerConfig
 
-  constructor() {}
-
   setConfig(config: ComputedStatsContainerConfig): void {
     this.config = config
   }
 
-  reset(): IncompleteBuffBuilder {
+  reset(): IncompleteActionBuff {
     this._actionKind = undefined
     this._elementTags = ALL_ELEMENT_TAGS
     this._damageTags = ALL_DAMAGE_TAGS
@@ -48,63 +47,67 @@ export class BuffBuilder<_Completed extends boolean = false> {
     this._targetTags = TargetTag.SelfAndPet
     this._deferrable = false
     this._source = Source.NONE
-    return this as IncompleteBuffBuilder
+    return this as IncompleteActionBuff
   }
 
-  elements(e: ElementTag): IncompleteBuffBuilder {
+  // Hit-filter methods - mark _HasHitFilter as true
+  elements(e: ElementTag): IncompleteHitBuff {
     this._elementTags = e
-    return this as IncompleteBuffBuilder
+    return this as IncompleteHitBuff
   }
 
-  damageType(d: DamageTag): IncompleteBuffBuilder {
+  damageType(d: DamageTag): IncompleteHitBuff {
     // BREAK buffs should also affect SUPER_BREAK hits
     if (d & DamageTag.BREAK) d |= DamageTag.SUPER_BREAK
     this._damageTags = d
-    return this as IncompleteBuffBuilder
+    return this as IncompleteHitBuff
   }
 
-  outputType(o: OutputTag): IncompleteBuffBuilder {
+  outputType(o: OutputTag): IncompleteHitBuff {
     this._outputTags = o
-    return this as IncompleteBuffBuilder
+    return this as IncompleteHitBuff
   }
 
-  directness(d: DirectnessTag): IncompleteBuffBuilder {
+  directness(d: DirectnessTag): IncompleteHitBuff {
     this._directnessTag = d
-    return this as IncompleteBuffBuilder
+    return this as IncompleteHitBuff
   }
 
-  actionKind(k: string): IncompleteBuffBuilder {
+  // Non-filter methods - propagate _HasHitFilter
+  actionKind(k: string): BuffBuilder<false, _HasHitFilter> {
     this._actionKind = k
-    return this as IncompleteBuffBuilder
+    return this as BuffBuilder<false, _HasHitFilter>
   }
 
-  origin(e: string): IncompleteBuffBuilder {
+  origin(e: string): BuffBuilder<false, _HasHitFilter> {
     this._origin = this.config.entityRegistry.getIndex(e)
-    return this as IncompleteBuffBuilder
+    return this as BuffBuilder<false, _HasHitFilter>
   }
 
-  target(e: string): IncompleteBuffBuilder {
+  target(e: string): BuffBuilder<false, _HasHitFilter> {
     this._target = this.config.entityRegistry.getIndex(e)
     this._targetTags = TargetTag.None
-    return this as IncompleteBuffBuilder
+    return this as BuffBuilder<false, _HasHitFilter>
   }
 
-  targets(t: TargetTag): IncompleteBuffBuilder {
+  targets(t: TargetTag): BuffBuilder<false, _HasHitFilter> {
     this._targetTags = t
     if (t & TargetTag.SingleTarget) this._deferrable = true
-    return this as IncompleteBuffBuilder
+    return this as BuffBuilder<false, _HasHitFilter>
   }
 
-  deferrable(): IncompleteBuffBuilder {
+  deferrable(): BuffBuilder<false, _HasHitFilter> {
     this._deferrable = true
-    return this as IncompleteBuffBuilder
+    return this as BuffBuilder<false, _HasHitFilter>
   }
 
-  source(s: BuffSource): CompleteBuffBuilder {
+  source(s: BuffSource): BuffBuilder<true, _HasHitFilter> {
     this._source = s
-    return this as CompleteBuffBuilder
+    return this as BuffBuilder<true, _HasHitFilter>
   }
 }
 
-export type IncompleteBuffBuilder = BuffBuilder<false>
-export type CompleteBuffBuilder = BuffBuilder<true>
+export type IncompleteActionBuff = BuffBuilder<false, false>
+export type IncompleteHitBuff = BuffBuilder<false, true>
+export type CompleteActionBuff = BuffBuilder<true, false>
+export type CompleteHitBuff = BuffBuilder<true, true>

--- a/src/lib/optimization/engine/container/computedStatsContainer.ts
+++ b/src/lib/optimization/engine/container/computedStatsContainer.ts
@@ -1,6 +1,9 @@
 import { aKeyToConvertibleStat } from 'lib/conditionals/evaluation/statConversionConfig'
+import {
+  Stats,
+  StatsValues,
+} from 'lib/constants/constants'
 import { evaluateConditional } from 'lib/gpu/conditionals/dynamicConditionals'
-import { Stats, StatsValues } from 'lib/constants/constants'
 import {
   BasicStatsArray,
   BasicStatsArrayCore,
@@ -12,9 +15,10 @@ import {
   AKeyType,
   AKeyValue,
   AToHKey,
-  GLOBAL_REGISTERS_LENGTH,
   getAKeyName,
+  GLOBAL_REGISTERS_LENGTH,
   HIT_STATS_LENGTH,
+  HitAKeyValue,
   HKeyValue,
   StatKey,
 } from 'lib/optimization/engine/config/keys'
@@ -32,8 +36,10 @@ import {
 } from 'lib/optimization/engine/config/tag'
 import {
   BuffBuilder,
-  CompleteBuffBuilder,
-  IncompleteBuffBuilder,
+  CompleteActionBuff,
+  CompleteHitBuff,
+  IncompleteActionBuff,
+  IncompleteHitBuff,
 } from 'lib/optimization/engine/container/buffBuilder'
 import { NamedArray } from 'lib/optimization/engine/util/namedArray'
 import {
@@ -128,7 +134,7 @@ function buildActionBuffIndexCache(
 function buildEntityTargetCaches(
   entities: OptimizerEntity[],
   entityStride: number,
-): { indices: Record<number, number[]>; offsets: Record<number, number[]> } {
+): { indices: Record<number, number[]>, offsets: Record<number, number[]> } {
   const indices: Record<number, number[]> = {}
   const offsets: Record<number, number[]> = {}
   const allTargetTags = Object.values(TargetTag).filter((v): v is number => typeof v === 'number')
@@ -408,7 +414,9 @@ export class ComputedStatsContainer {
 
   // ============== Buffs ==============
 
-  set(key: AKeyValue, value: number, config: BuffBuilder<true>) {
+  set(key: HitAKeyValue, value: number, config: CompleteActionBuff | CompleteHitBuff): void
+  set(key: AKeyValue, value: number, config: CompleteActionBuff): void
+  set(key: AKeyValue, value: number, config: CompleteActionBuff | CompleteHitBuff) {
     this.internalBuff(
       key,
       value,
@@ -426,7 +434,9 @@ export class ComputedStatsContainer {
     )
   }
 
-  buff(key: AKeyValue, value: number, config: BuffBuilder<true>) {
+  buff(key: HitAKeyValue, value: number, config: CompleteActionBuff | CompleteHitBuff): void
+  buff(key: AKeyValue, value: number, config: CompleteActionBuff): void
+  buff(key: AKeyValue, value: number, config: CompleteActionBuff | CompleteHitBuff) {
     this.internalBuff(
       key,
       value,
@@ -444,7 +454,9 @@ export class ComputedStatsContainer {
     )
   }
 
-  multiply(key: AKeyValue, value: number, config: BuffBuilder<true>) {
+  multiply(key: HitAKeyValue, value: number, config: CompleteActionBuff | CompleteHitBuff): void
+  multiply(key: AKeyValue, value: number, config: CompleteActionBuff): void
+  multiply(key: AKeyValue, value: number, config: CompleteActionBuff | CompleteHitBuff) {
     this.internalBuff(
       key,
       value,
@@ -462,7 +474,9 @@ export class ComputedStatsContainer {
     )
   }
 
-  multiplicativeComplement(key: AKeyValue, value: number, config: BuffBuilder<true>) {
+  multiplicativeComplement(key: HitAKeyValue, value: number, config: CompleteActionBuff | CompleteHitBuff): void
+  multiplicativeComplement(key: AKeyValue, value: number, config: CompleteActionBuff): void
+  multiplicativeComplement(key: AKeyValue, value: number, config: CompleteActionBuff | CompleteHitBuff) {
     this.internalBuff(
       key,
       value,
@@ -480,7 +494,9 @@ export class ComputedStatsContainer {
     )
   }
 
-  multiplicativeBoost(key: AKeyValue, value: number, config: BuffBuilder<true>) {
+  multiplicativeBoost(key: HitAKeyValue, value: number, config: CompleteActionBuff | CompleteHitBuff): void
+  multiplicativeBoost(key: AKeyValue, value: number, config: CompleteActionBuff): void
+  multiplicativeBoost(key: AKeyValue, value: number, config: CompleteActionBuff | CompleteHitBuff) {
     this.internalBuff(
       key,
       value,
@@ -498,7 +514,9 @@ export class ComputedStatsContainer {
     )
   }
 
-  buffDynamic(key: AKeyValue, value: number, action: OptimizerAction, context: OptimizerContext, config: BuffBuilder<true>) {
+  buffDynamic(key: HitAKeyValue, value: number, action: OptimizerAction, context: OptimizerContext, config: CompleteActionBuff | CompleteHitBuff): void
+  buffDynamic(key: AKeyValue, value: number, action: OptimizerAction, context: OptimizerContext, config: CompleteActionBuff): void
+  buffDynamic(key: AKeyValue, value: number, action: OptimizerAction, context: OptimizerContext, config: CompleteActionBuff | CompleteHitBuff) {
     this.internalBuff(
       key,
       value,
@@ -781,43 +799,43 @@ export class ComputedStatsContainer {
 
   // ============== Buff Builder ==============
 
-  elements(e: ElementTag): IncompleteBuffBuilder {
+  elements(e: ElementTag): IncompleteHitBuff {
     return this.builder.reset().elements(e)
   }
 
-  damageType(d: DamageTag): IncompleteBuffBuilder {
+  damageType(d: DamageTag): IncompleteHitBuff {
     return this.builder.reset().damageType(d)
   }
 
-  origin(o: string): IncompleteBuffBuilder {
+  origin(o: string): IncompleteActionBuff {
     return this.builder.reset().origin(o)
   }
 
-  target(e: string): IncompleteBuffBuilder {
+  target(e: string): IncompleteActionBuff {
     return this.builder.reset().target(e)
   }
 
-  targets(t: TargetTag): IncompleteBuffBuilder {
+  targets(t: TargetTag): IncompleteActionBuff {
     return this.builder.reset().targets(t)
   }
 
-  outputType(o: OutputTag): IncompleteBuffBuilder {
+  outputType(o: OutputTag): IncompleteHitBuff {
     return this.builder.reset().outputType(o)
   }
 
-  directness(d: DirectnessTag): IncompleteBuffBuilder {
+  directness(d: DirectnessTag): IncompleteHitBuff {
     return this.builder.reset().directness(d)
   }
 
-  actionKind(k: string): IncompleteBuffBuilder {
+  actionKind(k: string): IncompleteActionBuff {
     return this.builder.reset().actionKind(k)
   }
 
-  deferrable(): IncompleteBuffBuilder {
+  deferrable(): IncompleteActionBuff {
     return this.builder.reset().deferrable()
   }
 
-  source(s: BuffSource): CompleteBuffBuilder {
+  source(s: BuffSource): CompleteActionBuff {
     return this.builder.reset().source(s)
   }
 
@@ -871,10 +889,10 @@ const ContainerKeyToExternal: Partial<Record<AKeyType, StatsValues>> = {
 }
 
 export type OptimizerEntity = EntityDefinition & {
-  name: string
-  targetMask: number
-  baseAtk: number
-  baseDef: number
-  baseHp: number
-  baseSpd: number
+  name: string,
+  targetMask: number,
+  baseAtk: number,
+  baseDef: number,
+  baseHp: number,
+  baseSpd: number,
 }


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->
                                                                                                                                                                                                                                                                                                                                                                                           
- Reclassified percentage ATK buffs (ATK_P) to flat ATK with base multiplier                                                                                                                                                                                                                                                    
- Removed hit: true flag from percentage stats 
- Fixed AThanklessCoronation and InTheNameOfTheWorld

## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [ ] I have added commit messages that are descriptive and meaningful.
- [ ] I have tested the changes locally.
- [ ] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
