### PR TITLE
feat: restore extra combat buffs

### DIFF
--- a/public/locales/en_US/optimizerTab.yaml
+++ b/public/locales/en_US/optimizerTab.yaml
@@ -511,6 +511,7 @@ CombatBuffs:
   BREAK_EFFICIENCY: Break Efficiency %
   EHR: Effect Hit Rate %
   Title: Extra combat buffs
+  Clear: Clear
 Target_one: target
 Target_other: targets
 EnemyConfiguration:

--- a/public/locales/en_US/optimizerTab.yaml
+++ b/public/locales/en_US/optimizerTab.yaml
@@ -509,7 +509,6 @@ CombatBuffs:
   EFFECT_RES_PEN: Effect RES PEN %
   VULNERABILITY: Vulnerability %
   BREAK_EFFICIENCY: Break Efficiency %
-  FINAL_DMG_BOOST: Final DMG %
   EHR: Effect Hit Rate %
   Title: Extra combat buffs
 Target_one: target

--- a/public/locales/en_US/optimizerTab.yaml
+++ b/public/locales/en_US/optimizerTab.yaml
@@ -509,6 +509,8 @@ CombatBuffs:
   EFFECT_RES_PEN: Effect RES PEN %
   VULNERABILITY: Vulnerability %
   BREAK_EFFICIENCY: Break Efficiency %
+  FINAL_DMG_BOOST: Final DMG %
+  EHR: Effect Hit Rate %
   Title: Extra combat buffs
 Target_one: target
 Target_other: targets

--- a/src/lib/constants/constants.ts
+++ b/src/lib/constants/constants.ts
@@ -618,6 +618,16 @@ export const CombatBuffs = {
     key: 'BREAK_EFFICIENCY',
     percent: true,
   },
+  FINAL_DMG_BOOST: {
+    title: 'Final DMG %',
+    key: 'FINAL_DMG_BOOST',
+    percent: true,
+  },
+  EHR: {
+    title: 'Effect Hit Rate %',
+    key: 'EHR',
+    percent: true,
+  },
 } as const
 
 export const ABILITY_LIMIT = 12

--- a/src/lib/constants/constants.ts
+++ b/src/lib/constants/constants.ts
@@ -588,6 +588,11 @@ export const CombatBuffs = {
     key: 'BE',
     percent: true,
   },
+  EHR: {
+    title: 'Effect Hit Rate %',
+    key: 'EHR',
+    percent: true,
+  },
   DMG_BOOST: {
     title: 'Dmg Boost %',
     key: 'DMG_BOOST',
@@ -616,16 +621,6 @@ export const CombatBuffs = {
   BREAK_EFFICIENCY: {
     title: 'Break Efficiency %',
     key: 'BREAK_EFFICIENCY',
-    percent: true,
-  },
-  FINAL_DMG_BOOST: {
-    title: 'Final DMG %',
-    key: 'FINAL_DMG_BOOST',
-    percent: true,
-  },
-  EHR: {
-    title: 'Effect Hit Rate %',
-    key: 'EHR',
     percent: true,
   },
 } as const

--- a/src/lib/gpu/injection/injectSettings.ts
+++ b/src/lib/gpu/injection/injectSettings.ts
@@ -1,5 +1,4 @@
 import {
-  CombatBuffs,
   Constants,
   Stats,
 } from 'lib/constants/constants'
@@ -65,28 +64,17 @@ function generateRequest(request: Form) {
   wgsl += `const enemyWeaknessBroken: i32 = ${request.enemyWeaknessBroken ? 1 : 0};\n`
   wgsl += '\n'
 
-  // TODO: Refactor this to not duplicate res
-  // TODO: TEMPORARILY DISABLED - Extra combat buffs zeroed out (RES_PEN removed from resistance calc)
-  wgsl += `const enemyDamageResistance: f32 = ${(request.enemyElementalWeak ? 0 : request.enemyResistance) /* - request.combatBuffs.RES_PEN */};\n`
+  wgsl += `const enemyDamageResistance: f32 = ${request.enemyElementalWeak ? 0 : request.enemyResistance};\n`
   wgsl += '\n'
 
   // Filters
   for (const [key, value] of Object.entries(request)) {
     if ((key.startsWith('min') || key.startsWith('max'))) {
-      // Guard against undefined/NaN from missing form fields — emit 0 for min, MAX_INT for max.
       const n = Number(value)
       const isMin = key.startsWith('min')
       const safe = Number.isFinite(n) ? n : (isMin ? 0 : Constants.MAX_INT)
       wgsl += `const ${key}: f32 = ${safe};\n`
     }
-  }
-  wgsl += '\n'
-
-  // Buffs
-  // TODO: TEMPORARILY DISABLED - Extra combat buffs zeroed out
-  // Iterate over all known CombatBuffs keys (not request.combatBuffs which may be empty)
-  for (const buff of Object.values(CombatBuffs)) {
-    wgsl += `const combatBuffs${buff.key}: f32 = 0;\n`
   }
   wgsl += '\n'
 

--- a/src/lib/gpu/wgsl/computeShader.wgsl
+++ b/src/lib/gpu/wgsl/computeShader.wgsl
@@ -178,15 +178,15 @@ fn main(
     // ═════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝
     // END BASIC STAT FILTERS
 
-    let diffATK = c.ATK + combatBuffsATK + combatBuffsATK_P * baseATK;
-    let diffDEF = c.DEF + combatBuffsDEF + combatBuffsDEF_P * baseDEF;
-    let diffHP = c.HP   + combatBuffsHP  + combatBuffsHP_P  * baseHP;
-    let diffSPD = c.SPD + combatBuffsSPD + combatBuffsSPD_P * baseSPD;
-    let diffCD = c.CD   + combatBuffsCD;
-    let diffCR = c.CR   + combatBuffsCR;
+    let diffATK = c.ATK;
+    let diffDEF = c.DEF;
+    let diffHP = c.HP;
+    let diffSPD = c.SPD;
+    let diffCD = c.CD;
+    let diffCR = c.CR;
     let diffEHR = c.EHR;
     let diffRES = c.RES;
-    let diffBE = c.BE   + combatBuffsBE;
+    let diffBE = c.BE;
     let diffERR = c.ERR;
     let diffOHB = c.OHB;
 

--- a/src/lib/optimization/buffSource.ts
+++ b/src/lib/optimization/buffSource.ts
@@ -44,7 +44,14 @@ const setsSourceExpansion = Object.fromEntries(
   ]),
 ) as Record<SetKey, SetsBuffSource>
 
-export type BuffSource = CharacterBuffSource | SetsBuffSource | LightConeBuffSource | NoneBuffSource | CyreneSpecialBuffSource
+export type BuffSource = CharacterBuffSource | SetsBuffSource | LightConeBuffSource | NoneBuffSource | CyreneSpecialBuffSource | ExtraCombatBuffSource
+
+type ExtraCombatBuffSource = {
+  id: 'EXTRA_COMBAT_BUFFS',
+  label: 'EXTRA_COMBAT_BUFFS',
+  ability: BUFF_ABILITY.NONE,
+  buffType: BUFF_TYPE.COMBAT_STATS,
+}
 
 type CharacterBuffSource = {
   id: CharacterId,
@@ -127,5 +134,6 @@ export const Source = {
     }
   },
   NONE: { id: 'NONE', label: 'NONE', buffType: BUFF_TYPE.NONE, ability: BUFF_ABILITY.NONE } as NoneBuffSource,
+  EXTRA_COMBAT_BUFFS: { id: 'EXTRA_COMBAT_BUFFS', label: 'EXTRA_COMBAT_BUFFS', buffType: BUFF_TYPE.COMBAT_STATS, ability: BUFF_ABILITY.NONE } as ExtraCombatBuffSource,
   ...setsSourceExpansion,
 }

--- a/src/lib/optimization/calculateStats.ts
+++ b/src/lib/optimization/calculateStats.ts
@@ -150,7 +150,6 @@ export function calculateComputedStats(x: ComputedStatsContainer, action: Optimi
 
   transferBaseStats(x, a, c, context)
   calculateMemospriteBaseStats(x, a, c, context)
-  applyCombatBuffs(x, context)
   executeNonDynamicCombatSets(x, context, setConditionals, sets, setsArray)
   applyPercentStats(x, a, context)
   evaluateDynamicSetConditionals(x, sets, setsArray, action, context)
@@ -161,18 +160,16 @@ export function calculateComputedStats(x: ComputedStatsContainer, action: Optimi
 }
 
 function transferBaseStats(x: ComputedStatsContainer, a: Float32Array, c: BasicStatsArray, context: OptimizerContext) {
-  const buffs = context.combatBuffs
   const ca = c.a
   const offsets = x.config.entityBaseOffsets[TargetTag.SelfAndPet]
 
-  // Precompute values once, then write to all matched entities
-  const vATK = ca[StatKey.ATK] + buffs.ATK + buffs.ATK_P * context.baseATK
-  const vDEF = ca[StatKey.DEF] + buffs.DEF + buffs.DEF_P * context.baseDEF
-  const vHP = ca[StatKey.HP] + buffs.HP + buffs.HP_P * context.baseHP
-  const vSPD = ca[StatKey.SPD] + buffs.SPD + buffs.SPD_P * context.baseSPD
-  const vCD = ca[StatKey.CD] + buffs.CD
-  const vCR = ca[StatKey.CR] + buffs.CR
-  const vBE = ca[StatKey.BE] + buffs.BE
+  const vATK = ca[StatKey.ATK]
+  const vDEF = ca[StatKey.DEF]
+  const vHP = ca[StatKey.HP]
+  const vSPD = ca[StatKey.SPD]
+  const vCD = ca[StatKey.CD]
+  const vCR = ca[StatKey.CR]
+  const vBE = ca[StatKey.BE]
 
   for (let i = 0; i < offsets.length; i++) {
     const o = offsets[i]
@@ -231,20 +228,6 @@ function calculateMemospriteBaseStats(x: ComputedStatsContainer, a: Float32Array
     a[x.getActionIndex(entityIndex, StatKey.QUANTUM_DMG_BOOST)] += c.a[BasicKey.QUANTUM_DMG_BOOST]
     a[x.getActionIndex(entityIndex, StatKey.IMAGINARY_DMG_BOOST)] += c.a[BasicKey.IMAGINARY_DMG_BOOST]
     a[x.getActionIndex(entityIndex, StatKey.ELATION)] += c.a[BasicKey.ELATION]
-  }
-}
-
-function applyCombatBuffs(x: ComputedStatsContainer, context: OptimizerContext) {
-  const buffs = context.combatBuffs
-  const a = x.a
-  const offsets = x.config.entityBaseOffsets[TargetTag.FullTeam]
-
-  for (let i = 0; i < offsets.length; i++) {
-    const o = offsets[i]
-    a[o + StatKey.DMG_BOOST] += buffs.DMG_BOOST
-    a[o + StatKey.EFFECT_RES_PEN] += buffs.EFFECT_RES_PEN
-    a[o + StatKey.VULNERABILITY] += buffs.VULNERABILITY
-    a[o + StatKey.BREAK_EFFICIENCY_BOOST] += buffs.BREAK_EFFICIENCY
   }
 }
 

--- a/src/lib/optimization/context/calculateContext.ts
+++ b/src/lib/optimization/context/calculateContext.ts
@@ -27,7 +27,6 @@ export function generateContext(request: Form): OptimizerContext {
   generateEnemyContext(request, context)
   generateBaseStatsContext(request, context)
   generateCharacterMetadataContext(request, context)
-  generateCombatBuffsContext(request, context)
   generateFiltersContext(request, context)
 
   // calculateEntities(request, context)
@@ -38,28 +37,6 @@ export function generateContext(request: Form): OptimizerContext {
   return context
 }
 
-function generateCombatBuffsContext(request: Form, context: OptimizerContext) {
-  // TODO: TEMPORARILY DISABLED - Extra combat buffs zeroed out
-  context.combatBuffs = {
-    ATK: 0, // request.combatBuffs.ATK,
-    ATK_P: 0, // request.combatBuffs.ATK_P,
-    HP: 0, // request.combatBuffs.HP,
-    HP_P: 0, // request.combatBuffs.HP_P,
-    DEF: 0, // request.combatBuffs.DEF,
-    DEF_P: 0, // request.combatBuffs.DEF_P,
-    CR: 0, // request.combatBuffs.CR,
-    CD: 0, // request.combatBuffs.CD,
-    SPD: 0, // request.combatBuffs.SPD,
-    SPD_P: 0, // request.combatBuffs.SPD_P,
-    BE: 0, // request.combatBuffs.BE,
-    DMG_BOOST: 0, // request.combatBuffs.DMG_BOOST,
-    DEF_PEN: 0, // request.combatBuffs.DEF_PEN,
-    RES_PEN: 0, // request.combatBuffs.RES_PEN,
-    EFFECT_RES_PEN: 0, // request.combatBuffs.EFFECT_RES_PEN,
-    VULNERABILITY: 0, // request.combatBuffs.VULNERABILITY,
-    BREAK_EFFICIENCY: 0, // request.combatBuffs.BREAK_EFFICIENCY,
-  }
-}
 
 function generateFiltersContext(request: Form, context: OptimizerContext) {
   context.resultSort = request.resultSort!

--- a/src/lib/optimization/engine/damage/damageCalculator.ts
+++ b/src/lib/optimization/engine/damage/damageCalculator.ts
@@ -161,8 +161,8 @@ export const CritDamageFunction: DamageFunction = {
 {
   // Common multipliers
   let baseUniversalMulti = ${action.config.enemyWeaknessBroken ? '1.0' : '0.9'};
-  let defMulti = 100.0 / ((f32(enemyLevel) + 20.0) * max(0.0, 1.0 -${getValue(StatKey.DEF_PEN)}) + 100.0);
-  let resMulti = 1.0 - (enemyDamageResistance -${getValue(StatKey.RES_PEN)});
+  let defMulti = 100.0 / ((f32(enemyLevel) + 20.0) * max(0.0, 1.0 - ${getValue(StatKey.DEF_PEN)}) + 100.0);
+  let resMulti = 1.0 - (enemyDamageResistance - ${getValue(StatKey.RES_PEN)});
   let vulnMulti = 1.0 + ${getValue(StatKey.VULNERABILITY)};
   let finalDmgMulti = 1.0 + ${getValue(StatKey.FINAL_DMG_BOOST)};
 
@@ -262,8 +262,8 @@ export const DotDamageFunction: DamageFunction = {
 {
   // Common multipliers
   let baseUniversalMulti = ${action.config.enemyWeaknessBroken ? '1.0' : '0.9'};
-  let defMulti = 100.0 / ((f32(enemyLevel) + 20.0) * max(0.0, 1.0 -${getValue(StatKey.DEF_PEN)}) + 100.0);
-  let resMulti = 1.0 - (enemyDamageResistance -${getValue(StatKey.RES_PEN)});
+  let defMulti = 100.0 / ((f32(enemyLevel) + 20.0) * max(0.0, 1.0 - ${getValue(StatKey.DEF_PEN)}) + 100.0);
+  let resMulti = 1.0 - (enemyDamageResistance - ${getValue(StatKey.RES_PEN)});
   let vulnMulti = 1.0 + ${getValue(StatKey.VULNERABILITY)};
   let finalDmgMulti = 1.0 + ${getValue(StatKey.FINAL_DMG_BOOST)};
 
@@ -355,8 +355,8 @@ export const BreakDamageFunction: DamageFunction = {
 {
   // Common multipliers
   let baseUniversalMulti = ${action.config.enemyWeaknessBroken ? '1.0' : '0.9'};
-  let defMulti = 100.0 / ((f32(enemyLevel) + 20.0) * max(0.0, 1.0 -${getValue(StatKey.DEF_PEN)}) + 100.0);
-  let resMulti = 1.0 - (enemyDamageResistance -${getValue(StatKey.RES_PEN)});
+  let defMulti = 100.0 / ((f32(enemyLevel) + 20.0) * max(0.0, 1.0 - ${getValue(StatKey.DEF_PEN)}) + 100.0);
+  let resMulti = 1.0 - (enemyDamageResistance - ${getValue(StatKey.RES_PEN)});
   let vulnMulti = 1.0 + ${getValue(StatKey.VULNERABILITY)};
   let finalDmgMulti = 1.0 + ${getValue(StatKey.FINAL_DMG_BOOST)};
 
@@ -444,8 +444,8 @@ export const SuperBreakDamageFunction: DamageFunction = {
 {
   // Common multipliers
   let baseUniversalMulti = ${action.config.enemyWeaknessBroken ? '1.0' : '0.9'};
-  let defMulti = 100.0 / ((f32(enemyLevel) + 20.0) * max(0.0, 1.0 -${getValue(StatKey.DEF_PEN)}) + 100.0);
-  let resMulti = 1.0 - (enemyDamageResistance -${getValue(StatKey.RES_PEN)});
+  let defMulti = 100.0 / ((f32(enemyLevel) + 20.0) * max(0.0, 1.0 - ${getValue(StatKey.DEF_PEN)}) + 100.0);
+  let resMulti = 1.0 - (enemyDamageResistance - ${getValue(StatKey.RES_PEN)});
   let vulnMulti = 1.0 + ${getValue(StatKey.VULNERABILITY)};
   let finalDmgMulti = 1.0 + ${getValue(StatKey.FINAL_DMG_BOOST)};
 
@@ -543,8 +543,8 @@ export const AdditionalDamageFunction: DamageFunction = {
 {
   // Common multipliers
   let baseUniversalMulti = ${action.config.enemyWeaknessBroken ? '1.0' : '0.9'};
-  let defMulti = 100.0 / ((f32(enemyLevel) + 20.0) * max(0.0, 1.0 -${getValue(StatKey.DEF_PEN)}) + 100.0);
-  let resMulti = 1.0 - (enemyDamageResistance -${getValue(StatKey.RES_PEN)});
+  let defMulti = 100.0 / ((f32(enemyLevel) + 20.0) * max(0.0, 1.0 - ${getValue(StatKey.DEF_PEN)}) + 100.0);
+  let resMulti = 1.0 - (enemyDamageResistance - ${getValue(StatKey.RES_PEN)});
   let vulnMulti = 1.0 + ${getValue(StatKey.VULNERABILITY)};
   let finalDmgMulti = 1.0 + ${getValue(StatKey.FINAL_DMG_BOOST)};
 
@@ -765,8 +765,8 @@ export const HealTallyDamageFunction: DamageFunction = {
 {
   // Common multipliers
   let baseUniversalMulti = ${action.config.enemyWeaknessBroken ? '1.0' : '0.9'};
-  let defMulti = 100.0 / ((f32(enemyLevel) + 20.0) * max(0.0, 1.0 -${getValue(StatKey.DEF_PEN)}) + 100.0);
-  let resMulti = 1.0 - (enemyDamageResistance -${getValue(StatKey.RES_PEN)});
+  let defMulti = 100.0 / ((f32(enemyLevel) + 20.0) * max(0.0, 1.0 - ${getValue(StatKey.DEF_PEN)}) + 100.0);
+  let resMulti = 1.0 - (enemyDamageResistance - ${getValue(StatKey.RES_PEN)});
   let vulnMulti = 1.0 + ${getValue(StatKey.VULNERABILITY)};
   let finalDmgMulti = 1.0 + ${getValue(StatKey.FINAL_DMG_BOOST)};
 
@@ -853,8 +853,8 @@ export const ElationDamageFunction: DamageFunction = {
 {
   // Common multipliers
   let baseUniversalMulti = ${action.config.enemyWeaknessBroken ? '1.0' : '0.9'};
-  let defMulti = 100.0 / ((f32(enemyLevel) + 20.0) * max(0.0, 1.0 -${getValue(StatKey.DEF_PEN)}) + 100.0);
-  let resMulti = 1.0 - (enemyDamageResistance -${getValue(StatKey.RES_PEN)});
+  let defMulti = 100.0 / ((f32(enemyLevel) + 20.0) * max(0.0, 1.0 - ${getValue(StatKey.DEF_PEN)}) + 100.0);
+  let resMulti = 1.0 - (enemyDamageResistance - ${getValue(StatKey.RES_PEN)});
   let vulnMulti = 1.0 + ${getValue(StatKey.VULNERABILITY)};
   let finalDmgMulti = 1.0 + ${getValue(StatKey.FINAL_DMG_BOOST)};
 

--- a/src/lib/optimization/engine/damage/damageCalculator.ts
+++ b/src/lib/optimization/engine/damage/damageCalculator.ts
@@ -161,8 +161,8 @@ export const CritDamageFunction: DamageFunction = {
 {
   // Common multipliers
   let baseUniversalMulti = ${action.config.enemyWeaknessBroken ? '1.0' : '0.9'};
-  let defMulti = 100.0 / ((f32(enemyLevel) + 20.0) * max(0.0, 1.0 - combatBuffsDEF_PEN - ${getValue(StatKey.DEF_PEN)}) + 100.0);
-  let resMulti = 1.0 - (enemyDamageResistance - combatBuffsRES_PEN - ${getValue(StatKey.RES_PEN)});
+  let defMulti = 100.0 / ((f32(enemyLevel) + 20.0) * max(0.0, 1.0 -${getValue(StatKey.DEF_PEN)}) + 100.0);
+  let resMulti = 1.0 - (enemyDamageResistance -${getValue(StatKey.RES_PEN)});
   let vulnMulti = 1.0 + ${getValue(StatKey.VULNERABILITY)};
   let finalDmgMulti = 1.0 + ${getValue(StatKey.FINAL_DMG_BOOST)};
 
@@ -262,8 +262,8 @@ export const DotDamageFunction: DamageFunction = {
 {
   // Common multipliers
   let baseUniversalMulti = ${action.config.enemyWeaknessBroken ? '1.0' : '0.9'};
-  let defMulti = 100.0 / ((f32(enemyLevel) + 20.0) * max(0.0, 1.0 - combatBuffsDEF_PEN - ${getValue(StatKey.DEF_PEN)}) + 100.0);
-  let resMulti = 1.0 - (enemyDamageResistance - combatBuffsRES_PEN - ${getValue(StatKey.RES_PEN)});
+  let defMulti = 100.0 / ((f32(enemyLevel) + 20.0) * max(0.0, 1.0 -${getValue(StatKey.DEF_PEN)}) + 100.0);
+  let resMulti = 1.0 - (enemyDamageResistance -${getValue(StatKey.RES_PEN)});
   let vulnMulti = 1.0 + ${getValue(StatKey.VULNERABILITY)};
   let finalDmgMulti = 1.0 + ${getValue(StatKey.FINAL_DMG_BOOST)};
 
@@ -355,8 +355,8 @@ export const BreakDamageFunction: DamageFunction = {
 {
   // Common multipliers
   let baseUniversalMulti = ${action.config.enemyWeaknessBroken ? '1.0' : '0.9'};
-  let defMulti = 100.0 / ((f32(enemyLevel) + 20.0) * max(0.0, 1.0 - combatBuffsDEF_PEN - ${getValue(StatKey.DEF_PEN)}) + 100.0);
-  let resMulti = 1.0 - (enemyDamageResistance - combatBuffsRES_PEN - ${getValue(StatKey.RES_PEN)});
+  let defMulti = 100.0 / ((f32(enemyLevel) + 20.0) * max(0.0, 1.0 -${getValue(StatKey.DEF_PEN)}) + 100.0);
+  let resMulti = 1.0 - (enemyDamageResistance -${getValue(StatKey.RES_PEN)});
   let vulnMulti = 1.0 + ${getValue(StatKey.VULNERABILITY)};
   let finalDmgMulti = 1.0 + ${getValue(StatKey.FINAL_DMG_BOOST)};
 
@@ -444,8 +444,8 @@ export const SuperBreakDamageFunction: DamageFunction = {
 {
   // Common multipliers
   let baseUniversalMulti = ${action.config.enemyWeaknessBroken ? '1.0' : '0.9'};
-  let defMulti = 100.0 / ((f32(enemyLevel) + 20.0) * max(0.0, 1.0 - combatBuffsDEF_PEN - ${getValue(StatKey.DEF_PEN)}) + 100.0);
-  let resMulti = 1.0 - (enemyDamageResistance - combatBuffsRES_PEN - ${getValue(StatKey.RES_PEN)});
+  let defMulti = 100.0 / ((f32(enemyLevel) + 20.0) * max(0.0, 1.0 -${getValue(StatKey.DEF_PEN)}) + 100.0);
+  let resMulti = 1.0 - (enemyDamageResistance -${getValue(StatKey.RES_PEN)});
   let vulnMulti = 1.0 + ${getValue(StatKey.VULNERABILITY)};
   let finalDmgMulti = 1.0 + ${getValue(StatKey.FINAL_DMG_BOOST)};
 
@@ -543,8 +543,8 @@ export const AdditionalDamageFunction: DamageFunction = {
 {
   // Common multipliers
   let baseUniversalMulti = ${action.config.enemyWeaknessBroken ? '1.0' : '0.9'};
-  let defMulti = 100.0 / ((f32(enemyLevel) + 20.0) * max(0.0, 1.0 - combatBuffsDEF_PEN - ${getValue(StatKey.DEF_PEN)}) + 100.0);
-  let resMulti = 1.0 - (enemyDamageResistance - combatBuffsRES_PEN - ${getValue(StatKey.RES_PEN)});
+  let defMulti = 100.0 / ((f32(enemyLevel) + 20.0) * max(0.0, 1.0 -${getValue(StatKey.DEF_PEN)}) + 100.0);
+  let resMulti = 1.0 - (enemyDamageResistance -${getValue(StatKey.RES_PEN)});
   let vulnMulti = 1.0 + ${getValue(StatKey.VULNERABILITY)};
   let finalDmgMulti = 1.0 + ${getValue(StatKey.FINAL_DMG_BOOST)};
 
@@ -765,8 +765,8 @@ export const HealTallyDamageFunction: DamageFunction = {
 {
   // Common multipliers
   let baseUniversalMulti = ${action.config.enemyWeaknessBroken ? '1.0' : '0.9'};
-  let defMulti = 100.0 / ((f32(enemyLevel) + 20.0) * max(0.0, 1.0 - combatBuffsDEF_PEN - ${getValue(StatKey.DEF_PEN)}) + 100.0);
-  let resMulti = 1.0 - (enemyDamageResistance - combatBuffsRES_PEN - ${getValue(StatKey.RES_PEN)});
+  let defMulti = 100.0 / ((f32(enemyLevel) + 20.0) * max(0.0, 1.0 -${getValue(StatKey.DEF_PEN)}) + 100.0);
+  let resMulti = 1.0 - (enemyDamageResistance -${getValue(StatKey.RES_PEN)});
   let vulnMulti = 1.0 + ${getValue(StatKey.VULNERABILITY)};
   let finalDmgMulti = 1.0 + ${getValue(StatKey.FINAL_DMG_BOOST)};
 
@@ -853,8 +853,8 @@ export const ElationDamageFunction: DamageFunction = {
 {
   // Common multipliers
   let baseUniversalMulti = ${action.config.enemyWeaknessBroken ? '1.0' : '0.9'};
-  let defMulti = 100.0 / ((f32(enemyLevel) + 20.0) * max(0.0, 1.0 - combatBuffsDEF_PEN - ${getValue(StatKey.DEF_PEN)}) + 100.0);
-  let resMulti = 1.0 - (enemyDamageResistance - combatBuffsRES_PEN - ${getValue(StatKey.RES_PEN)});
+  let defMulti = 100.0 / ((f32(enemyLevel) + 20.0) * max(0.0, 1.0 -${getValue(StatKey.DEF_PEN)}) + 100.0);
+  let resMulti = 1.0 - (enemyDamageResistance -${getValue(StatKey.RES_PEN)});
   let vulnMulti = 1.0 + ${getValue(StatKey.VULNERABILITY)};
   let finalDmgMulti = 1.0 + ${getValue(StatKey.FINAL_DMG_BOOST)};
 
@@ -918,8 +918,8 @@ function computeCommonMultipliers(
   const resPen = x.getValue(StatKey.RES_PEN, hitIndex)
 
   m.baseUniversalMulti = x.config.enemyWeaknessBroken ? 1 : 0.9
-  m.defMulti = calculateDefMulti(context.enemyLevel, context.combatBuffs.DEF_PEN + defPen)
-  m.resMulti = 1 - (context.enemyDamageResistance - context.combatBuffs.RES_PEN - resPen)
+  m.defMulti = calculateDefMulti(context.enemyLevel, defPen)
+  m.resMulti = 1 - (context.enemyDamageResistance - resPen)
   m.vulnMulti = 1 + x.getValue(StatKey.VULNERABILITY, hitIndex)
   m.finalDmgMulti = 1 + x.getValue(StatKey.FINAL_DMG_BOOST, hitIndex)
 }

--- a/src/lib/optimization/rotation/actionTransform.ts
+++ b/src/lib/optimization/rotation/actionTransform.ts
@@ -19,6 +19,7 @@ import {
   precomputeConditionals,
   transformConditionals,
 } from 'lib/optimization/rotation/comboStateTransform'
+import { precomputeExtraCombatBuffs } from 'lib/optimization/rotation/precomputeExtraCombatBuffs'
 import { type TurnAbilityName } from 'lib/optimization/rotation/turnAbilityConfig'
 import { clone } from 'lib/utils/objectUtils'
 import { type CharacterConditionalsController } from 'types/conditionals'
@@ -179,6 +180,7 @@ export function newTransformStateActions(comboState: ComboState, request: Form, 
 
   for (const action of allActions) {
     precomputeConditionals(action, comboState, context)
+    precomputeExtraCombatBuffs(action.precomputedStats, request)
     calculateContextConditionalRegistry(action, context)
   }
 

--- a/src/lib/optimization/rotation/precomputeExtraCombatBuffs.ts
+++ b/src/lib/optimization/rotation/precomputeExtraCombatBuffs.ts
@@ -23,11 +23,11 @@ const COMBAT_BUFF_KEY_TO_STAT_KEY: Record<string, AKeyValue> = {
   EFFECT_RES_PEN: StatKey.EFFECT_RES_PEN,
   VULNERABILITY: StatKey.VULNERABILITY,
   BREAK_EFFICIENCY: StatKey.BREAK_EFFICIENCY_BOOST,
-  FINAL_DMG_BOOST: StatKey.FINAL_DMG_BOOST,
   EHR: StatKey.EHR,
 }
 
 const EXTRA_COMBAT_BUFF_SOURCE = Source.EXTRA_COMBAT_BUFFS
+const COMBAT_BUFFS_ENTRIES = Object.values(CombatBuffs)
 
 export function precomputeExtraCombatBuffs(x: ComputedStatsContainer, request: Form): void {
   const buffs = request.combatBuffs
@@ -35,7 +35,7 @@ export function precomputeExtraCombatBuffs(x: ComputedStatsContainer, request: F
 
   const config = x.targets(TargetTag.FullTeam).source(EXTRA_COMBAT_BUFF_SOURCE)
 
-  for (const entry of Object.values(CombatBuffs)) {
+  for (const entry of COMBAT_BUFFS_ENTRIES) {
     const value = buffs[entry.key]
     if (!value) continue
 

--- a/src/lib/optimization/rotation/precomputeExtraCombatBuffs.ts
+++ b/src/lib/optimization/rotation/precomputeExtraCombatBuffs.ts
@@ -1,0 +1,47 @@
+import { CombatBuffs } from 'lib/constants/constants'
+import { Source } from 'lib/optimization/buffSource'
+import { type AKeyValue, StatKey } from 'lib/optimization/engine/config/keys'
+import { TargetTag } from 'lib/optimization/engine/config/tag'
+import type { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
+import type { Form } from 'types/form'
+
+const COMBAT_BUFF_KEY_TO_STAT_KEY: Record<string, AKeyValue> = {
+  ATK: StatKey.ATK,
+  ATK_P: StatKey.ATK_P,
+  HP: StatKey.HP,
+  HP_P: StatKey.HP_P,
+  DEF: StatKey.DEF,
+  DEF_P: StatKey.DEF_P,
+  CR: StatKey.CR,
+  CD: StatKey.CD,
+  SPD: StatKey.SPD,
+  SPD_P: StatKey.SPD_P,
+  BE: StatKey.BE,
+  DMG_BOOST: StatKey.DMG_BOOST,
+  DEF_PEN: StatKey.DEF_PEN,
+  RES_PEN: StatKey.RES_PEN,
+  EFFECT_RES_PEN: StatKey.EFFECT_RES_PEN,
+  VULNERABILITY: StatKey.VULNERABILITY,
+  BREAK_EFFICIENCY: StatKey.BREAK_EFFICIENCY_BOOST,
+  FINAL_DMG_BOOST: StatKey.FINAL_DMG_BOOST,
+  EHR: StatKey.EHR,
+}
+
+const EXTRA_COMBAT_BUFF_SOURCE = Source.EXTRA_COMBAT_BUFFS
+
+export function precomputeExtraCombatBuffs(x: ComputedStatsContainer, request: Form): void {
+  const buffs = request.combatBuffs
+  if (!buffs) return
+
+  const config = x.targets(TargetTag.FullTeam).source(EXTRA_COMBAT_BUFF_SOURCE)
+
+  for (const entry of Object.values(CombatBuffs)) {
+    const value = buffs[entry.key]
+    if (!value) continue
+
+    const statKey = COMBAT_BUFF_KEY_TO_STAT_KEY[entry.key]
+    if (statKey == null) continue
+
+    x.buff(statKey, value, config)
+  }
+}

--- a/src/lib/tabs/tabOptimizer/optimizerForm/components/AdvancedOptionsPanel.tsx
+++ b/src/lib/tabs/tabOptimizer/optimizerForm/components/AdvancedOptionsPanel.tsx
@@ -42,10 +42,8 @@ export function AdvancedOptionsPanel() {
         {t('CustomTracesButtonText') /* Custom stat traces */}
       </Button>
 
-      {/* TODO: TEMPORARILY DISABLED - Extra combat buffs */}
       <Button
         variant='default'
-        disabled
         onClick={() => setOpen(OpenCloseIDs.COMBAT_BUFFS_DRAWER)}
         leftSection={<IconSettings size={16} />}
       >

--- a/src/lib/tabs/tabOptimizer/optimizerForm/components/CombatBuffsDrawer.tsx
+++ b/src/lib/tabs/tabOptimizer/optimizerForm/components/CombatBuffsDrawer.tsx
@@ -60,7 +60,8 @@ function CombatBuff({ title, name }: { title: string, name: string }) {
         // Coerce undefined → 0 to keep Mantine's useUncontrolled in controlled mode.
         // combatBuffs is seeded to 0 for all known keys, but a new buff key on an old save
         // state could slip through as undefined. See `.claude/react-guidelines.md` → "Mantine Controlled Inputs".
-        value={value ?? 0}
+        value={value || undefined}
+        placeholder=""
         onChange={(val: number | string) => useOptimizerRequestStore.getState().setCombatBuff(name, typeof val === 'number' ? val : 0)}
       />
     </Flex>

--- a/src/lib/tabs/tabOptimizer/optimizerForm/components/CombatBuffsDrawer.tsx
+++ b/src/lib/tabs/tabOptimizer/optimizerForm/components/CombatBuffsDrawer.tsx
@@ -1,4 +1,5 @@
 import {
+  Button,
   Drawer,
   Flex,
 } from '@mantine/core'
@@ -8,6 +9,7 @@ import {
   OpenCloseIDs,
   useOpenClose,
 } from 'lib/hooks/useOpenClose'
+import { createDefaultCombatBuffs } from 'lib/stores/optimizerForm/optimizerFormDefaults'
 import { useOptimizerRequestStore } from 'lib/stores/optimizerForm/useOptimizerRequestStore'
 import { InputNumberStyled } from 'lib/tabs/tabOptimizer/optimizerForm/components/InputNumberStyled'
 import { optimizerTabDefaultGap } from 'lib/tabs/tabOptimizer/optimizerForm/grid/optimizerGridColumns'
@@ -43,6 +45,13 @@ function CombatBuffsDrawerContent() {
       <Flex direction='column' gap={optimizerTabDefaultGap}>
         {combatBuffsList}
       </Flex>
+      <Button
+        fullWidth
+        variant='default'
+        onClick={() => useOptimizerRequestStore.setState({ combatBuffs: createDefaultCombatBuffs() })}
+      >
+        {t('Clear')}
+      </Button>
     </Flex>
   )
 }
@@ -57,8 +66,7 @@ function CombatBuff({ title, name }: { title: string, name: string }) {
       </div>
       <InputNumberStyled
         hideControls
-        value={value || undefined}
-        placeholder=""
+        value={value || ''}
         onChange={(val: number | string) => useOptimizerRequestStore.getState().setCombatBuff(name, typeof val === 'number' ? val : 0)}
       />
     </Flex>

--- a/src/lib/tabs/tabOptimizer/optimizerForm/components/CombatBuffsDrawer.tsx
+++ b/src/lib/tabs/tabOptimizer/optimizerForm/components/CombatBuffsDrawer.tsx
@@ -57,9 +57,6 @@ function CombatBuff({ title, name }: { title: string, name: string }) {
       </div>
       <InputNumberStyled
         hideControls
-        // Coerce undefined → 0 to keep Mantine's useUncontrolled in controlled mode.
-        // combatBuffs is seeded to 0 for all known keys, but a new buff key on an old save
-        // state could slip through as undefined. See `.claude/react-guidelines.md` → "Mantine Controlled Inputs".
         value={value || undefined}
         placeholder=""
         onChange={(val: number | string) => useOptimizerRequestStore.getState().setCombatBuff(name, typeof val === 'number' ? val : 0)}

--- a/src/types/optimizer.ts
+++ b/src/types/optimizer.ts
@@ -135,7 +135,6 @@ export type OptimizerContext = CharacterMetadata & {
   // Optimizer environment
   resultSort: string,
   primaryAbilityKey: string, // Primary ability from scoringMetadata.sortOption.key (e.g., 'BASIC', 'SKILL')
-  combatBuffs: OptimizerCombatBuffs,
   deprioritizeBuffs: boolean,
 
   // Character data
@@ -161,24 +160,4 @@ export type OptimizerContext = CharacterMetadata & {
   enemyWeaknessBroken: boolean,
 
   lightConeController: LightConeConditionalsController,
-}
-
-export type OptimizerCombatBuffs = {
-  ATK: number,
-  ATK_P: number,
-  HP: number,
-  HP_P: number,
-  DEF: number,
-  DEF_P: number,
-  CR: number,
-  CD: number,
-  SPD: number,
-  SPD_P: number,
-  BE: number,
-  DMG_BOOST: number,
-  DEF_PEN: number,
-  RES_PEN: number,
-  EFFECT_RES_PEN: number,
-  VULNERABILITY: number,
-  BREAK_EFFICIENCY: number,
 }


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

- Re-enable the Extra combat buffs optimizer menu
- Add Effect Hit Rate % as a new extra combat buff option
- Move extra combat buffs from per-permutation engine threading to precompute phase for automatic GPU-CPU parity
- Add Clear button to the extra combat buffs drawer

## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [ ] I have added commit messages that are descriptive and meaningful.
- [ ] I have tested the changes locally.
- [ ] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
