### PR TITLE
fix: dont close character modal on validation failures, missing lc message

### DIFF
--- a/public/locales/en_US/charactersTab.yaml
+++ b/public/locales/en_US/charactersTab.yaml
@@ -34,6 +34,7 @@ Messages:
   RemoveSuccess: Successfully removed character
   UnequipSuccess: Successfully unequipped character
   NoSelectedCharacter: No selected character
+  NoSelectedLightCone: No selected light cone
   SwitchSuccess: 'Successfully switched relics with $t(gameData:Characters.{{charId}}.Name)'
   SortByScoreWarning: Are you sure you want to sort all characters? You will lose any custom rankings you have set.
   SaveSuccess: 'Successfully saved build: {{name}}'

--- a/public/locales/en_US/charactersTab.yaml
+++ b/public/locales/en_US/charactersTab.yaml
@@ -87,7 +87,7 @@ CharacterPreview:
     SavedPortrait: Successfully saved portrait
     RevertedPortrait: Successfully reverted portrait
     NoSelectedCharacter: No selected character
-    NoSelectedLightCone: No Selected light cone
+    NoSelectedLightCone: No selected light cone
   ScoreHeader:
     Title: Combat Sim
     TitleBenchmark: '{{spd}} SPD Benchmark'

--- a/public/locales/en_US/relicScorerTab.yaml
+++ b/public/locales/en_US/relicScorerTab.yaml
@@ -5,6 +5,7 @@ Messages:
   SuccessMsg: Successfully loaded profile
   LookupError: Error during lookup, please try again in a bit
   NoCharacterSelected: No selected character
+  NoSelectedLightCone: No selected light cone
   CharacterAlreadyExists: Selected character already exists
   UnknownButtonClicked: Unknown button clicked
 Header:

--- a/src/lib/characterPreview/scoring/ShowcaseDpsScore.tsx
+++ b/src/lib/characterPreview/scoring/ShowcaseDpsScore.tsx
@@ -249,13 +249,15 @@ function createOnCharacterModalOk(
   characterId: CharacterId,
   selectedTeammateIndex: number,
 ) {
-  return (form: CharacterModalForm) => {
+  return (form: CharacterModalForm): boolean => {
     const t = i18next.getFixedT(null, 'charactersTab', 'CharacterPreview.Messages')
     if (!form.characterId) {
-      return Message.error(t('NoSelectedCharacter') /* No selected character */)
+      Message.error(t('NoSelectedCharacter'))
+      return false
     }
     if (!form.lightCone) {
-      return Message.error(t('NoSelectedLightCone') /* No Selected light cone */)
+      Message.error(t('NoSelectedLightCone'))
+      return false
     }
 
     const simulation = getScoringMetadata(characterId).simulation
@@ -267,6 +269,7 @@ function createOnCharacterModalOk(
     useScoringStore.getState().updateSimulationOverrides(characterId, update)
     SaveState.delayedSave()
     setTeamSelectionByCharacter(characterId, CUSTOM_TEAM)
+    return true
   }
 }
 

--- a/src/lib/overlays/modals/CharacterModal.tsx
+++ b/src/lib/overlays/modals/CharacterModal.tsx
@@ -93,8 +93,10 @@ function CharacterModalContent() {
   })
 
   function onModalOk() {
-    onOk(characterForm.getValues())
-    closeOverlay()
+    const result = onOk(characterForm.getValues())
+    if (result !== false) {
+      closeOverlay()
+    }
   }
 
   return (

--- a/src/lib/overlays/modals/characterModalStore.ts
+++ b/src/lib/overlays/modals/characterModalStore.ts
@@ -13,7 +13,7 @@ export type CharacterModalForm = {
 
 export type CharacterModalConfig = {
   initialCharacter?: { form: CharacterModalForm } | null,
-  onOk: (form: CharacterModalForm) => void,
+  onOk: (form: CharacterModalForm) => boolean | void,
   showSetSelection?: boolean,
 }
 

--- a/src/lib/services/persistenceService.test.ts
+++ b/src/lib/services/persistenceService.test.ts
@@ -299,6 +299,7 @@ describe('loadSaveData', () => {
   // menuState loading must create a new object, not mutate the store reference in-place
   it('loadSaveData creates new menuState object reference not in-place mutation', () => {
     const menuStateBefore = useOptimizerDisplayStore.getState().menuState
+    const snapshotBefore = { ...menuStateBefore }
 
     const saveData = emptySaveData({
       optimizerMenuState: {
@@ -311,8 +312,11 @@ describe('loadSaveData', () => {
 
     const menuStateAfter = useOptimizerDisplayStore.getState().menuState
 
-    // A new object reference should have been created, not in-place mutation
+    // A new object reference should have been created
     expect(menuStateAfter).not.toBe(menuStateBefore)
+    // The original reference must be untouched — catches in-place mutation
+    // even when the caller re-writes the store with a fresh object afterwards
+    expect(menuStateBefore).toEqual(snapshotBefore)
   })
 
   it('loadSaveData merges settings with DefaultSettingOptions for missing keys', () => {

--- a/src/lib/spine/SpinePortrait.tsx
+++ b/src/lib/spine/SpinePortrait.tsx
@@ -92,7 +92,10 @@ export function SpinePortrait({
       instanceRef.current?.dispose()
       instanceRef.current = null
     }
-  }, [characterId, isActiveRef])
+    // isActiveRef is a stable ref from context — .current is read in the async
+    // path but the ref identity never changes, so it's not a real dep.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [characterId])
 
   return (
     <canvas

--- a/src/lib/tabs/tabBenchmarks/useBenchmarksTabStore.ts
+++ b/src/lib/tabs/tabBenchmarks/useBenchmarksTabStore.ts
@@ -103,8 +103,8 @@ export const useBenchmarksTabStore = createTabAwareStore<BenchmarksTabState>((se
       teammate2: index === 2 ? data : state.teammate2,
     })),
 
-  onCharacterModalOk: (form: CharacterModalForm) => {
-    if (!form.characterId || !form.lightCone) return
+  onCharacterModalOk: (form: CharacterModalForm): boolean => {
+    if (!form.characterId || !form.lightCone) return false
 
     const character: SimpleCharacterSets = {
       characterId: form.characterId,
@@ -124,6 +124,7 @@ export const useBenchmarksTabStore = createTabAwareStore<BenchmarksTabState>((se
     set({
       selectedTeammateIndex: undefined,
     })
+    return true
   },
 
   setSelectedTeammateIndex: (index) => set({ selectedTeammateIndex: index }),

--- a/src/lib/tabs/tabChangelog/changelogData.ts
+++ b/src/lib/tabs/tabChangelog/changelogData.ts
@@ -52,7 +52,7 @@ export function getChangelogContent() {
         `filtermodal.webp`,
         `filterdisplay.webp`,
         `Fix: DPS Score loading state no longer hides combat stats`,
-        `Fix: Ode to Reason light cone was not buffing skill damage when Anaxa is used as a teammate`,
+        `Fix: Ode to Reason was not buffing skill damage when Anaxa is used as a teammate`,
         `Fix: Dr. Ratio E2 Additional DMG was incorrectly tagged as Follow-Up Attack damage`,
         `Fix: Silver Wolf Lv.999 200% benchmarks were generating invalid builds due to lack of effective substats`,
         `Fix: Silver Wolf Lv.999 Hidden MMR crit conversion calculations`,

--- a/src/lib/tabs/tabCharacters/CharacterGrid.tsx
+++ b/src/lib/tabs/tabCharacters/CharacterGrid.tsx
@@ -289,9 +289,10 @@ const SortableCharacterRow = memo(
       const el = scrollRef.current
       if (!el) return
       const observer = new IntersectionObserver(
-        ([entry]) => {
+        ([entry], obs) => {
           if (entry.isIntersecting) {
             setLoadImages(true)
+            obs.disconnect() // load-once — no point watching after src is set
           }
         },
         { rootMargin: '500px 0px', threshold: 0 },

--- a/src/lib/tabs/tabCharacters/characterTabController.ts
+++ b/src/lib/tabs/tabCharacters/characterTabController.ts
@@ -12,13 +12,21 @@ import type { CharacterId } from 'types/character'
 import type { Form } from 'types/form'
 
 export const CharacterTabController = {
-  onCharacterModalOk: (form: CharacterModalForm) => {
+  onCharacterModalOk: (form: CharacterModalForm): boolean => {
     const t = i18next.getFixedT(null, 'charactersTab', 'Messages')
-    if (!form.characterId || !form.lightCone) return Message.error(t('NoSelectedCharacter'))
+    if (!form.characterId) {
+      Message.error(t('NoSelectedCharacter'))
+      return false
+    }
+    if (!form.lightCone) {
+      Message.error(t('NoSelectedLightCone'))
+      return false
+    }
     // Safe cast: after guards, characterId and lightCone are non-null. upsertCharacterFromForm spreads form into character.form
     const character = persistenceService.upsertCharacterFromForm(form as Form)
     SaveState.delayedSave()
     useCharacterTabStore.getState().setFocusCharacter(character.id)
+    return true
   },
 
   onSwitchRelicsOk: (switchTo: SwitchRelicsFormSelectedCharacter) => {

--- a/src/lib/tabs/tabShowcase/showcaseTabController.ts
+++ b/src/lib/tabs/tabShowcase/showcaseTabController.ts
@@ -131,15 +131,21 @@ export function syncShowcaseUrl(): void {
  * Keep: null characterId check.
  * Dropped: duplicate character restriction (users can simulate same character on multiple slots).
  */
-export function handleCharacterModalOk(form: CharacterModalForm): void {
+export function handleCharacterModalOk(form: CharacterModalForm): boolean {
   const t = i18next.getFixedT(null, 'relicScorerTab', 'Messages')
 
-  if (!form.characterId || !form.lightCone) {
-    return Message.error(t('NoCharacterSelected') /* No selected character */)
+  if (!form.characterId) {
+    Message.error(t('NoCharacterSelected'))
+    return false
+  }
+  if (!form.lightCone) {
+    Message.error(t('NoSelectedLightCone'))
+    return false
   }
 
   // Safe cast: after guards, characterId and lightCone are non-null
   useShowcaseTabStore.getState().applyCharacterOverride(form as ShowcaseTabCharacter['form'])
+  return true
 }
 
 /**

--- a/src/types/resources.d.ts
+++ b/src/types/resources.d.ts
@@ -150,6 +150,7 @@ interface Resources {
           "Standard": "Standard"
         },
         "PaletteLabel": "Portrait color palette",
+        "ShowL2D": "Show Live2D",
         "ShowUID": "Show UID"
       },
       "DMGUpgrades": "Damage Upgrades",
@@ -176,7 +177,7 @@ interface Resources {
       "Messages": {
         "AddedRelic": "Successfully added relic",
         "NoSelectedCharacter": "No selected character",
-        "NoSelectedLightCone": "No Selected light cone",
+        "NoSelectedLightCone": "No selected light cone",
         "RevertedPortrait": "Successfully reverted portrait",
         "SavedPortrait": "Successfully saved portrait"
       },
@@ -268,6 +269,7 @@ interface Resources {
       "NoBuilds": "Attempted to overwrite build {{name}} but $t(gameData:Characters.{{charId}}.Name) has no saved builds",
       "NoMatchingBuild": "Attempted to overwrite build {{name}} but no such build exists",
       "NoSelectedCharacter": "No selected character",
+      "NoSelectedLightCone": "No selected light cone",
       "RemoveSuccess": "Successfully removed character",
       "SaveSuccess": "Successfully saved build: {{name}}",
       "SortByScoreWarning": "Are you sure you want to sort all characters? You will lose any custom rankings you have set.",
@@ -1365,7 +1367,7 @@ interface Resources {
             "text": "Enhanced SPD buff"
           },
           "superBreakDmg": {
-            "content": "When SAM is in Complete Combustion with a Break Effect that is equal to or greater than 200%/360%, attacking a Weakness-Broken enemy target will convert the Toughness Reduction of this attack into 1 instance of 100%/150% Super Break DMG.",
+            "content": "When SAM is in Complete Combustion with a Break Effect that is equal to or greater than 150%/300%, attacking a Weakness-Broken enemy target will convert the Toughness Reduction of this attack into 1 instance of 100%/150% Super Break DMG.",
             "text": "Super Break enabled (force weakness break)"
           },
           "talentDmgReductionBuff": {
@@ -7486,6 +7488,7 @@ interface Resources {
       "InvalidIdWarning": "Invalid ID",
       "LookupError": "Error during lookup, please try again in a bit",
       "NoCharacterSelected": "No selected character",
+      "NoSelectedLightCone": "No selected light cone",
       "SuccessMsg": "Successfully loaded profile",
       "ThrottleWarning": "Please wait {{seconds}} seconds before retrying",
       "UnknownButtonClicked": "Unknown button clicked"


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

- Fix character modal showing wrong error when light cone is missing
- Keep character modal open on validation failure instead of closing
- Disconnect IntersectionObserver after image load in character grid
- Fix SpinePortrait effect re-running on stable ref
- Strengthen loadSaveData test to detect in-place mutation


## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [ ] I have added commit messages that are descriptive and meaningful.
- [ ] I have tested the changes locally.
- [ ] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
