### PR TITLE
fix: separate stores for benchmark conditionals drawer

### DIFF
--- a/src/lib/conditionals/evaluation/applyPresets.ts
+++ b/src/lib/conditionals/evaluation/applyPresets.ts
@@ -24,10 +24,7 @@ import { TheDahlia } from 'lib/conditionals/character/1300/TheDahlia'
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
 import { getGameMetadata } from 'lib/state/gameMetadata'
 import { useScoringStore } from 'lib/stores/scoring/scoringStore'
-import type {
-  BenchmarkForm,
-  SimpleCharacter,
-} from 'lib/tabs/tabBenchmarks/useBenchmarksTabStore'
+import type { BenchmarkForm } from 'lib/tabs/tabBenchmarks/useBenchmarksTabStore'
 import type { PresetDefinition } from 'lib/scoring/presetEffects'
 import { setSortColumn } from 'lib/stores/gridStore'
 import { clone, mergeDefinedValues, mergeUndefinedValues } from 'lib/utils/objectUtils'
@@ -163,24 +160,4 @@ export function applyTeamAwareSetConditionalPresetsToStore() {
 
   // Update the store with the modified set conditionals
   useOptimizerRequestStore.getState().setSetConditionals(form.setConditionals)
-}
-
-export function applyTeamAwareSetConditionalPresetsToBenchmarkFormInstance(
-  formInstance: UseFormReturnType<BenchmarkForm>,
-  teammate0?: SimpleCharacter,
-  teammate1?: SimpleCharacter,
-  teammate2?: SimpleCharacter,
-) {
-  const form = formInstance.getValues()
-  const teammateIds = [
-    teammate0?.characterId,
-    teammate1?.characterId,
-    teammate2?.characterId,
-  ]
-
-  applyTeamAwareSetConditionalPresets(form, teammateIds)
-
-  if (form.setConditionals) {
-    formInstance.setFieldValue(`setConditionals.${Sets.ArcadiaOfWovenDreams}.1` as never, form.setConditionals[Sets.ArcadiaOfWovenDreams][1] as never)
-  }
 }

--- a/src/lib/stores/optimizerForm/optimizerFormStoreActions.ts
+++ b/src/lib/stores/optimizerForm/optimizerFormStoreActions.ts
@@ -5,6 +5,7 @@ import type { MainConditionalType, TeammateConditionalType } from 'lib/stores/op
 import { type SetFilters } from 'lib/stores/optimizerForm/setFilterTypes'
 import { mergeDefinedValues } from 'lib/utils/objectUtils'
 import { type Form } from 'types/form'
+import type { SetConditionals } from 'lib/optimization/combo/comboTypes'
 
 export type SuggestionFixes = {
   setFilters?: SetFilters
@@ -117,10 +118,10 @@ export function computeSetTeammateConditional(
  * Set conditionals use the legacy [undefined, value] tuple format.
  */
 export function computeSetSetConditional(
-  state: OptimizerRequestState,
+  state: { setConditionals: SetConditionals },
   key: string,
   value: boolean | number,
-): Partial<OptimizerRequestState> {
+): { setConditionals: SetConditionals } {
   const setConditionals = { ...state.setConditionals } as Record<string, [undefined, boolean | number]>
   const existing = setConditionals[key]
   const tuple: [undefined, boolean | number] = existing ? [...existing] : [undefined, value]

--- a/src/lib/tabs/tabBenchmarks/BenchmarksTab.tsx
+++ b/src/lib/tabs/tabBenchmarks/BenchmarksTab.tsx
@@ -11,7 +11,6 @@ import type { UseFormReturnType } from '@mantine/form'
 import {
   OverlayText,
 } from 'lib/characterPreview/CharacterPreviewComponents'
-import { applyTeamAwareSetConditionalPresetsToBenchmarkFormInstance } from 'lib/conditionals/evaluation/applyPresets'
 import { Sets } from 'lib/constants/constants'
 import {
   OpenCloseIDs,
@@ -32,6 +31,7 @@ import { getGameMetadata } from 'lib/state/gameMetadata'
 import { BenchmarkResults } from 'lib/tabs/tabBenchmarks/BenchmarkResults'
 import { BenchmarkSetting } from 'lib/tabs/tabBenchmarks/BenchmarkSettings'
 import {
+  applyTeamAwareSetConditionalPresetsToBenchmarkFormInstance,
   handleBenchmarkFormSubmit,
   handleCharacterSelectChange,
   handleResetBenchmarks,

--- a/src/lib/tabs/tabBenchmarks/benchmarksTabController.ts
+++ b/src/lib/tabs/tabBenchmarks/benchmarksTabController.ts
@@ -3,6 +3,7 @@ import i18next from 'i18next'
 import {
   applyScoringMetadataPresets,
   applySetConditionalPresets,
+  applyTeamAwareSetConditionalPresets,
 } from 'lib/conditionals/evaluation/applyPresets'
 import { Message } from 'lib/interactions/message'
 import { defaultSetConditionals } from 'lib/optimization/defaultForm'
@@ -38,7 +39,7 @@ export function handleResetBenchmarks() {
 }
 
 export function handleBenchmarkFormSubmit(benchmarkForm: BenchmarkForm) {
-  const { teammate0, teammate1, teammate2, setResults, storedRelics, storedOrnaments, setLoading } = useBenchmarksTabStore.getState()
+  const { teammate0, teammate1, teammate2, setResults, storedRelics, storedOrnaments, setLoading, setConditionals } = useBenchmarksTabStore.getState()
 
   const validationForm: BenchmarkForm = {
     ...benchmarkForm,
@@ -80,6 +81,7 @@ export function handleBenchmarkFormSubmit(benchmarkForm: BenchmarkForm) {
           teammate0,
           teammate1,
           teammate2,
+          setConditionals, // Must be after spread
         }
 
         const fullHash = objectHash(mergedBenchmarkForm)
@@ -192,4 +194,28 @@ export function handleCharacterSelectChange(id: CharacterId | null, formInstance
   state.updateTeammate(2, simulationMetadata.teammates[2])
 
   formInstance.setValues(form)
+  state.setSetConditionals(form.setConditionals)
+}
+
+export function applyTeamAwareSetConditionalPresetsToBenchmarkFormInstance(
+  formInstance: UseFormReturnType<BenchmarkForm>,
+  teammate0?: SimpleCharacter,
+  teammate1?: SimpleCharacter,
+  teammate2?: SimpleCharacter,
+) {
+  // Clone from store (source of truth) - applyTeamAwareSetConditionalPresets mutates
+  const currentSetConditionals = clone(useBenchmarksTabStore.getState().setConditionals)
+  const form = { ...formInstance.getValues(), setConditionals: currentSetConditionals }
+
+  const teammateIds = [
+    teammate0?.characterId,
+    teammate1?.characterId,
+    teammate2?.characterId,
+  ]
+
+  applyTeamAwareSetConditionalPresets(form, teammateIds)
+
+  if (form.setConditionals) {
+    useBenchmarksTabStore.getState().setSetConditionals(form.setConditionals)
+  }
 }

--- a/src/lib/tabs/tabBenchmarks/useBenchmarksTabStore.test.ts
+++ b/src/lib/tabs/tabBenchmarks/useBenchmarksTabStore.test.ts
@@ -8,6 +8,8 @@ import { Robin } from 'lib/conditionals/character/1300/Robin'
 import { PatienceIsAllYouNeed } from 'lib/conditionals/lightcone/5star/PatienceIsAllYouNeed'
 import { IShallBeMyOwnSword } from 'lib/conditionals/lightcone/5star/IShallBeMyOwnSword'
 import { Sets } from 'lib/constants/constants'
+import { defaultSetConditionals } from 'lib/optimization/defaultForm'
+import { clone } from 'lib/utils/objectUtils'
 import type { BenchmarkSimulationOrchestrator } from 'lib/simulations/orchestrator/benchmarkSimulationOrchestrator'
 
 // ---- Constants ----
@@ -66,6 +68,11 @@ describe('useBenchmarksTabStore', () => {
       expect(state().storedOrnaments).toEqual([])
       expect(state().loading).toBe(false)
       expect(state().orchestrators).toEqual([])
+    })
+
+    it('store initializes with default setConditionals', () => {
+      // clone() converts undefined to null, so compare cloned values
+      expect(state().setConditionals).toEqual(clone(defaultSetConditionals))
     })
   })
 
@@ -235,6 +242,29 @@ describe('useBenchmarksTabStore', () => {
       expect(state().loading).toBe(true)
       state().setLoading(false)
       expect(state().loading).toBe(false)
+    })
+  })
+
+  describe('setConditionals management', () => {
+    it('setSetConditional updates a single set conditional value', () => {
+      // Get current value (don't assume specific default)
+      const initialValue = state().setConditionals[Sets.BandOfSizzlingThunder]?.[1]
+
+      // Toggle to opposite of current value
+      const newValue = !initialValue
+      state().setSetConditional(Sets.BandOfSizzlingThunder, newValue)
+
+      expect(state().setConditionals[Sets.BandOfSizzlingThunder][1]).toBe(newValue)
+    })
+
+    it('setSetConditionals replaces entire setConditionals object', () => {
+      const newConditionals = clone(defaultSetConditionals)
+      // clone converts undefined to null, so use type assertion
+      newConditionals[Sets.BandOfSizzlingThunder] = [null as unknown as undefined, true]
+
+      state().setSetConditionals(newConditionals)
+
+      expect(state().setConditionals).toEqual(newConditionals)
     })
   })
 

--- a/src/lib/tabs/tabBenchmarks/useBenchmarksTabStore.ts
+++ b/src/lib/tabs/tabBenchmarks/useBenchmarksTabStore.ts
@@ -5,6 +5,9 @@ import type { CharacterModalForm } from 'lib/overlays/modals/characterModalStore
 import type { CharacterId } from 'types/character'
 import type { LightConeId } from 'types/lightCone'
 import { createTabAwareStore } from 'lib/stores/infrastructure/createTabAwareStore'
+import { defaultSetConditionals } from 'lib/optimization/defaultForm'
+import { clone } from 'lib/utils/objectUtils'
+import { computeSetSetConditional } from 'lib/stores/optimizerForm/optimizerFormStoreActions'
 import type {
   SetsOrnaments,
   SetsRelics,
@@ -75,6 +78,10 @@ type BenchmarksTabState = {
   ) => void,
   resetCache: () => void,
   setLoading: (loading: boolean) => void,
+
+  setConditionals: SetConditionals,
+  setSetConditional: (key: string, value: boolean | number) => void,
+  setSetConditionals: (conditionals: SetConditionals) => void,
 }
 
 export const useBenchmarksTabStore = createTabAwareStore<BenchmarksTabState>((set, get) => ({
@@ -88,6 +95,7 @@ export const useBenchmarksTabStore = createTabAwareStore<BenchmarksTabState>((se
   loading: false,
 
   orchestrators: [],
+  setConditionals: clone(defaultSetConditionals),
 
   updateTeammate: (index, data?: SimpleCharacterSets) =>
     set((state) => ({
@@ -138,4 +146,11 @@ export const useBenchmarksTabStore = createTabAwareStore<BenchmarksTabState>((se
     set({
       loading,
     }),
+
+  setSetConditional: (key, value) => set((state) =>
+    computeSetSetConditional(state, key, value)
+  ),
+
+  setSetConditionals: (conditionals: SetConditionals) =>
+    set({ setConditionals: conditionals }),
 }))

--- a/src/lib/tabs/tabOptimizer/optimizerForm/components/FormSetConditionals.tsx
+++ b/src/lib/tabs/tabOptimizer/optimizerForm/components/FormSetConditionals.tsx
@@ -9,18 +9,28 @@ import {
   setToId,
 } from 'lib/sets/setConfigRegistry'
 import {
-  type OpenCloseIDs,
+  OpenCloseIDs,
   useOpenClose,
 } from 'lib/hooks/useOpenClose'
 import type { SelectOptionContent } from 'types/setConfig'
 import { Assets } from 'lib/rendering/assets'
 import { useOptimizerRequestStore } from 'lib/stores/optimizerForm/useOptimizerRequestStore'
+import { useBenchmarksTabStore } from 'lib/tabs/tabBenchmarks/useBenchmarksTabStore'
 import { handleConditionalChange } from 'lib/tabs/tabOptimizer/optimizerForm/optimizerFormActions'
 import { ColorizeNumbers } from 'lib/ui/ColorizeNumbers'
 import { VerticalDivider } from 'lib/ui/Dividers'
 import { HeaderText } from 'lib/ui/HeaderText'
 import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import type { SetConditionals } from 'lib/optimization/combo/comboTypes'
+
+/**
+ * Enum for identifying which store to use for set conditionals.
+ */
+export enum SetConditionalsStoreType {
+  Optimizer = 'optimizer',
+  Benchmark = 'benchmark',
+}
 
 const setConditionalsIconWidth = 32
 const setConditionalsNameWidth = 255
@@ -28,10 +38,21 @@ const setConditionalsWidth = 100
 const defaultGap = 5
 const columnGap = 6
 
+function getSetConditionalValue(
+  setConditionals: SetConditionals,
+  set: string,
+  storeType: SetConditionalsStoreType,
+  forStore: SetConditionalsStoreType,
+): boolean | number | undefined {
+  if (storeType !== forStore) return undefined
+  return (setConditionals as Record<string, [unknown, boolean | number]>)[set]?.[1]
+}
+
 interface BaseConditionalSetOptionProps {
   description: string
   conditional: string
   selectOptions?: Array<SelectOptionContent>
+  storeType: SetConditionalsStoreType
 }
 interface RelicConditionalSetOptionProps extends BaseConditionalSetOptionProps {
   set: SetsRelics
@@ -43,14 +64,27 @@ interface OrnamentConditionalSetOptionProps extends BaseConditionalSetOptionProp
 }
 type ConditionalSetOptionsProps = OrnamentConditionalSetOptionProps | RelicConditionalSetOptionProps
 
-function ConditionalSetOption({ set, description, conditional, selectOptions, ...rest }: ConditionalSetOptionsProps) {
+function ConditionalSetOption({ set, description, conditional, selectOptions, storeType, ...rest }: ConditionalSetOptionsProps) {
   const { t } = useTranslation('optimizerTab', { keyPrefix: 'SetConditionals' })
 
-  const itemName = ['setConditionals', set, 1] as (string | number)[]
-  const value = useOptimizerRequestStore((s) => {
-    const setData = (s.setConditionals as Record<string, [undefined, boolean | number]>)[set]
-    return setData?.[1]
-  })
+  const fromOptimizer = useOptimizerRequestStore((s) =>
+    getSetConditionalValue(s.setConditionals, set, storeType, SetConditionalsStoreType.Optimizer)
+  )
+  const fromBenchmark = useBenchmarksTabStore((s) =>
+    getSetConditionalValue(s.setConditionals, set, storeType, SetConditionalsStoreType.Benchmark)
+  )
+
+  const value = storeType === SetConditionalsStoreType.Optimizer ? fromOptimizer : fromBenchmark
+
+  const handleChange = (newValue: boolean | number | null) => {
+    if (newValue == null) return
+
+    if (storeType === SetConditionalsStoreType.Optimizer) {
+      handleConditionalChange(['setConditionals', set, 1], newValue) // Also patches comboStateJson
+    } else {
+      useBenchmarksTabStore.getState().setSetConditional(set, newValue)
+    }
+  }
 
   const content = (
     <Flex direction="column" gap={12}>
@@ -81,7 +115,7 @@ function ConditionalSetOption({ set, description, conditional, selectOptions, ..
         comboboxProps={{ keepMounted: false, width: 160 }}
         data={stringSelectOptions}
         value={value != null ? String(value) : null}
-        onChange={(val) => handleConditionalChange(itemName, val != null ? Number(val) : val)}
+        onChange={(val) => handleChange(val != null ? Number(val) : null)}
       />
     )
   } else {
@@ -89,7 +123,7 @@ function ConditionalSetOption({ set, description, conditional, selectOptions, ..
       <Switch
         disabled={disabled}
         checked={value as boolean}
-        onChange={(event) => handleConditionalChange(itemName, event.currentTarget.checked)}
+        onChange={(event) => handleChange(event.currentTarget.checked)}
       />
     )
   }
@@ -133,6 +167,10 @@ export function FormSetConditionals({ id }: { id: OpenCloseIDs }) {
   const [hasOpened, setHasOpened] = useState(false)
   if (isOpen && !hasOpened) setHasOpened(true)
 
+  const storeType = id === OpenCloseIDs.BENCHMARKS_SETS_DRAWER
+    ? SetConditionalsStoreType.Benchmark
+    : SetConditionalsStoreType.Optimizer
+
   return (
     <Drawer
       title={t('Title')} // 'Conditional set effects'
@@ -142,12 +180,12 @@ export function FormSetConditionals({ id }: { id: OpenCloseIDs }) {
       size={900}
       keepMounted
     >
-      {hasOpened && <FormSetConditionalsContent />}
+      {hasOpened && <FormSetConditionalsContent storeType={storeType} />}
     </Drawer>
   )
 }
 
-function FormSetConditionalsContent() {
+function FormSetConditionalsContent({ storeType }: { storeType: SetConditionalsStoreType }) {
   const { t } = useTranslation('optimizerTab', { keyPrefix: 'SetConditionals' })
   const { t: tSelectOptions } = useTranslation('optimizerTab', { keyPrefix: 'SetConditionals.SelectOptions' })
 
@@ -158,6 +196,7 @@ function FormSetConditionalsContent() {
         <ConditionalSetOption
           key={set}
           set={set}
+          storeType={storeType}
           p4Checked={!config.display.modifiable}
           description={t('RelicDescription', { id: setToId[set] })}
           conditional={t(setToConditionalKey(set))}
@@ -172,6 +211,7 @@ function FormSetConditionalsContent() {
         <ConditionalSetOption
           key={set}
           set={set}
+          storeType={storeType}
           p2Checked={!config.display.modifiable}
           description={t('PlanarDescription', { id: setToId[set] })}
           conditional={t(setToConditionalKey(set))}
@@ -181,7 +221,7 @@ function FormSetConditionalsContent() {
     })
 
     return { relicOptions, ornamentOptions }
-  }, [tSelectOptions, t])
+  }, [tSelectOptions, t, storeType])
 
   return (
     <Flex justify='space-around'>


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->


  - Move benchmark set conditionals from form to Zustand store
  - Share set conditionals drawer between optimizer and benchmark tabs

## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [ ] I have added commit messages that are descriptive and meaningful.
- [ ] I have tested the changes locally.
- [ ] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
