### PR TITLE
fix: showcase import relic duplication

### DIFF
--- a/src/lib/relics/relicUtils.test.ts
+++ b/src/lib/relics/relicUtils.test.ts
@@ -23,8 +23,10 @@ import {
 
 // ---- Factories ----
 
-function makeStat(stat: RelicSubstatMetadata['stat'], value: number): RelicSubstatMetadata {
-  return { stat, value }
+function makeStat(stat: RelicSubstatMetadata['stat'], value: number, rolls?: RelicSubstatMetadata['rolls']): RelicSubstatMetadata {
+  if (!rolls) return { stat, value }
+  const addedRolls = Math.max(0, rolls.high + rolls.mid + rolls.low - 1)
+  return { stat, value, rolls, addedRolls }
 }
 
 function makeRelic(overrides: Partial<Relic> = {}): Relic {
@@ -34,7 +36,7 @@ function makeRelic(overrides: Partial<Relic> = {}): Relic {
     part: Parts.Head,
     grade: 5,
     enhance: 15,
-    main: { stat: Stats.HP as Relic['main']['stat'], value: 705 },
+    main: { stat: Stats.HP, value: 705 },
     substats: [
       makeStat(Stats.ATK, 38.1),
       makeStat(Stats.CR, 6.48),
@@ -201,5 +203,140 @@ describe('findRelicMatch (additional)', () => {
       substats: [makeStat(Stats.ATK, 30), makeStat(Stats.CR, 6.4)],
     })
     expect(findRelicMatch(newRelic, [oldRelic])).toBe(oldRelic)
+  })
+})
+
+describe('findRelicMatch — best-fit selection', () => {
+  // Regression for the "showcase re-import duplicates equipped relic" bug: when the
+  // save contains both an enh=0 precursor and the enh=15 upgraded twin, greedy
+  // first-match would promote the precursor and orphan the real upgrade.
+  it('returns the enh=15 exact match over an enh=0 precursor when both are valid', () => {
+    const precursor = makeRelic({
+      id: 'precursor',
+      enhance: 0,
+      main: { stat: Stats.ATK, value: 56.448 },
+      substats: [
+        makeStat(Stats.DEF_P, 4.32, { high: 0, mid: 0, low: 1 }),
+        makeStat(Stats.CR, 2.916, { high: 0, mid: 1, low: 0 }),
+        makeStat(Stats.CD, 5.832, { high: 0, mid: 1, low: 0 }),
+      ],
+    })
+    const upgradedSubstats = [
+      makeStat(Stats.DEF_P, 9.18, { high: 0, mid: 1, low: 1 }),
+      makeStat(Stats.SPD, 7.5, { high: 2, mid: 1, low: 0 }),
+      makeStat(Stats.CR, 3.24, { high: 1, mid: 0, low: 0 }),
+      makeStat(Stats.CD, 10.368, { high: 0, mid: 0, low: 2 }),
+    ]
+    const exactMatch = makeRelic({
+      id: 'exact',
+      enhance: 15,
+      main: { stat: Stats.ATK, value: 352.8 },
+      substats: upgradedSubstats,
+    })
+    const incoming = makeRelic({
+      id: 'incoming',
+      enhance: 15,
+      main: { stat: Stats.ATK, value: 352.8 },
+      substats: upgradedSubstats,
+    })
+    expect(findRelicMatch(incoming, [precursor, exactMatch])).toBe(exactMatch)
+  })
+
+  it('picks the higher-enhance candidate among multiple valid progressions', () => {
+    const lowEnhance = makeRelic({
+      id: 'low',
+      enhance: 3,
+      substats: [
+        makeStat(Stats.ATK, 16.935, { high: 0, mid: 0, low: 1 }),
+        makeStat(Stats.CR, 2.916, { high: 0, mid: 1, low: 0 }),
+        makeStat(Stats.CD, 5.832, { high: 0, mid: 1, low: 0 }),
+        makeStat(Stats.SPD, 2.3, { high: 0, mid: 0, low: 1 }),
+      ],
+    })
+    const highEnhance = makeRelic({
+      id: 'high',
+      enhance: 12,
+      substats: [
+        makeStat(Stats.ATK, 33.87, { high: 0, mid: 0, low: 2 }),
+        makeStat(Stats.CR, 2.916, { high: 0, mid: 1, low: 0 }),
+        makeStat(Stats.CD, 8.2, { high: 0, mid: 1, low: 1 }),
+        makeStat(Stats.SPD, 4.9, { high: 0, mid: 1, low: 1 }),
+      ],
+    })
+    const incoming = makeRelic({
+      enhance: 15,
+      substats: [
+        makeStat(Stats.ATK, 33.87, { high: 0, mid: 0, low: 2 }),
+        makeStat(Stats.CR, 6.156, { high: 1, mid: 1, low: 0 }),
+        makeStat(Stats.CD, 8.2, { high: 0, mid: 1, low: 1 }),
+        makeStat(Stats.SPD, 4.9, { high: 0, mid: 1, low: 1 }),
+      ],
+    })
+    expect(findRelicMatch(incoming, [lowEnhance, highEnhance])).toBe(highEnhance)
+    expect(findRelicMatch(incoming, [highEnhance, lowEnhance])).toBe(highEnhance)
+  })
+})
+
+describe('findRelicMatch — roll-quality constraint', () => {
+  // A substat's initial-roll quality (low/mid/high) is fixed at drop time. Subsequent
+  // enhance tiers only ADD rolls, so new.rolls must be a per-bucket superset of old.
+  it('rejects candidate when a same-count substat has different roll quality', () => {
+    // CR stays at addedRolls=0 on both sides, but quality flips mid → high: impossible.
+    const old = makeRelic({
+      enhance: 0,
+      substats: [
+        makeStat(Stats.ATK, 16.935, { high: 0, mid: 0, low: 1 }),
+        makeStat(Stats.CR, 2.916, { high: 0, mid: 1, low: 0 }),
+        makeStat(Stats.CD, 5.832, { high: 0, mid: 1, low: 0 }),
+      ],
+    })
+    const incoming = makeRelic({
+      enhance: 15,
+      substats: [
+        makeStat(Stats.ATK, 16.935, { high: 0, mid: 0, low: 1 }),
+        makeStat(Stats.CR, 3.24, { high: 1, mid: 0, low: 0 }),
+        makeStat(Stats.CD, 5.832, { high: 0, mid: 1, low: 0 }),
+        makeStat(Stats.SPD, 2.6, { high: 0, mid: 0, low: 1 }),
+      ],
+    })
+    expect(findRelicMatch(incoming, [old])).toBeUndefined()
+  })
+
+  it('rejects when old rolls distribution is not a subset of new', () => {
+    // Old: 1 high roll. New: 2 low rolls. New would have to drop the initial high.
+    const old = makeRelic({
+      enhance: 3,
+      substats: [makeStat(Stats.CR, 3.24, { high: 1, mid: 0, low: 0 })],
+    })
+    const incoming = makeRelic({
+      enhance: 6,
+      substats: [makeStat(Stats.CR, 5.1, { high: 0, mid: 0, low: 2 })],
+    })
+    expect(findRelicMatch(incoming, [old])).toBeUndefined()
+  })
+
+  it('accepts candidate when new rolls distribution extends old in every bucket', () => {
+    const old = makeRelic({
+      enhance: 3,
+      substats: [makeStat(Stats.ATK, 19, { high: 0, mid: 1, low: 0 })],
+    })
+    const incoming = makeRelic({
+      enhance: 6,
+      substats: [makeStat(Stats.ATK, 35, { high: 0, mid: 1, low: 1 })],
+    })
+    expect(findRelicMatch(incoming, [old])).toBe(old)
+  })
+
+  it('falls back to value-only comparison when rolls metadata is missing on either side', () => {
+    // Non-verified importers may omit rolls; matching must still succeed via values.
+    const old = makeRelic({
+      enhance: 3,
+      substats: [makeStat(Stats.ATK, 19)],
+    })
+    const incoming = makeRelic({
+      enhance: 6,
+      substats: [makeStat(Stats.ATK, 35)],
+    })
+    expect(findRelicMatch(incoming, [old])).toBe(old)
   })
 })

--- a/src/lib/relics/relicUtils.ts
+++ b/src/lib/relics/relicUtils.ts
@@ -81,17 +81,13 @@ export function partialHashRelic(relic: Relic) {
 }
 
 export function findRelicMatch(relic: Relic, oldRelics: Relic[]) {
-  // part set grade mainstat substatStats
-  const oldRelicPartialHashes: Record<string, Relic[]> = {}
-  for (const oldRelic of oldRelics) {
-    const hash = partialHashRelic(oldRelic)
-    if (!oldRelicPartialHashes[hash]) oldRelicPartialHashes[hash] = []
-    oldRelicPartialHashes[hash].push(oldRelic)
-  }
   const partialHash = partialHashRelic(relic)
-  const partialMatches = oldRelicPartialHashes[partialHash] || []
+  const partialMatches = oldRelics.filter((r) => partialHashRelic(r) === partialHash)
 
-  let match: Relic | undefined = undefined
+  // Score every valid candidate and return the best fit. First-match-wins would
+  // pick a low-enhance precursor when the already-upgraded twin is also in the
+  // store, orphaning the twin and producing a visible duplicate.
+  const validCandidates: Array<{ relic: Relic, enhanceDelta: number, substatCountDelta: number }> = []
   for (const partialMatch of partialMatches) {
     if (relic.enhance < partialMatch.enhance) continue
     if (relic.substats.length < partialMatch.substats.length) continue
@@ -102,20 +98,31 @@ export function findRelicMatch(relic: Relic, oldRelics: Relic[]) {
       const matchSubstat = partialMatch.substats[i]
       const newSubstat = relic.substats.find((x) => x.stat === matchSubstat.stat)
 
-      // Different substats mean different relics - break
       if (!newSubstat) {
         exit = true
         break
       }
-      if (compareSameTypeSubstat(matchSubstat, newSubstat) === -1) {
+      const cmp = compareSameTypeSubstat(matchSubstat, newSubstat)
+      if (cmp === -1) {
         exit = true
         break
       }
 
-      // Track if the number of stat increases make sense
-      if (compareSameTypeSubstat(matchSubstat, newSubstat) === 1) {
-        upgrades++
+      // A substat's initial-roll quality is fixed at drop; later tiers only ADD
+      // rolls. So new.rolls must be a per-bucket superset of old — otherwise
+      // they're different relics even when the new values are strictly higher.
+      if (matchSubstat.rolls && newSubstat.rolls) {
+        if (
+          newSubstat.rolls.low < matchSubstat.rolls.low
+          || newSubstat.rolls.mid < matchSubstat.rolls.mid
+          || newSubstat.rolls.high < matchSubstat.rolls.high
+        ) {
+          exit = true
+          break
+        }
       }
+
+      if (cmp === 1) upgrades++
     }
 
     if (exit) continue
@@ -123,11 +130,21 @@ export function findRelicMatch(relic: Relic, oldRelics: Relic[]) {
     const possibleUpgrades = Math.round((Math.floor(relic.enhance / 3) * 3 - Math.floor(partialMatch.enhance / 3) * 3) / 3)
     if (upgrades > possibleUpgrades) continue
 
-    // If it passes all the tests, keep it
-    match = partialMatch
-    break
+    const enhanceDelta = relic.enhance - partialMatch.enhance
+    const substatCountDelta = relic.substats.length - partialMatch.substats.length
+    // Exact match on both dimensions is provably optimal — no need to score the rest.
+    if (enhanceDelta === 0 && substatCountDelta === 0) return partialMatch
+    validCandidates.push({ relic: partialMatch, enhanceDelta, substatCountDelta })
   }
-  return match
+
+  if (validCandidates.length === 0) return undefined
+
+  // Smallest enhance gap, then smallest substat-count gap.
+  validCandidates.sort((a, b) =>
+    a.enhanceDelta - b.enhanceDelta
+    || a.substatCountDelta - b.substatCountDelta
+  )
+  return validCandidates[0].relic
 }
 
 // -1: old > new, 0: old === new, 1: new > old


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

- Fix showcase re-import duplicating a relic when the save contains both the original drop and its upgraded twin
- Reject candidate matches whose roll quality distribution is not a per-bucket superset of the stored relic's
## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [ ] I have added commit messages that are descriptive and meaningful.
- [ ] I have tested the changes locally.
- [ ] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
