### PR TITLE
feat: buffs display improvements

### DIFF
--- a/src/lib/characterPreview/buffsAnalysis/BuffRow.tsx
+++ b/src/lib/characterPreview/buffsAnalysis/BuffRow.tsx
@@ -23,10 +23,7 @@ import {
   BUFF_TYPE,
 } from 'lib/optimization/buffSource'
 import type { ReactElement } from 'react'
-import {
-  useContext,
-  useMemo,
-} from 'react'
+import { useContext } from 'react'
 import { useTranslation } from 'react-i18next'
 
 export function BuffRow({ buff, isLast }: { buff: Buff, isLast: boolean }) {
@@ -118,20 +115,21 @@ function DamageTagPills({ damageTags }: { damageTags?: number }) {
   const onFilterChange = useContext(FilterChangeContext)
   const selectedFilter = useContext(FilterContext)
 
-  const pills = useMemo(() => {
-    if (damageTags == null) {
-      return [renderPill('ALL', ABILITY_COLORS.ALL, 'ALL', undefined, () => onFilterChange?.(null))]
-    }
+  if (damageTags == null) {
+    return (
+      <div style={{ display: 'flex', gap: 2, flexWrap: 'wrap', flexShrink: 0 }}>
+        {renderPill('ALL', ABILITY_COLORS.ALL, 'ALL', { onClick: () => onFilterChange?.(null) })}
+      </div>
+    )
+  }
 
-    const result: ReactElement[] = []
-    for (const entry of DAMAGE_TAG_ENTRIES) {
-      if ((damageTags & entry.tag) !== 0) {
-        const active = selectedFilter != null && (entry.tag & selectedFilter) !== 0
-        result.push(renderPill(String(entry.tag), entry.color, entry.label, undefined, () => onFilterChange?.(entry.tag), active))
-      }
+  const pills: ReactElement[] = []
+  for (const entry of DAMAGE_TAG_ENTRIES) {
+    if ((damageTags & entry.tag) !== 0) {
+      const active = selectedFilter != null && (entry.tag & selectedFilter) !== 0
+      pills.push(renderPill(String(entry.tag), entry.color, entry.label, { onClick: () => onFilterChange?.(entry.tag), active }))
     }
-    return result
-  }, [damageTags, onFilterChange, selectedFilter])
+  }
 
   if (pills.length === 0) return null
   return <div style={{ display: 'flex', gap: 2, flexWrap: 'wrap', flexShrink: 0 }}>{pills}</div>

--- a/src/lib/characterPreview/buffsAnalysis/BuffRow.tsx
+++ b/src/lib/characterPreview/buffsAnalysis/BuffRow.tsx
@@ -91,7 +91,6 @@ export function BuffRow({ buff, isLast }: { buff: Buff, isLast: boolean }) {
         borderBottom: borderBottomStyle,
         background: rowBackground,
         opacity: dimmed ? 0.15 : 1,
-        transition: 'opacity 0.15s',
       }}
     >
       <span style={{ minWidth: 60, textWrap: 'nowrap', fontSize: options.fontSize }}>{value}</span>

--- a/src/lib/characterPreview/buffsAnalysis/BuffRow.tsx
+++ b/src/lib/characterPreview/buffsAnalysis/BuffRow.tsx
@@ -12,6 +12,7 @@ import {
 import {
   DesignContext,
   ellipsisStyle,
+  FilterChangeContext,
   FilterContext,
   getSourceLabelStyle,
 } from 'lib/characterPreview/buffsAnalysis/designContext'
@@ -115,19 +116,23 @@ export function BuffRow({ buff, isLast }: { buff: Buff, isLast: boolean }) {
 }
 
 function DamageTagPills({ damageTags }: { damageTags?: number }) {
+  const onFilterChange = useContext(FilterChangeContext)
+  const selectedFilter = useContext(FilterContext)
+
   const pills = useMemo(() => {
     if (damageTags == null) {
-      return [renderPill('ALL', ABILITY_COLORS.ALL, 'ALL')]
+      return [renderPill('ALL', ABILITY_COLORS.ALL, 'ALL', undefined, () => onFilterChange?.(null))]
     }
 
     const result: ReactElement[] = []
     for (const entry of DAMAGE_TAG_ENTRIES) {
       if ((damageTags & entry.tag) !== 0) {
-        result.push(renderPill(String(entry.tag), entry.color, entry.label))
+        const active = selectedFilter != null && (entry.tag & selectedFilter) !== 0
+        result.push(renderPill(String(entry.tag), entry.color, entry.label, undefined, () => onFilterChange?.(entry.tag), active))
       }
     }
     return result
-  }, [damageTags])
+  }, [damageTags, onFilterChange, selectedFilter])
 
   if (pills.length === 0) return null
   return <div style={{ display: 'flex', gap: 2, flexWrap: 'wrap', flexShrink: 0 }}>{pills}</div>

--- a/src/lib/characterPreview/buffsAnalysis/FilterBar.module.css
+++ b/src/lib/characterPreview/buffsAnalysis/FilterBar.module.css
@@ -8,5 +8,4 @@
   font-weight: 600;
   cursor: pointer;
   user-select: none;
-  transition: all 0.15s;
 }

--- a/src/lib/characterPreview/buffsAnalysis/HitDefinitionDisplay.tsx
+++ b/src/lib/characterPreview/buffsAnalysis/HitDefinitionDisplay.tsx
@@ -8,6 +8,8 @@ import {
 import {
   DesignContext,
   ellipsisStyle,
+  FilterChangeContext,
+  FilterContext,
   getRowBaseStyle,
   getSourceLabelStyle,
   TEXT_DIM,
@@ -132,6 +134,8 @@ function HitSubHeader({ label }: { label: string }) {
 
 function HitRow({ hit, isLastHit }: { hit: Hit, isLastHit: boolean }) {
   const options = useContext(DesignContext)
+  const onFilterChange = useContext(FilterChangeContext)
+  const selectedFilter = useContext(FilterContext)
   const rowBase = getRowBaseStyle(options)
   const sourceLabelStyle = getSourceLabelStyle(options)
 
@@ -141,7 +145,10 @@ function HitRow({ hit, isLastHit }: { hit: Hit, isLastHit: boolean }) {
   const tagPills = hit.outputTag === OutputTag.DAMAGE
     ? DAMAGE_TAG_ENTRIES
       .filter((e) => (hit.damageType & e.tag) !== 0)
-      .map((e) => renderPill(String(e.tag), e.color, e.label))
+      .map((e) => {
+        const active = selectedFilter != null && (e.tag & selectedFilter) !== 0
+        return renderPill(String(e.tag), e.color, e.label, undefined, () => onFilterChange?.(e.tag), active)
+      })
     : []
 
   return (

--- a/src/lib/characterPreview/buffsAnalysis/HitDefinitionDisplay.tsx
+++ b/src/lib/characterPreview/buffsAnalysis/HitDefinitionDisplay.tsx
@@ -147,7 +147,7 @@ function HitRow({ hit, isLastHit }: { hit: Hit, isLastHit: boolean }) {
       .filter((e) => (hit.damageType & e.tag) !== 0)
       .map((e) => {
         const active = selectedFilter != null && (e.tag & selectedFilter) !== 0
-        return renderPill(String(e.tag), e.color, e.label, undefined, () => onFilterChange?.(e.tag), active)
+        return renderPill(String(e.tag), e.color, e.label, { onClick: () => onFilterChange?.(e.tag), active })
       })
     : []
 

--- a/src/lib/characterPreview/buffsAnalysis/StatSummary.tsx
+++ b/src/lib/characterPreview/buffsAnalysis/StatSummary.tsx
@@ -19,6 +19,7 @@ import {
 import {
   DesignContext,
   ellipsisStyle,
+  FilterChangeContext,
   FilterContext,
   getRowBaseStyle,
   getSourceLabelStyle,
@@ -172,12 +173,17 @@ function isPillActive(pillKey: AbilityColorKey, filter: DamageTag | null): boole
 
 function SummaryTagPills(props: { allContributions: StatSumContribution[] }) {
   const filter = useContext(FilterContext)
+  const onFilterChange = useContext(FilterChangeContext)
   const pills = getContributionTagPills(props.allContributions)
   if (pills.length === 0) return null
 
   return (
     <div style={{ display: 'flex', gap: 2, flexShrink: 0 }}>
-      {pills.map((p) => renderPill(p.key, p.color, p.label, !isPillActive(p.key, filter)))}
+      {pills.map((p) => {
+        const tag = p.key === 'ALL' ? null : DAMAGE_TAG_ENTRIES.find((e) => e.key === p.key)?.tag ?? null
+        const active = p.key !== 'ALL' && tag != null && filter != null && (tag & filter) !== 0
+        return renderPill(p.key, p.color, p.label, !isPillActive(p.key, filter), () => onFilterChange?.(tag), active)
+      })}
     </div>
   )
 }

--- a/src/lib/characterPreview/buffsAnalysis/StatSummary.tsx
+++ b/src/lib/characterPreview/buffsAnalysis/StatSummary.tsx
@@ -4,6 +4,7 @@ import type {
 } from 'lib/characterPreview/buffsAnalysis/abilityColors'
 import {
   ABILITY_COLORS,
+  DAMAGE_TAG_BY_KEY,
   DAMAGE_TAG_ENTRIES,
 } from 'lib/characterPreview/buffsAnalysis/abilityColors'
 import {
@@ -167,7 +168,7 @@ function getContributionTagPills(contributions: StatSumContribution[]): TagColor
 function isPillActive(pillKey: AbilityColorKey, filter: DamageTag | null): boolean {
   if (pillKey === 'ALL') return true
   if (filter === null) return false
-  const entry = DAMAGE_TAG_ENTRIES.find((e) => e.key === pillKey)
+  const entry = DAMAGE_TAG_BY_KEY.get(pillKey)
   return entry != null && (entry.tag & filter) !== 0
 }
 
@@ -180,9 +181,9 @@ function SummaryTagPills(props: { allContributions: StatSumContribution[] }) {
   return (
     <div style={{ display: 'flex', gap: 2, flexShrink: 0 }}>
       {pills.map((p) => {
-        const tag = p.key === 'ALL' ? null : DAMAGE_TAG_ENTRIES.find((e) => e.key === p.key)?.tag ?? null
+        const tag = p.key === 'ALL' ? null : DAMAGE_TAG_BY_KEY.get(p.key)?.tag ?? null
         const active = p.key !== 'ALL' && tag != null && filter != null && (tag & filter) !== 0
-        return renderPill(p.key, p.color, p.label, !isPillActive(p.key, filter), () => onFilterChange?.(tag), active)
+        return renderPill(p.key, p.color, p.label, { dimmed: !isPillActive(p.key, filter), onClick: () => onFilterChange?.(tag), active })
       })}
     </div>
   )

--- a/src/lib/characterPreview/buffsAnalysis/StatSummary.tsx
+++ b/src/lib/characterPreview/buffsAnalysis/StatSummary.tsx
@@ -210,7 +210,6 @@ export function StatSummaryTable(props: {
             ...rowBase,
             borderBottom: i < props.sums.length - 1 ? `1px solid ${options.borderColor}` : undefined,
             opacity: sum.total === 0 ? 0.15 : 1,
-            transition: 'opacity 0.15s',
           }}
         >
           <span style={{ minWidth: 60, fontSize: options.fontSize, textWrap: 'nowrap' }}>

--- a/src/lib/characterPreview/buffsAnalysis/abilityColors.ts
+++ b/src/lib/characterPreview/buffsAnalysis/abilityColors.ts
@@ -22,7 +22,7 @@ export const ABILITY_COLORS = {
 
 export type AbilityColorKey = keyof typeof ABILITY_COLORS
 export type TagColorEntry = { key: AbilityColorKey, label: string, color: string }
-type DamageTagEntry = TagColorEntry & { tag: DamageTag }
+export type DamageTagEntry = TagColorEntry & { tag: DamageTag }
 
 export const DAMAGE_TAG_ENTRIES: DamageTagEntry[] = [
   { tag: DamageTag.BASIC, key: 'BASIC', label: 'BASIC', color: ABILITY_COLORS.BASIC },
@@ -36,6 +36,10 @@ export const DAMAGE_TAG_ENTRIES: DamageTagEntry[] = [
   { tag: DamageTag.ADDITIONAL, key: 'ADDITIONAL', label: 'ADDITIONAL', color: ABILITY_COLORS.ADDITIONAL },
   { tag: DamageTag.ELATION, key: 'ELATION', label: 'ELATION', color: ABILITY_COLORS.ELATION },
 ]
+
+export const DAMAGE_TAG_BY_KEY = new Map<AbilityColorKey, DamageTagEntry>(
+  DAMAGE_TAG_ENTRIES.map((e) => [e.key, e]),
+)
 
 export const ACTION_COLORS: Partial<Record<AbilityKind, string>> = {
   [AbilityKind.BASIC]: ABILITY_COLORS.BASIC,

--- a/src/lib/characterPreview/buffsAnalysis/buffUtils.tsx
+++ b/src/lib/characterPreview/buffsAnalysis/buffUtils.tsx
@@ -60,20 +60,23 @@ export function formatBuffValue(value: number, percent: boolean): string {
   return precisionRound(value, 0).toLocaleString(currentLocale())
 }
 
-export function renderPill(key: string, color: string, label: string, dimmed?: boolean): ReactElement {
+export function renderPill(key: string, color: string, label: string, dimmed?: boolean, onClick?: () => void, active?: boolean): ReactElement {
   const displayColor = dimmed ? TEXT_DIM : color
   return (
     <span
       key={key}
+      onClick={onClick}
       style={{
         padding: PILL_SIZE.padding,
         borderRadius: 2,
         fontSize: PILL_SIZE.fontSize,
         fontWeight: 600,
         lineHeight: PILL_SIZE.lineHeight,
-        color: displayColor,
+        color: active ? '#141414' : displayColor,
+        backgroundColor: active ? color : undefined,
         whiteSpace: 'nowrap',
         border: `1px solid ${displayColor}`,
+        cursor: onClick ? 'pointer' : undefined,
       }}
     >
       {label}

--- a/src/lib/characterPreview/buffsAnalysis/buffUtils.tsx
+++ b/src/lib/characterPreview/buffsAnalysis/buffUtils.tsx
@@ -60,23 +60,29 @@ export function formatBuffValue(value: number, percent: boolean): string {
   return precisionRound(value, 0).toLocaleString(currentLocale())
 }
 
-export function renderPill(key: string, color: string, label: string, dimmed?: boolean, onClick?: () => void, active?: boolean): ReactElement {
-  const displayColor = dimmed ? TEXT_DIM : color
+type PillOptions = {
+  dimmed?: boolean,
+  onClick?: () => void,
+  active?: boolean,
+}
+
+export function renderPill(key: string, color: string, label: string, opts?: PillOptions): ReactElement {
+  const displayColor = opts?.dimmed ? TEXT_DIM : color
   return (
     <span
       key={key}
-      onClick={onClick}
+      onClick={opts?.onClick}
       style={{
         padding: PILL_SIZE.padding,
         borderRadius: 2,
         fontSize: PILL_SIZE.fontSize,
         fontWeight: 600,
         lineHeight: PILL_SIZE.lineHeight,
-        color: active ? '#141414' : displayColor,
-        backgroundColor: active ? color : undefined,
+        color: opts?.active ? '#141414' : displayColor,
+        backgroundColor: opts?.active ? color : undefined,
         whiteSpace: 'nowrap',
         border: `1px solid ${displayColor}`,
-        cursor: onClick ? 'pointer' : undefined,
+        cursor: opts?.onClick ? 'pointer' : undefined,
       }}
     >
       {label}

--- a/src/lib/characterPreview/buffsAnalysis/designContext.ts
+++ b/src/lib/characterPreview/buffsAnalysis/designContext.ts
@@ -45,6 +45,7 @@ export const DEFAULT_OPTIONS: DesignOptions = {
 
 export const DesignContext = createContext<DesignOptions>(DEFAULT_OPTIONS)
 export const FilterContext = createContext<DamageTag | null>(null)
+export const FilterChangeContext = createContext<((f: DamageTag | null) => void) | null>(null)
 
 export const ellipsisStyle = (fontSize: number): React.CSSProperties => ({
   overflow: 'hidden',

--- a/src/lib/characterPreview/buildAnalysis/BuffsAnalysisDisplay.tsx
+++ b/src/lib/characterPreview/buildAnalysis/BuffsAnalysisDisplay.tsx
@@ -156,12 +156,33 @@ export const BuffsAnalysisDisplay = memo(function BuffsAnalysisDisplay({
           )
           : (
             <div style={{ display: 'flex', flexDirection: 'column', gap: GROUP_SPACING, width: options.panelWidth }}>
+              <DeferCreate>
+                <StatSummaryTable
+                  sums={statSums}
+                  avatarSrc={summaryAvatarSrc}
+                />
+              </DeferCreate>
+              <FilterBar selectedFilter={selectedFilter} onFilterChange={setSelectedFilter} relevantTags={relevantTags} />
               {actionSelector}
-              <FilterBar selectedFilter={selectedFilter} onFilterChange={setSelectedFilter} relevantTags={relevantTags} />
-              {summaryColumn}
-              <FilterBar selectedFilter={selectedFilter} onFilterChange={setSelectedFilter} relevantTags={relevantTags} />
               {buffsColumn}
               <FilterBar selectedFilter={selectedFilter} onFilterChange={setSelectedFilter} relevantTags={relevantTags} />
+              {context && (
+                <DeferCreate>
+                  <HitDefinitionTable
+                    avatarSrc={summaryAvatarSrc}
+                    context={context}
+                    selectedAction={selectedAction}
+                  />
+                </DeferCreate>
+              )}
+              {context && (
+                <DeferCreate>
+                  <EnemyPanel
+                    avatarSrc={summaryAvatarSrc}
+                    context={context}
+                  />
+                </DeferCreate>
+              )}
             </div>
           )}
       </FilterContext.Provider>

--- a/src/lib/characterPreview/buildAnalysis/BuffsAnalysisDisplay.tsx
+++ b/src/lib/characterPreview/buildAnalysis/BuffsAnalysisDisplay.tsx
@@ -3,6 +3,7 @@ import { BuffGroup } from 'lib/characterPreview/buffsAnalysis/BuffGroup'
 import {
   DEFAULT_OPTIONS,
   DesignContext,
+  FilterChangeContext,
   FilterContext,
   GROUP_ORDER,
   GROUP_SPACING,
@@ -139,6 +140,7 @@ export const BuffsAnalysisDisplay = memo(function BuffsAnalysisDisplay({
   return (
     <DesignContext.Provider value={options}>
       <FilterContext.Provider value={selectedFilter}>
+        <FilterChangeContext.Provider value={setSelectedFilter}>
         {twoColumn
           ? (
             <div style={{ display: 'flex', flexDirection: 'column', gap: GROUP_SPACING }}>
@@ -185,6 +187,7 @@ export const BuffsAnalysisDisplay = memo(function BuffsAnalysisDisplay({
               )}
             </div>
           )}
+        </FilterChangeContext.Provider>
       </FilterContext.Provider>
     </DesignContext.Provider>
   )

--- a/src/lib/characterPreview/buildAnalysis/BuffsAnalysisDisplay.tsx
+++ b/src/lib/characterPreview/buildAnalysis/BuffsAnalysisDisplay.tsx
@@ -79,13 +79,15 @@ export const BuffsAnalysisDisplay = memo(function BuffsAnalysisDisplay({
   }), [size])
 
   const byAction = perActionBuffGroups?.byAction
+  const rotationSteps = perActionBuffGroups?.rotationSteps
+  const primaryAction = perActionBuffGroups?.primaryAction
   const buffGroups = useMemo(() => {
     if (!byAction || Object.keys(byAction).length === 0) return null
-    if (selectedAction != null && perActionBuffGroups?.rotationSteps[selectedAction]) {
-      return perActionBuffGroups.rotationSteps[selectedAction].groups
+    if (selectedAction != null && rotationSteps?.[selectedAction]) {
+      return rotationSteps[selectedAction].groups
     }
-    return byAction[perActionBuffGroups!.primaryAction] ?? byAction[Object.keys(byAction)[0]]
-  }, [byAction, selectedAction, perActionBuffGroups])
+    return (primaryAction != null ? byAction[primaryAction] : undefined) ?? byAction[Object.keys(byAction)[0]]
+  }, [byAction, selectedAction, rotationSteps, primaryAction])
 
   const allBuffs = useMemo(() => buffGroups ? collectAllBuffs(buffGroups) : [], [buffGroups])
   const relevantTags = useMemo(() => computeRelevantTags(allBuffs), [allBuffs])
@@ -99,14 +101,17 @@ export const BuffsAnalysisDisplay = memo(function BuffsAnalysisDisplay({
   const firstPrimaryId = primaryGroup ? Object.keys(primaryGroup)[0] : undefined
   const summaryAvatarSrc = firstPrimaryId ? Assets.getCharacterAvatarById(firstPrimaryId) : Assets.getBlank()
 
-  const summaryColumn = (
+  const statSummary = (
+    <DeferCreate>
+      <StatSummaryTable
+        sums={statSums}
+        avatarSrc={summaryAvatarSrc}
+      />
+    </DeferCreate>
+  )
+
+  const hitAndEnemy = (
     <>
-      <DeferCreate>
-        <StatSummaryTable
-          sums={statSums}
-          avatarSrc={summaryAvatarSrc}
-        />
-      </DeferCreate>
       {context && (
         <DeferCreate>
           <HitDefinitionTable
@@ -129,9 +134,9 @@ export const BuffsAnalysisDisplay = memo(function BuffsAnalysisDisplay({
 
   const buffsColumn = <GroupedLayout buffGroups={buffGroups} />
 
-  const actionSelector = (
+  const actionSelector = rotationSteps && (
     <ActionSelector
-      rotationSteps={perActionBuffGroups!.rotationSteps}
+      rotationSteps={rotationSteps}
       selectedAction={selectedAction}
       onActionChange={setSelectedAction}
     />
@@ -148,7 +153,8 @@ export const BuffsAnalysisDisplay = memo(function BuffsAnalysisDisplay({
               <FilterBar selectedFilter={selectedFilter} onFilterChange={setSelectedFilter} relevantTags={relevantTags} />
               <div style={{ display: 'flex', gap: GROUP_SPACING, alignItems: 'start' }}>
                 <div style={{ display: 'flex', flexDirection: 'column', gap: GROUP_SPACING, width: options.panelWidth }}>
-                  {summaryColumn}
+                  {statSummary}
+                  {hitAndEnemy}
                 </div>
                 <div style={{ display: 'flex', flexDirection: 'column', gap: GROUP_SPACING, width: options.panelWidth }}>
                   {buffsColumn}
@@ -158,33 +164,12 @@ export const BuffsAnalysisDisplay = memo(function BuffsAnalysisDisplay({
           )
           : (
             <div style={{ display: 'flex', flexDirection: 'column', gap: GROUP_SPACING, width: options.panelWidth }}>
-              <DeferCreate>
-                <StatSummaryTable
-                  sums={statSums}
-                  avatarSrc={summaryAvatarSrc}
-                />
-              </DeferCreate>
+              {statSummary}
               <FilterBar selectedFilter={selectedFilter} onFilterChange={setSelectedFilter} relevantTags={relevantTags} />
               {actionSelector}
               {buffsColumn}
               <FilterBar selectedFilter={selectedFilter} onFilterChange={setSelectedFilter} relevantTags={relevantTags} />
-              {context && (
-                <DeferCreate>
-                  <HitDefinitionTable
-                    avatarSrc={summaryAvatarSrc}
-                    context={context}
-                    selectedAction={selectedAction}
-                  />
-                </DeferCreate>
-              )}
-              {context && (
-                <DeferCreate>
-                  <EnemyPanel
-                    avatarSrc={summaryAvatarSrc}
-                    context={context}
-                  />
-                </DeferCreate>
-              )}
+              {hitAndEnemy}
             </div>
           )}
         </FilterChangeContext.Provider>

--- a/src/lib/characterPreview/buildAnalysis/BuffsAnalysisDisplay.tsx
+++ b/src/lib/characterPreview/buildAnalysis/BuffsAnalysisDisplay.tsx
@@ -78,22 +78,22 @@ export const BuffsAnalysisDisplay = memo(function BuffsAnalysisDisplay({
     panelWidth: size ?? DEFAULT_OPTIONS.panelWidth,
   }), [size])
 
-  if (!perActionBuffGroups || Object.keys(perActionBuffGroups.byAction).length === 0) {
-    return null
-  }
+  const byAction = perActionBuffGroups?.byAction
+  const buffGroups = useMemo(() => {
+    if (!byAction || Object.keys(byAction).length === 0) return null
+    if (selectedAction != null && perActionBuffGroups?.rotationSteps[selectedAction]) {
+      return perActionBuffGroups.rotationSteps[selectedAction].groups
+    }
+    return byAction[perActionBuffGroups!.primaryAction] ?? byAction[Object.keys(byAction)[0]]
+  }, [byAction, selectedAction, perActionBuffGroups])
 
-  const byAction = perActionBuffGroups.byAction
-  const buffGroups = selectedAction != null && perActionBuffGroups.rotationSteps[selectedAction]
-    ? perActionBuffGroups.rotationSteps[selectedAction].groups
-    : byAction[perActionBuffGroups.primaryAction] ?? byAction[Object.keys(byAction)[0]]
+  const allBuffs = useMemo(() => buffGroups ? collectAllBuffs(buffGroups) : [], [buffGroups])
+  const relevantTags = useMemo(() => computeRelevantTags(allBuffs), [allBuffs])
+  const statSums = useMemo(() => computeStatSums(allBuffs, selectedFilter), [allBuffs, selectedFilter])
 
   if (!buffGroups) {
     return null
   }
-
-  const allBuffs = useMemo(() => collectAllBuffs(buffGroups), [buffGroups])
-  const relevantTags = useMemo(() => computeRelevantTags(allBuffs), [allBuffs])
-  const statSums = useMemo(() => computeStatSums(allBuffs, selectedFilter), [allBuffs, selectedFilter])
 
   const primaryGroup = buffGroups[BUFF_TYPE.PRIMARY]
   const firstPrimaryId = primaryGroup ? Object.keys(primaryGroup)[0] : undefined
@@ -131,7 +131,7 @@ export const BuffsAnalysisDisplay = memo(function BuffsAnalysisDisplay({
 
   const actionSelector = (
     <ActionSelector
-      rotationSteps={perActionBuffGroups.rotationSteps}
+      rotationSteps={perActionBuffGroups!.rotationSteps}
       selectedAction={selectedAction}
       onActionChange={setSelectedAction}
     />


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

- Add clickable damage tag pills to filter buffs across buff rows, hit definitions, and stat summaries
- Add active state styling for selected filter pills
- Reorder single-column layout to show stat summary on top and hit/enemy panels at bottom
- Remove CSS transitions from filter bar, buff rows, and stat summary
- Fix hooks called after early return in BuffsAnalysisDisplay

## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [ ] I have added commit messages that are descriptive and meaningful.
- [ ] I have tested the changes locally.
- [ ] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
