### PR TITLE
fix: scoring metadata overrides persistence

### DIFF
--- a/src/lib/characterPreview/buildAnalysis/CharacterScoringSummary.tsx
+++ b/src/lib/characterPreview/buildAnalysis/CharacterScoringSummary.tsx
@@ -186,6 +186,7 @@ function BenchmarkDefaultLayout() {
               <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }} className={classes.combatResultsWidth}>
                 <ScoringText
                   label={t('CombatResults.Primary')}
+                  // @ts-expect-error - not all sortOption keys have translations yet
                   text={t(`CombatResults.Abilities.${preview.characterMetadata.scoringMetadata.sortOption.key}`)}
                 />
                 <ScoringNumber label={t('CombatResults.Character')} number={preview.originalSimResult.simScore} precision={1} />

--- a/src/lib/characterPreview/buildAnalysis/CharacterScoringSummary.tsx
+++ b/src/lib/characterPreview/buildAnalysis/CharacterScoringSummary.tsx
@@ -186,7 +186,6 @@ function BenchmarkDefaultLayout() {
               <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }} className={classes.combatResultsWidth}>
                 <ScoringText
                   label={t('CombatResults.Primary')}
-                  // @ts-expect-error - sortOption.key is always an ability key in combat scoring context
                   text={t(`CombatResults.Abilities.${preview.characterMetadata.scoringMetadata.sortOption.key}`)}
                 />
                 <ScoringNumber label={t('CombatResults.Character')} number={preview.originalSimResult.simScore} precision={1} />

--- a/src/lib/characterPreview/customization/ShowcaseCustomizationSidebar.tsx
+++ b/src/lib/characterPreview/customization/ShowcaseCustomizationSidebar.tsx
@@ -161,8 +161,7 @@ const ScoringPanel = memo(function ScoringPanel({ characterId, scoringType }: {
   }
 
   function onSpdValueChange(value: number) {
-    const meta = getScoringMetadata(characterId)
-    useScoringStore.getState().updateCharacterOverrides(characterId, { stats: { ...meta.stats, [Stats.SPD]: value } })
+    useScoringStore.getState().updateCharacterOverrides(characterId, { stats: { [Stats.SPD]: value } })
     SaveState.delayedSave()
   }
 

--- a/src/lib/overlays/modals/ScoringModal.tsx
+++ b/src/lib/overlays/modals/ScoringModal.tsx
@@ -14,7 +14,6 @@ import { Assets } from 'lib/rendering/assets'
 import { getGameMetadata } from 'lib/state/gameMetadata'
 import { SaveState } from 'lib/state/saveState'
 import { useGlobalStore } from 'lib/stores/app/appStore'
-import { useCharacterStore } from 'lib/stores/character/characterStore'
 import { getScoringMetadata, useScoringStore } from 'lib/stores/scoring/scoringStore'
 import { CharacterSelect } from 'lib/ui/selectors/CharacterSelect'
 import { ColorizedLinkWithIcon } from 'lib/ui/ColorizedLink'
@@ -89,22 +88,13 @@ function ResetAllCharactersButton({ focusCharacter, form }: {
   const { t } = useTranslation(['modals', 'common'])
 
   const resetAllCharacters = () => {
-    const charactersById = useCharacterStore.getState().charactersById
-    for (const character of Object.keys(charactersById) as CharacterId[]) {
-      const defaultScoringMetadata = getGameMetadata().characters[character].scoringMetadata
-      const scoringMetadataToMerge: Partial<ScoringMetadata> = {
-        stats: { ...defaultScoringMetadata.stats },
-        parts: { ...defaultScoringMetadata.parts },
-      }
-      useScoringStore.getState().updateCharacterOverrides(character, scoringMetadataToMerge)
-    }
+    useScoringStore.getState().setScoringMetadataOverrides({})
     SaveState.delayedSave()
 
-    // Update values for current screen
+    // Update form values for current screen
     if (focusCharacter) {
-      const defaultScoringMetadata = getGameMetadata().characters[focusCharacter].scoringMetadata
-      const displayScoringMetadata = getScoringValuesForDisplay(defaultScoringMetadata)
-      form.setValues(displayScoringMetadata)
+      const defaults = getGameMetadata().characters[focusCharacter].scoringMetadata
+      form.setValues(getScoringValuesForDisplay(defaults))
     }
   }
 
@@ -187,15 +177,11 @@ function ScoringModalContent({ close }: { close: () => void }) {
   const handleResetDefault = () => {
     if (!scoringAlgorithmFocusCharacter) return
 
-    const defaultScoringMetadata = getGameMetadata().characters[scoringAlgorithmFocusCharacter].scoringMetadata
-    const displayScoringMetadata = getScoringValuesForDisplay(defaultScoringMetadata)
-    const scoringMetadataToMerge: Partial<ScoringMetadata> = {
-      stats: { ...defaultScoringMetadata.stats },
-      parts: { ...defaultScoringMetadata.parts },
-    }
+    useScoringStore.getState().clearCharacterOverrides(scoringAlgorithmFocusCharacter)
 
-    scoringAlgorithmForm.setValues(displayScoringMetadata)
-    useScoringStore.getState().updateCharacterOverrides(scoringAlgorithmFocusCharacter, scoringMetadataToMerge); SaveState.delayedSave()
+    const defaults = getGameMetadata().characters[scoringAlgorithmFocusCharacter].scoringMetadata
+    scoringAlgorithmForm.setValues(getScoringValuesForDisplay(defaults))
+    SaveState.delayedSave()
   }
 
   const previewSrc = scoringAlgorithmFocusCharacter ? Assets.getCharacterPreviewById(scoringAlgorithmFocusCharacter) : Assets.getBlank()

--- a/src/lib/scoring/scoreComparison.ts
+++ b/src/lib/scoring/scoreComparison.ts
@@ -2,7 +2,6 @@ import {
   Stats,
   SubStats,
 } from 'lib/constants/constants'
-import { nullUndefinedToZero } from 'lib/utils/mathUtils'
 import type { ScoringMetadata } from 'types/metadata'
 
 export enum ScoreCategory {
@@ -34,13 +33,4 @@ export function getScoreCategory(defaultMeta: Metadata, customMeta: Metadata) {
   if (!difference && defaultMeta.stats[Stats.SPD] == 0) return ScoreCategory.DEFAULT_NO_SPEED
   if (difference) return ScoreCategory.MODIFIED
   return ScoreCategory.DEFAULT
-}
-
-export function setModifiedScoringMetadata(defaultMeta: Metadata, customMeta: Metadata) {
-  customMeta.modified = false
-  for (const stat of SubStats) {
-    if (nullUndefinedToZero(customMeta.stats[stat]) != nullUndefinedToZero(defaultMeta.stats[stat])) {
-      customMeta.modified = true
-    }
-  }
 }

--- a/src/lib/services/persistenceService.ts
+++ b/src/lib/services/persistenceService.ts
@@ -7,7 +7,7 @@ import { Message } from 'lib/interactions/message'
 import { getDefaultForm } from 'lib/optimization/defaultForm'
 import { SortOption } from 'lib/optimization/sortOptions'
 import { RelicAugmenter } from 'lib/relics/relicAugmenter'
-import { setModifiedScoringMetadata } from 'lib/scoring/scoreComparison'
+import { pruneOverridesOnLoad } from 'lib/stores/scoring/scoringDelta'
 import * as equipmentService from 'lib/services/equipmentService'
 import { OpenCloseIDs, setClose, setOpen } from 'lib/hooks/useOpenClose'
 import { DefaultSettingOptions } from 'lib/overlays/drawers/SettingsDrawer'
@@ -35,7 +35,7 @@ import type {
 import type { Form } from 'types/form'
 import type { LightConeId } from 'types/lightCone'
 import type { SavedBuild } from 'types/savedBuild'
-import type { DBMetadata, ScoringMetadata } from 'types/metadata'
+import type { DBMetadata } from 'types/metadata'
 import type { Relic } from 'types/relic'
 import type {
   GlobalSavedSession,
@@ -61,17 +61,20 @@ export function loadSaveData(saveData: HsrOptimizerSaveFormat, autosave = true, 
   // Remove invalid characters
   saveData.characters = saveData.characters.filter((x) => dbCharacters[x.id])
 
-  {
-    const validOverrides: Record<string, ScoringMetadata> = {}
-    for (const [key, scoringMetadataOverrides] of Object.entries(saveData.scoringMetadataOverrides ?? {}) as [CharacterId, ScoringMetadata][]) {
-      if (!dbCharacters[key]?.scoringMetadata) continue
-      if (!scoringMetadataOverrides?.stats) continue
-      const defaultScoringMetadata = dbCharacters[key].scoringMetadata
-      setModifiedScoringMetadata(defaultScoringMetadata, scoringMetadataOverrides)
-      validOverrides[key] = scoringMetadataOverrides
-    }
+  // Clear any pending save to avoid race condition
+  SaveState.clearPendingTimeout()
 
-    useScoringStore.getState().setScoringMetadataOverrides(validOverrides)
+  // Prune overrides to delta format (converts old full-snapshots)
+  const { result: prunedOverrides, changed } = pruneOverridesOnLoad(
+    saveData.scoringMetadataOverrides ?? {},
+    (id) => dbCharacters[id as CharacterId]?.scoringMetadata,
+  )
+
+  useScoringStore.getState().setScoringMetadataOverrides(prunedOverrides)
+
+  // Save if anything was pruned (triggers save outside of the normal autosave check)
+  if (changed && autosave) {
+    SaveState.delayedSave()
   }
 
   const relicsById = new Map(saveData.relics.map((r) => [r.id, r]))

--- a/src/lib/services/persistenceService.ts
+++ b/src/lib/services/persistenceService.ts
@@ -61,9 +61,6 @@ export function loadSaveData(saveData: HsrOptimizerSaveFormat, autosave = true, 
   // Remove invalid characters
   saveData.characters = saveData.characters.filter((x) => dbCharacters[x.id])
 
-  // Clear any pending save to avoid race condition
-  SaveState.clearPendingTimeout()
-
   // Prune overrides to delta format (converts old full-snapshots)
   const { result: prunedOverrides, changed } = pruneOverridesOnLoad(
     saveData.scoringMetadataOverrides ?? {},

--- a/src/lib/state/saveState.ts
+++ b/src/lib/state/saveState.ts
@@ -96,6 +96,7 @@ export const SaveState = {
     const stateString = JSON.stringify(state)
     try {
       localStorage.setItem(STATE_KEY, stateString)
+      console.log('SaveState: Saved')
     } catch (e) {
       console.error('Failed to save state (storage quota exceeded?)', e)
     }
@@ -112,13 +113,6 @@ export const SaveState = {
     saveTimeout = setTimeout(() => {
       SaveState.save()
     }, ms)
-  },
-
-  clearPendingTimeout: () => {
-    if (saveTimeout) {
-      clearTimeout(saveTimeout)
-      saveTimeout = null
-    }
   },
 
   // Bypass the empty-save guard for the next save (used by "Clear data")

--- a/src/lib/state/saveState.ts
+++ b/src/lib/state/saveState.ts
@@ -114,6 +114,13 @@ export const SaveState = {
     }, ms)
   },
 
+  clearPendingTimeout: () => {
+    if (saveTimeout) {
+      clearTimeout(saveTimeout)
+      saveTimeout = null
+    }
+  },
+
   // Bypass the empty-save guard for the next save (used by "Clear data")
   permitEmptySave: () => {
     allowEmptySave = true

--- a/src/lib/stores/scoring/scoringDelta.test.ts
+++ b/src/lib/stores/scoring/scoringDelta.test.ts
@@ -1,0 +1,430 @@
+import { describe, expect, it } from 'vitest'
+import { Parts, Stats, SubStats } from 'lib/constants/constants'
+import type { MainStats } from 'lib/constants/constants'
+import type { ScoringMetadata, ScoringMetadataOverride, ScoringParts } from 'types/metadata'
+import {
+  extractPartsDelta,
+  extractStatsDelta,
+  mergeAndPruneOverride,
+  mergeDeltaWithDefaults,
+  pruneOverridesOnLoad,
+} from './scoringDelta'
+
+// Helper to create a full stats record with all zeros except specified
+function makeStats(overrides: Partial<Record<SubStats, number>> = {}): Record<SubStats, number> {
+  const stats = {} as Record<SubStats, number>
+  for (const stat of SubStats) {
+    stats[stat] = 0
+  }
+  return { ...stats, ...overrides }
+}
+
+// Helper to create minimal ScoringMetadata for testing
+function makeDefaults(overrides: Partial<ScoringMetadata> = {}): ScoringMetadata {
+  return {
+    stats: makeStats(overrides.stats),
+    parts: {
+      Body: [Stats.HP_P],
+      Feet: [Stats.SPD],
+      PlanarSphere: [Stats.HP_P],
+      LinkRope: [Stats.ERR],
+      ...overrides.parts,
+    },
+    presets: [],
+    sortOption: {} as ScoringMetadata['sortOption'],
+    hiddenColumns: [],
+    ...overrides,
+  }
+}
+
+describe('extractStatsDelta', () => {
+  it('keeps stats differing from defaults', () => {
+    const stats = { [Stats.SPD]: 1, [Stats.ATK_P]: 0.5 }
+    const defaults = makeStats({ [Stats.SPD]: 0.75, [Stats.ATK_P]: 1 })
+
+    const delta = extractStatsDelta(stats, defaults)
+
+    expect(delta).toEqual({ [Stats.SPD]: 1, [Stats.ATK_P]: 0.5 })
+  })
+
+  it('prunes stats matching defaults', () => {
+    const stats = { [Stats.SPD]: 1, [Stats.ATK_P]: 1 }
+    const defaults = makeStats({ [Stats.SPD]: 0.75, [Stats.ATK_P]: 1 }) // ATK_P matches
+
+    const delta = extractStatsDelta(stats, defaults)
+
+    expect(delta).toEqual({ [Stats.SPD]: 1 }) // ATK_P pruned
+  })
+
+  it('returns undefined when all match', () => {
+    const stats = { [Stats.SPD]: 0.75, [Stats.ATK_P]: 1 }
+    const defaults = makeStats({ [Stats.SPD]: 0.75, [Stats.ATK_P]: 1 })
+
+    const delta = extractStatsDelta(stats, defaults)
+
+    expect(delta).toBeUndefined()
+  })
+
+  it('returns undefined for undefined input', () => {
+    const defaults = makeStats()
+    expect(extractStatsDelta(undefined, defaults)).toBeUndefined()
+  })
+})
+
+// Helper to create parts defaults
+function makeParts(): Record<ScoringParts, MainStats[]> {
+  return {
+    [Parts.Body]: [Stats.HP_P],
+    [Parts.Feet]: [Stats.SPD],
+    [Parts.PlanarSphere]: [Stats.HP_P],
+    [Parts.LinkRope]: [Stats.ERR],
+  }
+}
+
+describe('extractPartsDelta', () => {
+  it('keeps parts differing from defaults', () => {
+    const parts: Partial<Record<ScoringParts, MainStats[]>> = {
+      [Parts.Body]: [Stats.DEF_P],
+      [Parts.Feet]: [Stats.SPD],
+    }
+    const defaults = makeParts()
+
+    const delta = extractPartsDelta(parts, defaults)
+
+    expect(delta).toEqual({ [Parts.Body]: [Stats.DEF_P] })
+  })
+
+  it('prunes parts matching defaults', () => {
+    const parts: Partial<Record<ScoringParts, MainStats[]>> = {
+      [Parts.Body]: [Stats.HP_P],
+      [Parts.Feet]: [Stats.SPD],
+    }
+    const defaults = makeParts()
+
+    const delta = extractPartsDelta(parts, defaults)
+
+    expect(delta).toBeUndefined()
+  })
+
+  it('empty array is valid override', () => {
+    const parts: Partial<Record<ScoringParts, MainStats[]>> = {
+      [Parts.Body]: [],
+    }
+    const defaults = makeParts()
+
+    const delta = extractPartsDelta(parts, defaults)
+
+    expect(delta).toEqual({ [Parts.Body]: [] })
+  })
+})
+
+describe('mergeDeltaWithDefaults', () => {
+  it('overlays delta onto defaults', () => {
+    const override: ScoringMetadataOverride = {
+      stats: { [Stats.SPD]: 1 },
+    }
+    const defaults = makeDefaults({ stats: makeStats({ [Stats.SPD]: 0.75, [Stats.ATK_P]: 1 }) })
+
+    const result = mergeDeltaWithDefaults(override, defaults)
+
+    expect(result.stats[Stats.SPD]).toBe(1)
+    expect(result.stats[Stats.ATK_P]).toBe(1)
+  })
+
+  it('non-overridden stats use defaults', () => {
+    const override: ScoringMetadataOverride = { stats: { [Stats.SPD]: 1 } }
+    const defaults = makeDefaults({ stats: makeStats({ [Stats.CR]: 0.5, [Stats.CD]: 1 }) })
+
+    const result = mergeDeltaWithDefaults(override, defaults)
+
+    expect(result.stats[Stats.CR]).toBe(0.5)
+    expect(result.stats[Stats.CD]).toBe(1)
+  })
+
+  it('sets modified=true when has stats override', () => {
+    const override: ScoringMetadataOverride = { stats: { [Stats.SPD]: 1 } }
+    const defaults = makeDefaults()
+
+    const result = mergeDeltaWithDefaults(override, defaults)
+
+    expect(result.modified).toBe(true)
+  })
+
+  it('sets modified=false when no stats override', () => {
+    const override: ScoringMetadataOverride = { traces: { deactivated: ['A2'] } }
+    const defaults = makeDefaults()
+
+    const result = mergeDeltaWithDefaults(override, defaults)
+
+    expect(result.modified).toBe(false)
+  })
+
+  it('returns defaults when no override', () => {
+    const defaults = makeDefaults({ stats: makeStats({ [Stats.SPD]: 0.75 }) })
+
+    const result = mergeDeltaWithDefaults(undefined, defaults)
+
+    expect(result.stats[Stats.SPD]).toBe(0.75)
+    expect(result.modified).toBe(false)
+  })
+})
+
+describe('mergeAndPruneOverride', () => {
+  it('merges new stats with existing', () => {
+    const existing: ScoringMetadataOverride = { stats: { [Stats.SPD]: 1 } }
+    const update: Partial<ScoringMetadataOverride> = { stats: { [Stats.ATK_P]: 0.5 } }
+    const defaults = makeDefaults({ stats: makeStats({ [Stats.ATK_P]: 1 }) })
+
+    const result = mergeAndPruneOverride(existing, update, defaults)
+
+    expect(result?.stats).toEqual({ [Stats.SPD]: 1, [Stats.ATK_P]: 0.5 })
+  })
+
+  it('setting to default removes from delta', () => {
+    const existing: ScoringMetadataOverride = { stats: { [Stats.SPD]: 1, [Stats.ATK_P]: 0.5 } }
+    const update: Partial<ScoringMetadataOverride> = { stats: { [Stats.ATK_P]: 1 } } // matches default
+    const defaults = makeDefaults({ stats: makeStats({ [Stats.ATK_P]: 1 }) })
+
+    const result = mergeAndPruneOverride(existing, update, defaults)
+
+    expect(result?.stats).toEqual({ [Stats.SPD]: 1 }) // ATK_P removed
+  })
+
+  it('returns undefined when no content', () => {
+    const existing: ScoringMetadataOverride = { stats: { [Stats.SPD]: 0.75 } }
+    const update: Partial<ScoringMetadataOverride> = { stats: { [Stats.SPD]: 0.75 } } // matches default
+    const defaults = makeDefaults({ stats: makeStats({ [Stats.SPD]: 0.75 }) })
+
+    const result = mergeAndPruneOverride(existing, update, defaults)
+
+    expect(result).toBeUndefined()
+  })
+
+  it('preserves simulation when stats change', () => {
+    const existing: ScoringMetadataOverride = {
+      stats: { [Stats.SPD]: 1 },
+      simulation: { deprioritizeBuffs: true },
+    }
+    const update: Partial<ScoringMetadataOverride> = { stats: { [Stats.ATK_P]: 0.5 } }
+    const defaults = makeDefaults({ stats: makeStats({ [Stats.ATK_P]: 1 }) })
+
+    const result = mergeAndPruneOverride(existing, update, defaults)
+
+    expect(result?.simulation).toEqual({ deprioritizeBuffs: true })
+  })
+})
+
+describe('pruneOverridesOnLoad', () => {
+  it('converts full-snapshot to delta', () => {
+    // User has a full snapshot with many values matching defaults
+    const overrides: Record<string, ScoringMetadataOverride> = {
+      char1: {
+        stats: {
+          [Stats.ATK_P]: 1,
+          [Stats.SPD]: 1,
+          [Stats.EHR]: 0,
+          [Stats.CR]: 1,
+        },
+      },
+    }
+    const defaults = makeDefaults({
+      stats: makeStats({
+        [Stats.ATK_P]: 1, // matches
+        [Stats.SPD]: 0.75, // differs
+        [Stats.EHR]: 1, // differs
+        [Stats.CR]: 1, // matches
+      }),
+    })
+
+    const { result, changed } = pruneOverridesOnLoad(overrides, () => defaults)
+
+    expect(changed).toBe(true)
+    expect(result.char1.stats).toEqual({
+      [Stats.SPD]: 1, // kept (differs)
+      [Stats.EHR]: 0, // kept (differs)
+    })
+  })
+
+  it('preserves simulation and traces', () => {
+    const overrides: Record<string, ScoringMetadataOverride> = {
+      char1: {
+        stats: { [Stats.SPD]: 1 },
+        simulation: { deprioritizeBuffs: true },
+        traces: { deactivated: ['A2'] },
+      },
+    }
+    const defaults = makeDefaults()
+
+    const { result } = pruneOverridesOnLoad(overrides, () => defaults)
+
+    expect(result.char1.simulation).toEqual({ deprioritizeBuffs: true })
+    expect(result.char1.traces).toEqual({ deactivated: ['A2'] })
+  })
+
+  it('returns changed=true when pruned', () => {
+    const overrides: Record<string, ScoringMetadataOverride> = {
+      char1: { stats: { [Stats.SPD]: 0.75 } }, // matches default
+    }
+    const defaults = makeDefaults({ stats: makeStats({ [Stats.SPD]: 0.75 }) })
+
+    const { result, changed } = pruneOverridesOnLoad(overrides, () => defaults)
+
+    expect(changed).toBe(true)
+    expect(result.char1).toBeUndefined() // entire override removed
+  })
+
+  it('skips characters with no defaults', () => {
+    const overrides: Record<string, ScoringMetadataOverride> = {
+      orphaned: { stats: { [Stats.SPD]: 1 } },
+      valid: { stats: { [Stats.SPD]: 1 } },
+    }
+    const defaults = makeDefaults()
+
+    const { result } = pruneOverridesOnLoad(overrides, (id) => id === 'valid' ? defaults : undefined)
+
+    expect(result.orphaned).toBeUndefined()
+    expect(result.valid).toBeDefined()
+  })
+
+  it('returns changed=false when nothing actually changes', () => {
+    const overrides: Record<string, ScoringMetadataOverride> = {
+      char1: { stats: { [Stats.SPD]: 1 } }, // differs from default
+    }
+    const defaults = makeDefaults({ stats: makeStats({ [Stats.SPD]: 0.75 }) })
+
+    const { result, changed } = pruneOverridesOnLoad(overrides, () => defaults)
+
+    expect(changed).toBe(false)
+    expect(result.char1.stats).toEqual({ [Stats.SPD]: 1 })
+  })
+
+  it('keeps original override when getDefaults throws an error', () => {
+    const overrides: Record<string, ScoringMetadataOverride> = {
+      error: { stats: { [Stats.SPD]: 1 } },
+      valid: { stats: { [Stats.SPD]: 1 } },
+    }
+    const defaults = makeDefaults()
+
+    const { result } = pruneOverridesOnLoad(overrides, (id) => {
+      if (id === 'error') throw new Error('Test error')
+      return defaults
+    })
+
+    // Error character keeps original
+    expect(result.error).toEqual({ stats: { [Stats.SPD]: 1 } })
+    // Valid character still processed
+    expect(result.valid).toBeDefined()
+  })
+})
+
+describe('extractStatsDelta edge cases', () => {
+  it('ignores unknown keys not in SubStats', () => {
+    // Create stats object with a garbage key
+    const stats = {
+      [Stats.SPD]: 1,
+      garbage: 999,
+    } as unknown as Partial<Record<SubStats, number>>
+    const defaults = makeStats()
+
+    const delta = extractStatsDelta(stats, defaults)
+
+    // Should only contain SPD, not the garbage key
+    expect(delta).toEqual({ [Stats.SPD]: 1 })
+    expect(delta).not.toHaveProperty('garbage')
+  })
+
+  it('ignores empty strings from form display', () => {
+    // Form displays 0 as '', which should be ignored during extraction
+    const stats = {
+      [Stats.SPD]: 1,
+      [Stats.ATK_P]: '' as unknown as number,
+      [Stats.CR]: '' as unknown as number,
+    }
+    const defaults = makeStats({ [Stats.ATK_P]: 0.5 })
+
+    const delta = extractStatsDelta(stats, defaults)
+
+    // Only SPD should be in delta, empty strings skipped
+    expect(delta).toEqual({ [Stats.SPD]: 1 })
+    expect(delta).not.toHaveProperty(Stats.ATK_P)
+    expect(delta).not.toHaveProperty(Stats.CR)
+  })
+})
+
+describe('mergeDeltaWithDefaults edge cases', () => {
+  it('ignores empty strings in stored override stats', () => {
+    // Old saves may have empty strings from form display bug
+    const override = {
+      stats: {
+        [Stats.SPD]: 1,
+        [Stats.ATK_P]: '' as unknown as number,
+      },
+    } as ScoringMetadataOverride
+    const defaults = makeDefaults({ stats: makeStats({ [Stats.ATK_P]: 0.5, [Stats.CR]: 0.8 }) })
+
+    const result = mergeDeltaWithDefaults(override, defaults)
+
+    expect(result.stats[Stats.SPD]).toBe(1) // from override
+    expect(result.stats[Stats.ATK_P]).toBe(0.5) // from defaults (empty string ignored)
+    expect(result.stats[Stats.CR]).toBe(0.8) // from defaults
+  })
+
+  it('coerces non-numeric stats to 0', () => {
+    // Ensure final result has all numeric values
+    const override: ScoringMetadataOverride = {}
+    const defaults = makeDefaults()
+    // Simulate corrupt defaults with empty string
+    defaults.stats[Stats.EHR] = '' as unknown as number
+
+    const result = mergeDeltaWithDefaults(override, defaults)
+
+    expect(typeof result.stats[Stats.EHR]).toBe('number')
+    expect(result.stats[Stats.EHR]).toBe(0)
+  })
+
+  it('clones simulation to avoid shared reference mutation', () => {
+    const override: ScoringMetadataOverride = {
+      simulation: { deprioritizeBuffs: true },
+    }
+    const defaults = makeDefaults()
+
+    const result = mergeDeltaWithDefaults(override, defaults)
+
+    // Mutate the result
+    if (result.simulation) {
+      result.simulation.deprioritizeBuffs = false
+    }
+
+    // Original override should be unchanged
+    expect(override.simulation?.deprioritizeBuffs).toBe(true)
+  })
+
+  it('overlays parts from delta onto defaults', () => {
+    const override: ScoringMetadataOverride = {
+      parts: { [Parts.Body]: [Stats.DEF_P] },
+    }
+    const defaults = makeDefaults()
+
+    const result = mergeDeltaWithDefaults(override, defaults)
+
+    expect(result.parts[Parts.Body]).toEqual([Stats.DEF_P])
+    expect(result.parts[Parts.Feet]).toEqual([Stats.SPD]) // default preserved
+  })
+})
+
+describe('mergeAndPruneOverride edge cases', () => {
+  it('merges parts from update with existing override', () => {
+    const existing: ScoringMetadataOverride = {
+      parts: { [Parts.Body]: [Stats.DEF_P] },
+    }
+    const update: Partial<ScoringMetadataOverride> = {
+      parts: { [Parts.Feet]: [Stats.ATK_P] },
+    }
+    const defaults = makeDefaults()
+
+    const result = mergeAndPruneOverride(existing, update, defaults)
+
+    expect(result?.parts?.[Parts.Body]).toEqual([Stats.DEF_P])
+    expect(result?.parts?.[Parts.Feet]).toEqual([Stats.ATK_P])
+  })
+})

--- a/src/lib/stores/scoring/scoringDelta.ts
+++ b/src/lib/stores/scoring/scoringDelta.ts
@@ -1,0 +1,212 @@
+import { MainStatPartsArray, SubStats } from 'lib/constants/constants'
+import type { MainStats } from 'lib/constants/constants'
+import type { ScoringMetadata, ScoringMetadataOverride, ScoringParts, SimulationMetadata } from 'types/metadata'
+import { clone } from 'lib/utils/objectUtils'
+import { arraysEqual } from 'lib/utils/arrayUtils'
+
+// ─── Delta Extraction ────────────────────────────────────────────
+
+/**
+ * Extract only stats that differ from defaults.
+ * Returns undefined if no stats differ.
+ */
+export function extractStatsDelta(
+  stats: Partial<Record<SubStats, number>> | undefined,
+  defaults: Record<SubStats, number>,
+): Partial<Record<SubStats, number>> | undefined {
+  if (!stats) return undefined
+
+  const delta: Partial<Record<SubStats, number>> = {}
+
+  // Iterate over known SubStats only (not Object.entries) to avoid garbage keys
+  for (const stat of SubStats) {
+    const value = stats[stat]
+    // Skip non-numeric values (empty strings from form display, undefined, null)
+    if (typeof value !== 'number') continue
+
+    const defaultValue = defaults[stat] ?? 0
+    if (value !== defaultValue) {
+      delta[stat] = value
+    }
+  }
+
+  return Object.keys(delta).length > 0 ? delta : undefined
+}
+
+/**
+ * Extract only parts that differ from defaults.
+ * Returns undefined if no parts differ.
+ */
+export function extractPartsDelta(
+  parts: Partial<Record<ScoringParts, MainStats[]>> | undefined,
+  defaults: Record<ScoringParts, MainStats[]>,
+): Partial<Record<ScoringParts, MainStats[]>> | undefined {
+  if (!parts) return undefined
+
+  const delta: Partial<Record<ScoringParts, MainStats[]>> = {}
+
+  for (const part of MainStatPartsArray) {
+    const value = parts[part]
+    if (value === undefined) continue
+
+    if (!arraysEqual(value, defaults[part])) {
+      delta[part] = value
+    }
+  }
+
+  return Object.keys(delta).length > 0 ? delta : undefined
+}
+
+// ─── Delta Merging ───────────────────────────────────────────────
+
+/**
+ * Merge delta override onto defaults to produce full ScoringMetadata.
+ * Works for both old full-snapshots AND new delta format.
+ */
+export function mergeDeltaWithDefaults(
+  override: ScoringMetadataOverride | undefined,
+  defaults: ScoringMetadata,
+): ScoringMetadata {
+  const result = clone(defaults)
+
+  // Overlay stats (works for full-snapshot or delta)
+  if (override?.stats) {
+    for (const stat of SubStats) {
+      const value = override.stats[stat]
+      // Only overlay numeric values (skip empty strings from old saves)
+      if (typeof value === 'number') {
+        result.stats[stat] = value
+      }
+    }
+  }
+
+  // Overlay parts
+  if (override?.parts) {
+    for (const part of MainStatPartsArray) {
+      const value = override.parts[part]
+      if (value !== undefined) {
+        result.parts[part] = value
+      }
+    }
+  }
+
+  // Deep-merge simulation
+  if (override?.simulation && defaults.simulation) {
+    result.simulation = { ...clone(defaults.simulation), ...override.simulation } as SimulationMetadata
+  } else if (override?.simulation) {
+    result.simulation = clone(override.simulation) as SimulationMetadata // Clone to avoid shared reference
+  }
+
+  // Traces: full replacement
+  if (override?.traces) {
+    result.traces = override.traces
+  }
+
+  // Ensure all SubStats have numeric values (catch empty strings, null, undefined)
+  for (const stat of SubStats) {
+    if (typeof result.stats[stat] !== 'number') {
+      result.stats[stat] = 0
+    }
+  }
+
+  // Derive modified flag from override existence (replaces setModifiedScoringMetadata)
+  result.modified = !!(override?.stats && Object.keys(override.stats).length > 0)
+
+  return result
+}
+
+// ─── Store Update Helper ─────────────────────────────────────────
+
+/**
+ * Merge incoming update with existing override, prune to delta.
+ * Returns undefined if result has no content (should remove override).
+ */
+export function mergeAndPruneOverride(
+  existing: ScoringMetadataOverride | undefined,
+  update: Partial<ScoringMetadataOverride>,
+  defaults: ScoringMetadata,
+): ScoringMetadataOverride | undefined {
+  // Merge stats (not replace)
+  const mergedStats = { ...existing?.stats, ...update.stats }
+  const prunedStats = extractStatsDelta(mergedStats, defaults.stats)
+
+  // Merge parts (not replace)
+  const mergedParts = { ...existing?.parts, ...update.parts }
+  const prunedParts = extractPartsDelta(mergedParts, defaults.parts)
+
+  // Build result
+  const result: ScoringMetadataOverride = {}
+
+  if (prunedStats) result.stats = prunedStats
+  if (prunedParts) result.parts = prunedParts
+  if (update.simulation !== undefined) {
+    result.simulation = update.simulation
+  } else if (existing?.simulation) {
+    result.simulation = existing.simulation
+  }
+  if (update.traces !== undefined) {
+    result.traces = update.traces
+  } else if (existing?.traces) {
+    result.traces = existing.traces
+  }
+
+  // Check if result has any content
+  const hasContent = result.stats || result.parts || result.simulation || result.traces
+  return hasContent ? result : undefined
+}
+
+// ─── On-Load Prune (Replaces Migration) ──────────────────────────
+
+/**
+ * Prune all overrides to delta format on load.
+ * Uses same logic as write path - no separate migration code.
+ * Returns pruned overrides and whether anything changed.
+ */
+export function pruneOverridesOnLoad(
+  overrides: Record<string, ScoringMetadataOverride>,
+  getDefaults: (id: string) => ScoringMetadata | undefined,
+): { result: Record<string, ScoringMetadataOverride>; changed: boolean } {
+  const result: Record<string, ScoringMetadataOverride> = {}
+  let changed = false
+
+  for (const [id, override] of Object.entries(overrides)) {
+    try {
+      const defaults = getDefaults(id)
+      if (!defaults) continue // Skip orphaned characters
+
+      // Prune to delta using same functions as write path
+      const prunedStats = extractStatsDelta(override.stats, defaults.stats)
+      const prunedParts = extractPartsDelta(override.parts, defaults.parts)
+
+      // Check if pruning removed any keys (compare key counts since extract functions create new objects)
+      const statsKeysBefore = override.stats ? Object.keys(override.stats).length : 0
+      const statsKeysAfter = prunedStats ? Object.keys(prunedStats).length : 0
+      const partsKeysBefore = override.parts ? Object.keys(override.parts).length : 0
+      const partsKeysAfter = prunedParts ? Object.keys(prunedParts).length : 0
+
+      if (statsKeysAfter !== statsKeysBefore || partsKeysAfter !== partsKeysBefore) {
+        changed = true
+      }
+
+      // Build pruned override
+      const pruned: ScoringMetadataOverride = {}
+      if (prunedStats) pruned.stats = prunedStats
+      if (prunedParts) pruned.parts = prunedParts
+      if (override.simulation) pruned.simulation = override.simulation
+      if (override.traces) pruned.traces = override.traces
+
+      // Only store if has content
+      const hasContent = pruned.stats || pruned.parts || pruned.simulation || pruned.traces
+      if (hasContent) {
+        result[id] = pruned
+      } else {
+        changed = true // Entire override removed
+      }
+    } catch (e) {
+      console.error(`Prune failed for character ${id}`, e)
+      result[id] = override // Keep original on error
+    }
+  }
+
+  return { result, changed }
+}

--- a/src/lib/stores/scoring/scoringDelta.ts
+++ b/src/lib/stores/scoring/scoringDelta.ts
@@ -2,7 +2,7 @@ import { MainStatPartsArray, SubStats } from 'lib/constants/constants'
 import type { MainStats } from 'lib/constants/constants'
 import type { ScoringMetadata, ScoringMetadataOverride, ScoringParts, SimulationMetadata } from 'types/metadata'
 import { clone } from 'lib/utils/objectUtils'
-import { arraysEqual } from 'lib/utils/arrayUtils'
+import { arraysShallowEqual } from 'lib/utils/arrayUtils'
 
 // ─── Delta Extraction ────────────────────────────────────────────
 
@@ -49,7 +49,7 @@ export function extractPartsDelta(
     const value = parts[part]
     if (value === undefined) continue
 
-    if (!arraysEqual(value, defaults[part])) {
+    if (!arraysShallowEqual(value, defaults[part])) {
       delta[part] = value
     }
   }

--- a/src/lib/stores/scoring/scoringStore.test.ts
+++ b/src/lib/stores/scoring/scoringStore.test.ts
@@ -6,7 +6,7 @@ import { Jingliu } from 'lib/conditionals/character/1200/Jingliu'
 import { SubStats, Stats } from 'lib/constants/constants'
 import { Metadata } from 'lib/state/metadataInitializer'
 import { getGameMetadata } from 'lib/state/gameMetadata'
-import type { ScoringMetadata, SimulationMetadata } from 'types/metadata'
+import type { ScoringMetadata, ScoringMetadataOverride, SimulationMetadata } from 'types/metadata'
 import type { CharacterId } from 'types/character'
 
 // ---- Setup ----
@@ -23,8 +23,8 @@ function kafkaDefaults(): ScoringMetadata {
   return getGameMetadata().characters[Kafka.id].scoringMetadata
 }
 
-function statsOverride(stats: Partial<Record<string, number>>): Partial<ScoringMetadata> {
-  return { stats: stats as ScoringMetadata['stats'] }
+function statsOverride(stats: Partial<Record<string, number>>): Partial<ScoringMetadataOverride> {
+  return { stats: stats as ScoringMetadataOverride['stats'] }
 }
 
 // ---- Reset ----
@@ -47,7 +47,7 @@ describe('useScoringStore', () => {
     // getScoringMetadata must not mutate the stored override in-place via mergeUndefinedValues
     it('getScoringMetadata does not add default keys to the stored override after being called', () => {
       const override = statsOverride({ [Stats.ATK_P]: 1 })
-      state().setScoringMetadataOverrides({ [Kafka.id]: override as ScoringMetadata })
+      state().setScoringMetadataOverrides({ [Kafka.id]: override as ScoringMetadataOverride })
 
       const keysBefore = Object.keys(state().scoringMetadataOverrides[Kafka.id] ?? {})
 
@@ -55,20 +55,6 @@ describe('useScoringStore', () => {
 
       const keysAfter = Object.keys(state().scoringMetadataOverrides[Kafka.id] ?? {})
       expect(keysAfter.length).toBe(keysBefore.length)
-    })
-
-    // getScoringMetadata must not delete presets from the stored override
-    it('getScoringMetadata does not delete presets from the stored override', () => {
-      const defaults = kafkaDefaults()
-      const override = {
-        ...statsOverride({ [Stats.ATK_P]: 1 }),
-        presets: defaults.presets,
-      }
-      state().setScoringMetadataOverrides({ [Kafka.id]: override as ScoringMetadata })
-
-      getScoringMetadata(Kafka.id)
-
-      expect(state().scoringMetadataOverrides[Kafka.id]?.presets).toBeDefined()
     })
 
     it('getScoringMetadata returns a numeric weight for every SubStat when no override exists', () => {
@@ -79,7 +65,7 @@ describe('useScoringStore', () => {
     })
 
     it('getScoringMetadata merges override stat weights over defaults where they exist', () => {
-      state().setScoringMetadataOverrides({ [Kafka.id]: statsOverride({ [Stats.ATK_P]: 0.75 }) as ScoringMetadata })
+      state().setScoringMetadataOverrides({ [Kafka.id]: statsOverride({ [Stats.ATK_P]: 0.75 }) as ScoringMetadataOverride })
 
       const result = getScoringMetadata(Kafka.id)
       expect(result.stats[Stats.ATK_P]).toBe(0.75)
@@ -125,12 +111,12 @@ describe('useScoringStore', () => {
     })
 
     it('mutating getScoringMetadata stats does not corrupt the stored override', () => {
-      state().setScoringMetadataOverrides({ [Kafka.id]: statsOverride({ [Stats.ATK_P]: 0.5 }) as ScoringMetadata })
+      state().setScoringMetadataOverrides({ [Kafka.id]: statsOverride({ [Stats.ATK_P]: 0.5 }) as ScoringMetadataOverride })
 
       const result = getScoringMetadata(Kafka.id)
       result.stats[Stats.ATK_P] = 999
 
-      expect(state().scoringMetadataOverrides[Kafka.id]?.stats[Stats.ATK_P]).toBe(0.5)
+      expect(state().scoringMetadataOverrides[Kafka.id]?.stats?.[Stats.ATK_P]).toBe(0.5)
     })
   })
 
@@ -143,11 +129,13 @@ describe('useScoringStore', () => {
     })
 
     it('updateCharacterOverrides merges new stat weights into an existing override', () => {
+      // Use values that differ from Kafka's defaults (ATK_P=1, SPD=1) to avoid delta pruning
       state().updateCharacterOverrides(Kafka.id, statsOverride({ [Stats.ATK_P]: 0.5 }))
-      state().updateCharacterOverrides(Kafka.id, statsOverride({ [Stats.SPD]: 1 }))
+      state().updateCharacterOverrides(Kafka.id, statsOverride({ [Stats.SPD]: 0.75 }))
 
       const override = state().scoringMetadataOverrides[Kafka.id]
-      expect(override?.stats[Stats.SPD]).toBe(1)
+      expect(override?.stats?.[Stats.ATK_P]).toBe(0.5)
+      expect(override?.stats?.[Stats.SPD]).toBe(0.75)
     })
 
     it('updateCharacterOverrides increments scoringVersion on each call', () => {
@@ -162,9 +150,9 @@ describe('useScoringStore', () => {
       state().updateCharacterOverrides(Kafka.id, statsOverride({ [Stats.ATK_P]: 0.5 }))
       state().updateCharacterOverrides(Jingliu.id, statsOverride({ [Stats.ATK_P]: 0.8 }))
 
-      state().setScoringMetadataOverrides({ [Kafka.id]: statsOverride({ [Stats.HP_P]: 1 }) as ScoringMetadata })
+      state().setScoringMetadataOverrides({ [Kafka.id]: statsOverride({ [Stats.HP_P]: 1 }) as ScoringMetadataOverride })
 
-      expect(state().scoringMetadataOverrides[Kafka.id]?.stats[Stats.HP_P]).toBe(1)
+      expect(state().scoringMetadataOverrides[Kafka.id]?.stats?.[Stats.HP_P]).toBe(1)
       expect(state().scoringMetadataOverrides[Jingliu.id]).toBeUndefined()
       expect(state().scoringVersion).toBe(3)
     })
@@ -194,7 +182,62 @@ describe('useScoringStore', () => {
       state().clearSimulationOverrides(Kafka.id)
 
       expect(state().scoringMetadataOverrides[Kafka.id]?.simulation).toBeUndefined()
-      expect(state().scoringMetadataOverrides[Kafka.id]?.stats[Stats.ATK_P]).toBe(0.5)
+      expect(state().scoringMetadataOverrides[Kafka.id]?.stats?.[Stats.ATK_P]).toBe(0.5)
+    })
+
+    it('clearSimulationOverrides removes entire override when only simulation existed', () => {
+      state().updateSimulationOverrides(Kafka.id, { deprioritizeBuffs: true } as Partial<SimulationMetadata>)
+
+      expect(state().scoringMetadataOverrides[Kafka.id]?.simulation).toBeDefined()
+
+      state().clearSimulationOverrides(Kafka.id)
+
+      expect(state().scoringMetadataOverrides[Kafka.id]).toBeUndefined()
+    })
+  })
+
+  describe('clearCharacterOverrides', () => {
+    it('removes all overrides for a character', () => {
+      state().updateCharacterOverrides(Kafka.id, statsOverride({ [Stats.ATK_P]: 0.5 }))
+      state().updateSimulationOverrides(Kafka.id, { deprioritizeBuffs: true } as Partial<SimulationMetadata>)
+
+      expect(state().scoringMetadataOverrides[Kafka.id]).toBeDefined()
+
+      state().clearCharacterOverrides(Kafka.id)
+
+      expect(state().scoringMetadataOverrides[Kafka.id]).toBeUndefined()
+    })
+
+    it('increments scoringVersion', () => {
+      state().updateCharacterOverrides(Kafka.id, statsOverride({ [Stats.ATK_P]: 0.5 }))
+      const versionBefore = state().scoringVersion
+
+      state().clearCharacterOverrides(Kafka.id)
+
+      expect(state().scoringVersion).toBe(versionBefore + 1)
+    })
+
+    it('is idempotent when no override exists', () => {
+      expect(state().scoringMetadataOverrides[Kafka.id]).toBeUndefined()
+
+      state().clearCharacterOverrides(Kafka.id)
+
+      expect(state().scoringMetadataOverrides[Kafka.id]).toBeUndefined()
+    })
+  })
+
+  describe('delta pruning behavior', () => {
+    it('updateCharacterOverrides removes override when all values match defaults', () => {
+      const defaults = kafkaDefaults()
+      // Set an override different from defaults
+      state().updateCharacterOverrides(Kafka.id, statsOverride({ [Stats.ATK_P]: 0.5 }))
+      expect(state().scoringMetadataOverrides[Kafka.id]).toBeDefined()
+
+      // Now set it back to the default value
+      state().updateCharacterOverrides(Kafka.id, statsOverride({ [Stats.ATK_P]: defaults.stats[Stats.ATK_P] }))
+
+      // The override should be completely removed
+      expect(state().scoringMetadataOverrides[Kafka.id]).toBeUndefined()
     })
   })
 })

--- a/src/lib/stores/scoring/scoringStore.ts
+++ b/src/lib/stores/scoring/scoringStore.ts
@@ -1,6 +1,7 @@
 import { getGameMetadata } from 'lib/state/gameMetadata'
 import { createTabAwareStore } from 'lib/stores/infrastructure/createTabAwareStore'
 import { mergeAndPruneOverride, mergeDeltaWithDefaults } from 'lib/stores/scoring/scoringDelta'
+import { omit, setOrOmit } from 'lib/utils/objectUtils'
 import type { CharacterId } from 'types/character'
 import type { ScoringMetadata, ScoringMetadataOverride, SimulationMetadata } from 'types/metadata'
 
@@ -34,11 +35,7 @@ export const useScoringStore = createTabAwareStore<ScoringStore>((set, get) => (
     if (!defaults) return
 
     const newOverride = mergeAndPruneOverride(prev[id], updated, defaults)
-    const overrides = newOverride
-      ? { ...prev, [id]: newOverride }
-      : omit(prev, id)
-
-    set({ scoringMetadataOverrides: overrides, scoringVersion: get().scoringVersion + 1 })
+    set({ scoringMetadataOverrides: setOrOmit(prev, id, newOverride), scoringVersion: get().scoringVersion + 1 })
   },
 
   updateSimulationOverrides: (id, updatedSimulation) => {
@@ -52,10 +49,7 @@ export const useScoringStore = createTabAwareStore<ScoringStore>((set, get) => (
     const prev = get().scoringMetadataOverrides
     const { simulation, ...rest } = prev[id] ?? {}
     const hasContent = rest.stats || rest.parts || rest.traces
-    const overrides = hasContent
-      ? { ...prev, [id]: rest }
-      : omit(prev, id)
-    set({ scoringMetadataOverrides: overrides, scoringVersion: get().scoringVersion + 1 })
+    set({ scoringMetadataOverrides: setOrOmit(prev, id, hasContent ? rest : undefined), scoringVersion: get().scoringVersion + 1 })
   },
 
   clearCharacterOverrides: (id) => {
@@ -63,11 +57,6 @@ export const useScoringStore = createTabAwareStore<ScoringStore>((set, get) => (
     set({ scoringMetadataOverrides: omit(prev, id), scoringVersion: get().scoringVersion + 1 })
   },
 }))
-
-function omit<T extends Record<string, unknown>>(obj: T, key: string): T {
-  const { [key]: _, ...rest } = obj
-  return rest as T
-}
 
 const fallbackMetadata = { stats: {}, parts: {}, presets: [], sortOption: {}, hiddenColumns: [] } as unknown as ScoringMetadata
 

--- a/src/lib/stores/scoring/scoringStore.ts
+++ b/src/lib/stores/scoring/scoringStore.ts
@@ -1,21 +1,20 @@
-import { SubStats } from 'lib/constants/constants'
-import { setModifiedScoringMetadata } from 'lib/scoring/scoreComparison'
 import { getGameMetadata } from 'lib/state/gameMetadata'
 import { createTabAwareStore } from 'lib/stores/infrastructure/createTabAwareStore'
+import { mergeAndPruneOverride, mergeDeltaWithDefaults } from 'lib/stores/scoring/scoringDelta'
 import type { CharacterId } from 'types/character'
-import type { ScoringMetadata, SimulationMetadata } from 'types/metadata'
-import { clone, mergeUndefinedValues } from 'lib/utils/objectUtils'
+import type { ScoringMetadata, ScoringMetadataOverride, SimulationMetadata } from 'types/metadata'
 
 type ScoringStoreState = {
-  scoringMetadataOverrides: Partial<Record<CharacterId, ScoringMetadata>>
+  scoringMetadataOverrides: Partial<Record<CharacterId, ScoringMetadataOverride>>
   scoringVersion: number
 }
 
 type ScoringStoreActions = {
-  setScoringMetadataOverrides: (overrides: Partial<Record<CharacterId, ScoringMetadata>>) => void
-  updateCharacterOverrides: (id: CharacterId, updated: Partial<ScoringMetadata>) => void
+  setScoringMetadataOverrides: (overrides: Partial<Record<CharacterId, ScoringMetadataOverride>>) => void
+  updateCharacterOverrides: (id: CharacterId, updated: Partial<ScoringMetadataOverride>) => void
   updateSimulationOverrides: (id: CharacterId, simulation: Partial<SimulationMetadata>) => void
   clearSimulationOverrides: (id: CharacterId) => void
+  clearCharacterOverrides: (id: CharacterId) => void
 }
 
 export type ScoringStore = ScoringStoreState & ScoringStoreActions
@@ -31,12 +30,13 @@ export const useScoringStore = createTabAwareStore<ScoringStore>((set, get) => (
 
   updateCharacterOverrides: (id, updated) => {
     const prev = get().scoringMetadataOverrides
-    const overrides = { ...prev, [id]: { stats: {}, ...prev[id], ...updated } }
+    const defaults = getGameMetadata().characters[id]?.scoringMetadata
+    if (!defaults) return
 
-    const characterMeta = getGameMetadata().characters[id]
-    if (!characterMeta?.scoringMetadata) return
-    const defaultScoringMetadata = characterMeta.scoringMetadata
-    setModifiedScoringMetadata(defaultScoringMetadata, overrides[id]!)
+    const newOverride = mergeAndPruneOverride(prev[id], updated, defaults)
+    const overrides = newOverride
+      ? { ...prev, [id]: newOverride }
+      : omit(prev, id)
 
     set({ scoringMetadataOverrides: overrides, scoringVersion: get().scoringVersion + 1 })
   },
@@ -51,38 +51,40 @@ export const useScoringStore = createTabAwareStore<ScoringStore>((set, get) => (
   clearSimulationOverrides: (id) => {
     const prev = get().scoringMetadataOverrides
     const { simulation, ...rest } = prev[id] ?? {}
-    const overrides = { ...prev, [id]: rest }
+    const hasContent = rest.stats || rest.parts || rest.traces
+    const overrides = hasContent
+      ? { ...prev, [id]: rest }
+      : omit(prev, id)
     set({ scoringMetadataOverrides: overrides, scoringVersion: get().scoringVersion + 1 })
   },
+
+  clearCharacterOverrides: (id) => {
+    const prev = get().scoringMetadataOverrides
+    set({ scoringMetadataOverrides: omit(prev, id), scoringVersion: get().scoringVersion + 1 })
+  },
 }))
+
+function omit<T extends Record<string, unknown>>(obj: T, key: string): T {
+  const { [key]: _, ...rest } = obj
+  return rest as T
+}
+
+const fallbackMetadata = { stats: {}, parts: {}, presets: [], sortOption: {}, hiddenColumns: [] } as unknown as ScoringMetadata
 
 /**
  * Gets scoring metadata for a character, merged with overrides.
  */
 export function getScoringMetadata(id: CharacterId): ScoringMetadata {
   const characterMeta = getGameMetadata().characters[id]
-  if (!characterMeta?.scoringMetadata) return { stats: {}, parts: {}, presets: [], sortOption: {}, hiddenColumns: [] } as unknown as ScoringMetadata
-  const defaultScoringMetadata = characterMeta.scoringMetadata
+  if (!characterMeta?.scoringMetadata) return fallbackMetadata
+
+  const defaults = characterMeta.scoringMetadata
   const override = useScoringStore.getState().scoringMetadataOverrides[id]
-  const cloned = clone(override) ?? {}
-  const returnScoringMetadata = mergeUndefinedValues(cloned, defaultScoringMetadata) as ScoringMetadata
 
-  // Deep-merge simulation: partial overrides (e.g. deprioritizeBuffs) must inherit
-  // default simulation properties (e.g. teammates) that weren't overridden
-  if (override?.simulation && defaultScoringMetadata.simulation) {
-    returnScoringMetadata.simulation = { ...clone(defaultScoringMetadata.simulation), ...returnScoringMetadata.simulation }
-  }
-
-  for (const stat of SubStats) {
-    if (returnScoringMetadata.stats[stat] == null) {
-      returnScoringMetadata.stats[stat] = 0
-    }
-  }
-
-  setModifiedScoringMetadata(defaultScoringMetadata, returnScoringMetadata)
+  const result = mergeDeltaWithDefaults(override, defaults)
 
   // @ts-expect-error - presets are not needed for scoring
-  delete returnScoringMetadata.presets
+  delete result.presets
 
-  return returnScoringMetadata
+  return result
 }

--- a/src/lib/tabs/tabOptimizer/combo/comboDrawerService.ts
+++ b/src/lib/tabs/tabOptimizer/combo/comboDrawerService.ts
@@ -2,12 +2,9 @@ import { useOptimizerRequestStore } from 'lib/stores/optimizerForm/useOptimizerR
 import { preprocessTurnAbilityNames } from 'lib/optimization/rotation/turnPreprocessor'
 import type { ComboState } from 'lib/optimization/combo/comboTypes'
 import { COMBO_STATE_JSON_VERSION } from 'lib/optimization/combo/comboTypes'
+import { arraysEqual } from 'lib/utils/arrayUtils'
 import { persistFormToCharacterStore } from './comboDrawerUtils'
 import { useComboDrawerStore } from './useComboDrawerStore'
-
-function arraysEqual(a: readonly unknown[], b: readonly unknown[]): boolean {
-  return a.length === b.length && a.every((v, i) => v === b[i])
-}
 
 function syncToStores(comboState: ComboState) {
   const requestStore = useOptimizerRequestStore.getState()

--- a/src/lib/tabs/tabOptimizer/combo/comboDrawerService.ts
+++ b/src/lib/tabs/tabOptimizer/combo/comboDrawerService.ts
@@ -2,7 +2,7 @@ import { useOptimizerRequestStore } from 'lib/stores/optimizerForm/useOptimizerR
 import { preprocessTurnAbilityNames } from 'lib/optimization/rotation/turnPreprocessor'
 import type { ComboState } from 'lib/optimization/combo/comboTypes'
 import { COMBO_STATE_JSON_VERSION } from 'lib/optimization/combo/comboTypes'
-import { arraysEqual } from 'lib/utils/arrayUtils'
+import { arraysShallowEqual } from 'lib/utils/arrayUtils'
 import { persistFormToCharacterStore } from './comboDrawerUtils'
 import { useComboDrawerStore } from './useComboDrawerStore'
 
@@ -15,7 +15,7 @@ function syncToStores(comboState: ComboState) {
   if (requestStore.comboStateJson !== newJson) {
     requestStore.setComboStateJson(newJson)
   }
-  if (!arraysEqual(requestStore.comboTurnAbilities, comboState.comboTurnAbilities)) {
+  if (!arraysShallowEqual(requestStore.comboTurnAbilities, comboState.comboTurnAbilities)) {
     requestStore.setComboTurnAbilities(comboState.comboTurnAbilities)
   }
 

--- a/src/lib/utils/arrayUtils.ts
+++ b/src/lib/utils/arrayUtils.ts
@@ -55,3 +55,14 @@ export function arrayOfZeroes(n: number): number[] {
 export function arrayOfValue<T>(n: number, x: T): T[] {
   return new Array(n).fill(x)
 }
+
+/** Check if two arrays have equal elements (shallow comparison) */
+export function arraysEqual<T>(a: T[] | undefined, b: T[] | undefined): boolean {
+  if (a === b) return true
+  if (!a || !b) return false
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false
+  }
+  return true
+}

--- a/src/lib/utils/arrayUtils.ts
+++ b/src/lib/utils/arrayUtils.ts
@@ -57,7 +57,7 @@ export function arrayOfValue<T>(n: number, x: T): T[] {
 }
 
 /** Check if two arrays have equal elements (shallow comparison) */
-export function arraysEqual<T>(a: T[] | undefined, b: T[] | undefined): boolean {
+export function arraysShallowEqual<T>(a: T[] | undefined, b: T[] | undefined): boolean {
   if (a === b) return true
   if (!a || !b) return false
   if (a.length !== b.length) return false

--- a/src/lib/utils/objectUtils.ts
+++ b/src/lib/utils/objectUtils.ts
@@ -59,3 +59,14 @@ export function mergeUndefinedValues<T extends Record<string, unknown>>(target: 
   }
   return target
 }
+
+/** Remove a key from an object, returning a new object. */
+export function omit<T extends Record<string, unknown>>(obj: T, key: string): T {
+  const { [key]: _, ...rest } = obj
+  return rest as T
+}
+
+/** Set a key if value is truthy, otherwise remove it. */
+export function setOrOmit<T>(record: Record<string, T>, key: string, value: T | undefined): Record<string, T> {
+  return value ? { ...record, [key]: value } : omit(record, key)
+}

--- a/src/types/metadata.ts
+++ b/src/types/metadata.ts
@@ -42,6 +42,14 @@ export type ScoringMetadata = {
   /*      dps score       */ simulation?: SimulationMetadata,
 }
 
+export type ScoringParts = Exclude<Parts, typeof Parts.Head | typeof Parts.Hands>
+export type ScoringMetadataOverride = {
+  stats?: Partial<Record<SubStats, number>>
+  parts?: Partial<Record<ScoringParts, MainStats[]>>
+  simulation?: Partial<SimulationMetadata>
+  traces?: { deactivated: string[] }
+}
+
 export type SimulationMetadata = {
   parts: {
     [part: string]: MainStats[],

--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -10,7 +10,7 @@ import type {
   CharacterId,
 } from 'types/character'
 import type {
-  ScoringMetadata,
+  ScoringMetadataOverride,
   ShowcasePreferences,
 } from 'types/metadata'
 import type { Relic } from 'types/relic'
@@ -58,7 +58,7 @@ export type UserSettings = {
 export type HsrOptimizerSaveFormat = {
   relics: Relic[],
   characters: Character[],
-  scoringMetadataOverrides?: Record<string, ScoringMetadata>,
+  scoringMetadataOverrides?: Record<string, ScoringMetadataOverride>,
   showcasePreferences?: Record<string, ShowcasePreferences>,
   optimizerMenuState?: OptimizerMenuState,
   excludedRelicPotentialCharacters?: CharacterId[],


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->
  - Add delta storage for scoring metadata store only values differing from defaults so future default updates flow through
  - Fix empty strings from form being stored as false overrides
## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [ ] I have added commit messages that are descriptive and meaningful.
- [ ] I have tested the changes locally.
- [ ] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
