### PR TITLE
fix: resolve relic roll grader overcounting bug

### DIFF
--- a/src/lib/relics/relicRollGrader.ts
+++ b/src/lib/relics/relicRollGrader.ts
@@ -13,37 +13,37 @@ interface IncrementOptions {
   low: number
 }
 
-// TODO: We are currently not using the actual roll values, for we just care about the roll count
-// Revisit once we do care about roll values and clean up the overcount logic
-export const RelicRollGrader = {
-  calculateIncrementCounts(currentStat: number, incrementOptions: IncrementOptions): StatRolls | null {
-    let closestSum: number = Infinity
-    let closestCounts: StatRolls | null = null
+function generateDistributions(budget: number, buckets: number): number[][] {
+  if (buckets === 1) return [[budget]]
+  const dists: number[][] = []
+  for (let i = 0; i <= Math.min(5, budget); i++) {
+    const subDists = generateDistributions(budget - i, buckets - 1)
+    for (const subDist of subDists) {
+      dists.push([i, ...subDist])
+    }
+  }
+  return dists
+}
 
-    // TODO: There is a bug in this where it potentially overcounts the number of rolls when ambiguous.
-    // Needs the context of how many rolls are possible in the other stats to not overcount.
-    // We currently band-aid this by deducting 1 roll from the highest stat if overcounted.
-    function search(sum: number, counts: StatRolls, index: number): void {
-      if (index === Object.keys(incrementOptions).length) {
-        if (Math.abs(sum - currentStat) < Math.abs(closestSum - currentStat)) {
-          closestSum = sum
-          closestCounts = { ...counts }
-        }
-        return
-      }
+function findBestRollSplit(targetValue: number, totalRolls: number, incrementOptions: IncrementOptions): { rolls: StatRolls, error: number } {
+  let minError = Infinity
+  let bestRolls: StatRolls = { high: 0, mid: 0, low: 0 }
 
-      const increment: keyof IncrementOptions = Object.keys(incrementOptions)[index] as keyof IncrementOptions
-      for (let i = 0; sum + i * incrementOptions[increment] <= currentStat + 0.01; i++) {
-        counts[increment] = i
-        search(sum + i * incrementOptions[increment], counts, index + 1)
+  for (let high = 0; high <= totalRolls; high++) {
+    for (let mid = 0; mid <= totalRolls - high; mid++) {
+      const low = totalRolls - high - mid
+      const val = high * incrementOptions.high + mid * incrementOptions.mid + low * incrementOptions.low
+      const error = Math.abs(val - targetValue)
+      if (error < minError) {
+        minError = error
+        bestRolls = { high, mid, low }
       }
     }
+  }
+  return { rolls: bestRolls, error: minError }
+}
 
-    search(0, { high: 0, mid: 0, low: 0 }, 0)
-
-    return closestCounts
-  },
-
+export const RelicRollGrader = {
   calculateRelicSubstatRolls(relic: UnaugmentedRelic) {
     // Skip non 5 star relics for simplicity
     if (relic.grade < 5) {
@@ -55,6 +55,11 @@ export const RelicRollGrader = {
       return
     }
 
+    if (relic.substats.length === 0) {
+      calculateInitialRolls(relic)
+      return
+    }
+
     // Verified relics *should* have their rolls correct - validate that the roll counts match the stat value before continuing
     if (relic.verified && !relic.substats.some((substat) => substat.rolls == null)) {
       calculateInitialRolls(relic)
@@ -63,29 +68,44 @@ export const RelicRollGrader = {
       }
     }
 
-    let totalAddedRolls = 0
-    relic.substats.forEach((substat) => {
-      const incrementOptions = SubStatValues[substat.stat][relic.grade as 5 | 4 | 3 | 2]
-      const incrementCounts = this.calculateIncrementCounts(substat.value, incrementOptions)
+    const maxAddedRolls = Math.floor(relic.enhance / 3)
+    const numSubstats = relic.substats.length
+    
+    let bestDistError = Infinity
+    let bestDistResults: { addedRolls: number, rolls: StatRolls }[] | null = null
 
-      if (incrementCounts) {
-        // substat.rolls = incrementCounts
-        // Band-aid for invalid relics, clamp roll values to [0, 5]
-        substat.addedRolls = Math.min(5, Math.max(0, incrementCounts.high + incrementCounts.mid + incrementCounts.low - 1))
-        substat.rolls = incrementCounts
-        totalAddedRolls += substat.addedRolls
+    for (let budget = 0; budget <= maxAddedRolls; budget++) {
+      const distributions = generateDistributions(budget, numSubstats)
+      
+      for (const dist of distributions) {
+        let distError = 0
+        const distResults: { addedRolls: number, rolls: StatRolls }[] = []
+        
+        for (let i = 0; i < numSubstats; i++) {
+          const substat = relic.substats[i]
+          const incrementOptions = SubStatValues[substat.stat][relic.grade as 5 | 4 | 3 | 2]
+          const addedRolls = dist[i]
+          const totalRolls = addedRolls + 1
+          
+          const bestSplit = findBestRollSplit(substat.value, totalRolls, incrementOptions)
+          distError += bestSplit.error
+          distResults.push({ addedRolls, rolls: bestSplit.rolls })
+        }
+        
+        if (distError < bestDistError) {
+          bestDistError = distError
+          bestDistResults = distResults
+        }
       }
-    })
-
-    // Band-aid for overcounted rolls
-    if (totalAddedRolls > Math.floor(relic.enhance / 3)) {
-      const highestRolledSubstat = relic.substats.reduce(
-        // @ts-expect-error - addedRolls potentially undefined per the type
-        (max, substat) => max.addedRolls > substat.addedRolls ? max : substat,
-      )
-      // @ts-expect-error - addedRolls potentially undefined per the type
-      highestRolledSubstat.addedRolls -= 1
     }
+
+    if (bestDistResults) {
+      for (let i = 0; i < numSubstats; i++) {
+        relic.substats[i].addedRolls = bestDistResults[i].addedRolls
+        relic.substats[i].rolls = bestDistResults[i].rolls
+      }
+    }
+
     calculateInitialRolls(relic)
   },
 }

--- a/src/lib/relics/tests/relicRollGrader.test.ts
+++ b/src/lib/relics/tests/relicRollGrader.test.ts
@@ -136,6 +136,5 @@ test('Test when the value is not an exact addition from constants', () => {
     weightScore: 0,
   }
   RelicRollGrader.calculateRelicSubstatRolls(relic)
-  // this is the outcome because it only calculates to the closest value
-  expect(relic.substats[0].addedRolls).toEqual(1)
+  expect(relic.substats[0].addedRolls).toEqual(2)
 })


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

- **Fixed**: bug where the relic roll grader would overcount substat rolls due to independent greedy calculations and floating-point ambiguity.
- **Changed**: Fixed the overcounting bug by calculating rolls globally based on the relic's level, ensuring the math always adds up correctly across all stats
- **Added**: Updated `relicRollGrader.test.ts` to verify the new algorithm correctly identifies the nearest roll count for non-exact values.

## Related Issue

- N/a, refactors the overcounting logic mentioned in the `RelicRollGrader` TODOs.

## Checklist

- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots

<!-- N/A: This is a backend logic change for roll grading accuracy. -->
none