### PR TITLE
feat: sw/eva stat migrations

### DIFF
--- a/public/locales/en_US/hometab.yaml
+++ b/public/locales/en_US/hometab.yaml
@@ -28,13 +28,10 @@ FeatureCards:
       and find the top relics to upgrade for each character.
   WarpPlanner:
     Title: Warp Planner
-    Content: (TODO)
   BenchmarkGenerator:
     Title: Benchmark Generator
-    Content: (TODO)
   RarityAnalysis:
     Title: Rarity Analysis
-    Content: (TODO)
 Welcome: Welcome to the<1/>Fribbels Star Rail Optimizer
 Hero:
   Welcome: Welcome to the

--- a/public/locales/en_US/notifications.yaml
+++ b/public/locales/en_US/notifications.yaml
@@ -11,8 +11,3 @@ GPUCrash:
   Description:
     l1: The GPU acceleration process has crashed - results may be invalid. Please try again or report a bug to the Discord server.
     l2: For troubleshooting steps, check the <CustomLink text="documentation page."/>
-Changelog:
-  View: View changelog
-  Dismiss: Dismiss
-  Message: New updates!
-  Description: Check out the changelog for the latest optimizer updates.

--- a/src/lib/characterPreview/DebugSliderPanel.tsx
+++ b/src/lib/characterPreview/DebugSliderPanel.tsx
@@ -1,8 +1,9 @@
+import type { Icon } from '@tabler/icons-react'
 import { useState } from 'react'
 
 type SliderDef = { label: string, value: number, min: number, max: number, step: number, onChange: (v: number) => void }
 type SliderGroup = { title: string, sliders: SliderDef[] }
-type DebugPreset = { label: string, apply: () => void }
+type DebugPreset = { label: string, apply: () => void, icon?: Icon }
 type PillGroup = { title: string, active: string, options: { label: string, value: string, apply: () => void }[] }
 type PresetGroup = { title: string, presets: DebugPreset[] }
 
@@ -98,8 +99,9 @@ export function DebugSliderPanel({ groups, savedPresetGroups, pillGroups }: {
                       p.apply()
                       setActivePreset(p.label)
                     }}
-                    style={activePreset === p.label ? pillActiveStyle : pillStyle}
+                    style={{ ...activePreset === p.label ? pillActiveStyle : pillStyle, display: 'flex', alignItems: 'center', gap: 4 }}
                   >
+                    {p.icon && <p.icon size={12} />}
                     {p.label}
                   </span>
                 ))}

--- a/src/lib/characterPreview/customization/ShowcaseCustomizationSidebar.tsx
+++ b/src/lib/characterPreview/customization/ShowcaseCustomizationSidebar.tsx
@@ -7,10 +7,10 @@ import {
 import {
   IconCamera,
   IconCheck,
-  IconDiamond,
+  IconCircleHalf2,
   IconDownload,
-  IconLeaf,
   IconMoon,
+  IconPalette,
   IconSettings,
   IconSun,
   IconX,
@@ -392,8 +392,8 @@ const CustomizationPanel = memo(function CustomizationPanel({
 
       <SegmentedControl
         data={[
-          { value: ShowcasePreset.SHINE, label: <IconDiamond size={18} /> },
-          { value: ShowcasePreset.NATURAL, label: <IconLeaf size={18} /> },
+          { value: ShowcasePreset.SHINE, label: <IconPalette size={18} /> },
+          { value: ShowcasePreset.NATURAL, label: <IconCircleHalf2 size={18} /> },
         ]}
         fullWidth
         value={showcasePreset}

--- a/src/lib/characterPreview/debugPanelConfig.ts
+++ b/src/lib/characterPreview/debugPanelConfig.ts
@@ -1,3 +1,4 @@
+import { IconCircleHalf2, IconPalette } from '@tabler/icons-react'
 import { DEFAULT_CONFIG } from './color/colorPipelineConfig'
 import type {
   PillGroup,
@@ -94,10 +95,12 @@ function buildDebugPanelConfig(store: ReturnType<typeof useDebugVisualConfigStor
       presets: [
         {
           label: 'Shine',
+          icon: IconPalette,
           apply: () => store.applyPreset(SHINE_PRESET),
         },
         {
           label: 'Natural',
+          icon: IconCircleHalf2,
           apply: () => store.applyPreset(NATURAL_PRESET),
         },
       ],

--- a/src/lib/overlays/modals/ChangelogModal.tsx
+++ b/src/lib/overlays/modals/ChangelogModal.tsx
@@ -8,7 +8,7 @@ import { CURRENT_OPTIMIZER_VERSION } from 'lib/constants/constants'
 import { getChangelogContent } from 'lib/tabs/tabChangelog/changelogData'
 import { ColorizedLinkWithIcon } from 'lib/ui/ColorizedLink'
 import { CtaCards } from 'lib/overlays/modals/changelogCta/CtaCards'
-import { useCallback, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import classes from './ChangelogModal.module.css'
 
 globalThis.openChangelogModal = () => setOpen(OpenCloseIDs.CHANGELOG_MODAL)
@@ -16,9 +16,19 @@ globalThis.openChangelogModal = () => setOpen(OpenCloseIDs.CHANGELOG_MODAL)
 export function ChangelogModal() {
   const { isOpen, close } = useOpenClose(OpenCloseIDs.CHANGELOG_MODAL)
   const [atBottom, setAtBottom] = useState(false)
+  const [canDismiss, setCanDismiss] = useState(false)
   const viewportRef = useRef<HTMLDivElement>(null)
 
   const entry = useMemo(() => getChangelogContent()[1], [])
+
+  useEffect(() => {
+    if (!isOpen) {
+      setCanDismiss(false)
+      return
+    }
+    const t = setTimeout(() => setCanDismiss(true), 1000)
+    return () => clearTimeout(t)
+  }, [isOpen])
 
   const handleScroll = useCallback((position: { x: number; y: number }) => {
     const viewport = viewportRef.current
@@ -42,6 +52,8 @@ export function ChangelogModal() {
       size={1000}
       centered
       withCloseButton
+      closeOnClickOutside={canDismiss}
+      closeOnEscape={canDismiss}
       transitionProps={{ transition: 'pop', duration: 500, exitDuration: 150, timingFunction: 'ease' }}
       title={
         <div className={classes.headerTitle}>

--- a/src/lib/services/migrations/silverWolfLv999EvanesciaMainStats.test.ts
+++ b/src/lib/services/migrations/silverWolfLv999EvanesciaMainStats.test.ts
@@ -1,0 +1,159 @@
+import {
+  Parts,
+  Stats,
+} from 'lib/constants/constants'
+import type { MainStats } from 'lib/constants/constants'
+import type {
+  ScoringMetadata,
+  ScoringMetadataOverride,
+} from 'types/metadata'
+import {
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
+import { migrateSilverWolfLv999EvanesciaMainStats } from './silverWolfLv999EvanesciaMainStats'
+
+const SW999_ID = '1506'
+const EVA_ID = '1505'
+const UNRELATED_ID = '1005' // Kafka
+
+function metadata(parts: Partial<Record<(typeof Parts)[keyof typeof Parts], MainStats[]>>): ScoringMetadata {
+  return {
+    stats: {} as ScoringMetadata['stats'],
+    parts: {
+      [Parts.Body]: [],
+      [Parts.Feet]: [],
+      [Parts.PlanarSphere]: [],
+      [Parts.LinkRope]: [],
+      ...parts,
+    } as ScoringMetadata['parts'],
+    presets: [],
+    sortOption: {} as ScoringMetadata['sortOption'],
+    hiddenColumns: [],
+  }
+}
+
+const SW999_DEFAULTS = metadata({
+  [Parts.Body]: [Stats.CR, Stats.CD],
+  [Parts.Feet]: [Stats.SPD],
+})
+
+const EVA_DEFAULTS = metadata({
+  [Parts.Body]: [Stats.CR, Stats.CD],
+  [Parts.LinkRope]: [Stats.ATK_P, Stats.ERR],
+})
+
+function getDefaults(id: string): ScoringMetadata | undefined {
+  if (id === SW999_ID) return SW999_DEFAULTS
+  if (id === EVA_ID) return EVA_DEFAULTS
+  return undefined
+}
+
+describe('migrateSilverWolfLv999EvanesciaMainStats', () => {
+  it('no-ops when no targeted override exists', () => {
+    const input: Record<string, ScoringMetadataOverride> = {
+      [UNRELATED_ID]: { parts: { [Parts.Body]: [Stats.ATK_P] } },
+    }
+    const result = migrateSilverWolfLv999EvanesciaMainStats(input, getDefaults)
+    expect(result).toEqual(input)
+  })
+
+  it('skips targeted override with no parts field', () => {
+    const input: Record<string, ScoringMetadataOverride> = {
+      [SW999_ID]: { stats: { [Stats.ATK_P]: 0.5 } },
+    }
+    const result = migrateSilverWolfLv999EvanesciaMainStats(input, getDefaults)
+    expect(result).toEqual(input)
+  })
+
+  it('unions stale narrowed default into new broader default', () => {
+    const input: Record<string, ScoringMetadataOverride> = {
+      [SW999_ID]: { parts: { [Parts.Body]: [Stats.CR] } },
+    }
+    const result = migrateSilverWolfLv999EvanesciaMainStats(input, getDefaults)
+    expect(result[SW999_ID]!.parts![Parts.Body]).toEqual([Stats.CR, Stats.CD])
+  })
+
+  it('preserves user customizations alongside merged defaults', () => {
+    const input: Record<string, ScoringMetadataOverride> = {
+      [EVA_ID]: { parts: { [Parts.LinkRope]: [Stats.ATK_P] } },
+    }
+    const result = migrateSilverWolfLv999EvanesciaMainStats(input, getDefaults)
+    expect(result[EVA_ID]!.parts![Parts.LinkRope]).toEqual([Stats.ATK_P, Stats.ERR])
+  })
+
+  it('preserves stats not in defaults', () => {
+    const input: Record<string, ScoringMetadataOverride> = {
+      [SW999_ID]: { parts: { [Parts.Body]: [Stats.CR, Stats.ATK_P] } },
+    }
+    const result = migrateSilverWolfLv999EvanesciaMainStats(input, getDefaults)
+    expect(result[SW999_ID]!.parts![Parts.Body]).toEqual([Stats.CR, Stats.CD, Stats.ATK_P])
+  })
+
+  it('treats saved [] (user chose allow-all) as absorbing', () => {
+    const input: Record<string, ScoringMetadataOverride> = {
+      [EVA_ID]: { parts: { [Parts.Body]: [] } },
+    }
+    const result = migrateSilverWolfLv999EvanesciaMainStats(input, getDefaults)
+    expect(result[EVA_ID]!.parts![Parts.Body]).toEqual([])
+  })
+
+  it('treats current default [] (allow-all) as absorbing, releasing stale narrow list', () => {
+    const input: Record<string, ScoringMetadataOverride> = {
+      [SW999_ID]: { parts: { [Parts.PlanarSphere]: [Stats.Physical_DMG] } },
+    }
+    const result = migrateSilverWolfLv999EvanesciaMainStats(input, getDefaults)
+    expect(result[SW999_ID]!.parts![Parts.PlanarSphere]).toEqual([])
+  })
+
+  it('leaves non-targeted character overrides untouched', () => {
+    const input: Record<string, ScoringMetadataOverride> = {
+      [UNRELATED_ID]: { parts: { [Parts.Body]: [Stats.CR] } },
+    }
+    const result = migrateSilverWolfLv999EvanesciaMainStats(input, getDefaults)
+    expect(result[UNRELATED_ID]!.parts![Parts.Body]).toEqual([Stats.CR])
+  })
+
+  it('does not mutate the input overrides map', () => {
+    const input: Record<string, ScoringMetadataOverride> = {
+      [SW999_ID]: { parts: { [Parts.Body]: [Stats.CR] } },
+    }
+    const originalBody = input[SW999_ID]!.parts![Parts.Body]
+    migrateSilverWolfLv999EvanesciaMainStats(input, getDefaults)
+    expect(input[SW999_ID]!.parts![Parts.Body]).toBe(originalBody)
+    expect(input[SW999_ID]!.parts![Parts.Body]).toEqual([Stats.CR])
+  })
+
+  it('does not touch parts keys that are undefined in the override', () => {
+    const input: Record<string, ScoringMetadataOverride> = {
+      [EVA_ID]: { parts: { [Parts.Body]: [Stats.CR] } },
+    }
+    const result = migrateSilverWolfLv999EvanesciaMainStats(input, getDefaults)
+    expect(result[EVA_ID]!.parts![Parts.LinkRope]).toBeUndefined()
+  })
+
+  it('logs and skips a character whose defaults lookup throws, still migrates the other', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const input: Record<string, ScoringMetadataOverride> = {
+      [SW999_ID]: { parts: { [Parts.Body]: [Stats.CR] } },
+      [EVA_ID]: { parts: { [Parts.LinkRope]: [Stats.ATK_P] } },
+    }
+    const throwingGetDefaults = (id: string) => {
+      if (id === EVA_ID) throw new Error('boom')
+      return getDefaults(id)
+    }
+
+    const result = migrateSilverWolfLv999EvanesciaMainStats(input, throwingGetDefaults)
+
+    expect(result[SW999_ID]!.parts![Parts.Body]).toEqual([Stats.CR, Stats.CD])
+    expect(result[EVA_ID]).toBe(input[EVA_ID])
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining(EVA_ID),
+      expect.any(Error),
+    )
+
+    consoleError.mockRestore()
+  })
+})

--- a/src/lib/services/migrations/silverWolfLv999EvanesciaMainStats.ts
+++ b/src/lib/services/migrations/silverWolfLv999EvanesciaMainStats.ts
@@ -1,0 +1,59 @@
+// One-time migration (2026-04-20, lift ~2026-06-20). Unblocks users with pre-fix snapshot
+// overrides for SilverWolfLv999 (1506) / Evanescia (1505) by unioning saved parts with
+// current defaults. `[]` (allow-all) is absorbing in the union.
+import {
+  MainStatPartsArray,
+  type MainStats,
+} from 'lib/constants/constants'
+import { arraysShallowEqual } from 'lib/utils/arrayUtils'
+import type {
+  ScoringMetadata,
+  ScoringMetadataOverride,
+  ScoringParts,
+} from 'types/metadata'
+
+const TARGET_IDS = ['1505', '1506'] as const // Evanescia, SilverWolfLv999
+
+export function migrateSilverWolfLv999EvanesciaMainStats(
+  overrides: Record<string, ScoringMetadataOverride>,
+  getDefaults: (id: string) => ScoringMetadata | undefined,
+): Record<string, ScoringMetadataOverride> {
+  const result = { ...overrides }
+
+  for (const id of TARGET_IDS) {
+    try {
+      const override = result[id]
+      if (!override?.parts) continue
+
+      const defaults = getDefaults(id)
+      if (!defaults) continue
+
+      const nextParts: Partial<Record<ScoringParts, MainStats[]>> = { ...override.parts }
+      let partsChanged = false
+
+      for (const part of MainStatPartsArray) {
+        const saved = nextParts[part]
+        if (saved === undefined) continue
+
+        const unioned = unionMainStats(saved, defaults.parts[part] ?? [])
+        if (!arraysShallowEqual(unioned, saved)) {
+          nextParts[part] = unioned
+          partsChanged = true
+        }
+      }
+
+      if (partsChanged) {
+        result[id] = { ...override, parts: nextParts }
+      }
+    } catch (e) {
+      console.error(`[silverWolfLv999EvanesciaMainStats] Failed to migrate ${id}, skipping`, e)
+    }
+  }
+
+  return result
+}
+
+function unionMainStats(saved: MainStats[], current: MainStats[]): MainStats[] {
+  if (saved.length === 0 || current.length === 0) return []
+  return [...current, ...saved.filter((s) => !current.includes(s))]
+}

--- a/src/lib/services/persistenceService.ts
+++ b/src/lib/services/persistenceService.ts
@@ -23,6 +23,7 @@ import {
 } from 'lib/relics/relicUtils'
 import { migrateBuild } from 'lib/services/buildMigration'
 import * as equipmentService from 'lib/services/equipmentService'
+import { migrateSilverWolfLv999EvanesciaMainStats } from 'lib/services/migrations/silverWolfLv999EvanesciaMainStats'
 import type { Simulation } from 'lib/simulations/statSimulationTypes'
 import { getGameMetadata } from 'lib/state/gameMetadata'
 import { SaveState } from 'lib/state/saveState'
@@ -84,18 +85,18 @@ export function loadSaveData(saveData: HsrOptimizerSaveFormat, autosave = true, 
   // Remove invalid characters
   saveData.characters = saveData.characters.filter((x) => dbCharacters[x.id])
 
-  // Prune overrides to delta format (converts old full-snapshots)
-  const { result: prunedOverrides, changed } = pruneOverridesOnLoad(
+  const migratedOverrides = migrateSilverWolfLv999EvanesciaMainStats(
     saveData.scoringMetadataOverrides ?? {},
     (id) => dbCharacters[id as CharacterId]?.scoringMetadata,
   )
 
-  useScoringStore.getState().setScoringMetadataOverrides(prunedOverrides)
+  // Prune overrides to delta format (converts old full-snapshots)
+  const { result: prunedOverrides } = pruneOverridesOnLoad(
+    migratedOverrides,
+    (id) => dbCharacters[id as CharacterId]?.scoringMetadata,
+  )
 
-  // Save if anything was pruned (triggers save outside of the normal autosave check)
-  if (changed && autosave) {
-    SaveState.delayedSave()
-  }
+  useScoringStore.getState().setScoringMetadataOverrides(prunedOverrides)
 
   const relicsById = new Map(saveData.relics.map((r) => [r.id, r]))
 


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

- Prevent accidental dismissal of What's New modal for first 1s after opening
- Add one-time migration to repair stale Silver Wolf Lv999 / Evanescia main stat overrides on save load
- Swap Shine and Natural showcase preset icons to Palette and CircleHalf2, and surface the same icons on the debug panel pills
- Remove unused FeatureCards TODO copy and old Changelog notification strings from en_US locales

## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [ ] I have added commit messages that are descriptive and meaningful.
- [ ] I have tested the changes locally.
- [ ] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
