### PR TITLE
fix: various issues

### DIFF
--- a/src/lib/characterPreview/CharacterPreview.tsx
+++ b/src/lib/characterPreview/CharacterPreview.tsx
@@ -74,7 +74,6 @@ import { injectBenchmarkDebuggers } from 'lib/simulations/tests/simDebuggers'
 import { useGlobalStore } from 'lib/stores/app/appStore'
 import type { ShowcaseTabCharacter } from 'lib/tabs/tabShowcase/showcaseTabTypes'
 import { useShowcaseTabStore } from 'lib/tabs/tabShowcase/useShowcaseTabStore'
-import { DeferReveal } from 'lib/ui/DeferredRender'
 import {
   memo,
   useCallback,
@@ -654,14 +653,12 @@ const CharacterPreviewInner = memo(function CharacterPreviewInner({
           Hidden in forceDebug mode. */
         }
         {source !== ShowcaseSource.BUILDS_MODAL && !forceDebug && (
-          <DeferReveal>
-            <ShowcaseBuildAnalysis
-              showcaseMetadata={showcaseMetadata}
-              scoringType={state.storedScoringType}
-              displayRelics={displayRelics}
-              source={source}
-            />
-          </DeferReveal>
+          <ShowcaseBuildAnalysis
+            showcaseMetadata={showcaseMetadata}
+            scoringType={state.storedScoringType}
+            displayRelics={displayRelics}
+            source={source}
+          />
         )}
       </div>
     </SimScoringContextProvider>

--- a/src/lib/characterPreview/StatRow.tsx
+++ b/src/lib/characterPreview/StatRow.tsx
@@ -7,6 +7,7 @@ import {
   Stats,
   type StatsValues,
 } from 'lib/constants/constants'
+import { separatorColor } from 'lib/constants/constantsUi'
 import { type ComputedStatsObjectExternal } from 'lib/optimization/engine/container/computedStatsContainer'
 import iconClasses from 'style/icons.module.css'
 
@@ -88,7 +89,7 @@ const displayTextMap: Record<string, string> = {
 }
 
 function StatRowDivider() {
-  return <span role='separator' style={{ margin: 'auto 10px', flexGrow: 1, borderBottom: '1px dashed rgba(255, 255, 255, 0.10)' }} />
+  return <span role='separator' style={{ margin: 'auto 10px', flexGrow: 1, borderBottom: `1px dashed ${separatorColor}` }} />
 }
 
 export const StatRow = memo(function StatRow({

--- a/src/lib/characterPreview/color/colorUtils.ts
+++ b/src/lib/characterPreview/color/colorUtils.ts
@@ -68,7 +68,7 @@ export function pickBestSeed(palette: PaletteResponse): string {
     if (!Number.isNaN(h) && h >= 180 && h <= 310) score *= 1.5
 
     // Prefer mid-lightness; penalize very dark and very light colors
-    const lDist = Math.abs(l - 0.45)
+    const lDist = Math.abs(l - 0.35)
     score *= Math.max(0.2, 1 - lDist * 2)
 
     if (score > bestScore) {
@@ -165,7 +165,7 @@ export function modifyCustomColor(hex: string) {
   const color = chroma(hex)
 
   const currentV = color.get('hsv.v')
-  const newV = currentV + (1 - currentV) * 0.45
+  const newV = currentV + (1 - currentV) * 0.20
 
   const currentS = color.get('hsv.s')
   const newS = currentS - (currentS * 0.15)

--- a/src/lib/characterPreview/color/showcaseColorService.ts
+++ b/src/lib/characterPreview/color/showcaseColorService.ts
@@ -13,7 +13,7 @@ import type { ShowcaseTheme } from 'lib/tabs/tabRelics/RelicPreview'
 import type { CharacterId } from 'types/character'
 import type { ShowcasePreferences } from 'types/metadata'
 
-const STANDARD_COLOR = '#799ef4'
+const STANDARD_COLOR = '#647bb0'
 export const DEFAULT_SHOWCASE_COLOR = '#2473e1'
 // Placeholder shown while the worker extracts a custom portrait's color.
 const CUSTOM_PORTRAIT_PENDING_COLOR = '#6b7280'

--- a/src/lib/characterPreview/scoring/CharacterCardCombatStats.tsx
+++ b/src/lib/characterPreview/scoring/CharacterCardCombatStats.tsx
@@ -10,6 +10,7 @@ import {
   SubStats,
 } from 'lib/constants/constants'
 import { SavedSessionKeys } from 'lib/constants/constantsSession'
+import { separatorColor } from 'lib/constants/constantsUi'
 import { BasicStatToKey } from 'lib/optimization/basicStatsArray'
 import { SELF_ENTITY_INDEX } from 'lib/optimization/engine/config/tag'
 import { type ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
@@ -226,5 +227,5 @@ function Arrow() {
 }
 
 function CombatStatDivider() {
-  return <span style={{ margin: 'auto 10px', flexGrow: 1, borderBottom: '1px dashed rgba(255, 255, 255, 0.10)' }} />
+  return <span style={{ margin: 'auto 10px', flexGrow: 1, borderBottom: `1px dashed ${separatorColor}` }} />
 }

--- a/src/lib/conditionals/character/1000/Saber.ts
+++ b/src/lib/conditionals/character/1000/Saber.ts
@@ -395,6 +395,11 @@ const display = {
     y: 944,
     z: 1.15,
   },
+  backgroundCenterOffset: {
+    x: 277,
+    y: 213,
+    z: 0.5,
+  },
   showcaseColor: '#8395fb',
 }
 

--- a/src/lib/conditionals/character/1100/Topaz.ts
+++ b/src/lib/conditionals/character/1100/Topaz.ts
@@ -398,7 +398,7 @@ const display = {
     y: 886,
     z: 1.1,
   },
-  showcaseColor: '#5246bd',
+  showcaseColor: '#576ec2',
 }
 
 export const Topaz: CharacterConfig = {

--- a/src/lib/conditionals/character/1200/Huohuo.ts
+++ b/src/lib/conditionals/character/1200/Huohuo.ts
@@ -226,7 +226,7 @@ const display = {
     z: 1.075,
   },
   disableSpine: true,
-  showcaseColor: '#9fd9e0',
+  showcaseColor: '#8ebdaf',
 }
 
 export const Huohuo: CharacterConfig = {

--- a/src/lib/conditionals/character/1300/TheDahlia.ts
+++ b/src/lib/conditionals/character/1300/TheDahlia.ts
@@ -533,7 +533,7 @@ const display = {
     y: 965,
     z: 1.07,
   },
-  showcaseColor: '#9290f8',
+  showcaseColor: '#403ea3',
 }
 
 export const TheDahlia: CharacterConfig = {

--- a/src/lib/conditionals/character/1400/Castorice.ts
+++ b/src/lib/conditionals/character/1400/Castorice.ts
@@ -513,6 +513,11 @@ const display = {
     y: 1039,
     z: 1.3,
   },
+  backgroundCenterOffset: {
+    x: -156,
+    y: 171,
+    z: 0.17,
+  },
   showcaseColor: '#630f94',
 }
 

--- a/src/lib/conditionals/character/1400/Cipher.ts
+++ b/src/lib/conditionals/character/1400/Cipher.ts
@@ -552,6 +552,11 @@ const display = {
     y: 876,
     z: 1.05,
   },
+  backgroundCenterOffset: {
+    x: 95,
+    y: 364,
+    z: 0.17,
+  },
   showcaseColor: '#896ed4',
 }
 

--- a/src/lib/conditionals/character/1400/Hyacine.ts
+++ b/src/lib/conditionals/character/1400/Hyacine.ts
@@ -641,6 +641,11 @@ const display = {
     y: 1025,
     z: 1.05,
   },
+  backgroundCenterOffset: {
+    x: 30,
+    y: 172,
+    z: 0,
+  },
   showcaseColor: '#1cd4a0',
 }
 

--- a/src/lib/conditionals/character/1400/TheHerta.ts
+++ b/src/lib/conditionals/character/1400/TheHerta.ts
@@ -388,7 +388,12 @@ const display = {
     y: 1085,
     z: 1.275,
   },
-  showcaseColor: '#b185eb',
+  backgroundCenterOffset: {
+    x: 208,
+    y: -16,
+    z: 0.5,
+  },
+  showcaseColor: '#8d61c7',
 }
 
 export const TheHerta: CharacterConfig = {

--- a/src/lib/conditionals/character/1500/Yaoguang.ts
+++ b/src/lib/conditionals/character/1500/Yaoguang.ts
@@ -574,7 +574,7 @@ const display = {
     y: 1086,
     z: 1.2,
   },
-  showcaseColor: '#37a6f4',
+  showcaseColor: '#688ba3',
 }
 
 export function getYaoguangAhaPunchlineValue(action: OptimizerAction, context: OptimizerContext): number | undefined {

--- a/src/lib/constants/constantsUi.ts
+++ b/src/lib/constants/constantsUi.ts
@@ -21,6 +21,9 @@ export const newLcMargin = 8
 export const newLcHeight = 150
 export const simScoreInnerW = 950
 
+// Separator styling
+export const separatorColor = 'rgba(255, 255, 255, 0.125)'
+
 // Recharts tooltip styling
 export const RECHARTS_TOOLTIP_WRAPPER_STYLE: React.CSSProperties = {
   transition: 'opacity 0.15s ease-out',

--- a/src/lib/constants/constantsUi.ts
+++ b/src/lib/constants/constantsUi.ts
@@ -24,6 +24,9 @@ export const simScoreInnerW = 950
 // Separator styling
 export const separatorColor = 'rgba(255, 255, 255, 0.125)'
 
+// Single-line text clipping for inputs/pills
+export const ellipsisTextStyle: React.CSSProperties = { overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }
+
 // Recharts tooltip styling
 export const RECHARTS_TOOLTIP_WRAPPER_STYLE: React.CSSProperties = {
   transition: 'opacity 0.15s ease-out',

--- a/src/lib/constants/constantsUi.ts
+++ b/src/lib/constants/constantsUi.ts
@@ -29,3 +29,8 @@ export const RECHARTS_TOOLTIP_WRAPPER_STYLE: React.CSSProperties = {
   transition: 'opacity 0.15s ease-out',
   pointerEvents: 'none',
 }
+
+// Relics tab layout
+export const RELICS_TAB_WIDTH = 1460
+const DIVIDER_WIDTH = 4
+export const INSIGHTS_PANEL_WIDTH = RELICS_TAB_WIDTH - relicCardW - defaultGap * 2 - DIVIDER_WIDTH * 2 - 1

--- a/src/lib/hooks/useBlurCommittedNumberInput.ts
+++ b/src/lib/hooks/useBlurCommittedNumberInput.ts
@@ -1,0 +1,41 @@
+import {
+  useRef,
+  useState,
+} from 'react'
+
+/**
+ * Drives a Mantine NumberInput with local state, committing to the external
+ * value only on blur. Avoids `useUncontrolled` mode flips (which leak stale
+ * `numAsString` values through spurious onChange events) by keeping the
+ * component always controlled with a defined value (`number | ''`).
+ *
+ * See `.claude/react-guidelines.md` → "Mantine Controlled Inputs".
+ */
+export function useBlurCommittedNumberInput(
+  externalValue: number | undefined,
+  onCommit: (value: number | undefined) => void,
+) {
+  const [localValue, setLocalValue] = useState<number | string>(externalValue ?? '')
+  const focusedRef = useRef(false)
+
+  if (!focusedRef.current) {
+    if (externalValue != null && externalValue !== localValue) setLocalValue(externalValue)
+    else if (externalValue == null && localValue !== '') setLocalValue('')
+  }
+
+  const commit = () => {
+    focusedRef.current = false
+    const v = localValue === '' ? undefined : typeof localValue === 'number' ? localValue : Number(localValue)
+    if (v !== externalValue) onCommit(v)
+  }
+
+  return {
+    value: localValue,
+    onChange: setLocalValue,
+    onFocus: () => {
+      focusedRef.current = true
+    },
+    onBlur: commit,
+    setValue: setLocalValue,
+  }
+}

--- a/src/lib/optimization/optimizer.ts
+++ b/src/lib/optimization/optimizer.ts
@@ -278,6 +278,18 @@ export const Optimizer = {
       useOptimizerDisplayStore.getState().setOptimizerStartTime(Date.now())
       useOptimizerDisplayStore.getState().setOptimizerRunningEngine(COMPUTE_ENGINE_CPU)
 
+      function finalize() {
+        useOptimizerDisplayStore.getState().setOptimizationInProgress(false)
+        results = queueResults.toArray()
+        results.sort((a, b) => (b[gridSortColumn] as number) - (a[gridSortColumn] as number))
+        OptimizerTabController.setRows(results)
+        setSortColumn(gridSortColumn)
+        gridStore.optimizerGridApi()?.updateGridOptions({
+          datasource: OptimizerTabController.getDataSource({ colId: gridSortColumn, sort: 'desc' }),
+        })
+        resultsShown = true
+      }
+
       function dispatchNextRun() {
         if (CANCEL || nextRunIndex >= runs.length) return
         const run = runs[nextRunIndex++]
@@ -337,18 +349,8 @@ export const Optimizer = {
           releaseRetryBuffer(taskInput, result.buffer)
 
           if ((inProgress === 0 && nextRunIndex >= runs.length) || CANCEL) {
-            useOptimizerDisplayStore.getState().setOptimizationInProgress(false)
-            results = queueResults.toArray()
-            results.sort((a, b) => (b[gridSortColumn] as number) - (a[gridSortColumn] as number))
-
-            OptimizerTabController.setRows(results)
-            setSortColumn(gridSortColumn)
-
-            gridStore.optimizerGridApi()?.updateGridOptions({
-              datasource: OptimizerTabController.getDataSource({ colId: gridSortColumn, sort: 'desc' }),
-            })
+            finalize()
             console.log('Done', results.length)
-            resultsShown = true
             if (!results.length && !inProgress) activateZeroResultSuggestionsModal(request)
             return
           }
@@ -364,15 +366,7 @@ export const Optimizer = {
           releaseBuffer(BufferPacker.createFloatBuffer(Constants.THREAD_BUFFER_LENGTH))
 
           if (inProgress === 0 && nextRunIndex >= runs.length) {
-            useOptimizerDisplayStore.getState().setOptimizationInProgress(false)
-            results = queueResults.toArray()
-            results.sort((a, b) => (b[gridSortColumn] as number) - (a[gridSortColumn] as number))
-            OptimizerTabController.setRows(results)
-            setSortColumn(gridSortColumn)
-            gridStore.optimizerGridApi()?.updateGridOptions({
-              datasource: OptimizerTabController.getDataSource({ colId: gridSortColumn, sort: 'desc' }),
-            })
-            resultsShown = true
+            finalize()
             if (!results.length) activateZeroResultSuggestionsModal(request)
             return
           }

--- a/src/lib/optimization/optimizer.ts
+++ b/src/lib/optimization/optimizer.ts
@@ -339,11 +339,14 @@ export const Optimizer = {
           if ((inProgress === 0 && nextRunIndex >= runs.length) || CANCEL) {
             useOptimizerDisplayStore.getState().setOptimizationInProgress(false)
             results = queueResults.toArray()
+            results.sort((a, b) => (b[gridSortColumn] as number) - (a[gridSortColumn] as number))
 
             OptimizerTabController.setRows(results)
             setSortColumn(gridSortColumn)
 
-            gridStore.optimizerGridApi()?.updateGridOptions({ datasource: OptimizerTabController.getDataSource() })
+            gridStore.optimizerGridApi()?.updateGridOptions({
+              datasource: OptimizerTabController.getDataSource({ colId: gridSortColumn, sort: 'desc' }),
+            })
             console.log('Done', results.length)
             resultsShown = true
             if (!results.length && !inProgress) activateZeroResultSuggestionsModal(request)
@@ -363,9 +366,12 @@ export const Optimizer = {
           if (inProgress === 0 && nextRunIndex >= runs.length) {
             useOptimizerDisplayStore.getState().setOptimizationInProgress(false)
             results = queueResults.toArray()
+            results.sort((a, b) => (b[gridSortColumn] as number) - (a[gridSortColumn] as number))
             OptimizerTabController.setRows(results)
             setSortColumn(gridSortColumn)
-            gridStore.optimizerGridApi()?.updateGridOptions({ datasource: OptimizerTabController.getDataSource() })
+            gridStore.optimizerGridApi()?.updateGridOptions({
+              datasource: OptimizerTabController.getDataSource({ colId: gridSortColumn, sort: 'desc' }),
+            })
             resultsShown = true
             if (!results.length) activateZeroResultSuggestionsModal(request)
             return

--- a/src/lib/simulations/scoringUpgrades.ts
+++ b/src/lib/simulations/scoringUpgrades.ts
@@ -121,10 +121,10 @@ export function generateStatImprovements(
     upgrade.percent = percent
   }
 
-  // Sort upgrades descending
-  substatUpgradeResults.sort((a, b) => b.percent! - a.percent!)
-  setUpgradeResults.sort((a, b) => b.percent! - a.percent!)
-  mainUpgradeResults.sort((a, b) => b.percent! - a.percent!)
+  // Sort upgrades descending by combo damage
+  substatUpgradeResults.sort((a, b) => b.simulationResult.simScore - a.simulationResult.simScore)
+  setUpgradeResults.sort((a, b) => b.simulationResult.simScore - a.simulationResult.simScore)
+  mainUpgradeResults.sort((a, b) => b.simulationResult.simScore - a.simulationResult.simScore)
 
   return { substatUpgradeResults, setUpgradeResults, mainUpgradeResults }
 }

--- a/src/lib/stores/optimizerForm/useOptimizerRequestStore.ts
+++ b/src/lib/stores/optimizerForm/useOptimizerRequestStore.ts
@@ -2,6 +2,10 @@ import type { SetConditionals } from 'lib/optimization/combo/comboTypes'
 import type { ComboType } from 'lib/optimization/rotation/comboType'
 import { type TurnAbilityName } from 'lib/optimization/rotation/turnAbilityConfig'
 import { type SortOption } from 'lib/optimization/sortOptions'
+import type {
+  SetsOrnaments,
+  SetsRelics,
+} from 'lib/sets/setConfigRegistry'
 import type { SimulationRequest } from 'lib/simulations/statSimulationTypes'
 import { createTabAwareStore } from 'lib/stores/infrastructure/createTabAwareStore'
 import {
@@ -70,6 +74,9 @@ type OptimizerRequestActions = {
   setRelicFilterField: <K extends keyof RelicFilterFields>(key: K, value: RelicFilterFields[K]) => void,
   setMainStats: (part: MainStatPart, stats: string[]) => void,
   setSetFilters: (display: SetFilters) => void,
+  removeFourPieceFilter: (name: SetsRelics) => void,
+  removeTwoPieceComboFilter: (index: number) => void,
+  removeOrnamentFilter: (name: SetsOrnaments) => void,
   setWeight: (stat: keyof OptimizerRequestState['weights'], value: number) => void,
   setEidolon: (eidolon: Eidolon) => void,
   setLightCone: (lcId: LightConeId | undefined) => void,
@@ -168,6 +175,21 @@ export const useOptimizerRequestStore = createTabAwareStore<OptimizerRequestStor
   setMainStats: (part, stats) => set({ [part]: stats }),
 
   setSetFilters: (display) => set({ setFilters: display }),
+
+  removeFourPieceFilter: (name) =>
+    set((state) => ({
+      setFilters: { ...state.setFilters, fourPiece: state.setFilters.fourPiece.filter((s) => s !== name) },
+    })),
+
+  removeTwoPieceComboFilter: (index) =>
+    set((state) => ({
+      setFilters: { ...state.setFilters, twoPieceCombos: state.setFilters.twoPieceCombos.filter((_, i) => i !== index) },
+    })),
+
+  removeOrnamentFilter: (name) =>
+    set((state) => ({
+      setFilters: { ...state.setFilters, ornaments: state.setFilters.ornaments.filter((s) => s !== name) },
+    })),
 
   setWeight: (stat, value) =>
     set((state) => ({

--- a/src/lib/tabs/tabCharacters/CharacterGrid.tsx
+++ b/src/lib/tabs/tabCharacters/CharacterGrid.tsx
@@ -6,6 +6,7 @@ import {
   DragOverlay,
   type DragStartEvent,
   PointerSensor,
+  TouchSensor,
   useSensor,
   useSensors,
 } from '@dnd-kit/core'
@@ -148,6 +149,7 @@ export function CharacterGrid() {
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 3 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 200, tolerance: 5 } }),
   )
 
   function handleDragStart(event: DragStartEvent) {

--- a/src/lib/tabs/tabCharacters/CharacterTab.tsx
+++ b/src/lib/tabs/tabCharacters/CharacterTab.tsx
@@ -21,7 +21,6 @@ import { CharacterMenu } from 'lib/tabs/tabCharacters/CharacterMenu'
 import { CharacterTabController } from 'lib/tabs/tabCharacters/characterTabController'
 import { FilterBar } from 'lib/tabs/tabCharacters/FilterBar'
 import { useCharacterTabStore } from 'lib/tabs/tabCharacters/useCharacterTabStore'
-import { useDeferReveal } from 'lib/ui/DeferredRender'
 import {
   useCallback,
   useContext,
@@ -61,7 +60,6 @@ export function CharacterTab() {
 
   const focusCharacter = useCharacterTabStore((s) => s.focusCharacter)
   const selectedCharacter = useCharacterStore((s) => focusCharacter ? s.charactersById[focusCharacter] : null) ?? null
-  const containerRef = useDeferReveal()
 
   const density = useGlobalStore((s) => s.savedSession.characterGridDensity)
   const preset = characterGridPresets[density]
@@ -92,7 +90,6 @@ export function CharacterTab() {
 
   return (
     <Flex
-      ref={containerRef}
       style={{
         height: '100%',
         marginBottom: 200,

--- a/src/lib/tabs/tabHome/HomeTab.module.css
+++ b/src/lib/tabs/tabHome/HomeTab.module.css
@@ -95,11 +95,12 @@
 }
 
 .heroTitle {
-  font-size: 64px;
+  font-size: clamp(24px, 5vw, 64px);
   font-weight: 700;
   letter-spacing: -0.02em;
   line-height: 1.1;
   margin: 0;
+  white-space: nowrap;
   color: rgba(255, 255, 255, 0.95);
   text-shadow:
     0 0 20px rgba(0, 0, 0, 0.7),
@@ -456,7 +457,14 @@
   border-radius: var(--radius-md);
 }
 
-/* Responsive */
+/* Responsive - portrait/narrow screens */
+@media (max-aspect-ratio: 1/1) {
+  .hero {
+    min-height: auto;
+    height: clamp(500px, 75vh, 850px);
+  }
+}
+
 @media (max-width: 1300px) {
   .cardContent {
     padding: 60px 48px;

--- a/src/lib/tabs/tabOptimizer/OptimizerTab.tsx
+++ b/src/lib/tabs/tabOptimizer/OptimizerTab.tsx
@@ -15,8 +15,6 @@ import { UnreleasedCharacterDisclaimer } from 'lib/tabs/tabOptimizer/UnreleasedC
 import {
   DeferCreate,
   DeferCreateProvider,
-  DeferReveal,
-  useDeferReveal,
 } from 'lib/ui/DeferredRender'
 import {
   useContext,
@@ -28,7 +26,6 @@ export function OptimizerTab() {
   const expandedPanelPosition = useGlobalStore((s) => s.settings.ExpandedInfoPanelPosition)
   const { isActiveRef, addActivationListener } = useContext(TabVisibilityContext)
   const [activated, setActivated] = useState(isActiveRef.current)
-  const containerRef = useDeferReveal()
 
   // First activation: enable DeferCreateProvider for progressive first mount
   useEffect(() => {
@@ -38,26 +35,22 @@ export function OptimizerTab() {
 
   return (
     <DeferCreateProvider resetKey={null} enabled={activated}>
-      <Flex ref={containerRef}>
+      <Flex>
         <Flex direction='column' gap={10} style={{ marginBottom: 100, width: 1302 }}>
           <OptimizerForm />
           <DPSScoreDisclaimer />
           <UnreleasedCharacterDisclaimer />
           <DeferCreate>
-            <DeferReveal>
-              <OptimizerGrid />
-            </DeferReveal>
+            <OptimizerGrid />
           </DeferCreate>
           <DeferCreate>
-            <DeferReveal>
-              <Flex
-                gap={10}
-                style={{ flexDirection: expandedPanelPosition === SettingOptions.ExpandedInfoPanelPosition.Below ? 'column' : 'column-reverse' }}
-              >
-                <OptimizerBuildPreview />
-                <ExpandedDataPanel />
-              </Flex>
-            </DeferReveal>
+            <Flex
+              gap={10}
+              style={{ flexDirection: expandedPanelPosition === SettingOptions.ExpandedInfoPanelPosition.Below ? 'column' : 'column-reverse' }}
+            >
+              <OptimizerBuildPreview />
+              <ExpandedDataPanel />
+            </Flex>
           </DeferCreate>
         </Flex>
         <Sidebar />

--- a/src/lib/tabs/tabOptimizer/optimizerForm/OptimizerForm.tsx
+++ b/src/lib/tabs/tabOptimizer/optimizerForm/OptimizerForm.tsx
@@ -32,10 +32,7 @@ import {
 } from 'lib/tabs/tabOptimizer/optimizerForm/layout/FormRow'
 import { OptimizerMenuIds } from 'lib/tabs/tabOptimizer/optimizerForm/layout/optimizerMenuIds'
 import { updateCharacter } from 'lib/tabs/tabOptimizer/optimizerForm/optimizerFormActions'
-import {
-  DeferCreate,
-  DeferReveal,
-} from 'lib/ui/DeferredRender'
+import { DeferCreate } from 'lib/ui/DeferredRender'
 import { mergeDefinedValues } from 'lib/utils/objectUtils'
 import {
   memo,
@@ -106,11 +103,9 @@ export function OptimizerForm() {
         </TeammateFormRow>
 
         <DeferCreate>
-          <DeferReveal>
-            <FormRow id={OptimizerMenuIds.characterStatsSimulation}>
-              <StatSimulationDisplay />
-            </FormRow>
-          </DeferReveal>
+          <FormRow id={OptimizerMenuIds.characterStatsSimulation}>
+            <StatSimulationDisplay />
+          </FormRow>
         </DeferCreate>
       </FilterContainer>
     </div>

--- a/src/lib/tabs/tabOptimizer/optimizerForm/components/CombatBuffsDrawer.tsx
+++ b/src/lib/tabs/tabOptimizer/optimizerForm/components/CombatBuffsDrawer.tsx
@@ -57,7 +57,10 @@ function CombatBuff({ title, name }: { title: string, name: string }) {
       </div>
       <InputNumberStyled
         hideControls
-        value={value}
+        // Coerce undefined → 0 to keep Mantine's useUncontrolled in controlled mode.
+        // combatBuffs is seeded to 0 for all known keys, but a new buff key on an old save
+        // state could slip through as undefined. See `.claude/react-guidelines.md` → "Mantine Controlled Inputs".
+        value={value ?? 0}
         onChange={(val: number | string) => useOptimizerRequestStore.getState().setCombatBuff(name, typeof val === 'number' ? val : 0)}
       />
     </Flex>

--- a/src/lib/tabs/tabOptimizer/optimizerForm/components/RelicMainSetFilters.tsx
+++ b/src/lib/tabs/tabOptimizer/optimizerForm/components/RelicMainSetFilters.tsx
@@ -17,13 +17,13 @@ import {
 import { Hint } from 'lib/interactions/hint'
 import { Assets } from 'lib/rendering/assets'
 import type { MainStatPart } from 'lib/stores/optimizerForm/optimizerFormTypes'
-import type { TwoPieceSlot } from 'lib/stores/optimizerForm/setFilterTypes'
-import { TwoPieceSlotType } from 'lib/stores/optimizerForm/setFilterTypes'
+import { RelicSetMode } from 'lib/stores/optimizerForm/setFilterTypes'
 import { useOptimizerRequestStore } from 'lib/stores/optimizerForm/useOptimizerRequestStore'
 import {
   optimizerTabDefaultGap,
   panelWidth,
 } from 'lib/tabs/tabOptimizer/optimizerForm/grid/optimizerGridColumns'
+import { SlotImage } from 'lib/tabs/tabOptimizer/optimizerForm/components/RelicSetFilterModal/SetFilterBadges'
 import { HeaderText } from 'lib/ui/HeaderText'
 import { MultiSelectPills } from 'lib/ui/MultiSelectPills'
 import { TooltipImage } from 'lib/ui/TooltipImage'
@@ -170,44 +170,19 @@ function MainStatLinkRope() {
 }
 
 const relicBoxIcon = Assets.getDefaultRelic()
-
-function SlotIcon({ slot }: { slot: TwoPieceSlot }) {
-  switch (slot.type) {
-    case TwoPieceSlotType.Set:
-      return <img src={Assets.getSetImage(slot.value)} style={{ width: 20, height: 20 }} />
-    case TwoPieceSlotType.Stat:
-      return <img src={Assets.getStatIcon(slot.value)} style={{ width: 20, height: 20 }} />
-    case TwoPieceSlotType.Any:
-      return <IconCircleAsterisk size={20} opacity={0.5} />
-  }
-}
+const anyIcon20 = <IconCircleAsterisk size={20} opacity={0.5} />
 
 function RelicSetFilterRow() {
   const display = useOptimizerRequestStore((s) => s.setFilters)
   const hasSelection = display.fourPiece.length > 0 || display.twoPieceCombos.length > 0
   const totalCount = display.fourPiece.length + display.twoPieceCombos.length
 
-  const handleRemove4p = (e: React.MouseEvent, name: string) => {
-    e.stopPropagation()
-    const current = useOptimizerRequestStore.getState().setFilters
-    useOptimizerRequestStore.getState().setSetFilters({
-      ...current,
-      fourPiece: current.fourPiece.filter((s) => s !== name),
-    })
-  }
-
-  const handleRemove2p = (e: React.MouseEvent, index: number) => {
-    e.stopPropagation()
-    const current = useOptimizerRequestStore.getState().setFilters
-    useOptimizerRequestStore.getState().setSetFilters({
-      ...current,
-      twoPieceCombos: current.twoPieceCombos.filter((_, i) => i !== index),
-    })
-  }
+  const removeFourPiece = useOptimizerRequestStore((s) => s.removeFourPieceFilter)
+  const removeTwoPiece = useOptimizerRequestStore((s) => s.removeTwoPieceComboFilter)
 
   const combined = [
-    ...display.fourPiece.map((name) => ({ type: '4p' as const, name })),
-    ...display.twoPieceCombos.map((combo, i) => ({ type: '2p' as const, combo, index: i })),
+    ...display.fourPiece.map((name) => ({ type: RelicSetMode.FourPiece, name })),
+    ...display.twoPieceCombos.map((combo, i) => ({ type: RelicSetMode.TwoPiece, combo, index: i })),
   ]
 
   return (
@@ -223,19 +198,33 @@ function RelicSetFilterRow() {
         ? (
           <Group gap={10} wrap='nowrap' align='center' style={{ overflow: 'hidden', flex: 1 }}>
             {combined.slice(0, 2).map((item) =>
-              item.type === '4p'
+              item.type === RelicSetMode.FourPiece
                 ? (
                   <Group key={`4p-${item.name}`} gap={4} wrap='nowrap' align='center' style={{ marginBottom: 1 }}>
                     <img src={Assets.getSetImage(item.name)} style={{ width: 20, height: 20 }} />
                     <img src={Assets.getSetImage(item.name)} style={{ width: 20, height: 20 }} />
-                    <CloseButton size={14} variant='subtle' onClick={(e) => handleRemove4p(e, item.name)} />
+                    <CloseButton
+                      size={14}
+                      variant='subtle'
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        removeFourPiece(item.name)
+                      }}
+                    />
                   </Group>
                 )
                 : (
                   <Group key={`2p-${item.index}`} gap={4} wrap='nowrap' align='center' style={{ marginBottom: 1 }}>
-                    <SlotIcon slot={item.combo.a} />
-                    <SlotIcon slot={item.combo.b} />
-                    <CloseButton size={14} variant='subtle' onClick={(e) => handleRemove2p(e, item.index)} />
+                    <SlotImage slot={item.combo.a} size={20} anyIcon={anyIcon20} />
+                    <SlotImage slot={item.combo.b} size={20} anyIcon={anyIcon20} />
+                    <CloseButton
+                      size={14}
+                      variant='subtle'
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        removeTwoPiece(item.index)
+                      }}
+                    />
                   </Group>
                 ))}
             {totalCount > 2 && <span style={{ fontSize: 12, color: 'var(--mantine-color-dimmed)', marginLeft: 'auto' }}>+{totalCount - 2}</span>}
@@ -250,14 +239,7 @@ function OrnamentSetFilterRow() {
   const display = useOptimizerRequestStore((s) => s.setFilters)
   const hasSelection = display.ornaments.length > 0
 
-  const handleRemove = (e: React.MouseEvent, name: string) => {
-    e.stopPropagation()
-    const current = useOptimizerRequestStore.getState().setFilters
-    useOptimizerRequestStore.getState().setSetFilters({
-      ...current,
-      ornaments: current.ornaments.filter((s) => s !== name),
-    })
-  }
+  const removeOrnament = useOptimizerRequestStore((s) => s.removeOrnamentFilter)
 
   return (
     <PillsInput
@@ -274,7 +256,14 @@ function OrnamentSetFilterRow() {
             {display.ornaments.slice(0, 3).map((name) => (
               <Group key={name} gap={4} wrap='nowrap' align='center' style={{ marginBottom: 1 }}>
                 <img src={Assets.getSetImage(name)} style={{ width: 20, height: 20 }} />
-                <CloseButton size={14} variant='subtle' onClick={(e) => handleRemove(e, name)} />
+                <CloseButton
+                  size={14}
+                  variant='subtle'
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    removeOrnament(name)
+                  }}
+                />
               </Group>
             ))}
             {display.ornaments.length > 3 && (

--- a/src/lib/tabs/tabOptimizer/optimizerForm/components/RelicMainSetFilters.tsx
+++ b/src/lib/tabs/tabOptimizer/optimizerForm/components/RelicMainSetFilters.tsx
@@ -5,7 +5,7 @@ import {
   Group,
   PillsInput,
 } from '@mantine/core'
-import { IconSettings } from '@tabler/icons-react'
+import { IconCircleAsterisk, IconSettings } from '@tabler/icons-react'
 import {
   Constants,
   Parts,
@@ -17,6 +17,8 @@ import {
 import { Hint } from 'lib/interactions/hint'
 import { Assets } from 'lib/rendering/assets'
 import type { MainStatPart } from 'lib/stores/optimizerForm/optimizerFormTypes'
+import type { TwoPieceSlot } from 'lib/stores/optimizerForm/setFilterTypes'
+import { TwoPieceSlotType } from 'lib/stores/optimizerForm/setFilterTypes'
 import { useOptimizerRequestStore } from 'lib/stores/optimizerForm/useOptimizerRequestStore'
 import {
   optimizerTabDefaultGap,
@@ -169,12 +171,23 @@ function MainStatLinkRope() {
 
 const relicBoxIcon = Assets.getDefaultRelic()
 
+function SlotIcon({ slot }: { slot: TwoPieceSlot }) {
+  switch (slot.type) {
+    case TwoPieceSlotType.Set:
+      return <img src={Assets.getSetImage(slot.value)} style={{ width: 20, height: 20 }} />
+    case TwoPieceSlotType.Stat:
+      return <img src={Assets.getStatIcon(slot.value)} style={{ width: 20, height: 20 }} />
+    case TwoPieceSlotType.Any:
+      return <IconCircleAsterisk size={20} opacity={0.5} />
+  }
+}
+
 function RelicSetFilterRow() {
   const display = useOptimizerRequestStore((s) => s.setFilters)
   const hasSelection = display.fourPiece.length > 0 || display.twoPieceCombos.length > 0
   const totalCount = display.fourPiece.length + display.twoPieceCombos.length
 
-  const handleRemove = (e: React.MouseEvent, name: string) => {
+  const handleRemove4p = (e: React.MouseEvent, name: string) => {
     e.stopPropagation()
     const current = useOptimizerRequestStore.getState().setFilters
     useOptimizerRequestStore.getState().setSetFilters({
@@ -182,6 +195,20 @@ function RelicSetFilterRow() {
       fourPiece: current.fourPiece.filter((s) => s !== name),
     })
   }
+
+  const handleRemove2p = (e: React.MouseEvent, index: number) => {
+    e.stopPropagation()
+    const current = useOptimizerRequestStore.getState().setFilters
+    useOptimizerRequestStore.getState().setSetFilters({
+      ...current,
+      twoPieceCombos: current.twoPieceCombos.filter((_, i) => i !== index),
+    })
+  }
+
+  const combined = [
+    ...display.fourPiece.map((name) => ({ type: '4p' as const, name })),
+    ...display.twoPieceCombos.map((combo, i) => ({ type: '2p' as const, combo, index: i })),
+  ]
 
   return (
     <PillsInput
@@ -195,13 +222,22 @@ function RelicSetFilterRow() {
       {hasSelection
         ? (
           <Group gap={10} wrap='nowrap' align='center' style={{ overflow: 'hidden', flex: 1 }}>
-            {display.fourPiece.slice(0, 2).map((name) => (
-              <Group key={name} gap={4} wrap='nowrap' align='center' style={{ marginBottom: 1 }}>
-                <img src={Assets.getSetImage(name)} style={{ width: 20, height: 20 }} />
-                <img src={Assets.getSetImage(name)} style={{ width: 20, height: 20 }} />
-                <CloseButton size={14} variant='subtle' onClick={(e) => handleRemove(e, name)} />
-              </Group>
-            ))}
+            {combined.slice(0, 2).map((item) =>
+              item.type === '4p'
+                ? (
+                  <Group key={`4p-${item.name}`} gap={4} wrap='nowrap' align='center' style={{ marginBottom: 1 }}>
+                    <img src={Assets.getSetImage(item.name)} style={{ width: 20, height: 20 }} />
+                    <img src={Assets.getSetImage(item.name)} style={{ width: 20, height: 20 }} />
+                    <CloseButton size={14} variant='subtle' onClick={(e) => handleRemove4p(e, item.name)} />
+                  </Group>
+                )
+                : (
+                  <Group key={`2p-${item.index}`} gap={4} wrap='nowrap' align='center' style={{ marginBottom: 1 }}>
+                    <SlotIcon slot={item.combo.a} />
+                    <SlotIcon slot={item.combo.b} />
+                    <CloseButton size={14} variant='subtle' onClick={(e) => handleRemove2p(e, item.index)} />
+                  </Group>
+                ))}
             {totalCount > 2 && <span style={{ fontSize: 12, color: 'var(--mantine-color-dimmed)', marginLeft: 'auto' }}>+{totalCount - 2}</span>}
           </Group>
         )

--- a/src/lib/tabs/tabOptimizer/optimizerForm/components/RelicSetFilterModal/SetFilterBadges.tsx
+++ b/src/lib/tabs/tabOptimizer/optimizerForm/components/RelicSetFilterModal/SetFilterBadges.tsx
@@ -81,9 +81,16 @@ export function FourPieceBadges({ checked4p, onRemove }: {
   )
 }
 
-function SlotImage({ slot }: { slot: TwoPieceSlot }) {
+export function SlotImage({ slot, size, anyIcon }: {
+  slot: TwoPieceSlot,
+  size?: number,
+  anyIcon?: ReactNode,
+}) {
   if (slot.type === TwoPieceSlotType.Any) {
-    return <IconSquareAsteriskFilled size={22} opacity={0.5} />
+    return anyIcon ?? <IconSquareAsteriskFilled size={size ?? 22} opacity={0.5} />
+  }
+  if (size != null) {
+    return <img style={{ width: size, height: size }} src={slotIcon(slot)!} alt='' />
   }
   return <img className={classes.collectorImg} src={slotIcon(slot)!} alt='' />
 }

--- a/src/lib/tabs/tabOptimizer/optimizerForm/components/RelicSetFilterModal/SetFilterSummary.tsx
+++ b/src/lib/tabs/tabOptimizer/optimizerForm/components/RelicSetFilterModal/SetFilterSummary.tsx
@@ -4,15 +4,8 @@ import {
   type MantineSpacing,
   Stack,
 } from '@mantine/core'
-import type {
-  SetsOrnaments,
-  SetsRelics,
-} from 'lib/sets/setConfigRegistry'
 import { useOptimizerRequestStore } from 'lib/stores/optimizerForm/useOptimizerRequestStore'
-import {
-  useCallback,
-  useMemo,
-} from 'react'
+import { useMemo } from 'react'
 import classes from './RelicSetFilterModal.module.css'
 import {
   FourPieceBadges,
@@ -25,26 +18,14 @@ const MAX_VISIBLE_ORNAMENTS = 3
 
 export function SetFilterSummary({ mt }: { mt?: MantineSpacing }) {
   const display = useOptimizerRequestStore((s) => s.setFilters)
+  const remove4p = useOptimizerRequestStore((s) => s.removeFourPieceFilter)
+  const removeCombo = useOptimizerRequestStore((s) => s.removeTwoPieceComboFilter)
+  const removeOrnament = useOptimizerRequestStore((s) => s.removeOrnamentFilter)
 
   const checked4p = useMemo(() => new Set(display.fourPiece), [display.fourPiece])
   const checkedOrnaments = useMemo(() => new Set(display.ornaments), [display.ornaments])
   const combos = display.twoPieceCombos
   const hasAnything = checked4p.size > 0 || combos.length > 0 || checkedOrnaments.size > 0
-
-  const remove4p = useCallback((name: SetsRelics) => {
-    const current = useOptimizerRequestStore.getState().setFilters
-    useOptimizerRequestStore.getState().setSetFilters({ ...current, fourPiece: current.fourPiece.filter((s) => s !== name) })
-  }, [])
-
-  const removeCombo = useCallback((index: number) => {
-    const current = useOptimizerRequestStore.getState().setFilters
-    useOptimizerRequestStore.getState().setSetFilters({ ...current, twoPieceCombos: current.twoPieceCombos.filter((_, i) => i !== index) })
-  }, [])
-
-  const removeOrnament = useCallback((name: SetsOrnaments) => {
-    const current = useOptimizerRequestStore.getState().setFilters
-    useOptimizerRequestStore.getState().setSetFilters({ ...current, ornaments: current.ornaments.filter((s) => s !== name) })
-  }, [])
 
   const relicTotal = checked4p.size + combos.length
   const relicOverflow = Math.max(0, relicTotal - MAX_VISIBLE_RELICS)

--- a/src/lib/tabs/tabOptimizer/optimizerForm/components/statSimulation/StatInput.tsx
+++ b/src/lib/tabs/tabOptimizer/optimizerForm/components/statSimulation/StatInput.tsx
@@ -26,7 +26,9 @@ export function StatInput({ label, name, simType }: { label: string, name: strin
       </div>
       <InputNumberStyled
         hideControls
-        value={value}
+        // Coerce undefined → '' to keep Mantine's useUncontrolled in controlled mode.
+        // See `.claude/react-guidelines.md` → "Mantine Controlled Inputs".
+        value={value ?? ''}
         onChange={handleChange}
         style={{ width: STAT_SIMULATION_INPUT_WIDTH }}
       />

--- a/src/lib/tabs/tabOptimizer/optimizerForm/layout/FilterRow.tsx
+++ b/src/lib/tabs/tabOptimizer/optimizerForm/layout/FilterRow.tsx
@@ -1,4 +1,8 @@
 import { Flex } from '@mantine/core'
+import {
+  useRef,
+  useState,
+} from 'react'
 import type {
   RatingFilterState,
   StatFilterState,
@@ -6,14 +10,6 @@ import type {
 import { useOptimizerRequestStore } from 'lib/stores/optimizerForm/useOptimizerRequestStore'
 import { FormStatTextStyled } from 'lib/tabs/tabOptimizer/optimizerForm/components/FormStatTextStyled'
 import { InputNumberStyled } from 'lib/tabs/tabOptimizer/optimizerForm/components/InputNumberStyled'
-
-// Mantine NumberInput sends '' when cleared and intermediate strings like '133.' while typing decimals.
-// Only update the store for final numeric values or explicit clears.
-function filterValue(val: number | string): number | undefined | null {
-  if (typeof val === 'number') return val
-  if (val === '') return undefined
-  return null // intermediate string — don't update store
-}
 
 export function FilterRow({ name, label, type }: { name: string, label: string, type?: 'stat' | 'rating' }) {
   const minKey = `min${name}` as keyof StatFilterState & keyof RatingFilterState
@@ -28,6 +24,29 @@ export function FilterRow({ name, label, type }: { name: string, label: string, 
     isRating ? s.ratingFilters[maxKey as keyof RatingFilterState] : s.statFilters[maxKey as keyof StatFilterState]
   )
 
+  // Local-state pattern: NumberInput is driven by `localMin/Max`, not the store value directly.
+  // This is required because Mantine's `useUncontrolled` flips the component into uncontrolled mode
+  // whenever `value === undefined` (e.g., when presets reset the filter). On the transition back,
+  // react-number-format's stale internal `numAsString` leaks out as a spurious `onChange` with a
+  // truncated value (e.g., "16" after clearing "160"), which then corrupts the store.
+  // Fix: keep the component always controlled with a defined value (`number | ''`), and only commit
+  // to the store on blur. Spurious onChange events now only mutate local state, never the store.
+  // See `.claude/react-guidelines.md` → "Mantine Controlled Inputs — Never Pass `undefined` as `value`".
+  const [localMin, setLocalMin] = useState<number | string>(minValue ?? '')
+  const [localMax, setLocalMax] = useState<number | string>(maxValue ?? '')
+  const minFocusedRef = useRef(false)
+  const maxFocusedRef = useRef(false)
+
+  // Sync external store changes into local state, but not while the user is typing.
+  if (!minFocusedRef.current) {
+    if (minValue != null && minValue !== localMin) setLocalMin(minValue)
+    else if (minValue == null && localMin !== '') setLocalMin('')
+  }
+  if (!maxFocusedRef.current) {
+    if (maxValue != null && maxValue !== localMax) setLocalMax(maxValue)
+    else if (maxValue == null && localMax !== '') setLocalMax('')
+  }
+
   const setFilter = (key: string, val: number | undefined) => {
     if (isRating) {
       useOptimizerRequestStore.getState().setRatingFilter(key as keyof RatingFilterState, val)
@@ -36,26 +55,40 @@ export function FilterRow({ name, label, type }: { name: string, label: string, 
     }
   }
 
+  const commitMin = () => {
+    minFocusedRef.current = false
+    const v = localMin === '' ? undefined : typeof localMin === 'number' ? localMin : Number(localMin)
+    if (v !== minValue) setFilter(minKey, v)
+  }
+
+  const commitMax = () => {
+    maxFocusedRef.current = false
+    const v = localMax === '' ? undefined : typeof localMax === 'number' ? localMax : Number(localMax)
+    if (v !== maxValue) setFilter(maxKey, v)
+  }
+
   return (
     <Flex justify='space-between' style={{ margin: 0 }}>
       <InputNumberStyled
         hideControls
         style={{ margin: 0, width: 63 }}
-        value={minValue}
-        onChange={(val) => {
-          const v = filterValue(val)
-          if (v !== null) setFilter(minKey, v as number | undefined)
+        value={localMin}
+        onChange={setLocalMin}
+        onFocus={() => {
+          minFocusedRef.current = true
         }}
+        onBlur={commitMin}
       />
       <FormStatTextStyled>{label}</FormStatTextStyled>
       <InputNumberStyled
         hideControls
         style={{ margin: 0, width: 63 }}
-        value={maxValue}
-        onChange={(val) => {
-          const v = filterValue(val)
-          if (v !== null) setFilter(maxKey, v as number | undefined)
+        value={localMax}
+        onChange={setLocalMax}
+        onFocus={() => {
+          maxFocusedRef.current = true
         }}
+        onBlur={commitMax}
       />
     </Flex>
   )

--- a/src/lib/tabs/tabOptimizer/optimizerForm/layout/FilterRow.tsx
+++ b/src/lib/tabs/tabOptimizer/optimizerForm/layout/FilterRow.tsx
@@ -1,8 +1,5 @@
 import { Flex } from '@mantine/core'
-import {
-  useRef,
-  useState,
-} from 'react'
+import { useBlurCommittedNumberInput } from 'lib/hooks/useBlurCommittedNumberInput'
 import type {
   RatingFilterState,
   StatFilterState,
@@ -24,29 +21,6 @@ export function FilterRow({ name, label, type }: { name: string, label: string, 
     isRating ? s.ratingFilters[maxKey as keyof RatingFilterState] : s.statFilters[maxKey as keyof StatFilterState]
   )
 
-  // Local-state pattern: NumberInput is driven by `localMin/Max`, not the store value directly.
-  // This is required because Mantine's `useUncontrolled` flips the component into uncontrolled mode
-  // whenever `value === undefined` (e.g., when presets reset the filter). On the transition back,
-  // react-number-format's stale internal `numAsString` leaks out as a spurious `onChange` with a
-  // truncated value (e.g., "16" after clearing "160"), which then corrupts the store.
-  // Fix: keep the component always controlled with a defined value (`number | ''`), and only commit
-  // to the store on blur. Spurious onChange events now only mutate local state, never the store.
-  // See `.claude/react-guidelines.md` → "Mantine Controlled Inputs — Never Pass `undefined` as `value`".
-  const [localMin, setLocalMin] = useState<number | string>(minValue ?? '')
-  const [localMax, setLocalMax] = useState<number | string>(maxValue ?? '')
-  const minFocusedRef = useRef(false)
-  const maxFocusedRef = useRef(false)
-
-  // Sync external store changes into local state, but not while the user is typing.
-  if (!minFocusedRef.current) {
-    if (minValue != null && minValue !== localMin) setLocalMin(minValue)
-    else if (minValue == null && localMin !== '') setLocalMin('')
-  }
-  if (!maxFocusedRef.current) {
-    if (maxValue != null && maxValue !== localMax) setLocalMax(maxValue)
-    else if (maxValue == null && localMax !== '') setLocalMax('')
-  }
-
   const setFilter = (key: string, val: number | undefined) => {
     if (isRating) {
       useOptimizerRequestStore.getState().setRatingFilter(key as keyof RatingFilterState, val)
@@ -55,40 +29,27 @@ export function FilterRow({ name, label, type }: { name: string, label: string, 
     }
   }
 
-  const commitMin = () => {
-    minFocusedRef.current = false
-    const v = localMin === '' ? undefined : typeof localMin === 'number' ? localMin : Number(localMin)
-    if (v !== minValue) setFilter(minKey, v)
-  }
-
-  const commitMax = () => {
-    maxFocusedRef.current = false
-    const v = localMax === '' ? undefined : typeof localMax === 'number' ? localMax : Number(localMax)
-    if (v !== maxValue) setFilter(maxKey, v)
-  }
+  const min = useBlurCommittedNumberInput(minValue, (v) => setFilter(minKey, v))
+  const max = useBlurCommittedNumberInput(maxValue, (v) => setFilter(maxKey, v))
 
   return (
     <Flex justify='space-between' style={{ margin: 0 }}>
       <InputNumberStyled
         hideControls
         style={{ margin: 0, width: 63 }}
-        value={localMin}
-        onChange={setLocalMin}
-        onFocus={() => {
-          minFocusedRef.current = true
-        }}
-        onBlur={commitMin}
+        value={min.value}
+        onChange={min.onChange}
+        onFocus={min.onFocus}
+        onBlur={min.onBlur}
       />
       <FormStatTextStyled>{label}</FormStatTextStyled>
       <InputNumberStyled
         hideControls
         style={{ margin: 0, width: 63 }}
-        value={localMax}
-        onChange={setLocalMax}
-        onFocus={() => {
-          maxFocusedRef.current = true
-        }}
-        onBlur={commitMax}
+        value={max.value}
+        onChange={max.onChange}
+        onFocus={max.onFocus}
+        onBlur={max.onBlur}
       />
     </Flex>
   )

--- a/src/lib/tabs/tabOptimizer/optimizerTabController.ts
+++ b/src/lib/tabs/tabOptimizer/optimizerTabController.ts
@@ -49,7 +49,7 @@ type PermutationSizes = {
 
 type SortModel = {
   colId: string,
-  sort: string,
+  sort: 'asc' | 'desc' | null,
 }
 
 const controllerState: {
@@ -67,7 +67,7 @@ const controllerState: {
   rows: [],
   filteredIndices: [],
   filterModel: undefined,
-  sortModel: { colId: '', sort: '' },
+  sortModel: { colId: '', sort: null },
 }
 
 const columnsToAggregate = Object.keys(columnsToAggregateMap)

--- a/src/lib/tabs/tabRelics/RelicPreview.tsx
+++ b/src/lib/tabs/tabRelics/RelicPreview.tsx
@@ -9,6 +9,7 @@ import { Parts } from 'lib/constants/constants'
 import {
   relicCardH,
   relicCardW,
+  separatorColor,
 } from 'lib/constants/constantsUi'
 import { type RelicScoringResult } from 'lib/relics/scoring/relicScorer'
 import { Assets } from 'lib/rendering/assets'
@@ -189,7 +190,7 @@ export const RelicPreview = memo(function RelicPreview(props: {
 })
 
 // CSS divider - lighter than Mantine Divider component
-const relicDividerStyle: React.CSSProperties = { margin: '6px 0', borderBottom: '1px solid rgba(255, 255, 255, 0.10)' }
+const relicDividerStyle: React.CSSProperties = { margin: '6px 0', borderBottom: `1px solid ${separatorColor}` }
 
 function RelicDivider() {
   return <span style={relicDividerStyle} />

--- a/src/lib/tabs/tabRelics/RelicsGrid.tsx
+++ b/src/lib/tabs/tabRelics/RelicsGrid.tsx
@@ -22,7 +22,7 @@ import {
   generateBaselineColDefs,
   generateOptionalColDefs,
 } from 'lib/tabs/tabRelics/columnDefs'
-import { TAB_WIDTH } from 'lib/tabs/tabRelics/RelicsTab'
+import { RELICS_TAB_WIDTH } from 'lib/constants/constantsUi'
 import { RelicsTabController } from 'lib/tabs/tabRelics/relicsTabController'
 import {
   useRelicsTabStore,
@@ -170,7 +170,7 @@ export function RelicsGrid() {
       id='relicGrid'
       className='ag-theme-balham-dark'
       style={{
-        width: TAB_WIDTH,
+        width: RELICS_TAB_WIDTH,
         height: 600,
         overflow: 'hidden',
         resize: 'vertical',

--- a/src/lib/tabs/tabRelics/RelicsTab.tsx
+++ b/src/lib/tabs/tabRelics/RelicsTab.tsx
@@ -6,11 +6,7 @@ import { BottomDock } from 'lib/tabs/tabRelics/bottomDock/BottomDock'
 import { RecentRelics } from 'lib/tabs/tabRelics/RecentRelics'
 import { RelicsGrid } from 'lib/tabs/tabRelics/RelicsGrid'
 import { TopBar } from 'lib/tabs/tabRelics/topBar/TopBar'
-import {
-  DeferCreateProvider,
-  DeferReveal,
-  useDeferReveal,
-} from 'lib/ui/DeferredRender'
+import { DeferCreateProvider } from 'lib/ui/DeferredRender'
 import {
   useContext,
   useEffect,
@@ -18,23 +14,21 @@ import {
 } from 'react'
 import { useTranslation } from 'react-i18next'
 
-export const TAB_WIDTH = RELICS_TAB_WIDTH
-
 export function RelicsTab() {
   const hasRecentRelics = useScannerState((s) => s.connected && s.recentRelics.length > 0)
   const { t } = useTranslation('relicsTab')
-  const containerRef = useDeferReveal()
 
   // Enable deferred rendering after first tab activation
-  const { addActivationListener } = useContext(TabVisibilityContext)
-  const [activated, setActivated] = useState(false)
+  const { isActiveRef, addActivationListener } = useContext(TabVisibilityContext)
+  const [activated, setActivated] = useState(isActiveRef.current)
 
   useEffect(() => {
+    if (activated) return
     return addActivationListener(() => setActivated(true))
-  }, [addActivationListener])
+  }, [activated, addActivationListener])
 
   return (
-    <div ref={containerRef} style={{ display: 'flex', flexDirection: 'column', gap: 8, width: TAB_WIDTH, marginBottom: 100 }}>
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8, width: RELICS_TAB_WIDTH, marginBottom: 100 }}>
       <TopBar />
 
       {hasRecentRelics && (
@@ -69,15 +63,11 @@ export function RelicsTab() {
         </div>
       )}
 
-      <DeferReveal>
-        <RelicsGrid />
-      </DeferReveal>
+      <RelicsGrid />
 
-      <DeferReveal>
-        <DeferCreateProvider resetKey={null} enabled={activated}>
-          <BottomDock />
-        </DeferCreateProvider>
-      </DeferReveal>
+      <DeferCreateProvider resetKey={null} enabled={activated}>
+        <BottomDock />
+      </DeferCreateProvider>
     </div>
   )
 }

--- a/src/lib/tabs/tabRelics/RelicsTab.tsx
+++ b/src/lib/tabs/tabRelics/RelicsTab.tsx
@@ -1,21 +1,37 @@
 import { Accordion } from '@mantine/core'
+import { RELICS_TAB_WIDTH } from 'lib/constants/constantsUi'
+import { TabVisibilityContext } from 'lib/hooks/useTabVisibility'
 import { useScannerState } from 'lib/tabs/tabImport/ScannerWebsocketClient'
 import { BottomDock } from 'lib/tabs/tabRelics/bottomDock/BottomDock'
 import { RecentRelics } from 'lib/tabs/tabRelics/RecentRelics'
 import { RelicsGrid } from 'lib/tabs/tabRelics/RelicsGrid'
 import { TopBar } from 'lib/tabs/tabRelics/topBar/TopBar'
 import {
+  DeferCreateProvider,
   DeferReveal,
   useDeferReveal,
 } from 'lib/ui/DeferredRender'
+import {
+  useContext,
+  useEffect,
+  useState,
+} from 'react'
 import { useTranslation } from 'react-i18next'
 
-export const TAB_WIDTH = 1460
+export const TAB_WIDTH = RELICS_TAB_WIDTH
 
 export function RelicsTab() {
   const hasRecentRelics = useScannerState((s) => s.connected && s.recentRelics.length > 0)
   const { t } = useTranslation('relicsTab')
   const containerRef = useDeferReveal()
+
+  // Enable deferred rendering after first tab activation
+  const { addActivationListener } = useContext(TabVisibilityContext)
+  const [activated, setActivated] = useState(false)
+
+  useEffect(() => {
+    return addActivationListener(() => setActivated(true))
+  }, [addActivationListener])
 
   return (
     <div ref={containerRef} style={{ display: 'flex', flexDirection: 'column', gap: 8, width: TAB_WIDTH, marginBottom: 100 }}>
@@ -58,7 +74,9 @@ export function RelicsTab() {
       </DeferReveal>
 
       <DeferReveal>
-        <BottomDock />
+        <DeferCreateProvider resetKey={null} enabled={activated}>
+          <BottomDock />
+        </DeferCreateProvider>
       </DeferReveal>
     </div>
   )

--- a/src/lib/tabs/tabRelics/relicInsightsPanel/RelicInsightsPanel.tsx
+++ b/src/lib/tabs/tabRelics/relicInsightsPanel/RelicInsightsPanel.tsx
@@ -1,4 +1,4 @@
-import { useElementSize } from '@mantine/hooks'
+import { INSIGHTS_PANEL_WIDTH } from 'lib/constants/constantsUi'
 import { buffedCharacters } from 'lib/importer/kelzFormatParser'
 import { RelicScorer } from 'lib/relics/scoring/relicScorer'
 import { sortAlphabeticEmojiLast } from 'lib/rendering/displayUtils'
@@ -17,10 +17,8 @@ import {
   RelicInsights,
   useRelicsTabStore,
 } from 'lib/tabs/tabRelics/useRelicsTabStore'
-import {
-  memo,
-  useMemo,
-} from 'react'
+import { DeferCreate } from 'lib/ui/DeferredRender'
+import { memo, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { CharacterId } from 'types/character'
 import { useShallow } from 'zustand/react/shallow'
@@ -76,21 +74,20 @@ export const RelicInsightsPanel = memo(function RelicInsightsPanel() {
 })
 
 function RelicInsightsPanelContent({ scores, insightsMode }: { scores: Score[], insightsMode: RelicInsights }) {
-  const { ref: containerRef, width: containerWidth } = useElementSize()
-  const chartWidth = containerWidth || undefined
-
   return (
-    <div ref={containerRef} style={{ width: '100%', overflow: 'hidden' }}>
-      {(() => {
-        switch (insightsMode) {
-          case RelicInsights.Buckets:
-            return <BucketsPanel scores={scores} width={chartWidth} />
-          case RelicInsights.Top10:
-            return <Top10Panel scores={scores} width={chartWidth} />
-          case RelicInsights.ESTBP:
-            return <EstbpCard />
-        }
-      })()}
+    <div style={{ width: '100%', overflow: 'hidden' }}>
+      <DeferCreate>
+        {(() => {
+          switch (insightsMode) {
+            case RelicInsights.Buckets:
+              return <BucketsPanel scores={scores} width={INSIGHTS_PANEL_WIDTH} />
+            case RelicInsights.Top10:
+              return <Top10Panel scores={scores} width={INSIGHTS_PANEL_WIDTH} />
+            case RelicInsights.ESTBP:
+              return <EstbpCard />
+          }
+        })()}
+      </DeferCreate>
     </div>
   )
 }

--- a/src/lib/tabs/tabShowcase/ShowcaseTab.tsx
+++ b/src/lib/tabs/tabShowcase/ShowcaseTab.tsx
@@ -38,7 +38,6 @@ import {
   getSelectedCharacter,
   useShowcaseTabStore,
 } from 'lib/tabs/tabShowcase/useShowcaseTabStore'
-import { useDeferReveal } from 'lib/ui/DeferredRender'
 import { TooltipImage } from 'lib/ui/TooltipImage'
 import {
   startTransition,
@@ -129,7 +128,6 @@ function ShowcaseLoading() {
 }
 
 function ShowcaseLoaded() {
-  const containerRef = useDeferReveal()
   const selectedCharacter = useShowcaseTabStore((s) => s.availableCharacters?.[s.selectedIndex] ?? null)
 
   const { availableCharacters, selectedIndex, loading, sidebarOpen } = useShowcaseTabStore(
@@ -223,7 +221,7 @@ function ShowcaseLoaded() {
   ]
 
   return (
-    <Flex ref={containerRef} className={styles.outerWrapper} justify='space-around'>
+    <Flex className={styles.outerWrapper} justify='space-around'>
       <Flex direction='column' align='center' gap={8} className={styles.loadedContainer}>
         {SHOWCASE_DOWNTIME && (
           <h3 className={styles.downtimeWarning}>

--- a/src/lib/ui/ComboboxNumberInput.tsx
+++ b/src/lib/ui/ComboboxNumberInput.tsx
@@ -5,10 +5,8 @@ import {
   useCombobox,
 } from '@mantine/core'
 import { IconChevronDown } from '@tabler/icons-react'
-import {
-  useRef,
-  useState,
-} from 'react'
+import { useBlurCommittedNumberInput } from 'lib/hooks/useBlurCommittedNumberInput'
+import { useRef } from 'react'
 
 export interface ComboboxNumberOption {
   value: string
@@ -44,37 +42,19 @@ export function ComboboxNumberInput(props: ComboboxNumberInputProps) {
     dropdownMaxHeight = 800,
   } = props
 
-  const [localValue, setLocalValue] = useState<number | string>(value ?? '')
-  const focusedRef = useRef(false)
+  const input = useBlurCommittedNumberInput(value, onChange)
   const wasOpenRef = useRef(false)
-
-  // Sync external value changes into local state, but not while the user is typing
-  if (!focusedRef.current) {
-    if (value != null && value !== localValue) {
-      setLocalValue(value)
-    } else if (value == null && localValue !== '') {
-      setLocalValue('')
-    }
-  }
 
   const combobox = useCombobox({
     onDropdownClose: () => combobox.resetSelectedOption(),
   })
-
-  function commitLocalValue() {
-    focusedRef.current = false
-    const committed = localValue === '' ? undefined : Number(localValue)
-    if (committed !== value) {
-      onChange(committed)
-    }
-  }
 
   return (
     <Combobox
       store={combobox}
       onOptionSubmit={(val) => {
         const num = Number(val)
-        setLocalValue(num)
+        input.setValue(num)
         onChange(num)
         combobox.closeDropdown()
       }}
@@ -83,10 +63,10 @@ export function ComboboxNumberInput(props: ComboboxNumberInputProps) {
         <NumberInput
           hideControls
           style={{ width: '100%', ...style }}
-          value={localValue}
-          onChange={setLocalValue}
-          onFocus={() => focusedRef.current = true}
-          onBlur={commitLocalValue}
+          value={input.value}
+          onChange={input.onChange}
+          onFocus={input.onFocus}
+          onBlur={input.onBlur}
           placeholder={placeholder}
           min={min}
           max={max}

--- a/src/lib/ui/DeferredRender.test.ts
+++ b/src/lib/ui/DeferredRender.test.ts
@@ -10,7 +10,6 @@ describe('DeferredRender conceptual', () => {
     const mod = await import('lib/ui/DeferredRender')
     expect(mod.DeferCreateProvider).toBeDefined()
     expect(mod.DeferCreate).toBeDefined()
-    expect(mod.DeferReveal).toBeDefined()
     expect(mod.useDeferredSlot).toBeDefined()
   })
 })

--- a/src/lib/ui/DeferredRender.tsx
+++ b/src/lib/ui/DeferredRender.tsx
@@ -307,35 +307,24 @@ export function useDeferReveal() {
   const containerRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
-    let rafId: number
     let firstActivation = true
 
     const unsub = addActivationListener(() => {
       // First activation: content was in display:none during stagger mount and
       // was never visible. Progressive reveal would just add extra layout passes
       // (hide then re-show) with no benefit. Skip it.
+      //
+      // Subsequent activations: content was ALREADY visible before the tab switch.
+      // The hide-then-show cycle causes a visible flash (content → blank → content).
+      // Since the content is already rendered, progressive reveal provides no benefit
+      // and actively harms UX. Skip it entirely.
       if (firstActivation) {
         firstActivation = false
-        return
       }
-
-      const sections = containerRef.current?.querySelectorAll<HTMLElement>(':scope [data-defer-reveal]')
-      if (!sections?.length) return
-      for (const section of sections) section.style.display = 'none'
-      let i = 0
-      cancelAnimationFrame(rafId)
-      function tick() {
-        if (i < sections!.length) {
-          sections![i].style.display = ''
-          i++
-          rafId = requestAnimationFrame(tick)
-        }
-      }
-      rafId = requestAnimationFrame(tick)
+      // Progressive reveal disabled - content stays visible without hide/show cycle
     })
     return () => {
       unsub()
-      cancelAnimationFrame(rafId)
     }
   }, [addActivationListener])
 

--- a/src/lib/ui/DeferredRender.tsx
+++ b/src/lib/ui/DeferredRender.tsx
@@ -1,4 +1,3 @@
-import { TabVisibilityContext } from 'lib/hooks/useTabVisibility'
 import {
   createContext,
   type ReactNode,
@@ -9,30 +8,8 @@ import {
   useSyncExternalStore,
 } from 'react'
 
-// ---------------------------------------------------------------------------
-// Deferred Rendering — two complementary mechanisms
-//
-// DeferCreate — "don't CREATE this yet"
-//   Defers React mount via a rAF queue. Children don't exist until revealed.
-//   Requires DeferCreateProvider. Used for first-mount progressive rendering.
-//
-// DeferReveal — "don't SHOW this yet"
-//   Defers CSS display via imperative DOM. Children stay mounted, only
-//   visibility toggles. No provider needed. Used for tab-switch progressive
-//   reveal — an activation listener hides all [data-defer-reveal] elements,
-//   then a rAF loop shows them one per frame.
-//
-// Compose both when a section needs first-mount deferral AND tab-switch reveal:
-//   <DeferCreate><DeferReveal><Heavy /></DeferReveal></DeferCreate>
-//
-// When to use which:
-//   DeferCreate alone — scoring/analysis panel sections that mount once per
-//     character change (CharacterScoringSummary, BuffsAnalysisDisplay)
-//   DeferReveal alone — already-mounted content that's expensive to lay out
-//     on tab switch (CharacterGrid, ShowcaseBuildAnalysis)
-//   Both — tab sections that are heavy to mount AND heavy to lay out
-//     (OptimizerGrid, teammate cards, stat simulation)
-// ---------------------------------------------------------------------------
+// DeferCreate defers React mount via a rAF queue. Children don't exist until
+// their ticket is revealed by the provider's rAF loop. Requires DeferCreateProvider.
 
 // ---------------------------------------------------------------------------
 // Queue store (external, not React state — avoids parent re-renders)
@@ -281,52 +258,3 @@ export function DeferCreate({
   return visible ? children : fallback
 }
 
-/**
- * Marks a section for imperative progressive **reveal** on tab switches.
- * Children are always mounted. On each tab activation, an imperative rAF loop
- * hides all `[data-defer-reveal]` elements then shows them one per frame —
- * spreading browser layout work across frames without any React re-renders.
- *
- * This is a plain wrapper div — no React state, no queue integration.
- */
-export function DeferReveal({ children }: { children: ReactNode }) {
-  return <div data-defer-reveal>{children}</div>
-}
-
-/**
- * Hook that pairs with `<DeferReveal>`. Returns a ref to attach to the
- * container element. On every tab activation, all `[data-defer-reveal]`
- * descendants are hidden, then shown one per rAF frame.
- *
- * **Important:** Only one `useDeferReveal` should be an ancestor of any given
- * `<DeferReveal>` element. The selector finds ALL descendants at all depths,
- * so nested `useDeferReveal` hooks would race to toggle the same elements.
- */
-export function useDeferReveal() {
-  const { addActivationListener } = useContext(TabVisibilityContext)
-  const containerRef = useRef<HTMLDivElement>(null)
-
-  useEffect(() => {
-    let firstActivation = true
-
-    const unsub = addActivationListener(() => {
-      // First activation: content was in display:none during stagger mount and
-      // was never visible. Progressive reveal would just add extra layout passes
-      // (hide then re-show) with no benefit. Skip it.
-      //
-      // Subsequent activations: content was ALREADY visible before the tab switch.
-      // The hide-then-show cycle causes a visible flash (content → blank → content).
-      // Since the content is already rendered, progressive reveal provides no benefit
-      // and actively harms UX. Skip it entirely.
-      if (firstActivation) {
-        firstActivation = false
-      }
-      // Progressive reveal disabled - content stays visible without hide/show cycle
-    })
-    return () => {
-      unsub()
-    }
-  }, [addActivationListener])
-
-  return containerRef
-}

--- a/src/lib/ui/MultiSelectPills.tsx
+++ b/src/lib/ui/MultiSelectPills.tsx
@@ -10,6 +10,7 @@ import {
   type PillsInputProps,
   useCombobox,
 } from '@mantine/core'
+import { ellipsisTextStyle } from 'lib/constants/constantsUi'
 import {
   type CSSProperties,
   type ReactNode,
@@ -24,7 +25,6 @@ type DataItem = SimpleOption | GroupedOption
 
 const compactPillStyle = { '--pill-height': '20px' } as CSSProperties
 const ellipsisOptionStyle: CSSProperties = { overflow: 'hidden' }
-const ellipsisTextStyle: CSSProperties = { overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }
 
 function isGrouped(item: DataItem): item is GroupedOption {
   return 'group' in item

--- a/src/lib/ui/SearchableCombobox.tsx
+++ b/src/lib/ui/SearchableCombobox.tsx
@@ -95,6 +95,7 @@ export function SearchableCombobox(props: {
           rightSectionPointerEvents={clearable && value ? 'all' : 'none'}
           onClick={() => combobox.toggleDropdown()}
           style={style}
+          styles={{ input: { overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' } }}
         >
           {selected?.label || <Input.Placeholder>{placeholder}</Input.Placeholder>}
         </InputBase>

--- a/src/lib/ui/SearchableCombobox.tsx
+++ b/src/lib/ui/SearchableCombobox.tsx
@@ -7,12 +7,15 @@ import {
   InputBase,
   useCombobox,
 } from '@mantine/core'
+import { ellipsisTextStyle } from 'lib/constants/constantsUi'
 import {
   type ReactNode,
   useMemo,
   useState,
 } from 'react'
 import iconClasses from 'style/icons.module.css'
+
+const inputEllipsisStyles = { input: ellipsisTextStyle }
 
 export type SearchableComboboxOption = {
   value: string,
@@ -95,7 +98,7 @@ export function SearchableCombobox(props: {
           rightSectionPointerEvents={clearable && value ? 'all' : 'none'}
           onClick={() => combobox.toggleDropdown()}
           style={style}
-          styles={{ input: { overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' } }}
+          styles={inputEllipsisStyles}
         >
           {selected?.label || <Input.Placeholder>{placeholder}</Input.Placeholder>}
         </InputBase>


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

- Fix Mantine NumberInput state reset by adding blur-committed input hook
- Fix optimizer results not sorting on completion
- Fix scoring upgrades sorting by combo damage instead of percentage
- Add touch support for character grid drag on mobile
- Add backgroundCenterOffset for Saber, The Herta, Castorice, Cipher, Hyacine
- Update showcaseColor for Topaz, Huohuo, The Dahlia, The Herta, Yaoguang
- Update standard showcase color to #647bb0
- Show 2-piece combos in relic/ornament filter pills with remove buttons
- Remove DeferReveal component in favor of simpler DeferCreate usage
- Add responsive hero title sizing on home tab for narrow screens
- Consolidate separator color and layout constants to constantsUi
- Tune color pipeline lightness/brightness values for custom portraits

## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [ ] I have added commit messages that are descriptive and meaningful.
- [ ] I have tested the changes locally.
- [ ] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
