### PR TITLE
fix: harden relic roll grader tie behavior and memoize split search

### DIFF
--- a/src/lib/relics/relicRollGrader.ts
+++ b/src/lib/relics/relicRollGrader.ts
@@ -70,28 +70,41 @@ export const RelicRollGrader = {
 
     const maxAddedRolls = Math.floor(relic.enhance / 3)
     const numSubstats = relic.substats.length
-    
+
+    // Precompute best split per (substatIndex, totalRolls). distError is additive over
+    // substats and only totalRolls varies across distributions, so the same (i, totalRolls)
+    // pair gets computed many times otherwise.
+    const splitCache: { rolls: StatRolls, error: number }[][] = []
+    for (let i = 0; i < numSubstats; i++) {
+      const substat = relic.substats[i]
+      const incrementOptions = SubStatValues[substat.stat][relic.grade as 5 | 4 | 3 | 2]
+      splitCache[i] = []
+      for (let totalRolls = 1; totalRolls <= maxAddedRolls + 1; totalRolls++) {
+        splitCache[i][totalRolls] = findBestRollSplit(substat.value, totalRolls, incrementOptions)
+      }
+    }
+
     let bestDistError = Infinity
     let bestDistResults: { addedRolls: number, rolls: StatRolls }[] | null = null
 
-    for (let budget = 0; budget <= maxAddedRolls; budget++) {
+    // Descending so that on error ties the higher budget wins — matches the +15
+    // invariant that a well-formed relic has floor(enhance/3) added rolls total.
+    for (let budget = maxAddedRolls; budget >= 0; budget--) {
       const distributions = generateDistributions(budget, numSubstats)
-      
+
       for (const dist of distributions) {
         let distError = 0
         const distResults: { addedRolls: number, rolls: StatRolls }[] = []
-        
+
         for (let i = 0; i < numSubstats; i++) {
-          const substat = relic.substats[i]
-          const incrementOptions = SubStatValues[substat.stat][relic.grade as 5 | 4 | 3 | 2]
           const addedRolls = dist[i]
-          const totalRolls = addedRolls + 1
-          
-          const bestSplit = findBestRollSplit(substat.value, totalRolls, incrementOptions)
+          const bestSplit = splitCache[i][addedRolls + 1]
           distError += bestSplit.error
           distResults.push({ addedRolls, rolls: bestSplit.rolls })
         }
-        
+
+        // Round to neutralize fp noise so strict < produces deterministic ties.
+        distError = precisionRound(distError)
         if (distError < bestDistError) {
           bestDistError = distError
           bestDistResults = distResults

--- a/src/lib/relics/relicRollGrader.ts
+++ b/src/lib/relics/relicRollGrader.ts
@@ -71,9 +71,7 @@ export const RelicRollGrader = {
     const maxAddedRolls = Math.floor(relic.enhance / 3)
     const numSubstats = relic.substats.length
 
-    // Precompute best split per (substatIndex, totalRolls). distError is additive over
-    // substats and only totalRolls varies across distributions, so the same (i, totalRolls)
-    // pair gets computed many times otherwise.
+    // Memoized; many distributions query the same (i, totalRolls).
     const splitCache: { rolls: StatRolls, error: number }[][] = []
     for (let i = 0; i < numSubstats; i++) {
       const substat = relic.substats[i]
@@ -87,8 +85,8 @@ export const RelicRollGrader = {
     let bestDistError = Infinity
     let bestDistResults: { addedRolls: number, rolls: StatRolls }[] | null = null
 
-    // Descending so that on error ties the higher budget wins — matches the +15
-    // invariant that a well-formed relic has floor(enhance/3) added rolls total.
+    // Descending so ties favor the higher budget — well-formed relics always have
+    // floor(enhance/3) added rolls.
     for (let budget = maxAddedRolls; budget >= 0; budget--) {
       const distributions = generateDistributions(budget, numSubstats)
 
@@ -103,7 +101,7 @@ export const RelicRollGrader = {
           distResults.push({ addedRolls, rolls: bestSplit.rolls })
         }
 
-        // Round to neutralize fp noise so strict < produces deterministic ties.
+        // Without rounding, fp noise breaks tie resolution under strict <.
         distError = precisionRound(distError)
         if (distError < bestDistError) {
           bestDistError = distError

--- a/src/lib/relics/tests/relicRollGrader.test.ts
+++ b/src/lib/relics/tests/relicRollGrader.test.ts
@@ -140,12 +140,8 @@ test('Test when the value is not an exact addition from constants', () => {
 })
 
 test('Regression: overcount bug — joint search respects enhance budget', () => {
-  // All four substat values independently best-fit a 3-roll (addedRolls=2) interpretation.
-  // Old per-substat greedy: ATK%=(0,1,2), HP%=(0,0,3), CD=(0,0,3), CR=(0,0,3) → sum=8
-  // addedRolls on a +15 relic whose budget is floor(15/3)=5. The old band-aid deducted 1
-  // from the highest-rolled substat → sum=7, still over budget by 2.
-  // New joint search must never exceed the budget.
-  const character = '1205'
+  // Each value isolates to addedRolls=2 (sum=8) on a +15 relic whose budget is 5;
+  // the old band-aid only shaved 1 off the top, leaving sum=7.
   const relic: Relic = {
     enhance: 15,
     grade: 5,
@@ -167,7 +163,7 @@ test('Regression: overcount bug — joint search respects enhance budget', () =>
     previewSubstats: [],
     weightScore: 0,
     id: 'dc5ff7ac-f38b-4404-b261-9fdbb1db9173',
-    equippedBy: character,
+    equippedBy: '1205',
   }
 
   RelicRollGrader.calculateRelicSubstatRolls(relic)
@@ -190,11 +186,8 @@ test('Regression: overcount bug — joint search respects enhance budget', () =>
 })
 
 test('Tiebreaker: equal-error budgets favor higher addedRolls', () => {
-  // HP% value 5.616 is equidistant between 1 roll (1*high=4.32, error 1.296) and
-  // 2 rolls (2*low=6.912, error 1.296). Descending budget + strict < in the outer
-  // loop means the higher-budget fit wins — aligns with the +15 invariant that a
-  // well-formed relic has floor(enhance/3) added rolls total.
-  const character = '1205'
+  // 5.616 is equidistant from 1h=4.32 and 2l=6.912 (err 1.296 each);
+  // descending should pick the higher-budget fit.
   const relic: Relic = {
     enhance: 15,
     grade: 5,
@@ -213,7 +206,7 @@ test('Tiebreaker: equal-error budgets favor higher addedRolls', () => {
     previewSubstats: [],
     weightScore: 0,
     id: 'dc5ff7ac-f38b-4404-b261-9fdbb1db9173',
-    equippedBy: character,
+    equippedBy: '1205',
   }
   RelicRollGrader.calculateRelicSubstatRolls(relic)
   expect(relic.substats[0].addedRolls).toEqual(1)

--- a/src/lib/relics/tests/relicRollGrader.test.ts
+++ b/src/lib/relics/tests/relicRollGrader.test.ts
@@ -138,3 +138,84 @@ test('Test when the value is not an exact addition from constants', () => {
   RelicRollGrader.calculateRelicSubstatRolls(relic)
   expect(relic.substats[0].addedRolls).toEqual(2)
 })
+
+test('Regression: overcount bug — joint search respects enhance budget', () => {
+  // All four substat values independently best-fit a 3-roll (addedRolls=2) interpretation.
+  // Old per-substat greedy: ATK%=(0,1,2), HP%=(0,0,3), CD=(0,0,3), CR=(0,0,3) → sum=8
+  // addedRolls on a +15 relic whose budget is floor(15/3)=5. The old band-aid deducted 1
+  // from the highest-rolled substat → sum=7, still over budget by 2.
+  // New joint search must never exceed the budget.
+  const character = '1205'
+  const relic: Relic = {
+    enhance: 15,
+    grade: 5,
+    part: 'LinkRope',
+    set: 'Talia: Kingdom of Banditry',
+    main: {
+      stat: Constants.Stats.HP_P,
+      value: 100,
+    },
+    ageIndex: 0,
+    initialRolls: 0,
+    augmentedStats: {} as AugmentedStats,
+    substats: [
+      { stat: 'ATK%', value: 10.8, rolls: { high: 0, mid: 0, low: 0 } },
+      { stat: 'HP%', value: 10.368, rolls: { high: 0, mid: 0, low: 0 } },
+      { stat: 'CRIT DMG', value: 15.552, rolls: { high: 0, mid: 0, low: 0 } },
+      { stat: 'CRIT Rate', value: 7.776, rolls: { high: 0, mid: 0, low: 0 } },
+    ],
+    previewSubstats: [],
+    weightScore: 0,
+    id: 'dc5ff7ac-f38b-4404-b261-9fdbb1db9173',
+    equippedBy: character,
+  }
+
+  RelicRollGrader.calculateRelicSubstatRolls(relic)
+
+  const sumAddedRolls = relic.substats.reduce((acc, s) => acc + (s.addedRolls ?? 0), 0)
+  expect(sumAddedRolls).toBeLessThanOrEqual(Math.floor(relic.enhance / 3))
+  expect(sumAddedRolls).toEqual(5)
+
+  expect(relic.substats[0].addedRolls).toEqual(1)
+  expect(relic.substats[1].addedRolls).toEqual(1)
+  expect(relic.substats[2].addedRolls).toEqual(2)
+  expect(relic.substats[3].addedRolls).toEqual(1)
+
+  expect(relic.substats[0].rolls).toEqual({ high: 2, mid: 0, low: 0 })
+  expect(relic.substats[1].rolls).toEqual({ high: 2, mid: 0, low: 0 })
+  expect(relic.substats[2].rolls).toEqual({ high: 0, mid: 0, low: 3 })
+  expect(relic.substats[3].rolls).toEqual({ high: 2, mid: 0, low: 0 })
+
+  expect(relic.initialRolls).toEqual(4)
+})
+
+test('Tiebreaker: equal-error budgets favor higher addedRolls', () => {
+  // HP% value 5.616 is equidistant between 1 roll (1*high=4.32, error 1.296) and
+  // 2 rolls (2*low=6.912, error 1.296). Descending budget + strict < in the outer
+  // loop means the higher-budget fit wins — aligns with the +15 invariant that a
+  // well-formed relic has floor(enhance/3) added rolls total.
+  const character = '1205'
+  const relic: Relic = {
+    enhance: 15,
+    grade: 5,
+    part: 'LinkRope',
+    set: 'Talia: Kingdom of Banditry',
+    main: {
+      stat: Constants.Stats.HP_P,
+      value: 100,
+    },
+    ageIndex: 0,
+    initialRolls: 0,
+    augmentedStats: {} as AugmentedStats,
+    substats: [
+      { stat: 'HP%', value: 5.616, rolls: { high: 0, mid: 0, low: 0 } },
+    ],
+    previewSubstats: [],
+    weightScore: 0,
+    id: 'dc5ff7ac-f38b-4404-b261-9fdbb1db9173',
+    equippedBy: character,
+  }
+  RelicRollGrader.calculateRelicSubstatRolls(relic)
+  expect(relic.substats[0].addedRolls).toEqual(1)
+  expect(relic.substats[0].rolls).toEqual({ high: 0, mid: 0, low: 2 })
+})


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

-

## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [ ] I have added commit messages that are descriptive and meaningful.
- [ ] I have tested the changes locally.
- [ ] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
