### PR TITLE
hotfix: l2d / characters tab performance issues

### DIFF
--- a/src/lib/characterPreview/characterPreviewController.tsx
+++ b/src/lib/characterPreview/characterPreviewController.tsx
@@ -6,7 +6,6 @@ import {
   DEFAULT_TEAM,
   ElementToDamage,
   Parts,
-  Stats,
 } from 'lib/constants/constants'
 import {
   innerW,
@@ -218,13 +217,8 @@ export function getShowcaseStats(
   const context = generateContext(form)
   const { x } = simulateBuild(statCalculationRelics as SimulationRelicByPart, context, null)
   const basicStats = x.c.toBasicStatsObject()
-  const computedStats = x.toComputedStatsObject()
   const finalStats: BasicStatsObject = {
     ...basicStats,
-    // ERR and OHB from basicStats only include relic values. Override with computed stats
-    // to include light cone passive effects (e.g., UntilTheFlowersBloomAgain ERR buff).
-    [Stats.ERR]: computedStats[Stats.ERR],
-    [Stats.OHB]: computedStats[Stats.OHB],
   }
 
   // Element-specific DMG (e.g., "Ice DMG Boost") is already populated by toBasicStatsObject

--- a/src/lib/characterPreview/characterPreviewController.tsx
+++ b/src/lib/characterPreview/characterPreviewController.tsx
@@ -6,6 +6,7 @@ import {
   DEFAULT_TEAM,
   ElementToDamage,
   Parts,
+  Stats,
 } from 'lib/constants/constants'
 import {
   innerW,
@@ -217,8 +218,13 @@ export function getShowcaseStats(
   const context = generateContext(form)
   const { x } = simulateBuild(statCalculationRelics as SimulationRelicByPart, context, null)
   const basicStats = x.c.toBasicStatsObject()
+  const computedStats = x.toComputedStatsObject()
   const finalStats: BasicStatsObject = {
     ...basicStats,
+    // ERR and OHB from basicStats only include relic values. Override with computed stats
+    // to include light cone passive effects (e.g., UntilTheFlowersBloomAgain ERR buff).
+    [Stats.ERR]: computedStats[Stats.ERR],
+    [Stats.OHB]: computedStats[Stats.OHB],
   }
 
   // Element-specific DMG (e.g., "Ice DMG Boost") is already populated by toBasicStatsObject

--- a/src/lib/characterPreview/summary/DpsScoreGradeRuler.module.css
+++ b/src/lib/characterPreview/summary/DpsScoreGradeRuler.module.css
@@ -1,6 +1,22 @@
 .ruler {
   position: relative;
   overflow: hidden;
+  --color-1: #FF6355dd;
+  --color-2: #faf742dd;
+  --color-3: #b0fa42dd;
+  --color-4: #75ec46dd;
+  --color-5: #17D553dd;
+  --color-6: #23BBFFdd;
+  --color-7: #9F50FFdd;
+  --color-8: #BC38FFdD;
+  --grad-point-1: calc(0 * 100% / 7);
+  --grad-point-2: calc(1 * 100% / 7);
+  --grad-point-3: calc(2 * 100% / 7);
+  --grad-point-4: calc(3 * 100% / 7);
+  --grad-point-5: calc(4 * 100% / 7);
+  --grad-point-6: calc(5 * 100% / 7);
+  --grad-point-7: calc(6 * 100% / 7);
+  --grad-point-8: calc(7 * 100% / 7);
 }
 
 .chartArea {
@@ -74,24 +90,7 @@
   line-height: 1;
 }
 
-/* .gradient is used to target the runtime modification of the --grad-point-n variables */
-.gradientBg, .scoreFill, .gradient {
-  --color-1: #FF6355dd;
-  --color-2: #faf742dd;
-  --color-3: #b0fa42dd;
-  --color-4: #75ec46dd;
-  --color-5: #17D553dd;
-  --color-6: #23BBFFdd;
-  --color-7: #9F50FFdd;
-  --color-8: #BC38FFdD;
-  --grad-point-1: calc(0 * 100% / 7);
-  --grad-point-2: calc(1 * 100% / 7);
-  --grad-point-3: calc(2 * 100% / 7);
-  --grad-point-4: calc(3 * 100% / 7);
-  --grad-point-5: calc(4 * 100% / 7);
-  --grad-point-6: calc(5 * 100% / 7);
-  --grad-point-7: calc(6 * 100% / 7);
-  --grad-point-8: calc(7 * 100% / 7);
+.gradientBg, .scoreFill {
   background: linear-gradient(
     to right,
     var(--color-1) var(--grad-point-1),

--- a/src/lib/characterPreview/summary/DpsScoreGradeRuler.tsx
+++ b/src/lib/characterPreview/summary/DpsScoreGradeRuler.tsx
@@ -6,6 +6,7 @@ import { SimScoreGrades } from 'lib/scoring/dpsScore'
 import type { Languages } from 'lib/utils/i18nUtils'
 import { renderThousandsK } from 'lib/utils/i18nUtils'
 import {
+  type CSSProperties,
   memo,
   useEffect,
   useMemo,
@@ -69,48 +70,23 @@ function toPercent(value: number, minimum: number, maximum: number): string {
 
 // --- Component ---
 
-function getGradientStyleRule() {
-  for (const sheet of document.styleSheets) {
-    for (const rule of sheet.cssRules) {
-      if (!(rule instanceof CSSStyleRule)) continue
-      if (rule.selectorText.includes(styles.gradient)) {
-        return rule
-      }
-    }
-  }
-}
-
-const gradientStyleRule = getGradientStyleRule()
-
-function resetGradient() {
-  gradientStyleRule?.style.setProperty('--grad-point-1', 'calc(0 * 100% / 7)')
-  gradientStyleRule?.style.setProperty('--grad-point-2', 'calc(1 * 100% / 7)')
-  gradientStyleRule?.style.setProperty('--grad-point-3', 'calc(2 * 100% / 7)')
-  gradientStyleRule?.style.setProperty('--grad-point-4', 'calc(3 * 100% / 7)')
-  gradientStyleRule?.style.setProperty('--grad-point-5', 'calc(4 * 100% / 7)')
-  gradientStyleRule?.style.setProperty('--grad-point-6', 'calc(5 * 100% / 7)')
-  gradientStyleRule?.style.setProperty('--grad-point-7', 'calc(6 * 100% / 7)')
-  gradientStyleRule?.style.setProperty('--grad-point-8', 'calc(7 * 100% / 7)')
-}
-
-function setGradient(minimum: number, benchmark: number, maximum: number) {
+function computeGradientVars(minimum: number, benchmark: number, maximum: number): CSSProperties {
   const range = maximum - minimum
   const benchRatio = (benchmark - minimum) / range
   const maxRatio = (maximum - benchmark) / range
-  const offsets = [
-    0,
-    benchRatio / 2 * 100,
-    benchRatio * 0.75 * 100,
-    benchRatio * 100,
-    (maxRatio / 4 + benchRatio) * 100,
-    (maxRatio / 2 + benchRatio) * 100,
-    (maxRatio * 0.75 + benchRatio) * 100,
-    100,
-  ]
-  for (let i = 0; i < 8; i++) {
-    gradientStyleRule?.style.setProperty(`--grad-point-${i + 1}`, `${offsets[i]}%`)
-  }
+  return {
+    '--grad-point-1': '0%',
+    '--grad-point-2': `${benchRatio / 2 * 100}%`,
+    '--grad-point-3': `${benchRatio * 0.75 * 100}%`,
+    '--grad-point-4': `${benchRatio * 100}%`,
+    '--grad-point-5': `${(maxRatio / 4 + benchRatio) * 100}%`,
+    '--grad-point-6': `${(maxRatio / 2 + benchRatio) * 100}%`,
+    '--grad-point-7': `${(maxRatio * 0.75 + benchRatio) * 100}%`,
+    '--grad-point-8': '100%',
+  } as CSSProperties
 }
+
+const defaultGradientVars: CSSProperties = {}
 
 const smoothTransition = 'all 0.5s ease-in-out'
 type RulerState = {
@@ -123,6 +99,7 @@ type RulerState = {
   minPercent: string,
   benchPercent: string,
   maxPercent: string,
+  gradientVars: CSSProperties,
 }
 
 const initialState: RulerState = {
@@ -135,6 +112,7 @@ const initialState: RulerState = {
   minPercent: '0%',
   benchPercent: '50%',
   maxPercent: '100%',
+  gradientVars: defaultGradientVars,
 }
 
 const emptyState: RulerState = {
@@ -147,6 +125,7 @@ const emptyState: RulerState = {
   minPercent: '0%',
   benchPercent: '50%',
   maxPercent: '100%',
+  gradientVars: defaultGradientVars,
 }
 
 export const DpsScoreGradeRuler = memo(function DpsScoreGradeRuler() {
@@ -179,20 +158,15 @@ export const DpsScoreGradeRuler = memo(function DpsScoreGradeRuler() {
       minPercent: toPercent(minimum, minimum, maximum),
       benchPercent: toPercent(benchmark, minimum, maximum),
       maxPercent: toPercent(maximum, minimum, maximum),
+      gradientVars: computeGradientVars(minimum, benchmark, maximum),
     }
   }, [scoringResult])
 
-  // Update gradient CSS vars
   useEffect(() => {
-    if (!scoringResult) {
-      resetGradient()
-    } else {
-      setGradient(derivedState.minimum, derivedState.benchmark, derivedState.maximum)
-    }
     setState(derivedState)
-  }, [derivedState, scoringResult])
+  }, [derivedState])
 
-  const { transition, minimum, benchmark, maximum, barPercent, scorePercent, minPercent, benchPercent, maxPercent } = state
+  const { transition, minimum, benchmark, maximum, barPercent, scorePercent, minPercent, benchPercent, maxPercent, gradientVars } = state
 
   const dmgLabel = t('Damage')
   const reversedLabels = reversedLanguages[i18n.resolvedLanguage as Languages]
@@ -200,7 +174,7 @@ export const DpsScoreGradeRuler = memo(function DpsScoreGradeRuler() {
   const dmgOffset = reversedLabels ? HIGH : LOW
 
   return (
-    <div className={styles.ruler} style={{ width: RULER_WIDTH, height: CHART_HEIGHT }}>
+    <div className={styles.ruler} style={{ ...gradientVars, width: RULER_WIDTH, height: CHART_HEIGHT }}>
       <div className={styles.chartArea} style={{ left: MARGIN_LR, right: MARGIN_LR }}>
         <BackgroundGradient transition={transition} />
 

--- a/src/lib/conditionals/character/1300/Firefly.ts
+++ b/src/lib/conditionals/character/1300/Firefly.ts
@@ -458,7 +458,7 @@ const display = {
     y: 1104,
     z: 1.3,
   },
-  showcaseColor: '#90ccd1',
+  showcaseColor: '#62857b',
 }
 
 export const Firefly: CharacterConfig = {

--- a/src/lib/conditionals/character/1300/SparkleB1.ts
+++ b/src/lib/conditionals/character/1300/SparkleB1.ts
@@ -140,7 +140,10 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
       id: 'teammateCDValue',
       formItem: 'slider',
       text: t('TeammateContent.teammateCDValue.text'),
-      content: t('TeammateContent.teammateCDValue.content'),
+      content: t('TeammateContent.teammateCDValue.content', {
+        skillCdBuffScaling: precisionRound(100 * skillCdBuffScaling),
+        skillCdBuffBase: precisionRound(100 * skillCdBuffBase),
+      }),
       min: 0,
       max: 3.50,
       percent: true,

--- a/src/lib/hooks/useTabVisibility.ts
+++ b/src/lib/hooks/useTabVisibility.ts
@@ -6,11 +6,15 @@ export type TabVisibilityValue = {
   /** Register a callback to be called when the tab activates (hidden → visible).
    *  Returns an unsubscribe function. */
   addActivationListener: (cb: () => void) => () => void,
+  /** Register a callback to be called when the tab deactivates (visible → hidden).
+   *  Returns an unsubscribe function. */
+  addDeactivationListener: (cb: () => void) => () => void,
 }
 
 const defaultValue: TabVisibilityValue = {
   isActiveRef: { current: true },
   addActivationListener: () => () => {},
+  addDeactivationListener: () => () => {},
 }
 
 /**

--- a/src/lib/services/persistenceService.test.ts
+++ b/src/lib/services/persistenceService.test.ts
@@ -309,8 +309,10 @@ describe('loadSaveData', () => {
 
     loadSaveData(saveData, false, false)
 
-    // The original reference should NOT have been mutated
-    expect(menuStateBefore[OptimizerMenuIds.characterOptions]).toBeUndefined()
+    const menuStateAfter = useOptimizerDisplayStore.getState().menuState
+
+    // A new object reference should have been created, not in-place mutation
+    expect(menuStateAfter).not.toBe(menuStateBefore)
   })
 
   it('loadSaveData merges settings with DefaultSettingOptions for missing keys', () => {

--- a/src/lib/spine/SpinePortrait.tsx
+++ b/src/lib/spine/SpinePortrait.tsx
@@ -73,6 +73,11 @@ export function SpinePortrait({
 
     const canvas = canvasRef.current!
     let disposed = false
+    // Abort in-flight loads when characterId changes (or component unmounts).
+    // createSpineInstance checks this signal at each await boundary and skips
+    // shader compile + rAF bootstrap for doomed loads. `disposed` still guards
+    // the rare race where abort fires AFTER the instance is already returned.
+    const abortController = new AbortController()
 
     const count = getSkeletonCount(characterId)
 
@@ -80,7 +85,7 @@ export function SpinePortrait({
       const files = getSkeletonFiles(characterId, count)
       const baseUrl = getSpineAssetBaseUrl(characterId)
 
-      createSpineInstance(canvas, baseUrl, files)
+      createSpineInstance(canvas, baseUrl, files, abortController.signal)
         .then((instance) => {
           if (disposed) {
             console.log(`[SpinePortrait #${debugId}] DISPOSED BEFORE READY - char: ${characterId}`)
@@ -100,6 +105,8 @@ export function SpinePortrait({
           onReadyRef.current?.()
         })
         .catch((err) => {
+          // Expected path when user switches characters mid-load — not an error.
+          if ((err as DOMException | undefined)?.name === 'AbortError') return
           console.error('SpinePortrait: failed to load', characterId, err)
           if (!disposed) onUnsupportedRef.current?.()
         })
@@ -112,6 +119,7 @@ export function SpinePortrait({
       console.log(`[SpinePortrait #${debugId}] UNMOUNT - char: ${characterId}, remaining: ${mountedPortraits.size - 1}`)
       mountedPortraits.delete(debugId)
       disposed = true
+      abortController.abort()
       instanceRef.current?.dispose()
       instanceRef.current = null
     }

--- a/src/lib/spine/SpinePortrait.tsx
+++ b/src/lib/spine/SpinePortrait.tsx
@@ -16,18 +16,6 @@ import type { CharacterId } from 'types/character'
 
 const CANVAS_SIZE = 2048
 
-// Debug: track mounted SpinePortrait components
-let portraitMountCounter = 0
-const mountedPortraits = new Map<number, { characterId: string, mountedAt: number }>()
-
-// Expose to window for console debugging
-if (typeof window !== 'undefined') {
-  ;(window as any).__SPINE_PORTRAIT_DEBUG__ = {
-    getMountedCount: () => mountedPortraits.size,
-    getMountedPortraits: () => Array.from(mountedPortraits.entries()),
-  }
-}
-
 export function SpinePortrait({
   characterId,
   style,
@@ -49,28 +37,20 @@ export function SpinePortrait({
   const { isActiveRef, addActivationListener, addDeactivationListener } = useContext(TabVisibilityContext)
 
   // Pause the rAF loop when the host tab hides, resume when it shows again.
-  // See diagnostic logs in spineEngine.ts — after this lands, [Spine #N] FRAME
-  // logs should freeze between TAB HIDDEN and TAB SHOWN for the same instance.
   useEffect(() => {
     const unsubActivate = addActivationListener(() => {
-      console.log(`[SpinePortrait char:${characterId}] TAB SHOWN — resuming spine instance #${instanceRef.current?.debugId ?? '?'}`)
       instanceRef.current?.resume()
     })
     const unsubDeactivate = addDeactivationListener(() => {
-      console.log(`[SpinePortrait char:${characterId}] TAB HIDDEN — pausing spine instance #${instanceRef.current?.debugId ?? '?'}`)
       instanceRef.current?.pause()
     })
     return () => {
       unsubActivate()
       unsubDeactivate()
     }
-  }, [characterId, addActivationListener, addDeactivationListener])
+  }, [addActivationListener, addDeactivationListener])
 
   useEffect(() => {
-    const debugId = ++portraitMountCounter
-    mountedPortraits.set(debugId, { characterId, mountedAt: Date.now() })
-    console.log(`[SpinePortrait #${debugId}] MOUNT - char: ${characterId}, total mounted: ${mountedPortraits.size}`)
-
     const canvas = canvasRef.current!
     let disposed = false
     // Abort in-flight loads when characterId changes (or component unmounts).
@@ -88,7 +68,6 @@ export function SpinePortrait({
       createSpineInstance(canvas, baseUrl, files, abortController.signal)
         .then((instance) => {
           if (disposed) {
-            console.log(`[SpinePortrait #${debugId}] DISPOSED BEFORE READY - char: ${characterId}`)
             instance.dispose()
             return
           }
@@ -97,10 +76,7 @@ export function SpinePortrait({
           // Without this, a spine that loads while its tab is invisible would
           // run uselessly until the tab is focused and hidden again.
           if (!isActiveRef.current) {
-            console.log(`[SpinePortrait #${debugId}] READY but tab HIDDEN — starting paused, spine instance #${instance.debugId}`)
             instance.pause()
-          } else {
-            console.log(`[SpinePortrait #${debugId}] READY - char: ${characterId}, spine instance #${instance.debugId}`)
           }
           onReadyRef.current?.()
         })
@@ -111,19 +87,16 @@ export function SpinePortrait({
           if (!disposed) onUnsupportedRef.current?.()
         })
     } else {
-      console.log(`[SpinePortrait #${debugId}] NO SPINE DATA - char: ${characterId}`)
       onUnsupportedRef.current?.()
     }
 
     return () => {
-      console.log(`[SpinePortrait #${debugId}] UNMOUNT - char: ${characterId}, remaining: ${mountedPortraits.size - 1}`)
-      mountedPortraits.delete(debugId)
       disposed = true
       abortController.abort()
       instanceRef.current?.dispose()
       instanceRef.current = null
     }
-  }, [characterId])
+  }, [characterId, isActiveRef])
 
   return (
     <canvas

--- a/src/lib/spine/SpinePortrait.tsx
+++ b/src/lib/spine/SpinePortrait.tsx
@@ -53,10 +53,8 @@ export function SpinePortrait({
   useEffect(() => {
     const canvas = canvasRef.current!
     let disposed = false
-    // Abort in-flight loads when characterId changes (or component unmounts).
-    // createSpineInstance checks this signal at each await boundary and skips
-    // shader compile + rAF bootstrap for doomed loads. `disposed` still guards
-    // the rare race where abort fires AFTER the instance is already returned.
+    // Abort in-flight load on characterId change / unmount. `disposed` still
+    // guards the race where abort fires after the instance resolves.
     const abortController = new AbortController()
 
     const count = getSkeletonCount(characterId)
@@ -72,9 +70,7 @@ export function SpinePortrait({
             return
           }
           instanceRef.current = instance
-          // Start paused if the host tab became hidden during the async load.
-          // Without this, a spine that loads while its tab is invisible would
-          // run uselessly until the tab is focused and hidden again.
+          // Start paused if the tab hid mid-load.
           if (!isActiveRef.current) {
             instance.pause()
           }

--- a/src/lib/spine/SpinePortrait.tsx
+++ b/src/lib/spine/SpinePortrait.tsx
@@ -5,7 +5,9 @@ import {
 } from 'lib/spine/manifest'
 import { createSpineInstance } from 'lib/spine/spineEngine'
 import type { SpineInstance } from 'lib/spine/spineEngine'
+import { TabVisibilityContext } from 'lib/hooks/useTabVisibility'
 import {
+  useContext,
   useEffect,
   useRef,
 } from 'react'
@@ -13,6 +15,18 @@ import type { CSSProperties } from 'react'
 import type { CharacterId } from 'types/character'
 
 const CANVAS_SIZE = 2048
+
+// Debug: track mounted SpinePortrait components
+let portraitMountCounter = 0
+const mountedPortraits = new Map<number, { characterId: string, mountedAt: number }>()
+
+// Expose to window for console debugging
+if (typeof window !== 'undefined') {
+  ;(window as any).__SPINE_PORTRAIT_DEBUG__ = {
+    getMountedCount: () => mountedPortraits.size,
+    getMountedPortraits: () => Array.from(mountedPortraits.entries()),
+  }
+}
 
 export function SpinePortrait({
   characterId,
@@ -32,7 +46,31 @@ export function SpinePortrait({
   const onReadyRef = useRef(onReady)
   onReadyRef.current = onReady
 
+  const { isActiveRef, addActivationListener, addDeactivationListener } = useContext(TabVisibilityContext)
+
+  // Pause the rAF loop when the host tab hides, resume when it shows again.
+  // See diagnostic logs in spineEngine.ts — after this lands, [Spine #N] FRAME
+  // logs should freeze between TAB HIDDEN and TAB SHOWN for the same instance.
   useEffect(() => {
+    const unsubActivate = addActivationListener(() => {
+      console.log(`[SpinePortrait char:${characterId}] TAB SHOWN — resuming spine instance #${instanceRef.current?.debugId ?? '?'}`)
+      instanceRef.current?.resume()
+    })
+    const unsubDeactivate = addDeactivationListener(() => {
+      console.log(`[SpinePortrait char:${characterId}] TAB HIDDEN — pausing spine instance #${instanceRef.current?.debugId ?? '?'}`)
+      instanceRef.current?.pause()
+    })
+    return () => {
+      unsubActivate()
+      unsubDeactivate()
+    }
+  }, [characterId, addActivationListener, addDeactivationListener])
+
+  useEffect(() => {
+    const debugId = ++portraitMountCounter
+    mountedPortraits.set(debugId, { characterId, mountedAt: Date.now() })
+    console.log(`[SpinePortrait #${debugId}] MOUNT - char: ${characterId}, total mounted: ${mountedPortraits.size}`)
+
     const canvas = canvasRef.current!
     let disposed = false
 
@@ -45,10 +83,20 @@ export function SpinePortrait({
       createSpineInstance(canvas, baseUrl, files)
         .then((instance) => {
           if (disposed) {
+            console.log(`[SpinePortrait #${debugId}] DISPOSED BEFORE READY - char: ${characterId}`)
             instance.dispose()
             return
           }
           instanceRef.current = instance
+          // Start paused if the host tab became hidden during the async load.
+          // Without this, a spine that loads while its tab is invisible would
+          // run uselessly until the tab is focused and hidden again.
+          if (!isActiveRef.current) {
+            console.log(`[SpinePortrait #${debugId}] READY but tab HIDDEN — starting paused, spine instance #${instance.debugId}`)
+            instance.pause()
+          } else {
+            console.log(`[SpinePortrait #${debugId}] READY - char: ${characterId}, spine instance #${instance.debugId}`)
+          }
           onReadyRef.current?.()
         })
         .catch((err) => {
@@ -56,10 +104,13 @@ export function SpinePortrait({
           if (!disposed) onUnsupportedRef.current?.()
         })
     } else {
+      console.log(`[SpinePortrait #${debugId}] NO SPINE DATA - char: ${characterId}`)
       onUnsupportedRef.current?.()
     }
 
     return () => {
+      console.log(`[SpinePortrait #${debugId}] UNMOUNT - char: ${characterId}, remaining: ${mountedPortraits.size - 1}`)
+      mountedPortraits.delete(debugId)
       disposed = true
       instanceRef.current?.dispose()
       instanceRef.current = null

--- a/src/lib/spine/spineEngine.ts
+++ b/src/lib/spine/spineEngine.ts
@@ -16,35 +16,6 @@ export interface SpineInstance {
   pause(): void
   /** Restart the rAF loop. No-op if already running or disposed. */
   resume(): void
-  /** Debug: unique ID for this instance */
-  readonly debugId: number
-}
-
-// Debug: track all active spine instances
-let spineInstanceCounter = 0
-const activeSpineInstances = new Map<number, { baseUrl: string, createdAt: number, frameCount: number }>()
-
-/** Debug: get current spine instance stats */
-export function getSpineDebugStats() {
-  const instances = Array.from(activeSpineInstances.entries()).map(([id, info]) => ({
-    id,
-    baseUrl: info.baseUrl,
-    ageMs: Date.now() - info.createdAt,
-    frameCount: info.frameCount,
-  }))
-  return {
-    activeCount: activeSpineInstances.size,
-    instances,
-    totalFrames: instances.reduce((sum, i) => sum + i.frameCount, 0),
-  }
-}
-
-// Expose to window for console debugging
-if (typeof window !== 'undefined') {
-  ;(window as any).__SPINE_DEBUG__ = {
-    getStats: getSpineDebugStats,
-    getActiveInstances: () => activeSpineInstances,
-  }
 }
 
 interface SkeletonEntry {
@@ -96,16 +67,8 @@ export async function createSpineInstance(
   files: { skelFile: string, atlasFile: string }[],
   signal?: AbortSignal,
 ): Promise<SpineInstance> {
-  const debugId = ++spineInstanceCounter
-  const debugInfo = { baseUrl, createdAt: Date.now(), frameCount: 0 }
-  activeSpineInstances.set(debugId, debugInfo)
-
-  console.log(`[Spine #${debugId}] CREATE - baseUrl: ${baseUrl}, files: ${files.length}, total active: ${activeSpineInstances.size}`)
-
   // Fast-path if already aborted before we did any work.
   if (signal?.aborted) {
-    activeSpineInstances.delete(debugId)
-    console.log(`[Spine #${debugId}] ABORTED before start`)
     throw new DOMException('Spine load aborted', 'AbortError')
   }
 
@@ -159,10 +122,6 @@ export async function createSpineInstance(
     })
   } catch (err) {
     assetManager.dispose()
-    activeSpineInstances.delete(debugId)
-    if ((err as DOMException | undefined)?.name === 'AbortError') {
-      console.log(`[Spine #${debugId}] ABORTED during load`)
-    }
     throw err
   }
 
@@ -252,12 +211,6 @@ export async function createSpineInstance(
     const delta = Math.min((now - lastTime) / 1000, 0.1) // clamp to 100ms to avoid animation jumps on tab-resume
     lastTime = now
 
-    debugInfo.frameCount++
-    // Log every 300 frames (~5 seconds at 60fps) to track running instances
-    if (debugInfo.frameCount % 300 === 0) {
-      console.log(`[Spine #${debugId}] FRAME ${debugInfo.frameCount} - still running, total active: ${activeSpineInstances.size}`)
-    }
-
     for (const entry of entries) {
       entry.animState.update(delta)
       entry.animState.apply(entry.skeleton)
@@ -287,18 +240,14 @@ export async function createSpineInstance(
   if (signal?.aborted) {
     renderer.dispose()
     assetManager.dispose()
-    activeSpineInstances.delete(debugId)
-    console.log(`[Spine #${debugId}] ABORTED after setup`)
     throw new DOMException('Spine load aborted', 'AbortError')
   }
 
   rafId = requestAnimationFrame(loop)
-  console.log(`[Spine #${debugId}] LOOP STARTED`)
 
   // --- Cleanup handle ---
 
   return {
-    debugId,
     pause() {
       if (paused || disposed) return
       paused = true
@@ -306,20 +255,16 @@ export async function createSpineInstance(
         cancelAnimationFrame(rafId)
         rafId = null
       }
-      console.log(`[Spine #${debugId}] PAUSE at frame ${debugInfo.frameCount}`)
     },
     resume() {
       if (!paused || disposed) return
       paused = false
       lastTime = performance.now() // avoid a large delta on the resumed frame
       rafId = requestAnimationFrame(loop)
-      console.log(`[Spine #${debugId}] RESUME at frame ${debugInfo.frameCount}`)
     },
     dispose() {
       if (disposed) return
       disposed = true
-      console.log(`[Spine #${debugId}] DISPOSE - ran ${debugInfo.frameCount} frames, remaining: ${activeSpineInstances.size - 1}`)
-      activeSpineInstances.delete(debugId)
       if (rafId != null) {
         cancelAnimationFrame(rafId)
         rafId = null

--- a/src/lib/spine/spineEngine.ts
+++ b/src/lib/spine/spineEngine.ts
@@ -200,9 +200,10 @@ export async function createSpineInstance(
   renderer.camera.setViewport(canvasSize, canvasSize)
   renderer.camera.update()
 
+  // Lifecycle invariant: `rafId != null` iff the loop is scheduled.
+  // `rafId == null && !disposed` means paused. `disposed` is terminal.
   let rafId: number | null = null
   let lastTime = performance.now()
-  let paused = false
   let disposed = false
 
   function loop(now: number) {
@@ -240,16 +241,12 @@ export async function createSpineInstance(
 
   return {
     pause() {
-      if (paused || disposed) return
-      paused = true
-      if (rafId != null) {
-        cancelAnimationFrame(rafId)
-        rafId = null
-      }
+      if (disposed || rafId == null) return
+      cancelAnimationFrame(rafId)
+      rafId = null
     },
     resume() {
-      if (!paused || disposed) return
-      paused = false
+      if (disposed || rafId != null) return
       lastTime = performance.now() // avoid a large delta on the resumed frame
       rafId = requestAnimationFrame(loop)
     },

--- a/src/lib/spine/spineEngine.ts
+++ b/src/lib/spine/spineEngine.ts
@@ -77,10 +77,8 @@ export async function createSpineInstance(
   // premultipliedAlpha:true because blending naturally produces premultiplied
   // output on a cleared framebuffer — tells browser not to multiply again.
   // drawSkeleton uses PMA=false because atlas textures are straight (un-premultiplied).
-  // antialias:false and preserveDrawingBuffer:false to avoid the MSAA resolve buffer
-  // and persistent backing store — each saves ~60MB+ per 2048² canvas. We redraw
-  // every rAF frame so there's nothing to preserve between composites, and spine
-  // character edges are alpha-blended bitmaps (MSAA is near-imperceptible).
+  // antialias/preserveDrawingBuffer off: we redraw every frame (nothing to
+  // preserve) and spine edges are alpha-blended bitmaps (MSAA is moot).
   const glContext = canvas.getContext('webgl2', { alpha: true, premultipliedAlpha: true, antialias: false, preserveDrawingBuffer: false })
     || canvas.getContext('webgl', { alpha: true, premultipliedAlpha: true, antialias: false, preserveDrawingBuffer: false })
   if (!glContext) throw new Error('WebGL not available')
@@ -227,16 +225,9 @@ export async function createSpineInstance(
     }
     renderer.end()
 
-    // Re-check paused/disposed in case pause()/dispose() was called during this frame
-    if (!paused && !disposed) {
-      rafId = requestAnimationFrame(loop)
-    } else {
-      rafId = null
-    }
+    rafId = requestAnimationFrame(loop)
   }
 
-  // Final abort check after all synchronous setup (skeleton parsing, shader
-  // compile, renderer creation) but before we kick off the rAF loop.
   if (signal?.aborted) {
     renderer.dispose()
     assetManager.dispose()

--- a/src/lib/spine/spineEngine.ts
+++ b/src/lib/spine/spineEngine.ts
@@ -12,6 +12,39 @@ import {
 
 export interface SpineInstance {
   dispose(): void
+  /** Stop the rAF loop. No-op if already paused or disposed. */
+  pause(): void
+  /** Restart the rAF loop. No-op if already running or disposed. */
+  resume(): void
+  /** Debug: unique ID for this instance */
+  readonly debugId: number
+}
+
+// Debug: track all active spine instances
+let spineInstanceCounter = 0
+const activeSpineInstances = new Map<number, { baseUrl: string, createdAt: number, frameCount: number }>()
+
+/** Debug: get current spine instance stats */
+export function getSpineDebugStats() {
+  const instances = Array.from(activeSpineInstances.entries()).map(([id, info]) => ({
+    id,
+    baseUrl: info.baseUrl,
+    ageMs: Date.now() - info.createdAt,
+    frameCount: info.frameCount,
+  }))
+  return {
+    activeCount: activeSpineInstances.size,
+    instances,
+    totalFrames: instances.reduce((sum, i) => sum + i.frameCount, 0),
+  }
+}
+
+// Expose to window for console debugging
+if (typeof window !== 'undefined') {
+  ;(window as any).__SPINE_DEBUG__ = {
+    getStats: getSpineDebugStats,
+    getActiveInstances: () => activeSpineInstances,
+  }
 }
 
 interface SkeletonEntry {
@@ -62,13 +95,23 @@ export async function createSpineInstance(
   baseUrl: string,
   files: { skelFile: string, atlasFile: string }[],
 ): Promise<SpineInstance> {
+  const debugId = ++spineInstanceCounter
+  const debugInfo = { baseUrl, createdAt: Date.now(), frameCount: 0 }
+  activeSpineInstances.set(debugId, debugInfo)
+
+  console.log(`[Spine #${debugId}] CREATE - baseUrl: ${baseUrl}, files: ${files.length}, total active: ${activeSpineInstances.size}`)
+
   // --- WebGL context ---
 
   // premultipliedAlpha:true because blending naturally produces premultiplied
   // output on a cleared framebuffer — tells browser not to multiply again.
   // drawSkeleton uses PMA=false because atlas textures are straight (un-premultiplied).
-  const glContext = canvas.getContext('webgl2', { alpha: true, premultipliedAlpha: true, antialias: true, preserveDrawingBuffer: true })
-    || canvas.getContext('webgl', { alpha: true, premultipliedAlpha: true, antialias: true, preserveDrawingBuffer: true })
+  // antialias:false and preserveDrawingBuffer:false to avoid the MSAA resolve buffer
+  // and persistent backing store — each saves ~60MB+ per 2048² canvas. We redraw
+  // every rAF frame so there's nothing to preserve between composites, and spine
+  // character edges are alpha-blended bitmaps (MSAA is near-imperceptible).
+  const glContext = canvas.getContext('webgl2', { alpha: true, premultipliedAlpha: true, antialias: false, preserveDrawingBuffer: false })
+    || canvas.getContext('webgl', { alpha: true, premultipliedAlpha: true, antialias: false, preserveDrawingBuffer: false })
   if (!glContext) throw new Error('WebGL not available')
   const gl = glContext
 
@@ -183,10 +226,18 @@ export async function createSpineInstance(
 
   let rafId: number | null = null
   let lastTime = performance.now()
+  let paused = false
+  let disposed = false
 
   function loop(now: number) {
     const delta = Math.min((now - lastTime) / 1000, 0.1) // clamp to 100ms to avoid animation jumps on tab-resume
     lastTime = now
+
+    debugInfo.frameCount++
+    // Log every 300 frames (~5 seconds at 60fps) to track running instances
+    if (debugInfo.frameCount % 300 === 0) {
+      console.log(`[Spine #${debugId}] FRAME ${debugInfo.frameCount} - still running, total active: ${activeSpineInstances.size}`)
+    }
 
     for (const entry of entries) {
       entry.animState.update(delta)
@@ -204,16 +255,46 @@ export async function createSpineInstance(
     }
     renderer.end()
 
-    rafId = requestAnimationFrame(loop)
+    // Re-check paused/disposed in case pause()/dispose() was called during this frame
+    if (!paused && !disposed) {
+      rafId = requestAnimationFrame(loop)
+    } else {
+      rafId = null
+    }
   }
 
   rafId = requestAnimationFrame(loop)
+  console.log(`[Spine #${debugId}] LOOP STARTED`)
 
   // --- Cleanup handle ---
 
   return {
+    debugId,
+    pause() {
+      if (paused || disposed) return
+      paused = true
+      if (rafId != null) {
+        cancelAnimationFrame(rafId)
+        rafId = null
+      }
+      console.log(`[Spine #${debugId}] PAUSE at frame ${debugInfo.frameCount}`)
+    },
+    resume() {
+      if (!paused || disposed) return
+      paused = false
+      lastTime = performance.now() // avoid a large delta on the resumed frame
+      rafId = requestAnimationFrame(loop)
+      console.log(`[Spine #${debugId}] RESUME at frame ${debugInfo.frameCount}`)
+    },
     dispose() {
-      if (rafId != null) cancelAnimationFrame(rafId)
+      if (disposed) return
+      disposed = true
+      console.log(`[Spine #${debugId}] DISPOSE - ran ${debugInfo.frameCount} frames, remaining: ${activeSpineInstances.size - 1}`)
+      activeSpineInstances.delete(debugId)
+      if (rafId != null) {
+        cancelAnimationFrame(rafId)
+        rafId = null
+      }
       renderer.dispose()
       assetManager.dispose()
     },

--- a/src/lib/spine/spineEngine.ts
+++ b/src/lib/spine/spineEngine.ts
@@ -94,12 +94,20 @@ export async function createSpineInstance(
   canvas: HTMLCanvasElement,
   baseUrl: string,
   files: { skelFile: string, atlasFile: string }[],
+  signal?: AbortSignal,
 ): Promise<SpineInstance> {
   const debugId = ++spineInstanceCounter
   const debugInfo = { baseUrl, createdAt: Date.now(), frameCount: 0 }
   activeSpineInstances.set(debugId, debugInfo)
 
   console.log(`[Spine #${debugId}] CREATE - baseUrl: ${baseUrl}, files: ${files.length}, total active: ${activeSpineInstances.size}`)
+
+  // Fast-path if already aborted before we did any work.
+  if (signal?.aborted) {
+    activeSpineInstances.delete(debugId)
+    console.log(`[Spine #${debugId}] ABORTED before start`)
+    throw new DOMException('Spine load aborted', 'AbortError')
+  }
 
   // --- WebGL context ---
 
@@ -130,6 +138,13 @@ export async function createSpineInstance(
   try {
     await new Promise<void>((resolve, reject) => {
       function check() {
+        // Bail out each rAF tick if the caller aborted — skips all downstream
+        // skeleton parsing, shader compilation, and rAF bootstrap for doomed
+        // loads during rapid character switching.
+        if (signal?.aborted) {
+          reject(new DOMException('Spine load aborted', 'AbortError'))
+          return
+        }
         if (assetManager.isLoadingComplete()) {
           if (assetManager.hasErrors()) {
             reject(new Error(JSON.stringify(assetManager.getErrors())))
@@ -144,6 +159,10 @@ export async function createSpineInstance(
     })
   } catch (err) {
     assetManager.dispose()
+    activeSpineInstances.delete(debugId)
+    if ((err as DOMException | undefined)?.name === 'AbortError') {
+      console.log(`[Spine #${debugId}] ABORTED during load`)
+    }
     throw err
   }
 
@@ -261,6 +280,16 @@ export async function createSpineInstance(
     } else {
       rafId = null
     }
+  }
+
+  // Final abort check after all synchronous setup (skeleton parsing, shader
+  // compile, renderer creation) but before we kick off the rAF loop.
+  if (signal?.aborted) {
+    renderer.dispose()
+    assetManager.dispose()
+    activeSpineInstances.delete(debugId)
+    console.log(`[Spine #${debugId}] ABORTED after setup`)
+    throw new DOMException('Spine load aborted', 'AbortError')
   }
 
   rafId = requestAnimationFrame(loop)

--- a/src/lib/stores/optimizerUI/useOptimizerDisplayStore.test.ts
+++ b/src/lib/stores/optimizerUI/useOptimizerDisplayStore.test.ts
@@ -7,7 +7,7 @@ import {
 } from 'lib/simulations/statSimulationTypes'
 import { type PermutationDetails } from 'lib/stores/optimizerUI/optimizerUITypes'
 import { useOptimizerDisplayStore } from 'lib/stores/optimizerUI/useOptimizerDisplayStore'
-import { OptimizerMenuIds } from 'lib/tabs/tabOptimizer/optimizerForm/layout/optimizerMenuIds'
+import { initialMenuState } from 'lib/tabs/tabOptimizer/optimizerForm/layout/optimizerMenuIds'
 import { type OptimizerContext } from 'types/optimizer'
 import {
   beforeEach,
@@ -53,13 +53,7 @@ describe('useOptimizerDisplayStore', () => {
       expect(state().statSimulations).toEqual([])
       expect(state().selectedStatSimulations).toEqual([])
       expect(state().characterSelectModalOpen).toBe(false)
-      expect(state().menuState).toEqual({
-        [OptimizerMenuIds.characterOptions]: true,
-        [OptimizerMenuIds.relicAndStatFilters]: true,
-        [OptimizerMenuIds.teammates]: true,
-        [OptimizerMenuIds.characterStatsSimulation]: false,
-        [OptimizerMenuIds.analysis]: true,
-      })
+      expect(state().menuState).toEqual(initialMenuState)
       expect(state().permutationDetails).toEqual({
         Head: 0,
         Hands: 0,

--- a/src/lib/stores/optimizerUI/useOptimizerDisplayStore.test.ts
+++ b/src/lib/stores/optimizerUI/useOptimizerDisplayStore.test.ts
@@ -7,6 +7,7 @@ import {
 } from 'lib/simulations/statSimulationTypes'
 import { type PermutationDetails } from 'lib/stores/optimizerUI/optimizerUITypes'
 import { useOptimizerDisplayStore } from 'lib/stores/optimizerUI/useOptimizerDisplayStore'
+import { OptimizerMenuIds } from 'lib/tabs/tabOptimizer/optimizerForm/layout/optimizerMenuIds'
 import { type OptimizerContext } from 'types/optimizer'
 import {
   beforeEach,
@@ -52,7 +53,13 @@ describe('useOptimizerDisplayStore', () => {
       expect(state().statSimulations).toEqual([])
       expect(state().selectedStatSimulations).toEqual([])
       expect(state().characterSelectModalOpen).toBe(false)
-      expect(state().menuState).toEqual({})
+      expect(state().menuState).toEqual({
+        [OptimizerMenuIds.characterOptions]: true,
+        [OptimizerMenuIds.relicAndStatFilters]: true,
+        [OptimizerMenuIds.teammates]: true,
+        [OptimizerMenuIds.characterStatsSimulation]: false,
+        [OptimizerMenuIds.analysis]: true,
+      })
       expect(state().permutationDetails).toEqual({
         Head: 0,
         Hands: 0,

--- a/src/lib/stores/optimizerUI/useOptimizerDisplayStore.ts
+++ b/src/lib/stores/optimizerUI/useOptimizerDisplayStore.ts
@@ -8,6 +8,7 @@ import type {
   OptimizerDisplayState,
   PermutationDetails,
 } from 'lib/stores/optimizerUI/optimizerUITypes'
+import { OptimizerMenuIds } from 'lib/tabs/tabOptimizer/optimizerForm/layout/optimizerMenuIds'
 import type {
   Build,
   CharacterId,
@@ -74,7 +75,13 @@ const initialState: OptimizerDisplayState = {
   selectedStatSimulations: [],
   characterSelectModalOpen: false,
   lightConeSelectModalOpen: false,
-  menuState: {},
+  menuState: {
+    [OptimizerMenuIds.characterOptions]: true,
+    [OptimizerMenuIds.relicAndStatFilters]: true,
+    [OptimizerMenuIds.teammates]: true,
+    [OptimizerMenuIds.characterStatsSimulation]: false,
+    [OptimizerMenuIds.analysis]: true,
+  },
 }
 
 export const useOptimizerDisplayStore = createTabAwareStore<OptimizerDisplayStore>((set) => ({

--- a/src/lib/stores/optimizerUI/useOptimizerDisplayStore.ts
+++ b/src/lib/stores/optimizerUI/useOptimizerDisplayStore.ts
@@ -8,7 +8,7 @@ import type {
   OptimizerDisplayState,
   PermutationDetails,
 } from 'lib/stores/optimizerUI/optimizerUITypes'
-import { OptimizerMenuIds } from 'lib/tabs/tabOptimizer/optimizerForm/layout/optimizerMenuIds'
+import { initialMenuState } from 'lib/tabs/tabOptimizer/optimizerForm/layout/optimizerMenuIds'
 import type {
   Build,
   CharacterId,
@@ -75,13 +75,7 @@ const initialState: OptimizerDisplayState = {
   selectedStatSimulations: [],
   characterSelectModalOpen: false,
   lightConeSelectModalOpen: false,
-  menuState: {
-    [OptimizerMenuIds.characterOptions]: true,
-    [OptimizerMenuIds.relicAndStatFilters]: true,
-    [OptimizerMenuIds.teammates]: true,
-    [OptimizerMenuIds.characterStatsSimulation]: false,
-    [OptimizerMenuIds.analysis]: true,
-  },
+  menuState: { ...initialMenuState },
 }
 
 export const useOptimizerDisplayStore = createTabAwareStore<OptimizerDisplayStore>((set) => ({

--- a/src/lib/tabs/Tabs.tsx
+++ b/src/lib/tabs/Tabs.tsx
@@ -174,6 +174,7 @@ function TabRenderer({ activeKey, fallbackKey, tabKey, children }: {
   const isFallback = fallbackKey === tabKey
   const prevActiveRef = useRef(isActive)
   const listenersRef = useRef(new Set<() => void>())
+  const deactivationListenersRef = useRef(new Set<() => void>())
   const isActiveRef = useRef(isActive)
 
   // Always keep the ref in sync — gated listeners read this synchronously
@@ -189,6 +190,12 @@ function TabRenderer({ activeKey, fallbackKey, tabKey, children }: {
         listenersRef.current.delete(cb)
       }
     },
+    addDeactivationListener: (cb: () => void) => {
+      deactivationListenersRef.current.add(cb)
+      return () => {
+        deactivationListenersRef.current.delete(cb)
+      }
+    },
   }))
 
   // On activation (hidden → visible): fire listeners in a macrotask (setTimeout)
@@ -200,6 +207,17 @@ function TabRenderer({ activeKey, fallbackKey, tabKey, children }: {
     setTimeout(() => {
       if (!isActiveRef.current) return // tab already hidden (rapid switch)
       for (const listener of listenersRef.current) {
+        listener()
+      }
+    }, 0)
+  }
+  // On deactivation (visible → hidden): fire synchronously in a microtask.
+  // Unlike activation, we don't need to wait for paint — callers just want to
+  // stop work (pause rAF loops, release resources) as soon as the tab is gone.
+  if (!isActive && prevActiveRef.current) {
+    setTimeout(() => {
+      if (isActiveRef.current) return // tab already visible again (rapid switch)
+      for (const listener of deactivationListenersRef.current) {
         listener()
       }
     }, 0)

--- a/src/lib/tabs/Tabs.tsx
+++ b/src/lib/tabs/Tabs.tsx
@@ -205,7 +205,13 @@ function TabRenderer({ activeKey, fallbackKey, tabKey, children }: {
     const wantActive = isActive
     setTimeout(() => {
       if (isActiveRef.current !== wantActive) return // rapid switch
-      for (const listener of listeners) listener()
+      for (const listener of listeners) {
+        try {
+          listener()
+        } catch (err) {
+          console.error('TabRenderer: listener threw', err)
+        }
+      }
     }, 0)
   }
   prevActiveRef.current = isActive

--- a/src/lib/tabs/Tabs.tsx
+++ b/src/lib/tabs/Tabs.tsx
@@ -198,28 +198,14 @@ function TabRenderer({ activeKey, fallbackKey, tabKey, children }: {
     },
   }))
 
-  // On activation (hidden → visible): fire listeners in a macrotask (setTimeout)
-  // so the browser can paint the display toggle first. rAF runs BEFORE paint,
-  // which would block the tab from appearing until all catch-up re-renders finish.
-  // setTimeout runs AFTER paint, so the tab appears immediately with stale content,
-  // then catch-ups update it.
-  if (isActive && !prevActiveRef.current) {
+  // Fire listeners in a macrotask so the browser paints the display toggle
+  // first — rAF-timed callbacks would block the tab from appearing.
+  if (isActive !== prevActiveRef.current) {
+    const listeners = isActive ? listenersRef.current : deactivationListenersRef.current
+    const wantActive = isActive
     setTimeout(() => {
-      if (!isActiveRef.current) return // tab already hidden (rapid switch)
-      for (const listener of listenersRef.current) {
-        listener()
-      }
-    }, 0)
-  }
-  // On deactivation (visible → hidden): fire synchronously in a microtask.
-  // Unlike activation, we don't need to wait for paint — callers just want to
-  // stop work (pause rAF loops, release resources) as soon as the tab is gone.
-  if (!isActive && prevActiveRef.current) {
-    setTimeout(() => {
-      if (isActiveRef.current) return // tab already visible again (rapid switch)
-      for (const listener of deactivationListenersRef.current) {
-        listener()
-      }
+      if (isActiveRef.current !== wantActive) return // rapid switch
+      for (const listener of listeners) listener()
     }, 0)
   }
   prevActiveRef.current = isActive

--- a/src/lib/tabs/tabCharacters/CharacterGrid.module.css
+++ b/src/lib/tabs/tabCharacters/CharacterGrid.module.css
@@ -78,11 +78,11 @@
   cursor: grab;
   user-select: none;
 
-  /* Skip paint/layout/style for off-screen rows. `auto <length>` caches the
-     first-rendered size so density switches (68/48 px) track without overrides;
-     declared box keeps dnd-kit's layout math correct. */
+  /* Skip paint/layout/style for off-screen rows. Intrinsic size is fixed to
+     the row-height token so dnd-kit's layout math stays correct and density
+     changes (68 ↔ 48 px) propagate to skipped rows without a cache stale. */
   content-visibility: auto;
-  contain-intrinsic-size: auto var(--cr-row-height, 68px);
+  contain-intrinsic-size: var(--cr-row-height, 68px);
 }
 
 /* Visual frame — clips children and does the hover lift while .root stays

--- a/src/lib/tabs/tabCharacters/CharacterGrid.module.css
+++ b/src/lib/tabs/tabCharacters/CharacterGrid.module.css
@@ -77,6 +77,17 @@
   flex-shrink: 0;
   cursor: grab;
   user-select: none;
+
+  /* Browser skips paint + layout + style for off-screen rows. Complements #3
+     (lazy image loading): images only fetch when near viewport; this also
+     skips the non-image work for the same set. dnd-kit sees the DOM unchanged
+     because `contain-intrinsic-size` declares the box for layout math even
+     when contents aren't rendered. The `auto` keyword tells the browser to
+     remember the actually-rendered size after first paint and use that on
+     subsequent viewport exits — so the value tracks whatever density preset
+     rendered (68px / 48px) without needing per-preset overrides. */
+  content-visibility: auto;
+  contain-intrinsic-size: auto var(--cr-row-height, 68px);
 }
 
 /* Visual frame — clips children and does the hover lift while .root stays

--- a/src/lib/tabs/tabCharacters/CharacterGrid.module.css
+++ b/src/lib/tabs/tabCharacters/CharacterGrid.module.css
@@ -78,14 +78,9 @@
   cursor: grab;
   user-select: none;
 
-  /* Browser skips paint + layout + style for off-screen rows. Complements #3
-     (lazy image loading): images only fetch when near viewport; this also
-     skips the non-image work for the same set. dnd-kit sees the DOM unchanged
-     because `contain-intrinsic-size` declares the box for layout math even
-     when contents aren't rendered. The `auto` keyword tells the browser to
-     remember the actually-rendered size after first paint and use that on
-     subsequent viewport exits — so the value tracks whatever density preset
-     rendered (68px / 48px) without needing per-preset overrides. */
+  /* Skip paint/layout/style for off-screen rows. `auto <length>` caches the
+     first-rendered size so density switches (68/48 px) track without overrides;
+     declared box keeps dnd-kit's layout math correct. */
   content-visibility: auto;
   contain-intrinsic-size: auto var(--cr-row-height, 68px);
 }
@@ -138,8 +133,8 @@
     calc(-1 * var(--cr-portrait-y, 31%))
   );
   display: block;
-  /* Hidden until `showImageOnLoad` flips inline opacity on successful decode.
-     Prevents the broken-image glyph flash while `<img src>` is in-flight. */
+  /* Hidden until `showImageOnLoad` reveals it — avoids broken-glyph flash
+     while the `<img src>` is in-flight. */
   opacity: 0;
 }
 

--- a/src/lib/tabs/tabCharacters/CharacterGrid.module.css
+++ b/src/lib/tabs/tabCharacters/CharacterGrid.module.css
@@ -127,6 +127,9 @@
     calc(-1 * var(--cr-portrait-y, 31%))
   );
   display: block;
+  /* Hidden until `showImageOnLoad` flips inline opacity on successful decode.
+     Prevents the broken-image glyph flash while `<img src>` is in-flight. */
+  opacity: 0;
 }
 
 .root:hover .portraitBg {

--- a/src/lib/tabs/tabCharacters/CharacterGrid.tsx
+++ b/src/lib/tabs/tabCharacters/CharacterGrid.tsx
@@ -62,12 +62,22 @@ function trackImageLoad(characterId: string, type: 'portrait' | 'lightcone') {
   }
 }
 
+// Viewport observer state for lazy image loading.
+// Per-row IntersectionObservers update `visibleRows` with rootMargin:500px and
+// flip `loadImages` to true on first intersection (never back to false — see
+// comment in the observer effect). The summary log below shows how many rows
+// have ever been visible, which caps at the total ever-loaded image count.
+const visibleRows = new Set<string>()
+const unloadedImages = 0 // kept at 0 in the load-once scheme; diagnostic only
+
 // Expose to window for console debugging
 if (typeof window !== 'undefined') {
   ;(window as any).__CHARGRID_DEBUG__ = {
     getLoadedImages: () => Array.from(loadedImages),
     getLoadedCount: () => loadedImages.size,
     getImageLoadTimes: () => imageLoadTimes,
+    getVisibleRows: () => Array.from(visibleRows),
+    getUnloadedCount: () => unloadedImages,
   }
 }
 import { showImageOnLoad } from 'lib/utils/frontendUtils'
@@ -131,11 +141,6 @@ const dropAnimationConfig: DropAnimation = {
   }),
 }
 
-// Progressive image loading: set src on the first visible rows immediately,
-// then trickle one-by-one to avoid concurrent requests competing for bandwidth.
-const INITIAL_LOAD_COUNT = 12
-const TRICKLE_DELAY = 50
-
 export function CharacterGrid() {
   const gridRef = useRef<HTMLDivElement>(null)
   const osRef = useCallback((instance: OverlayScrollbarsComponentRef<'div'> | null) => {
@@ -151,6 +156,22 @@ export function CharacterGrid() {
   useEffect(() => {
     setLocalFocus(null)
   }, [focusCharacter])
+
+  // DIAGNOSTIC: 1-second summary of CharacterGrid image/viewport state.
+  // Baseline expectation (before #3/#8):
+  //   loaded ≈ 2× character_count (portrait + lightcone per row)
+  //   unloaded = 0 (nothing unloads today)
+  //   visible ≈ 10–20 depending on scroll position + 500px buffer
+  // After #3 lands: unloaded should grow as user scrolls,
+  //   and (loaded - unloaded) should plateau close to `visible`.
+  useEffect(() => {
+    const interval = setInterval(() => {
+      console.log(
+        `[CharGrid summary] loaded: ${loadedImages.size}, unloaded: ${unloadedImages}, visible-per-observer: ${visibleRows.size}`,
+      )
+    }, 1000)
+    return () => clearInterval(interval)
+  }, [])
 
   const displayFocus = localFocus ?? focusCharacter
 
@@ -258,13 +279,12 @@ export function CharacterGrid() {
         onDragCancel={handleDragCancel}
       >
         <SortableContext items={itemIds} strategy={verticalListSortingStrategy}>
-          {filteredCharacters.map((character, i) => (
+          {filteredCharacters.map((character) => (
             <SortableCharacterRow
               key={character.id}
               character={character}
               rank={rankMap.get(character.id) ?? 0}
               isFocused={character.id === displayFocus}
-              loadDelay={i < INITIAL_LOAD_COUNT ? 0 : (i - INITIAL_LOAD_COUNT + 1) * TRICKLE_DELAY}
               onClick={handleRowClick}
               onDoubleClick={handleRowDoubleClick}
               onEdit={handleEdit}
@@ -289,7 +309,6 @@ type CharacterRowProps = {
   character: Character,
   rank: number,
   isFocused: boolean,
-  loadDelay: number,
   onClick: (id: CharacterId) => void,
   onDoubleClick: (id: CharacterId) => void,
   onEdit: (id: CharacterId) => void,
@@ -297,27 +316,60 @@ type CharacterRowProps = {
 }
 
 const SortableCharacterRow = memo(
-  function SortableCharacterRow({ character, rank, isFocused, loadDelay, onClick, onDoubleClick, onEdit, onRemove }: CharacterRowProps) {
+  function SortableCharacterRow({ character, rank, isFocused, onClick, onDoubleClick, onEdit, onRemove }: CharacterRowProps) {
     const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
       id: character.id,
       animateLayoutChanges: () => false,
     })
     const scrollRef = useRef<HTMLDivElement>(null)
 
-    // Per-row staggered image loading — replaces parent-level trickle to avoid parent re-renders
-    const [loadImages, setLoadImages] = useState(loadDelay === 0)
-    useEffect(() => {
-      if (loadDelay === 0) return
-      const timer = setTimeout(() => setLoadImages(true), loadDelay)
-      return () => clearTimeout(timer)
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []) // mount-only: delay is captured from initial render
+    // Image `src` is gated on viewport intersection via the IntersectionObserver
+    // below. Rows outside the 500 px buffer never fetch, and rows that scroll
+    // far enough away have their src cleared so the decoded bitmap can be GC'd.
+    // Replaces the old setTimeout trickle, which set src regardless of viewport
+    // and caused ~134 eager decodes during tab stagger-mount.
+    const [loadImages, setLoadImages] = useState(false)
 
     useEffect(() => {
       if (isFocused) {
         scrollRef.current?.scrollIntoView({ block: 'nearest' })
       }
     }, [isFocused])
+
+    // Per-row viewport observer. Triggers `loadImages=true` on first
+    // intersection; never reverts. Once a row's image has decoded, we keep its
+    // `src` set so rapid scroll and tab-switch don't cause re-decode flashes
+    // (empty/broken-glyph state during the fetch+decode round-trip). The
+    // win comes from the initial deferral: rows never visited never fetch.
+    // Long-term memory reclaim relies on the browser's own decoded-bitmap
+    // eviction heuristics when memory pressure is high.
+    useEffect(() => {
+      const el = scrollRef.current
+      if (!el) return
+      const charId = character.id
+      const observer = new IntersectionObserver(
+        ([entry]) => {
+          if (entry.isIntersecting) {
+            if (!visibleRows.has(charId)) {
+              visibleRows.add(charId)
+              console.log(`[CharGrid] row VISIBLE: ${charId} (visible total: ${visibleRows.size})`)
+            }
+            setLoadImages(true)
+          } else {
+            if (visibleRows.has(charId)) {
+              visibleRows.delete(charId)
+              console.log(`[CharGrid] row FAR: ${charId} (visible total: ${visibleRows.size})`)
+            }
+          }
+        },
+        { rootMargin: '500px 0px', threshold: 0 },
+      )
+      observer.observe(el)
+      return () => {
+        observer.disconnect()
+        visibleRows.delete(charId)
+      }
+    }, [character.id])
 
     const mergedRef = useMergedRef(setNodeRef, scrollRef)
 
@@ -425,7 +477,10 @@ const CharacterRowContent = memo(function CharacterRowContent({ character, rank,
           alt=''
           draggable={false}
           decoding='async'
-          onLoad={() => trackImageLoad(character.id, 'portrait')}
+          onLoad={(e) => {
+            showImageOnLoad(e)
+            trackImageLoad(character.id, 'portrait')
+          }}
           style={getCharacterConfig(character.id)?.display.gridPortraitOffset
             ? { marginTop: -(getCharacterConfig(character.id)?.display.gridPortraitOffset ?? 0) }
             : undefined}

--- a/src/lib/tabs/tabCharacters/CharacterGrid.tsx
+++ b/src/lib/tabs/tabCharacters/CharacterGrid.tsx
@@ -275,11 +275,8 @@ const SortableCharacterRow = memo(
     })
     const scrollRef = useRef<HTMLDivElement>(null)
 
-    // Image `src` is gated on viewport intersection via the IntersectionObserver
-    // below. Rows outside the 500 px buffer never fetch, and rows that scroll
-    // far enough away have their src cleared so the decoded bitmap can be GC'd.
-    // Replaces the old setTimeout trickle, which set src regardless of viewport
-    // and caused ~134 eager decodes during tab stagger-mount.
+    // Load-once, gated on viewport intersection. Never reverts — keeps `src`
+    // set to avoid re-decode flashes on scroll or tab-switch.
     const [loadImages, setLoadImages] = useState(false)
 
     useEffect(() => {
@@ -288,13 +285,6 @@ const SortableCharacterRow = memo(
       }
     }, [isFocused])
 
-    // Per-row viewport observer. Triggers `loadImages=true` on first
-    // intersection; never reverts. Once a row's image has decoded, we keep its
-    // `src` set so rapid scroll and tab-switch don't cause re-decode flashes
-    // (empty/broken-glyph state during the fetch+decode round-trip). The
-    // win comes from the initial deferral: rows never visited never fetch.
-    // Long-term memory reclaim relies on the browser's own decoded-bitmap
-    // eviction heuristics when memory pressure is high.
     useEffect(() => {
       const el = scrollRef.current
       if (!el) return

--- a/src/lib/tabs/tabCharacters/CharacterGrid.tsx
+++ b/src/lib/tabs/tabCharacters/CharacterGrid.tsx
@@ -48,6 +48,28 @@ import {
 import { CharacterTabController } from 'lib/tabs/tabCharacters/characterTabController'
 import { useCharacterTabStore } from 'lib/tabs/tabCharacters/useCharacterTabStore'
 import { switchToCharacter } from 'lib/tabs/tabOptimizer/optimizerForm/optimizerFormActions'
+
+// Debug: track loaded images
+const loadedImages = new Set<string>()
+const imageLoadTimes: { id: string, time: number }[] = []
+
+function trackImageLoad(characterId: string, type: 'portrait' | 'lightcone') {
+  const key = `${type}:${characterId}`
+  if (!loadedImages.has(key)) {
+    loadedImages.add(key)
+    imageLoadTimes.push({ id: key, time: Date.now() })
+    console.log(`[CharGrid] IMAGE LOADED: ${key}, total: ${loadedImages.size}`)
+  }
+}
+
+// Expose to window for console debugging
+if (typeof window !== 'undefined') {
+  ;(window as any).__CHARGRID_DEBUG__ = {
+    getLoadedImages: () => Array.from(loadedImages),
+    getLoadedCount: () => loadedImages.size,
+    getImageLoadTimes: () => imageLoadTimes,
+  }
+}
 import { showImageOnLoad } from 'lib/utils/frontendUtils'
 import { afterPaint } from 'lib/utils/frontendUtils'
 import {
@@ -403,6 +425,7 @@ const CharacterRowContent = memo(function CharacterRowContent({ character, rank,
           alt=''
           draggable={false}
           decoding='async'
+          onLoad={() => trackImageLoad(character.id, 'portrait')}
           style={getCharacterConfig(character.id)?.display.gridPortraitOffset
             ? { marginTop: -(getCharacterConfig(character.id)?.display.gridPortraitOffset ?? 0) }
             : undefined}
@@ -443,7 +466,16 @@ const CharacterRowContent = memo(function CharacterRowContent({ character, rank,
         {/* Light cone icon */}
         {lightConeId && (
           <div className={classes.lcWrap} data-lc-style='shadow'>
-            <img src={loadImages ? Assets.getLightConeIconById(lightConeId) : undefined} alt='' draggable={false} decoding='async' onLoad={showImageOnLoad} />
+            <img
+              src={loadImages ? Assets.getLightConeIconById(lightConeId) : undefined}
+              alt=''
+              draggable={false}
+              decoding='async'
+              onLoad={(e) => {
+                showImageOnLoad(e)
+                trackImageLoad(lightConeId, 'lightcone')
+              }}
+            />
           </div>
         )}
       </div>

--- a/src/lib/tabs/tabCharacters/CharacterGrid.tsx
+++ b/src/lib/tabs/tabCharacters/CharacterGrid.tsx
@@ -48,38 +48,6 @@ import {
 import { CharacterTabController } from 'lib/tabs/tabCharacters/characterTabController'
 import { useCharacterTabStore } from 'lib/tabs/tabCharacters/useCharacterTabStore'
 import { switchToCharacter } from 'lib/tabs/tabOptimizer/optimizerForm/optimizerFormActions'
-
-// Debug: track loaded images
-const loadedImages = new Set<string>()
-const imageLoadTimes: { id: string, time: number }[] = []
-
-function trackImageLoad(characterId: string, type: 'portrait' | 'lightcone') {
-  const key = `${type}:${characterId}`
-  if (!loadedImages.has(key)) {
-    loadedImages.add(key)
-    imageLoadTimes.push({ id: key, time: Date.now() })
-    console.log(`[CharGrid] IMAGE LOADED: ${key}, total: ${loadedImages.size}`)
-  }
-}
-
-// Viewport observer state for lazy image loading.
-// Per-row IntersectionObservers update `visibleRows` with rootMargin:500px and
-// flip `loadImages` to true on first intersection (never back to false — see
-// comment in the observer effect). The summary log below shows how many rows
-// have ever been visible, which caps at the total ever-loaded image count.
-const visibleRows = new Set<string>()
-const unloadedImages = 0 // kept at 0 in the load-once scheme; diagnostic only
-
-// Expose to window for console debugging
-if (typeof window !== 'undefined') {
-  ;(window as any).__CHARGRID_DEBUG__ = {
-    getLoadedImages: () => Array.from(loadedImages),
-    getLoadedCount: () => loadedImages.size,
-    getImageLoadTimes: () => imageLoadTimes,
-    getVisibleRows: () => Array.from(visibleRows),
-    getUnloadedCount: () => unloadedImages,
-  }
-}
 import { showImageOnLoad } from 'lib/utils/frontendUtils'
 import { afterPaint } from 'lib/utils/frontendUtils'
 import {
@@ -156,22 +124,6 @@ export function CharacterGrid() {
   useEffect(() => {
     setLocalFocus(null)
   }, [focusCharacter])
-
-  // DIAGNOSTIC: 1-second summary of CharacterGrid image/viewport state.
-  // Baseline expectation (before #3/#8):
-  //   loaded ≈ 2× character_count (portrait + lightcone per row)
-  //   unloaded = 0 (nothing unloads today)
-  //   visible ≈ 10–20 depending on scroll position + 500px buffer
-  // After #3 lands: unloaded should grow as user scrolls,
-  //   and (loaded - unloaded) should plateau close to `visible`.
-  useEffect(() => {
-    const interval = setInterval(() => {
-      console.log(
-        `[CharGrid summary] loaded: ${loadedImages.size}, unloaded: ${unloadedImages}, visible-per-observer: ${visibleRows.size}`,
-      )
-    }, 1000)
-    return () => clearInterval(interval)
-  }, [])
 
   const displayFocus = localFocus ?? focusCharacter
 
@@ -346,20 +298,10 @@ const SortableCharacterRow = memo(
     useEffect(() => {
       const el = scrollRef.current
       if (!el) return
-      const charId = character.id
       const observer = new IntersectionObserver(
         ([entry]) => {
           if (entry.isIntersecting) {
-            if (!visibleRows.has(charId)) {
-              visibleRows.add(charId)
-              console.log(`[CharGrid] row VISIBLE: ${charId} (visible total: ${visibleRows.size})`)
-            }
             setLoadImages(true)
-          } else {
-            if (visibleRows.has(charId)) {
-              visibleRows.delete(charId)
-              console.log(`[CharGrid] row FAR: ${charId} (visible total: ${visibleRows.size})`)
-            }
           }
         },
         { rootMargin: '500px 0px', threshold: 0 },
@@ -367,7 +309,6 @@ const SortableCharacterRow = memo(
       observer.observe(el)
       return () => {
         observer.disconnect()
-        visibleRows.delete(charId)
       }
     }, [character.id])
 
@@ -477,10 +418,7 @@ const CharacterRowContent = memo(function CharacterRowContent({ character, rank,
           alt=''
           draggable={false}
           decoding='async'
-          onLoad={(e) => {
-            showImageOnLoad(e)
-            trackImageLoad(character.id, 'portrait')
-          }}
+          onLoad={showImageOnLoad}
           style={getCharacterConfig(character.id)?.display.gridPortraitOffset
             ? { marginTop: -(getCharacterConfig(character.id)?.display.gridPortraitOffset ?? 0) }
             : undefined}
@@ -526,10 +464,7 @@ const CharacterRowContent = memo(function CharacterRowContent({ character, rank,
               alt=''
               draggable={false}
               decoding='async'
-              onLoad={(e) => {
-                showImageOnLoad(e)
-                trackImageLoad(lightConeId, 'lightcone')
-              }}
+              onLoad={showImageOnLoad}
             />
           </div>
         )}

--- a/src/lib/tabs/tabCharacters/CharacterGrid.tsx
+++ b/src/lib/tabs/tabCharacters/CharacterGrid.tsx
@@ -335,7 +335,7 @@ const SortableCharacterRow = memo(
           <CharacterRowContent
             character={character}
             rank={rank}
-            loadImages={loadImages}
+            loadImages={loadImages || isFocused}
             onEdit={onEdit}
             onRemove={onRemove}
           />

--- a/src/lib/tabs/tabOptimizer/optimizerForm/layout/optimizerMenuIds.ts
+++ b/src/lib/tabs/tabOptimizer/optimizerForm/layout/optimizerMenuIds.ts
@@ -5,3 +5,11 @@ export const OptimizerMenuIds = {
   characterStatsSimulation: 'Character custom stats simulation',
   analysis: 'Analysis',
 }
+
+export const initialMenuState: Record<string, boolean> = {
+  [OptimizerMenuIds.characterOptions]: true,
+  [OptimizerMenuIds.relicAndStatFilters]: true,
+  [OptimizerMenuIds.teammates]: true,
+  [OptimizerMenuIds.characterStatsSimulation]: false,
+  [OptimizerMenuIds.analysis]: true,
+}

--- a/src/lib/tabs/tabShowcase/ShowcaseTab.tsx
+++ b/src/lib/tabs/tabShowcase/ShowcaseTab.tsx
@@ -65,20 +65,9 @@ export function ShowcaseTab() {
   const { isActiveRef, addActivationListener } = useContext(TabVisibilityContext)
 
   useEffect(() => {
-    if (isActiveRef.current) {
-      // Tab is active on mount — initialize immediately
-      initializeShowcaseOnMount()
-    } else {
-      // Tab mounted in background — defer until first activation
-      let initialized = false
-      return addActivationListener(() => {
-        if (!initialized) {
-          initialized = true
-          initializeShowcaseOnMount()
-        }
-      })
-    }
-  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+    if (isActiveRef.current) initializeShowcaseOnMount()
+    return addActivationListener(() => initializeShowcaseOnMount())
+  }, [addActivationListener, isActiveRef])
 
   useEffect(() => addActivationListener(() => syncShowcaseUrl()), [addActivationListener])
 

--- a/src/lib/tabs/tabShowcase/showcaseApi.ts
+++ b/src/lib/tabs/tabShowcase/showcaseApi.ts
@@ -96,12 +96,6 @@ export function submitForm(form: ShowcaseTabForm, options?: { skipCooldown?: boo
         ) => self.map((x) => x.id).indexOf(value.id) === index)
       converted.forEach((x, index) => x.index = index)
 
-      // Previously preloaded portrait + avatar for each roster character via
-      // `new Image().src = …`. That decoded ~128 MB of bitmaps on every showcase
-      // load and saturated the browser's resource scheduler (triggering
-      // `ERR_INSUFFICIENT_RESOURCES` and dynamic-import failures in workers).
-      // Relying on the natural `<img>` decode when ShowcasePortraitRow renders.
-
       // Set data immediately — ShowcaseLoaded mounts hidden behind the loading spinner
       const wasOnLoadingScreen = useShowcaseTabStore.getState().screen === ShowcaseScreen.Loading
       setFetchResult(converted)

--- a/src/lib/tabs/tabShowcase/showcaseApi.ts
+++ b/src/lib/tabs/tabShowcase/showcaseApi.ts
@@ -96,11 +96,11 @@ export function submitForm(form: ShowcaseTabForm, options?: { skipCooldown?: boo
         ) => self.map((x) => x.id).indexOf(value.id) === index)
       converted.forEach((x, index) => x.index = index)
 
-      // Preload portrait + avatar images
-      for (const char of converted) {
-        new Image().src = Assets.getCharacterPortraitById(char.id)
-        new Image().src = Assets.getCharacterAvatarById(char.id)
-      }
+      // Previously preloaded portrait + avatar for each roster character via
+      // `new Image().src = …`. That decoded ~128 MB of bitmaps on every showcase
+      // load and saturated the browser's resource scheduler (triggering
+      // `ERR_INSUFFICIENT_RESOURCES` and dynamic-import failures in workers).
+      // Relying on the natural `<img>` decode when ShowcasePortraitRow renders.
 
       // Set data immediately — ShowcaseLoaded mounts hidden behind the loading spinner
       const wasOnLoadingScreen = useShowcaseTabStore.getState().screen === ShowcaseScreen.Loading

--- a/src/lib/tabs/tabShowcase/showcaseTabController.ts
+++ b/src/lib/tabs/tabShowcase/showcaseTabController.ts
@@ -90,21 +90,21 @@ export function parseShowcaseUrlId(): string | null {
 }
 
 /**
- * Called once on mount — handles URL parameter and saved session auto-load.
- * URL parameter takes priority over saved session.
+ * Called on tab activation — handles URL parameter and saved session auto-load.
+ * Idempotent: skips fetch if already loading or if the same ID is already loaded.
  */
 export function initializeShowcaseOnMount(): void {
   const urlId = parseShowcaseUrlId()
-  const { savedSession, availableCharacters } = useShowcaseTabStore.getState()
+  const { savedSession, availableCharacters, loading } = useShowcaseTabStore.getState()
+
+  if (loading) return
 
   if (urlId) {
-    // URL parameter takes priority — load that profile
+    if (availableCharacters?.length && savedSession.scorerId === urlId) return
     submitForm({ scorerId: urlId }, { skipCooldown: true })
   } else if (!availableCharacters?.length && savedSession.scorerId) {
-    // No URL param, no data yet, but saved session has a UID — auto-load
     submitForm({ scorerId: savedSession.scorerId }, { skipCooldown: true })
   }
-  // Otherwise: stay on Landing screen, wait for user input
 }
 
 /**

--- a/tests/OptimizerForm/characterConditionals/jingliu.spec.ts
+++ b/tests/OptimizerForm/characterConditionals/jingliu.spec.ts
@@ -2,11 +2,17 @@ import {
   expect,
   test,
 } from '@playwright/test'
+import {
+  initialMenuState,
+  OptimizerMenuIds,
+} from '../../../src/lib/tabs/tabOptimizer/optimizerForm/layout/optimizerMenuIds'
 
 test('Jingliu conditionals show correct popover text', async ({ page }) => {
   await page.goto('/#showcase')
   await page.getByText('Optimizer', { exact: true }).click()
-  await page.getByText('Character options').click()
+  if (!initialMenuState[OptimizerMenuIds.characterOptions]) {
+    await page.getByText('Character options').click()
+  }
 
   await page.locator('#OPTIMIZER').getByText('Enhanced state').hover()
   await expect(page.getByTestId('conditional-popover').getByText('Spectral Transmigration')).toBeVisible()

--- a/tests/OptimizerForm/lightConeConditionals/i-shall-be-my-own-sword.spec.ts
+++ b/tests/OptimizerForm/lightConeConditionals/i-shall-be-my-own-sword.spec.ts
@@ -2,11 +2,17 @@ import {
   expect,
   test,
 } from '@playwright/test'
+import {
+  initialMenuState,
+  OptimizerMenuIds,
+} from '../../../src/lib/tabs/tabOptimizer/optimizerForm/layout/optimizerMenuIds'
 
 test('I Shall Be My Own Sword LC conditional shows popover text', async ({ page }) => {
   await page.goto('/#showcase')
   await page.getByText('Optimizer', { exact: true }).click()
-  await page.getByText('Character options').click()
+  if (!initialMenuState[OptimizerMenuIds.characterOptions]) {
+    await page.getByText('Character options').click()
+  }
 
   await page.locator('#OPTIMIZER').getByText('Eclipse Stacks').hover()
   await expect(page.getByTestId('conditional-popover').getByText('gets attacked or loses HP, the wearer gains 1 stack of Eclipse')).toBeVisible()


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

- Fix Sparkle B1 teammate CD tooltip to show scaling values
- Reduce spine WebGL memory by disabling MSAA and preserveDrawingBuffer
- Pause spine rAF loop when host tab is hidden
- Abort in-flight spine loads during rapid character switch
- Defer character grid image loads until rows intersect viewport
- Skip paint/layout for off-screen character rows
- Remove eager portrait/avatar preload in showcase submission
- Move DpsScoreGradeRuler gradient vars from stylesheet mutation to inline styles
- Make showcase initialization idempotent and re-fire on tab activation
- Set default expanded state for optimizer form menu sections
- Update Firefly showcase color

## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [ ] I have added commit messages that are descriptive and meaningful.
- [ ] I have tested the changes locally.
- [ ] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
