### PR TITLE
fix: aggrid row bugs, conditional fixes

### DIFF
--- a/src/lib/conditionals/character/1000/DanHeng.ts
+++ b/src/lib/conditionals/character/1000/DanHeng.ts
@@ -180,7 +180,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
       x.buff(StatKey.CR, (e >= 1 && r.e1EnemyHp50) ? 0.12 : 0, x.source(SOURCE_E1))
       x.buff(StatKey.SPD_P, (r.spdBuff) ? 0.20 : 0, x.source(SOURCE_TRACE))
 
-      x.buff(StatKey.RES_PEN, (r.talentPenBuff) ? extraPenValue : 0, x.source(SOURCE_TALENT))
+      x.buff(StatKey.RES_PEN, (r.talentPenBuff) ? extraPenValue : 0, x.elements(ElementTag.Wind).source(SOURCE_TALENT))
       x.buff(StatKey.DMG_BOOST, (r.enemySlowed) ? 0.40 : 0, x.damageType(DamageTag.BASIC).source(SOURCE_TRACE))
     },
 

--- a/src/lib/conditionals/character/1000/Himeko.ts
+++ b/src/lib/conditionals/character/1000/Himeko.ts
@@ -185,7 +185,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
           hits: [
             HitDefinitionBuilder.standardUlt()
               .damageElement(ElementTag.Fire)
-              .atkScaling(ultScaling + e6UltScaling)
+              .atkScaling(ultScaling + e6UltScaling / context.enemyCount)
               .toughnessDmg(20)
               .build(),
           ],

--- a/src/lib/conditionals/character/1000/WeltB1.ts
+++ b/src/lib/conditionals/character/1000/WeltB1.ts
@@ -105,7 +105,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   const defaults = {
     enemySlowed: true,
     enemyWeightless: true,
-    retributionDmgStacks: 15,
+    retributionDmgStacks: 10,
     ehrToAtkBoost: true,
     traceAdditionalDmg: true,
     skillExtraHits: skillExtraHitsMax,
@@ -116,7 +116,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 
   const teammateDefaults = {
     enemyWeightless: true,
-    retributionDmgStacks: 15,
+    retributionDmgStacks: 10,
     e4WeightlessResPen: true,
   }
 
@@ -335,7 +335,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     precomputeMutualEffectsContainer: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
       const m = action.characterConditionals as Conditionals<typeof teammateContent>
 
-      // Trace: Retribution - DMG boost 6% per stack when attacking Weightless, max 15 stacks
+      // Trace: Retribution - DMG boost 10% per stack when attacking Weightless, max 10 stacks
       x.buff(StatKey.DMG_BOOST, (m.enemyWeightless) ? 0.10 * m.retributionDmgStacks : 0, x.targets(TargetTag.FullTeam).source(SOURCE_TRACE))
 
       // Talent: Weightless DEF shred 40%

--- a/src/lib/tabs/tabOptimizer/optimizerForm/optimizerFormActions.ts
+++ b/src/lib/tabs/tabOptimizer/optimizerForm/optimizerFormActions.ts
@@ -297,7 +297,6 @@ export function validateForm(form: Form): boolean {
  * Equip the currently selected optimizer result to the character.
  */
 export function equipClicked(): void {
-  console.log('Equip clicked')
   const form = getForm()
   const characterId = form.characterId
 
@@ -310,7 +309,6 @@ export function equipClicked(): void {
 
   const selectedNodes = gridStore.optimizerGridApi()?.getSelectedNodes()
   if (!selectedNodes || selectedNodes.length === 0 || (selectedNodes[0]?.data?.statSim)) {
-    // Cannot equip a stat sim or empty row
     return
   }
 

--- a/src/lib/tabs/tabOptimizer/optimizerTabController.ts
+++ b/src/lib/tabs/tabOptimizer/optimizerTabController.ts
@@ -87,14 +87,24 @@ export const OptimizerTabController = {
   },
 
   setTopRow: (row: OptimizerDisplayData, overwrite = false) => {
+    const gridApi = gridStore.optimizerGridApi()
+    if (!gridApi) return
+
     if (overwrite) {
-      gridStore.optimizerGridApi()?.updateGridOptions({ pinnedTopRowData: [row] })
+      gridApi.updateGridOptions({ pinnedTopRowData: [row] })
       return
     }
 
-    const currentPinned = gridStore.optimizerGridApi()?.getGridOption('pinnedTopRowData') ?? []
-    currentPinned[0] = row
-    gridStore.optimizerGridApi()?.updateGridOptions({ pinnedTopRowData: currentPinned })
+    // Update existing pinned row node's data directly instead of replacing the
+    // pinnedTopRowData array via updateGridOptions. The updateGridOptions path
+    // triggers AG Grid's deferred rendering cycle which creates duplicate row
+    // DOM elements when batched Zustand store updates are pending.
+    const pinnedNode = gridApi.getPinnedTopRow(0)
+    if (pinnedNode) {
+      pinnedNode.setData(row)
+    } else {
+      gridApi.updateGridOptions({ pinnedTopRowData: [row] })
+    }
   },
 
   getRows: () => {


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

- Fix Dan Heng talent RES PEN to only apply to Wind element
- Fix Himeko ult E6 extra scaling to split across enemy count
- Fix Welt B1 Retribution default stacks from 15 to 10 and correct trace description
- Fix optimizer pinned top row causing duplicate DOM elements during batched state updates

## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [ ] I have added commit messages that are descriptive and meaningful.
- [ ] I have tested the changes locally.
- [ ] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
