### PR TITLE
fix: Ode to Reason doesn't buff skill damage when Anaxa is teammate

### DIFF
--- a/src/lib/conditionals/character/1400/Anaxa.ts
+++ b/src/lib/conditionals/character/1400/Anaxa.ts
@@ -103,7 +103,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 
   const teammateDefaults = {
     eruditionTeammateBuffs: true,
-    cyreneSpecialEffect: true,
+    cyreneSpecialEffect: false,
     e1DefPen: true,
     e2ResPen: true,
     e6Buffs: true,


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

- Fixed Ode to Reason's skill dmg buff not being applied when Anaxa is a teammate

## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
