### PR TITLE
fix: sw search tree bug / ux tweaks

### DIFF
--- a/src/lib/characterPreview/buildAnalysis/CharacterScoringSummary.tsx
+++ b/src/lib/characterPreview/buildAnalysis/CharacterScoringSummary.tsx
@@ -145,7 +145,7 @@ function BenchmarkDefaultLayout() {
               <div className={classes.sectionLabel} style={{ margin: '5px auto' }}>
                 {t('SimulationSets')}
               </div>
-              <div style={{ display: 'flex', flexDirection: 'column', gap: defaultGap }}>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 26 }}>
                 <div style={{ display: 'flex' }}>
                   <SuspenseNode
                     selector={(score: SimulationScore | null) =>

--- a/src/lib/characterPreview/buildAnalysis/ScoringColumns.tsx
+++ b/src/lib/characterPreview/buildAnalysis/ScoringColumns.tsx
@@ -94,7 +94,7 @@ const ScoringColumn = memo(function ScoringColumn(props: ScoringColumnProps) {
   // only the character scoring column will pass as null as all other info is available synchronously
   const headerText = props.percent !== null
     ? t(`CharacterPreview.ScoringColumn.${props.type}.Header`, {
-      score: truncate10ths(precisionRound(props.percent * 100)),
+      score: truncate10ths(precisionRound(props.percent * 100)).toFixed(1),
     })
     : null
 

--- a/src/lib/conditionals/character/1200/Sushang.ts
+++ b/src/lib/conditionals/character/1200/Sushang.ts
@@ -253,6 +253,7 @@ const simulation = (): SimulationMetadata => ({
     Stats.CD,
     Stats.ATK_P,
     Stats.BE,
+    Stats.ATK,
   ],
   comboTurnAbilities: [
     NULL_TURN_ABILITY_NAME,

--- a/src/lib/conditionals/character/1300/TheDahlia.ts
+++ b/src/lib/conditionals/character/1300/TheDahlia.ts
@@ -438,6 +438,7 @@ const simulation = (): SimulationMetadata => ({
     Stats.ATK_P,
     Stats.CR,
     Stats.CD,
+    Stats.ATK,
   ],
   errRopeEidolon: 0,
   comboTurnAbilities: [

--- a/src/lib/conditionals/character/1500/SilverWolfLv999.ts
+++ b/src/lib/conditionals/character/1500/SilverWolfLv999.ts
@@ -515,6 +515,8 @@ const simulation = (): SimulationMetadata => ({
     Stats.CD,
     Stats.CR,
     Stats.SPD,
+    Stats.DEF_P,
+    Stats.HP_P,
   ],
   comboTurnAbilities: [
     NULL_TURN_ABILITY_NAME,

--- a/src/lib/constants/appPages.ts
+++ b/src/lib/constants/appPages.ts
@@ -54,5 +54,11 @@ const RouteToPage: Record<string, AppPages> = {
 export function getDefaultActiveKey() {
   const pathname = stripTrailingSlashes(window.location.pathname)
   const page = RouteToPage[pathname + window.location.hash.split('?')[0] as Route]
+
+  // Redirect #main to HOME for first-time users (no prior save data)
+  if (page === AppPages.OPTIMIZER && localStorage.getItem('state') === null) {
+    return AppPages.HOME
+  }
+
   return page ?? AppPages.HOME
 }

--- a/src/lib/services/equipmentService.test.ts
+++ b/src/lib/services/equipmentService.test.ts
@@ -129,6 +129,101 @@ describe('equipmentService', () => {
       expect(() => switchRelics(NON_EXISTENT_CHAR, CHAR_2)).not.toThrow()
       expect(getCharacterById(CHAR_2)!.equipped).toEqual({})
     })
+
+    it('returns early when target character does not exist in store', () => {
+      useCharacterStore.getState().setCharacters([makeCharacter(CHAR_1)])
+
+      expect(() => switchRelics(CHAR_1, NON_EXISTENT_CHAR)).not.toThrow()
+      expect(getCharacterById(CHAR_1)!.equipped).toEqual({})
+    })
+  })
+
+  describe('switchRelics — swaps all relics between characters', () => {
+    it('swaps relics when target has more equipped than source', () => {
+      // Source has Head only, Target has Head + Body
+      const sourceHead = makeRelic({ id: 'src-head', part: Parts.Head, equippedBy: CHAR_1 })
+      const targetHead = makeRelic({ id: 'tgt-head', part: Parts.Head, equippedBy: CHAR_2 })
+      const targetBody = makeRelic({ id: 'tgt-body', part: Parts.Body, equippedBy: CHAR_2 })
+
+      useRelicStore.getState().setRelics([sourceHead, targetHead, targetBody])
+      useCharacterStore.getState().setCharacters([
+        makeCharacter(CHAR_1, { equipped: { [Parts.Head]: 'src-head' } }),
+        makeCharacter(CHAR_2, { equipped: { [Parts.Head]: 'tgt-head', [Parts.Body]: 'tgt-body' } }),
+      ])
+
+      switchRelics(CHAR_1, CHAR_2)
+
+      // Source should now have target's Head + Body
+      expect(getCharacterById(CHAR_1)!.equipped[Parts.Head]).toBe('tgt-head')
+      expect(getCharacterById(CHAR_1)!.equipped[Parts.Body]).toBe('tgt-body')
+      // Target should now have source's Head only
+      expect(getCharacterById(CHAR_2)!.equipped[Parts.Head]).toBe('src-head')
+      expect(getCharacterById(CHAR_2)!.equipped[Parts.Body]).toBeUndefined()
+    })
+
+    it('swaps relics when source has more equipped than target', () => {
+      // Source has Head + Body, Target has Head only
+      const sourceHead = makeRelic({ id: 'src-head', part: Parts.Head, equippedBy: CHAR_1 })
+      const sourceBody = makeRelic({ id: 'src-body', part: Parts.Body, equippedBy: CHAR_1 })
+      const targetHead = makeRelic({ id: 'tgt-head', part: Parts.Head, equippedBy: CHAR_2 })
+
+      useRelicStore.getState().setRelics([sourceHead, sourceBody, targetHead])
+      useCharacterStore.getState().setCharacters([
+        makeCharacter(CHAR_1, { equipped: { [Parts.Head]: 'src-head', [Parts.Body]: 'src-body' } }),
+        makeCharacter(CHAR_2, { equipped: { [Parts.Head]: 'tgt-head' } }),
+      ])
+
+      switchRelics(CHAR_1, CHAR_2)
+
+      // Source should now have target's Head only
+      expect(getCharacterById(CHAR_1)!.equipped[Parts.Head]).toBe('tgt-head')
+      expect(getCharacterById(CHAR_1)!.equipped[Parts.Body]).toBeUndefined()
+      // Target should now have source's Head + Body
+      expect(getCharacterById(CHAR_2)!.equipped[Parts.Head]).toBe('src-head')
+      expect(getCharacterById(CHAR_2)!.equipped[Parts.Body]).toBe('src-body')
+    })
+
+    it('moves all relics to target when source has zero relics', () => {
+      // Source has no relics, Target has Head + Body
+      const targetHead = makeRelic({ id: 'tgt-head', part: Parts.Head, equippedBy: CHAR_2 })
+      const targetBody = makeRelic({ id: 'tgt-body', part: Parts.Body, equippedBy: CHAR_2 })
+
+      useRelicStore.getState().setRelics([targetHead, targetBody])
+      useCharacterStore.getState().setCharacters([
+        makeCharacter(CHAR_1, { equipped: {} }),
+        makeCharacter(CHAR_2, { equipped: { [Parts.Head]: 'tgt-head', [Parts.Body]: 'tgt-body' } }),
+      ])
+
+      switchRelics(CHAR_1, CHAR_2)
+
+      // Source should now have target's relics
+      expect(getCharacterById(CHAR_1)!.equipped[Parts.Head]).toBe('tgt-head')
+      expect(getCharacterById(CHAR_1)!.equipped[Parts.Body]).toBe('tgt-body')
+      // Target should now be empty
+      expect(getCharacterById(CHAR_2)!.equipped[Parts.Head]).toBeUndefined()
+      expect(getCharacterById(CHAR_2)!.equipped[Parts.Body]).toBeUndefined()
+    })
+
+    it('moves all relics to source when target has zero relics', () => {
+      // Source has Head + Body, Target has no relics
+      const sourceHead = makeRelic({ id: 'src-head', part: Parts.Head, equippedBy: CHAR_1 })
+      const sourceBody = makeRelic({ id: 'src-body', part: Parts.Body, equippedBy: CHAR_1 })
+
+      useRelicStore.getState().setRelics([sourceHead, sourceBody])
+      useCharacterStore.getState().setCharacters([
+        makeCharacter(CHAR_1, { equipped: { [Parts.Head]: 'src-head', [Parts.Body]: 'src-body' } }),
+        makeCharacter(CHAR_2, { equipped: {} }),
+      ])
+
+      switchRelics(CHAR_1, CHAR_2)
+
+      // Source should now be empty
+      expect(getCharacterById(CHAR_1)!.equipped[Parts.Head]).toBeUndefined()
+      expect(getCharacterById(CHAR_1)!.equipped[Parts.Body]).toBeUndefined()
+      // Target should now have source's relics
+      expect(getCharacterById(CHAR_2)!.equipped[Parts.Head]).toBe('src-head')
+      expect(getCharacterById(CHAR_2)!.equipped[Parts.Body]).toBe('src-body')
+    })
   })
 
   describe('upsertRelicWithEquipment — M3 empty store', () => {

--- a/src/lib/services/equipmentService.ts
+++ b/src/lib/services/equipmentService.ts
@@ -121,15 +121,27 @@ export function equipRelicIds(relicIds: RelicId[], characterId: CharacterId, for
 }
 
 /**
- * Transfers all equipped relics from one character to another.
+ * Swaps all equipped relics between two characters.
  */
 export function switchRelics(fromId: CharacterId, toId: CharacterId): void {
   if (!fromId) return console.warn('No characterId to equip from')
   if (!toId) return console.warn('No characterId to equip to')
   const fromCharacter = getCharacterById(fromId)
   if (!fromCharacter) return console.warn('Source character not found', fromId)
-  const relicIds = Object.values(fromCharacter.equipped).filter((id): id is RelicId => id != null)
-  equipRelicIds(relicIds, toId, true)
+  const toCharacter = getCharacterById(toId)
+  if (!toCharacter) return console.warn('Target character not found', toId)
+
+  // Collect relics from both characters before any mutations
+  const fromRelics = Object.values(fromCharacter.equipped).filter((id): id is RelicId => id != null).map(getRelicById).filter((r): r is Relic => r != null)
+  const toRelics = Object.values(toCharacter.equipped).filter((id): id is RelicId => id != null).map(getRelicById).filter((r): r is Relic => r != null)
+
+  // Unequip both characters
+  unequipCharacter(fromId)
+  unequipCharacter(toId)
+
+  // Re-equip: source's relics → target, target's relics → source
+  for (const relic of fromRelics) equipRelic(relic, toId)
+  for (const relic of toRelics) equipRelic(relic, fromId)
 }
 
 /**

--- a/src/lib/tabs/tabHome/HomeTab.module.css
+++ b/src/lib/tabs/tabHome/HomeTab.module.css
@@ -9,9 +9,8 @@
 
 /* Hero container - wider for prominence */
 .heroContainer {
-  max-width: 2000px;
+  max-width: 1900px;
   margin: 0 auto;
-  padding: 0 20px;
 }
 
 /* Content container - narrower for cards */
@@ -25,7 +24,7 @@
 .hero {
   position: relative;
   width: 100%;
-  min-height: 80vh;
+  min-height: 85vh;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -50,19 +49,25 @@
   height: 100%;
   object-fit: cover;
   object-position: center top;
-  filter: brightness(0.95);
 }
 
 .heroOverlay {
   position: absolute;
   inset: 0;
   border-radius: 16px;
-  background: linear-gradient(
-    180deg,
-    rgba(0, 0, 0, 0.1) 0%,
-    rgba(0, 0, 0, 0.25) 60%,
-    rgba(0, 0, 0, 0.5) 100%
-  );
+  background:
+    linear-gradient(
+      180deg,
+      rgba(0, 0, 0, 0.3) 0%,
+      rgba(0, 0, 0, 0.1) 20%,
+      rgba(0, 0, 0, 0) 35%
+    ),
+    linear-gradient(
+      0deg,
+      rgba(0, 0, 0, 0.3) 0%,
+      rgba(0, 0, 0, 0.1) 10%,
+      rgba(0, 0, 0, 0) 20%
+    );
 }
 
 .heroContent {
@@ -80,10 +85,12 @@
 .heroWelcome {
   font-size: 24px;
   font-weight: 400;
-  color: rgba(200, 200, 200, 0.9);
+  color: rgba(255, 255, 255, 0.9);
   margin: 0 0 8px 0;
   letter-spacing: 0.02em;
-  text-shadow: 0 2px 20px rgba(0, 0, 0, 0.5);
+  text-shadow:
+    0 0 20px rgba(0, 0, 0, 0.7),
+    0 2px 30px rgba(0, 0, 0, 0.5);
 }
 
 .heroTitle {
@@ -92,8 +99,10 @@
   letter-spacing: -0.02em;
   line-height: 1.1;
   margin: 0;
-  color: var(--mantine-color-dark-0);
-  text-shadow: 0 4px 40px rgba(0, 0, 0, 0.5);
+  color: rgba(255, 255, 255, 0.95);
+  text-shadow:
+    0 0 20px rgba(0, 0, 0, 0.7),
+    0 2px 30px rgba(0, 0, 0, 0.5);
 }
 
 .searchBarContainer {
@@ -151,7 +160,7 @@
   flex-direction: column;
   align-items: center;
   gap: 8px;
-  color: rgba(168, 168, 168, 0.8);
+  color: rgba(220, 220, 220, 0.9);
   font-size: 12px;
   text-transform: uppercase;
   letter-spacing: 0.1em;

--- a/src/lib/tabs/tabHome/HomeTab.module.css
+++ b/src/lib/tabs/tabHome/HomeTab.module.css
@@ -11,6 +11,7 @@
 .heroContainer {
   max-width: 1900px;
   margin: 0 auto;
+  padding: 0 20px;
 }
 
 /* Content container - narrower for cards */

--- a/src/lib/tabs/tabHome/HomeTab.tsx
+++ b/src/lib/tabs/tabHome/HomeTab.tsx
@@ -335,6 +335,7 @@ function CommunitySection() {
             iconColor='#ffffff'
             iconBg='#b8863b'
             external={false}
+            appPage={AppPages.CHANGELOG}
           />
         </div>
       </FadeSection>
@@ -375,9 +376,10 @@ interface CommunityCardProps {
   iconColor?: string
   iconBg?: string
   external?: boolean
+  appPage?: AppPages
 }
 
-function CommunityCard({ icon, title, description, href, iconColor, iconBg, external = true }: CommunityCardProps) {
+function CommunityCard({ icon, title, description, href, iconColor, iconBg, external = true, appPage }: CommunityCardProps) {
   const iconStyle = {
     '--icon-color': iconColor,
     '--icon-bg': iconBg,
@@ -389,6 +391,13 @@ function CommunityCard({ icon, title, description, href, iconColor, iconBg, exte
       target={external ? '_blank' : undefined}
       rel={external ? 'noreferrer' : undefined}
       className={classes.communityCard}
+      onClick={!external && appPage != null
+        ? (e) => {
+          if (e.ctrlKey || e.metaKey || e.shiftKey) return
+          e.preventDefault()
+          useGlobalStore.getState().setActiveKey(appPage)
+        }
+        : undefined}
     >
       <div className={classes.communityCardHeader}>
         <div className={classes.communityCardIcon} style={iconStyle}>{icon}</div>

--- a/src/lib/tabs/tabOptimizer/analysis/DamageSplitsChart.tsx
+++ b/src/lib/tabs/tabOptimizer/analysis/DamageSplitsChart.tsx
@@ -270,6 +270,7 @@ export function DamageSplitsChart({ data }: { data: DamageSplitEntry[] }) {
       >
         <XAxis
           type='number'
+          domain={[0, maxTotal]}
           tick={{ fill: chartColor, textRendering: 'geometricPrecision', fontWeight: 300, fontSize: 13 }}
           tickFormatter={renderThousandsK}
           width={100}

--- a/src/lib/worker/computeOptimalSimulationWorker.ts
+++ b/src/lib/worker/computeOptimalSimulationWorker.ts
@@ -1,5 +1,8 @@
 import { Hysilens } from 'lib/conditionals/character/1400/Hysilens'
-import { Stats } from 'lib/constants/constants'
+import {
+  Stats,
+  SubStats,
+} from 'lib/constants/constants'
 import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
 import {
   applyScoringFunction,
@@ -17,7 +20,10 @@ import {
   type ComputeOptimalSimulationWorkerOutput,
 } from 'lib/worker/computeOptimalSimulationWorkerRunner'
 import { SearchTree } from 'lib/worker/maxima/tree/searchTree'
-import { toSubstatCounts } from 'lib/worker/maxima/tree/statIndexMap'
+import {
+  SUBSTAT_COUNT,
+  toSubstatCounts,
+} from 'lib/worker/maxima/tree/statIndexMap'
 import { SubstatDistributionValidator } from 'lib/worker/maxima/validator/substatDistributionValidator'
 
 export function computeOptimalSimulationWorker(e: MessageEvent<ComputeOptimalSimulationWorkerInput>) {
@@ -125,6 +131,20 @@ function computeOptimalSimulationSearch(input: ComputeOptimalSimulationWorkerInp
   ]
 
   const substatValidator = new SubstatDistributionValidator(goal, request)
+
+  let maxAssignments = 0
+  for (let i = 0; i < SUBSTAT_COUNT; i++) {
+    maxAssignments += Math.min(
+      maxSubstatRollCounts[SubStats[i]] ?? 0,
+      substatValidator.getAvailablePieces(i),
+    )
+  }
+  if (maxAssignments < 24) {
+    throw new Error(
+      `Search space assignment-infeasible: ${maxAssignments}/24 slots fillable. `
+      + `Character's effectiveSubstats needs more filler stats.`,
+    )
+  }
 
   const tree = new SearchTree(
     goal,

--- a/src/types/metadata.ts
+++ b/src/types/metadata.ts
@@ -54,6 +54,11 @@ export type SimulationMetadata = {
   parts: {
     [part: string]: MainStats[],
   },
+  /**
+   * Must contain at least 5 non-SPD stats so the benchmark search space can fill all 24 substat
+   * slots on a real 6-piece build. If the character only has 3-4 real damage stats, pad with a
+   * flat filler (`Stats.ATK` / `Stats.HP` / `Stats.DEF`) — SPD is implicit and doesn't count.
+   */
   substats: SubStats[],
   errRopeEidolon?: number,
   deprioritizeBuffs?: boolean,


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

- Fix relic switching not swapping relics in slots the source character doesn't have
- Redirect first-time users from #main to home page
- Add filler substats to Sushang, The Dahlia, and Silver Wolf Lv999 for benchmark search feasibility
- Add validation error when character's effectiveSubstats can't fill all 24 substat slots
- Fix damage splits chart x-axis domain to start at 0
- Fix scoring column percentage to always show one decimal place
- Add hero section left/right padding
- Update hero section styling - taller height, softer overlay gradients, brighter text
- Fix changelog community card to use internal navigation instead of page reload

## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [ ] I have added commit messages that are descriptive and meaningful.
- [ ] I have tested the changes locally.
- [ ] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
