### PR TITLE
fix: remove unnecessary fields in character modal

### DIFF
--- a/src/lib/characterPreview/ShowcaseDpsScore.tsx
+++ b/src/lib/characterPreview/ShowcaseDpsScore.tsx
@@ -490,6 +490,7 @@ function ShowcaseTeamSelectPanel(props: {
           open={isCharacterModalOpen}
           setOpen={setCharacterModalOpen}
           initialCharacter={characterModalInitialCharacter}
+          withSetSelection
         />
       </ConfigProvider>
 

--- a/src/lib/overlays/modals/CharacterModal.tsx
+++ b/src/lib/overlays/modals/CharacterModal.tsx
@@ -45,6 +45,7 @@ export default function CharacterModal(props: {
   onOk: (form: Form) => void,
   setOpen: (open: boolean) => void,
   initialCharacter?: Character | null,
+  withSetSelection?: boolean,
 }) {
   const [characterForm] = AntDForm.useForm<Form>()
 
@@ -173,37 +174,39 @@ export default function CharacterModal(props: {
             </AntDForm.Item>
           </Flex>
 
-          <Flex vertical gap={5}>
-            <HeaderText>{t('Sets')}</HeaderText>
+          {props.withSetSelection && (
+            <Flex vertical gap={5}>
+              <HeaderText>{t('Sets')}</HeaderText>
 
-            <AntDForm.Item name={`teamRelicSet`}>
-              <Select
-                className='teammate-set-select'
-                options={teammateRelicSetOptions}
-                placeholder={tTeammateCard('RelicsPlaceholder')} // 'Relics'
-                allowClear
-                popupMatchSelectWidth={false}
-                optionLabelProp='desc'
-                optionRender={optionRenderer()}
-                labelRender={labelRenderer}
-                disabled={false}
-              />
-            </AntDForm.Item>
+              <AntDForm.Item name={`teamRelicSet`}>
+                <Select
+                  className='teammate-set-select'
+                  options={teammateRelicSetOptions}
+                  placeholder={tTeammateCard('RelicsPlaceholder')} // 'Relics'
+                  allowClear
+                  popupMatchSelectWidth={false}
+                  optionLabelProp='desc'
+                  optionRender={optionRenderer()}
+                  labelRender={labelRenderer}
+                  disabled={false}
+                />
+              </AntDForm.Item>
 
-            <AntDForm.Item name={`teamOrnamentSet`}>
-              <Select
-                className='teammate-set-select'
-                options={teammateOrnamentSetOptions}
-                placeholder={tTeammateCard('OrnamentsPlaceholder')} // 'Ornaments'
-                allowClear
-                popupMatchSelectWidth={false}
-                optionLabelProp='desc'
-                optionRender={optionRenderer()}
-                labelRender={labelRenderer}
-                disabled={false}
-              />
-            </AntDForm.Item>
-          </Flex>
+              <AntDForm.Item name={`teamOrnamentSet`}>
+                <Select
+                  className='teammate-set-select'
+                  options={teammateOrnamentSetOptions}
+                  placeholder={tTeammateCard('OrnamentsPlaceholder')} // 'Ornaments'
+                  allowClear
+                  popupMatchSelectWidth={false}
+                  optionLabelProp='desc'
+                  optionRender={optionRenderer()}
+                  labelRender={labelRenderer}
+                  disabled={false}
+                />
+              </AntDForm.Item>
+            </Flex>
+          )}
         </Flex>
       </AntDForm>
     </Modal>

--- a/src/lib/tabs/tabBenchmarks/BenchmarksTab.tsx
+++ b/src/lib/tabs/tabBenchmarks/BenchmarksTab.tsx
@@ -18,7 +18,15 @@ import {
   OverlayText,
   showcaseOutline,
 } from 'lib/characterPreview/CharacterPreviewComponents'
+import { Lingsha } from 'lib/conditionals/character/1200/Lingsha'
+import { Jade } from 'lib/conditionals/character/1300/Jade'
+import { TheHerta } from 'lib/conditionals/character/1400/TheHerta'
+import { TrailblazerRemembranceStelle } from 'lib/conditionals/character/8000/TrailblazerRemembrance'
 import { applyTeamAwareSetConditionalPresetsToBenchmarkFormInstance } from 'lib/conditionals/evaluation/applyPresets'
+import { VictoryInABlink } from 'lib/conditionals/lightcone/4star/VictoryInABlink'
+import { IntotheUnreachableVeil } from 'lib/conditionals/lightcone/5star/IntotheUnreachableVeil'
+import { ScentAloneStaysTrue } from 'lib/conditionals/lightcone/5star/ScentAloneStaysTrue'
+import { YetHopeIsPriceless } from 'lib/conditionals/lightcone/5star/YetHopeIsPriceless'
 import { Sets } from 'lib/constants/constants'
 import {
   OpenCloseIDs,
@@ -27,14 +35,6 @@ import {
 import CharacterModal from 'lib/overlays/modals/CharacterModal'
 import { Assets } from 'lib/rendering/assets'
 import { StatSimTypes } from 'lib/simulations/statSimulationTypes'
-import { Jade } from 'lib/conditionals/character/1300/Jade'
-import { Lingsha } from 'lib/conditionals/character/1200/Lingsha'
-import { TheHerta } from 'lib/conditionals/character/1400/TheHerta'
-import { TrailblazerRemembranceStelle } from 'lib/conditionals/character/8000/TrailblazerRemembrance'
-import { IntotheUnreachableVeil } from 'lib/conditionals/lightcone/5star/IntotheUnreachableVeil'
-import { ScentAloneStaysTrue } from 'lib/conditionals/lightcone/5star/ScentAloneStaysTrue'
-import { VictoryInABlink } from 'lib/conditionals/lightcone/4star/VictoryInABlink'
-import { YetHopeIsPriceless } from 'lib/conditionals/lightcone/5star/YetHopeIsPriceless'
 import DB from 'lib/state/db'
 import { BenchmarkResults } from 'lib/tabs/tabBenchmarks/BenchmarkResults'
 import { BenchmarkSetting } from 'lib/tabs/tabBenchmarks/BenchmarkSettings'
@@ -164,6 +164,7 @@ export default function BenchmarksTab(): ReactElement {
         open={isCharacterModalOpen}
         setOpen={setCharacterModalOpen}
         initialCharacter={characterModalInitialCharacter ? { form: characterModalInitialCharacter } as unknown as Character : undefined}
+        withSetSelection
       />
     </Flex>
   )


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

- Changed character modal to only expose the teammate relic/ornament set fields when selecting a dps sim teammate

## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
