### PR TITLE
fix: saved builds preview doesn't use saved lightcone

### DIFF
--- a/src/lib/characterPreview/CharacterPreview.tsx
+++ b/src/lib/characterPreview/CharacterPreview.tsx
@@ -342,6 +342,7 @@ const CharacterPreviewInner = memo(function CharacterPreviewInner({
         ...rawCharacter,
         form: {
           ...rawCharacter.form,
+          characterEidolon: savedBuildOverride.characterEidolon,
           lightCone: savedBuildOverride.lightCone,
           lightConeSuperimposition: savedBuildOverride.lightConeSuperimposition,
         },

--- a/src/lib/characterPreview/CharacterPreview.tsx
+++ b/src/lib/characterPreview/CharacterPreview.tsx
@@ -335,16 +335,18 @@ const CharacterPreviewInner = memo(function CharacterPreviewInner({
   // Safe narrowing: ShowcaseTabCharacter is structurally compatible with Character for all
   // downstream usage. The source-aware branching in useCharacterPreviewState and getPreviewRelics
   // handles the equipped field difference (Relic objects vs string IDs).
-  const character = !savedBuildOverride
-    ? rawCharacter as Character
-    : {
-      ...rawCharacter,
-      form: {
-        ...rawCharacter.form,
-        lightCone: savedBuildOverride.lightCone,
-        lightConeSuperimposition: savedBuildOverride.lightConeSuperimposition,
-      },
-    } as Character
+  const character = useMemo(() => {
+    return !savedBuildOverride
+      ? rawCharacter as Character
+      : {
+        ...rawCharacter,
+        form: {
+          ...rawCharacter.form,
+          lightCone: savedBuildOverride.lightCone,
+          lightConeSuperimposition: savedBuildOverride.lightConeSuperimposition,
+        },
+      } as Character
+  }, [rawCharacter, savedBuildOverride])
 
   // Debug visual config with defaults — preset-aware (Satin/Gloss)
   const { t } = useTranslation('gameData')

--- a/src/lib/characterPreview/CharacterPreview.tsx
+++ b/src/lib/characterPreview/CharacterPreview.tsx
@@ -36,6 +36,7 @@ import { DebugSliderPanel } from 'lib/characterPreview/DebugSliderPanel'
 import {
   CARD_BG_ALPHA_DEFAULT,
   type DebugVisualConfig,
+  getShowcasePreset,
   INSET_BLUR,
   INSET_OPACITY,
   PORTRAIT_BLUR,
@@ -47,7 +48,6 @@ import {
   SHADOW_X,
   SHADOW_Y,
   TEXT_SHADOW_DEFAULT,
-  getShowcasePreset,
   useDebugVisualConfigStore,
 } from 'lib/characterPreview/debugVisualConfigStore'
 import { ShowcaseBuildAnalysis } from 'lib/characterPreview/scoring/ShowcaseBuildAnalysis'
@@ -90,7 +90,10 @@ import type {
   CustomImageConfig,
   CustomImagePayload,
 } from 'types/customImage'
-import type { ShowcaseDisplayDimensionsOverride, ShowcaseTemporaryOptions } from 'types/metadata'
+import type {
+  ShowcaseDisplayDimensionsOverride,
+  ShowcaseTemporaryOptions,
+} from 'types/metadata'
 import {
   ScoringSelector,
   SimScoringContextProvider,
@@ -294,7 +297,9 @@ export function CharacterPreview({
     return <CharacterPreviewWithDebug character={character} forceDebug={forceDebug} {...rest} />
   }
 
-  return <CharacterPreviewInner character={character} forceDebug={forceDebug} debugVisualConfig={debugVisualConfig} editorOverrides={editorOverrides} {...rest} />
+  return (
+    <CharacterPreviewInner character={character} forceDebug={forceDebug} debugVisualConfig={debugVisualConfig} editorOverrides={editorOverrides} {...rest} />
+  )
 }
 
 /** Wrapper that subscribes to debug store and renders panel - only used when CARD_DEBUG */
@@ -330,7 +335,16 @@ const CharacterPreviewInner = memo(function CharacterPreviewInner({
   // Safe narrowing: ShowcaseTabCharacter is structurally compatible with Character for all
   // downstream usage. The source-aware branching in useCharacterPreviewState and getPreviewRelics
   // handles the equipped field difference (Relic objects vs string IDs).
-  const character = rawCharacter as Character
+  const character = !savedBuildOverride
+    ? rawCharacter as Character
+    : {
+      ...rawCharacter,
+      form: {
+        ...rawCharacter.form,
+        lightCone: savedBuildOverride.lightCone,
+        lightConeSuperimposition: savedBuildOverride.lightConeSuperimposition,
+      },
+    } as Character
 
   // Debug visual config with defaults — preset-aware (Satin/Gloss)
   const { t } = useTranslation('gameData')
@@ -374,7 +388,16 @@ const CharacterPreviewInner = memo(function CharacterPreviewInner({
       return baseLayout
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [character, state.teamSelection, effectiveScoringType, savedBuildOverride, _scoringMetadataCacheBuster, t, forceDebug, editorOverrides?.forceSimScoreLayout],
+    [
+      character,
+      state.teamSelection,
+      effectiveScoringType,
+      savedBuildOverride,
+      _scoringMetadataCacheBuster,
+      t,
+      forceDebug,
+      editorOverrides?.forceSimScoreLayout,
+    ],
   )
 
   // ===== Color + Theme (color-dependent, cheap) =====
@@ -451,10 +474,10 @@ const CharacterPreviewInner = memo(function CharacterPreviewInner({
   // Apply editor overrides for live preview editing
   const displayDimensions = editorOverrides
     ? {
-        ...baseDisplayDimensions,
-        charCenter: editorOverrides.charCenter ?? baseDisplayDimensions.charCenter,
-        backgroundCenterOffset: editorOverrides.backgroundCenterOffset ?? baseDisplayDimensions.backgroundCenterOffset,
-      }
+      ...baseDisplayDimensions,
+      charCenter: editorOverrides.charCenter ?? baseDisplayDimensions.charCenter,
+      backgroundCenterOffset: editorOverrides.backgroundCenterOffset ?? baseDisplayDimensions.backgroundCenterOffset,
+    }
     : baseDisplayDimensions
 
   const scoredRelics = scoringResults.relics ?? EMPTY_SCORED

--- a/src/lib/characterPreview/characterPreviewController.tsx
+++ b/src/lib/characterPreview/characterPreviewController.tsx
@@ -219,6 +219,7 @@ export function getShowcaseStats(
     ? character.form
     : {
       ...character.form,
+      characterEidolon: savedBuildOverride.characterEidolon,
       lightCone: savedBuildOverride.lightCone,
       lightConeSuperimposition: savedBuildOverride.lightConeSuperimposition,
     }

--- a/src/lib/characterPreview/characterPreviewController.tsx
+++ b/src/lib/characterPreview/characterPreviewController.tsx
@@ -52,6 +52,7 @@ import type {
   CharacterId,
   SavedBuild,
 } from 'types/character'
+import type { Nullable } from 'types/common'
 import type {
   CustomImageConfig,
   CustomImagePayload,
@@ -210,10 +211,18 @@ export function getShowcaseDisplayDimensions(character: Character, simScore: boo
 export function getShowcaseStats(
   character: Character,
   displayRelics: PreviewRelics,
+  savedBuildOverride: Nullable<SavedBuild>,
 ) {
   const statCalculationRelics = clone(displayRelics)
   RelicFilters.condenseRelicSubstatsForOptimizerSingle(Object.values(statCalculationRelics).filter((relic) => !!relic))
-  const form = normalizeForm(character.form)
+  const preForm: Form = !savedBuildOverride
+    ? character.form
+    : {
+      ...character.form,
+      lightCone: savedBuildOverride.lightCone,
+      lightConeSuperimposition: savedBuildOverride.lightConeSuperimposition,
+    }
+  const form = normalizeForm(preForm)
   const context = generateContext(form)
   const { x } = simulateBuild(statCalculationRelics as SimulationRelicByPart, context, null)
   const basicStats = x.c.toBasicStatsObject()

--- a/src/lib/characterPreview/useCharacterPreviewState.ts
+++ b/src/lib/characterPreview/useCharacterPreviewState.ts
@@ -103,18 +103,15 @@ export function useCharacterPreviewState(
   // Reference changes when scoring overrides change (SPD weight, deprioritize buffs) — busts the memos below
   const scoringMetadata = useScoringMetadata(character.id)
 
-  // ShowcaseTabCharacter is handled correctly downstream via the source param — cast is safe
-  const narrowedCharacter = character as Character
-
-  const previewRelics = useMemo(() => {
-    return getPreviewRelics(source, narrowedCharacter, relicsById, savedBuildOverride)
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- scoringMetadata is an intentional cache-buster, not used inside the callback
-  }, [source, narrowedCharacter, relicsById, savedBuildOverride, scoringMetadata])
-
-  const finalStats = useMemo(() => {
-    if (!narrowedCharacter || !previewRelics) return undefined
-    return getShowcaseStats(narrowedCharacter, previewRelics.displayRelics, savedBuildOverride)
-  }, [narrowedCharacter, previewRelics])
+  const { previewRelics, finalStats } = useMemo(() => {
+    // ShowcaseTabCharacter is handled correctly downstream via the source param — casts are safe
+    const previewRelics = getPreviewRelics(source, character as Character, relicsById, savedBuildOverride)
+    const finalStats = (character && previewRelics)
+      ? getShowcaseStats(character as Character, previewRelics.displayRelics, savedBuildOverride)
+      : undefined
+    return { previewRelics, finalStats }
+    // scoringMetadata is an intentional cache-buster, not used inside the callback
+  }, [source, character, relicsById, savedBuildOverride, scoringMetadata])
 
   return {
     selectedRelic,

--- a/src/lib/characterPreview/useCharacterPreviewState.ts
+++ b/src/lib/characterPreview/useCharacterPreviewState.ts
@@ -113,7 +113,7 @@ export function useCharacterPreviewState(
 
   const finalStats = useMemo(() => {
     if (!narrowedCharacter || !previewRelics) return undefined
-    return getShowcaseStats(narrowedCharacter, previewRelics.displayRelics)
+    return getShowcaseStats(narrowedCharacter, previewRelics.displayRelics, savedBuildOverride)
   }, [narrowedCharacter, previewRelics])
 
   return {


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

-Changed CharacterPreview to read lightcone from saved build when appropriate

## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
