### PR TITLE
feat: cors fallback for profile images

### DIFF
--- a/src/lib/characterPreview/CharacterPreview.tsx
+++ b/src/lib/characterPreview/CharacterPreview.tsx
@@ -576,7 +576,6 @@ const CharacterPreviewInner = memo(function CharacterPreviewInner({
               scoringType={scoringType}
               displayDimensions={displayDimensions}
               customPortrait={portraitToUse}
-              defaultPortraitUrl={layout.defaultPortraitUrl}
               editPortraitModalOpen={state.editPortraitModalOpen}
               setEditPortraitModalOpen={state.setEditPortraitModalOpen}
               onEditPortraitOk={handleEditPortraitOk}

--- a/src/lib/characterPreview/CharacterPreview.tsx
+++ b/src/lib/characterPreview/CharacterPreview.tsx
@@ -159,12 +159,14 @@ function buildInsetShadow(blur: number, opacity: number) {
  */
 function ShowcaseBackgroundBlur({
   portraitUrl,
+  defaultPortraitUrl,
   portraitToUse,
   displayDimensions,
   portraitFilter,
   blendMode,
 }: {
   portraitUrl: string,
+  defaultPortraitUrl: string,
   portraitToUse: CustomImageConfig | undefined,
   displayDimensions: { charCenter: { x: number, y: number, z: number }, backgroundCenterOffset: { x: number, y: number, z: number } },
   portraitFilter: string,
@@ -229,6 +231,7 @@ function ShowcaseBackgroundBlur({
     >
       <img
         src={portraitUrl}
+        data-fallback-src={portraitToUse ? defaultPortraitUrl : undefined}
         style={{
           ...imgStyle,
           display: 'block',
@@ -558,6 +561,7 @@ const CharacterPreviewInner = memo(function CharacterPreviewInner({
         >
           <ShowcaseBackgroundBlur
             portraitUrl={portraitUrl}
+            defaultPortraitUrl={layout.defaultPortraitUrl}
             portraitToUse={portraitToUse}
             displayDimensions={displayDimensions}
             portraitFilter={portraitFilter}
@@ -572,6 +576,7 @@ const CharacterPreviewInner = memo(function CharacterPreviewInner({
               scoringType={scoringType}
               displayDimensions={displayDimensions}
               customPortrait={portraitToUse}
+              defaultPortraitUrl={layout.defaultPortraitUrl}
               editPortraitModalOpen={state.editPortraitModalOpen}
               setEditPortraitModalOpen={state.setEditPortraitModalOpen}
               onEditPortraitOk={handleEditPortraitOk}

--- a/src/lib/characterPreview/card/CharacterCustomPortrait.tsx
+++ b/src/lib/characterPreview/card/CharacterCustomPortrait.tsx
@@ -11,10 +11,12 @@ export function CharacterCustomPortrait({
   customPortrait,
   parentW,
   scoringType,
+  defaultPortraitUrl,
 }: {
   customPortrait: CustomImageConfig,
   parentW: number,
   scoringType: ScoringType,
+  defaultPortraitUrl: string,
 }) {
   // Scale by height so that the light cone in combat scoring doesn't cut off part of the image
   const scaleWidth = parentW / customPortrait.customImageParams.croppedAreaPixels.width
@@ -47,6 +49,7 @@ export function CharacterCustomPortrait({
       style={{
         position: 'absolute',
       }}
+      data-fallback-src={defaultPortraitUrl}
     >
       <LoadingBlurredImage
         src={customPortrait.imageUrl}

--- a/src/lib/characterPreview/card/ShowcasePortrait.tsx
+++ b/src/lib/characterPreview/card/ShowcasePortrait.tsx
@@ -39,6 +39,7 @@ export const ShowcasePortrait = memo(function ShowcasePortrait({
   scoringType,
   displayDimensions,
   customPortrait,
+  defaultPortraitUrl,
   editPortraitModalOpen,
   setEditPortraitModalOpen,
   onEditPortraitOk,
@@ -51,6 +52,7 @@ export const ShowcasePortrait = memo(function ShowcasePortrait({
   scoringType: ScoringType,
   displayDimensions: ShowcaseDisplayDimensions,
   customPortrait: CustomImageConfig | undefined,
+  defaultPortraitUrl: string,
   editPortraitModalOpen: boolean,
   setEditPortraitModalOpen: (b: boolean) => void,
   onEditPortraitOk: (p: CustomImagePayload) => void,
@@ -113,15 +115,13 @@ export const ShowcasePortrait = memo(function ShowcasePortrait({
     const n = typeof v === 'number' ? v : parseFloat(String(v))
     return String(Number.isFinite(n) ? n : 0)
   }
-  const portraitDataAttrs = hasCustomPortrait
-    ? {}
-    : {
-      'data-portrait-inject': '',
-      'data-portrait-url': Assets.getCharacterPortraitById(character.id),
-      'data-portrait-left': safeNum(portraitStyle.left),
-      'data-portrait-top': safeNum(portraitStyle.top),
-      'data-portrait-width': safeNum(portraitStyle.width),
-    }
+  const portraitDataAttrs = {
+    'data-portrait-inject': '',
+    'data-portrait-url': Assets.getCharacterPortraitById(character.id),
+    'data-portrait-left': safeNum(portraitStyle.left),
+    'data-portrait-top': safeNum(portraitStyle.top),
+    'data-portrait-width': safeNum(portraitStyle.width),
+  }
 
   return (
     <div
@@ -149,6 +149,7 @@ export const ShowcasePortrait = memo(function ShowcasePortrait({
             customPortrait={customPortrait ?? character.portrait!}
             parentW={parentW}
             scoringType={scoringType}
+            defaultPortraitUrl={defaultPortraitUrl}
           />
         )
         : (

--- a/src/lib/characterPreview/card/ShowcasePortrait.tsx
+++ b/src/lib/characterPreview/card/ShowcasePortrait.tsx
@@ -33,13 +33,17 @@ import {
   type CustomImagePayload,
 } from 'types/customImage'
 
+const safeNum = (v: string | number | undefined): string => {
+  const n = typeof v === 'number' ? v : parseFloat(String(v))
+  return String(Number.isFinite(n) ? n : 0)
+}
+
 export const ShowcasePortrait = memo(function ShowcasePortrait({
   source,
   character,
   scoringType,
   displayDimensions,
   customPortrait,
-  defaultPortraitUrl,
   editPortraitModalOpen,
   setEditPortraitModalOpen,
   onEditPortraitOk,
@@ -52,7 +56,6 @@ export const ShowcasePortrait = memo(function ShowcasePortrait({
   scoringType: ScoringType,
   displayDimensions: ShowcaseDisplayDimensions,
   customPortrait: CustomImageConfig | undefined,
-  defaultPortraitUrl: string,
   editPortraitModalOpen: boolean,
   setEditPortraitModalOpen: (b: boolean) => void,
   onEditPortraitOk: (p: CustomImagePayload) => void,
@@ -107,17 +110,14 @@ export const ShowcasePortrait = memo(function ShowcasePortrait({
   const hasSpineData = getSkeletonCount(character.id) != null
   const useSpine = hasSpineData && !disableSpine && !spineFallback && !hasCustomPortrait && showcaseL2D
 
-  // Expose portrait positioning as data attributes for screenshot injection.
-  // The screenshot util injects a hidden <img> at capture time (like bg injection),
-  // which is more reliable than React-rendered hidden imgs on iOS Safari.
-  // Guard against NaN: CSSProperties types allow undefined, ensure valid numbers.
-  const safeNum = (v: string | number | undefined): string => {
-    const n = typeof v === 'number' ? v : parseFloat(String(v))
-    return String(Number.isFinite(n) ? n : 0)
-  }
+  const defaultPortraitUrl = Assets.getCharacterPortraitById(character.id)
+
+  // Default portrait positioning for screenshot injection — prepareLiveDomForCapture
+  // uses these to inject a static portrait when L2D or cross-origin custom images
+  // can't be captured by snapdom.
   const portraitDataAttrs = {
     'data-portrait-inject': '',
-    'data-portrait-url': Assets.getCharacterPortraitById(character.id),
+    'data-portrait-url': defaultPortraitUrl,
     'data-portrait-left': safeNum(portraitStyle.left),
     'data-portrait-top': safeNum(portraitStyle.top),
     'data-portrait-width': safeNum(portraitStyle.width),
@@ -155,7 +155,7 @@ export const ShowcasePortrait = memo(function ShowcasePortrait({
         : (
           <div data-portrait-foreground>
             <LoadingBlurredImage
-              src={Assets.getCharacterPortraitById(character.id)}
+              src={defaultPortraitUrl}
               style={portraitStyle}
             />
           </div>

--- a/src/lib/characterPreview/card/ShowcasePortrait.tsx
+++ b/src/lib/characterPreview/card/ShowcasePortrait.tsx
@@ -194,7 +194,7 @@ export const ShowcasePortrait = memo(function ShowcasePortrait({
           open={editPortraitModalOpen}
           setOpen={setEditPortraitModalOpen}
           onOk={onEditPortraitOk}
-          defaultImageUrl={Assets.getCharacterPortraitById(character.id)}
+          defaultImageUrl={defaultPortraitUrl}
           width={500}
         />
       )}

--- a/src/lib/characterPreview/showcaseDerivedData.ts
+++ b/src/lib/characterPreview/showcaseDerivedData.ts
@@ -39,6 +39,7 @@ export interface ShowcaseLayout {
   scoringType: ScoringType
   portraitToUse: CustomImageConfig | undefined
   portraitUrl: string
+  defaultPortraitUrl: string
   displayDimensions: ShowcaseDisplayDimensions
   artistName: string | undefined
 }
@@ -53,7 +54,8 @@ export function resolveShowcaseLayout(params: ShowcaseLayoutParams): ShowcaseLay
   const scoringType = resolveScoringType(storedScoringType, hasSimulation)
 
   const portraitToUse = getCharacterById(character.id)?.portrait
-  const portraitUrl = portraitToUse?.imageUrl ?? Assets.getCharacterPortraitById(character.id)
+  const defaultPortraitUrl = Assets.getCharacterPortraitById(character.id)
+  const portraitUrl = portraitToUse?.imageUrl ?? defaultPortraitUrl
 
   const displayDimensions = getShowcaseDisplayDimensions(character, scoringType === ScoringType.COMBAT_SCORE)
   const artistName = getArtistName(character)
@@ -66,6 +68,7 @@ export function resolveShowcaseLayout(params: ShowcaseLayoutParams): ShowcaseLay
     scoringType,
     portraitToUse,
     portraitUrl,
+    defaultPortraitUrl,
     displayDimensions,
     artistName,
   }

--- a/src/lib/utils/screenshotUtils.ts
+++ b/src/lib/utils/screenshotUtils.ts
@@ -168,30 +168,55 @@ function patchCanvasForDisplayP3(): () => void {
  */
 async function prepareLiveDomForCapture(root: HTMLElement): Promise<() => void> {
   const restoreActions: Array<() => void> = []
-
-  const containers = Array.from(root.querySelectorAll<HTMLElement>('[data-portrait-inject]'))
   const loadPromises: Promise<void>[] = []
 
-  for (const container of containers) {
-    const spineWrapper = container.querySelector<HTMLElement>('[data-portrait-spine]')
-    if (!spineWrapper) continue // L2D-off: LoadingBlurredImage renders natively, skip
+  const containers = Array.from(root.querySelectorAll<HTMLElement>('[data-portrait-inject]'))
 
+  for (const container of containers) {
     const url = container.dataset.portraitUrl
     const left = container.dataset.portraitLeft
     const top = container.dataset.portraitTop
     const width = container.dataset.portraitWidth
     if (!url || !left || !top || !width) continue
 
-    // Hide spine wrapper
-    const originalDisplay = spineWrapper.style.display
-    spineWrapper.style.display = 'none'
+    const spineWrapper = container.querySelector<HTMLElement>('[data-portrait-spine]')
+    const customPortraitWrapper = container.querySelector<HTMLElement>('[data-fallback-src]')
+
+    // Default portrait without L2D — renders natively via LoadingBlurredImage, skip
+    if (!spineWrapper && !customPortraitWrapper) continue
+
+    // Determine which element to hide and what image URL to capture
+    let elementToHide: HTMLElement
+    let imageUrlToCapture: string
+
+    if (spineWrapper) {
+      // L2D/spine: hide the canvas, inject the default static portrait
+      elementToHide = spineWrapper
+      imageUrlToCapture = url
+    } else {
+      // Custom portrait: try to fetch the custom image first
+      const customImgUrl = customPortraitWrapper!.querySelector<HTMLImageElement>('img')?.src
+      if (customImgUrl) {
+        try {
+          // If fetchable (CORS OK, e.g. imgur), use the custom image
+          const resp = await withTimeout(fetch(customImgUrl, { method: 'HEAD' }), 3000)
+          if (resp.ok) continue // Custom image is CORS-friendly, let snapdom handle it natively
+        } catch { /* CORS blocked — fall through to inject default portrait */ }
+      }
+      elementToHide = customPortraitWrapper!
+      imageUrlToCapture = url // default portrait URL from data attributes
+    }
+
+    // Hide the element that can't be captured
+    const originalDisplay = elementToHide.style.display
+    elementToHide.style.display = 'none'
     restoreActions.push(() => {
-      if (spineWrapper.isConnected) spineWrapper.style.display = originalDisplay
+      if (elementToHide.isConnected) elementToHide.style.display = originalDisplay
     })
 
     // Fetch portrait as data URL to avoid iOS decode race conditions
     try {
-      const response = await withTimeout(fetch(url), 4000)
+      const response = await withTimeout(fetch(imageUrlToCapture), 4000)
       const blob = await response.blob()
       const dataUrl = await new Promise<string>((resolve, reject) => {
         const reader = new FileReader()
@@ -211,7 +236,7 @@ async function prepareLiveDomForCapture(root: HTMLElement): Promise<() => void> 
       const w = parseFloat(width)
       const h = w * (dims.h / dims.w)
 
-      // Inject visible portrait img
+      // Inject visible portrait img with correct charCenter-based positioning
       const img = new Image()
       img.src = dataUrl
       img.style.position = 'absolute'
@@ -234,7 +259,7 @@ async function prepareLiveDomForCapture(root: HTMLElement): Promise<() => void> 
         if (img.isConnected) img.remove()
       })
     } catch {
-      // Fetch failed - spine wrapper restore already registered, UI will recover
+      // Fetch failed - element hide restore already registered, UI will recover
     }
   }
 
@@ -249,8 +274,12 @@ async function prepareLiveDomForCapture(root: HTMLElement): Promise<() => void> 
   }
 }
 
-/** Convert loaded images to data URIs so snapdom doesn't re-fetch them. */
-function buildImageDataUriCache(root: Element): Map<string, string> {
+/** Convert loaded images to data URIs so snapdom doesn't re-fetch them.
+ *  For cross-origin images that taint the canvas, tries fetch() first (works
+ *  if the server sends CORS headers, e.g. imgur). If fetch also fails, falls
+ *  back to the same-origin default portrait URL from data-fallback-src so
+ *  screenshots show the character's default art instead of a blank area. */
+async function buildImageDataUriCache(root: Element): Promise<Map<string, string>> {
   const cache = new Map<string, string>()
   const canvas = document.createElement('canvas')
   const ctx = canvas.getContext('2d')!
@@ -261,7 +290,40 @@ function buildImageDataUriCache(root: Element): Map<string, string> {
       canvas.height = img.naturalHeight
       ctx.drawImage(img, 0, 0)
       cache.set(img.src, canvas.toDataURL())
-    } catch { /* tainted */ }
+    } catch {
+      // Tainted canvas — cross-origin image. Try fetch (works if server has CORS headers).
+      try {
+        const resp = await fetch(img.src)
+        const blob = await resp.blob()
+        const dataUrl = await new Promise<string>((resolve, reject) => {
+          const reader = new FileReader()
+          reader.onload = () => resolve(reader.result as string)
+          reader.onerror = reject
+          reader.readAsDataURL(blob)
+        })
+        cache.set(img.src, dataUrl)
+      } catch {
+        // CORS blocked — use default character portrait from data-fallback-src
+        const fallbackUrl = img.dataset.fallbackSrc
+          ?? img.closest<HTMLElement>('[data-fallback-src]')?.dataset.fallbackSrc
+        if (fallbackUrl) {
+          try {
+            const fallbackImg = new Image()
+            await new Promise<void>((resolve) => {
+              fallbackImg.onload = () => resolve()
+              fallbackImg.onerror = () => resolve()
+              fallbackImg.src = fallbackUrl
+            })
+            if (fallbackImg.naturalWidth) {
+              canvas.width = fallbackImg.naturalWidth
+              canvas.height = fallbackImg.naturalHeight
+              ctx.drawImage(fallbackImg, 0, 0)
+              cache.set(img.src, canvas.toDataURL())
+            }
+          } catch { /* best-effort */ }
+        }
+      }
+    }
   }
   return cache
 }
@@ -325,7 +387,7 @@ export async function screenshotElementById(
     try {
       await preCache(element)
     } catch { /* best-effort */ }
-    const imageCache = buildImageDataUriCache(element)
+    const imageCache = await buildImageDataUriCache(element)
 
     const restoreContext = patchCanvasForDisplayP3()
 

--- a/src/lib/utils/screenshotUtils.ts
+++ b/src/lib/utils/screenshotUtils.ts
@@ -61,12 +61,16 @@
  * - `data-portrait-inject`: The portrait container (has positioning data attributes)
  * - `data-portrait-spine`: Wrapper around spine canvas (L2D-on only) - hidden during capture
  * - `data-portrait-foreground`: Wrapper around LoadingBlurredImage (L2D-off only)
- * - `data-portrait-url/left/top/width`: Portrait positioning data on container
+ * - `data-portrait-url/left/top/width`: Default portrait positioning data on container
+ * - `data-fallback-src`: Same-origin fallback URL on cross-origin custom portrait images.
+ *   Set on the background blur `<img>` and the custom portrait wrapper `<div>`.
+ *   Used by buildImageDataUriCache for the blur layer and by prepareLiveDomForCapture
+ *   to detect custom portrait containers that need injection.
  *
  * ## Capture Flow
  *
  * 1. Patch canvas.getContext for Display P3 color space (better mobile colors)
- * 2. For L2D containers: hide spine wrapper, inject static portrait as data URL
+ * 2. For L2D/cross-origin containers: hide un-capturable element, inject static portrait as data URL
  * 3. snapdom() capture with retry loop (up to 3x, break when blob > 1MB)
  * 4. Restore live DOM (unhide spine, remove injected img)
  * 5. Hand blob to download / Web Share / clipboard
@@ -112,6 +116,17 @@ import {
 } from 'lib/constants/constantsUi'
 import { Message } from 'lib/interactions/message.js'
 
+const FETCH_TIMEOUT_MS = 8000
+
+function blobToDataUrl(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(reader.result as string)
+    reader.onerror = reject
+    reader.readAsDataURL(blob)
+  })
+}
+
 function isMobileOrSafari(): boolean {
   const userAgent = navigator.userAgent
   const isMobile = /Android|iPhone|iPad|iPod|Opera Mini|IEMobile|WPDesktop|BlackBerry/i.test(userAgent)
@@ -152,21 +167,19 @@ function patchCanvasForDisplayP3(): () => void {
 }
 
 /**
- * Prepares the live DOM for screenshot capture by handling L2D spine canvases.
+ * Prepares the live DOM for screenshot capture by replacing un-capturable portrait
+ * elements with static images that snapdom can serialize.
  *
- * ## Why this exists
- * Spine canvases use `preserveDrawingBuffer: false` for performance, which means
- * their pixels can't be read after presentation. Snapdom would capture a blank canvas.
- *
- * ## What it does
- * For each L2D-on container (has `data-portrait-spine`):
- * 1. Hide the spine canvas wrapper
- * 2. Fetch the static portrait as a data URL (external URLs have decode races on iOS)
- * 3. Inject a visible <img> with explicit pixel dimensions (height:auto doesn't work in clones)
+ * Handles two cases for `[data-portrait-inject]` containers:
+ * - **Spine/L2D** (`[data-portrait-spine]`): canvas uses preserveDrawingBuffer:false,
+ *   so snapdom captures a blank frame. Hides spine, injects static portrait.
+ * - **Cross-origin custom portrait** (`[data-fallback-src]`): external images from
+ *   servers without CORS headers can't be fetched/inlined by snapdom. Hides the custom
+ *   portrait and injects the default character portrait with charCenter positioning.
  *
  * Returns a restore function that undoes all changes in reverse order.
  */
-async function prepareLiveDomForCapture(root: HTMLElement): Promise<() => void> {
+async function prepareLiveDomForCapture(root: HTMLElement, corsFailed: Set<string>): Promise<() => void> {
   const restoreActions: Array<() => void> = []
   const loadPromises: Promise<void>[] = []
 
@@ -185,45 +198,30 @@ async function prepareLiveDomForCapture(root: HTMLElement): Promise<() => void> 
     // Default portrait without L2D — renders natively via LoadingBlurredImage, skip
     if (!spineWrapper && !customPortraitWrapper) continue
 
-    // Determine which element to hide and what image URL to capture
     let elementToHide: HTMLElement
     let imageUrlToCapture: string
 
     if (spineWrapper) {
-      // L2D/spine: hide the canvas, inject the default static portrait
       elementToHide = spineWrapper
       imageUrlToCapture = url
     } else {
-      // Custom portrait: try to fetch the custom image first
+      // Custom portrait: skip injection if buildImageDataUriCache already fetched it successfully
       const customImgUrl = customPortraitWrapper!.querySelector<HTMLImageElement>('img')?.src
-      if (customImgUrl) {
-        try {
-          // If fetchable (CORS OK, e.g. imgur), use the custom image
-          const resp = await withTimeout(fetch(customImgUrl, { method: 'HEAD' }), 3000)
-          if (resp.ok) continue // Custom image is CORS-friendly, let snapdom handle it natively
-        } catch { /* CORS blocked — fall through to inject default portrait */ }
-      }
+      if (customImgUrl && !corsFailed.has(customImgUrl)) continue
       elementToHide = customPortraitWrapper!
-      imageUrlToCapture = url // default portrait URL from data attributes
+      imageUrlToCapture = url
     }
 
-    // Hide the element that can't be captured
     const originalDisplay = elementToHide.style.display
     elementToHide.style.display = 'none'
     restoreActions.push(() => {
       if (elementToHide.isConnected) elementToHide.style.display = originalDisplay
     })
 
-    // Fetch portrait as data URL to avoid iOS decode race conditions
     try {
-      const response = await withTimeout(fetch(imageUrlToCapture), 4000)
+      const response = await withTimeout(fetch(imageUrlToCapture), FETCH_TIMEOUT_MS)
       const blob = await response.blob()
-      const dataUrl = await new Promise<string>((resolve, reject) => {
-        const reader = new FileReader()
-        reader.onload = () => resolve(reader.result as string)
-        reader.onerror = reject
-        reader.readAsDataURL(blob)
-      })
+      const dataUrl = await blobToDataUrl(blob)
 
       // Probe natural dimensions - explicit height required (height:auto = 0 in clones)
       const probe = new Image()
@@ -275,14 +273,17 @@ async function prepareLiveDomForCapture(root: HTMLElement): Promise<() => void> 
 }
 
 /** Convert loaded images to data URIs so snapdom doesn't re-fetch them.
- *  For cross-origin images that taint the canvas, tries fetch() first (works
- *  if the server sends CORS headers, e.g. imgur). If fetch also fails, falls
- *  back to the same-origin default portrait URL from data-fallback-src so
- *  screenshots show the character's default art instead of a blank area. */
-async function buildImageDataUriCache(root: Element): Promise<Map<string, string>> {
+ *  For cross-origin images that taint the canvas, tries fetch() (works if the
+ *  server sends CORS headers, e.g. imgur). If fetch also fails, falls back to
+ *  the same-origin URL from data-fallback-src (handles the background blur layer).
+ *  Returns the cache and a set of URLs that failed CORS — used by
+ *  prepareLiveDomForCapture to decide whether to inject the default portrait. */
+async function buildImageDataUriCache(root: Element): Promise<{ cache: Map<string, string>; corsFailed: Set<string> }> {
   const cache = new Map<string, string>()
+  const corsFailed = new Set<string>()
   const canvas = document.createElement('canvas')
-  const ctx = canvas.getContext('2d')!
+  const ctx = canvas.getContext('2d')
+  if (!ctx) return { cache, corsFailed }
   for (const img of root.querySelectorAll<HTMLImageElement>('img')) {
     if (!img.complete || !img.naturalWidth || img.src.startsWith('data:') || cache.has(img.src)) continue
     try {
@@ -291,19 +292,11 @@ async function buildImageDataUriCache(root: Element): Promise<Map<string, string
       ctx.drawImage(img, 0, 0)
       cache.set(img.src, canvas.toDataURL())
     } catch {
-      // Tainted canvas — cross-origin image. Try fetch (works if server has CORS headers).
       try {
-        const resp = await fetch(img.src)
-        const blob = await resp.blob()
-        const dataUrl = await new Promise<string>((resolve, reject) => {
-          const reader = new FileReader()
-          reader.onload = () => resolve(reader.result as string)
-          reader.onerror = reject
-          reader.readAsDataURL(blob)
-        })
-        cache.set(img.src, dataUrl)
+        const blob = await withTimeout(fetch(img.src), FETCH_TIMEOUT_MS).then((r) => r.blob())
+        cache.set(img.src, await blobToDataUrl(blob))
       } catch {
-        // CORS blocked — use default character portrait from data-fallback-src
+        corsFailed.add(img.src)
         const fallbackUrl = img.dataset.fallbackSrc
           ?? img.closest<HTMLElement>('[data-fallback-src]')?.dataset.fallbackSrc
         if (fallbackUrl) {
@@ -325,7 +318,7 @@ async function buildImageDataUriCache(root: Element): Promise<Map<string, string
       }
     }
   }
-  return cache
+  return { cache, corsFailed }
 }
 
 /** Snapdom plugin that replaces img srcs on the clone with pre-built data URIs. */
@@ -387,7 +380,7 @@ export async function screenshotElementById(
     try {
       await preCache(element)
     } catch { /* best-effort */ }
-    const imageCache = await buildImageDataUriCache(element)
+    const { cache: imageCache, corsFailed } = await buildImageDataUriCache(element)
 
     const restoreContext = patchCanvasForDisplayP3()
 
@@ -397,7 +390,7 @@ export async function screenshotElementById(
       for (let i = 0; i < maxAttempts; i++) {
         let restoreLiveDom: (() => void) | null = null
         try {
-          restoreLiveDom = await prepareLiveDomForCapture(element)
+          restoreLiveDom = await prepareLiveDomForCapture(element, corsFailed)
           const capture = await withTimeout(
             snapdom(element, {
               scale: 1.5,

--- a/src/lib/utils/screenshotUtils.ts
+++ b/src/lib/utils/screenshotUtils.ts
@@ -199,17 +199,14 @@ async function prepareLiveDomForCapture(root: HTMLElement, corsFailed: Set<strin
     if (!spineWrapper && !customPortraitWrapper) continue
 
     let elementToHide: HTMLElement
-    let imageUrlToCapture: string
 
     if (spineWrapper) {
       elementToHide = spineWrapper
-      imageUrlToCapture = url
     } else {
       // Custom portrait: skip injection if buildImageDataUriCache already fetched it successfully
       const customImgUrl = customPortraitWrapper!.querySelector<HTMLImageElement>('img')?.src
       if (customImgUrl && !corsFailed.has(customImgUrl)) continue
       elementToHide = customPortraitWrapper!
-      imageUrlToCapture = url
     }
 
     const originalDisplay = elementToHide.style.display
@@ -219,7 +216,7 @@ async function prepareLiveDomForCapture(root: HTMLElement, corsFailed: Set<strin
     })
 
     try {
-      const response = await withTimeout(fetch(imageUrlToCapture), FETCH_TIMEOUT_MS)
+      const response = await withTimeout(fetch(url), FETCH_TIMEOUT_MS)
       const blob = await response.blob()
       const dataUrl = await blobToDataUrl(blob)
 
@@ -272,10 +269,53 @@ async function prepareLiveDomForCapture(root: HTMLElement, corsFailed: Set<strin
   }
 }
 
+/**
+ * Resolves a data URI for a cross-origin image that tainted the canvas.
+ * Tries fetch (works when the server sends CORS headers), then falls back
+ * to the same-origin URL from data-fallback-src.
+ */
+async function resolveTaintedImage(
+  img: HTMLImageElement,
+  cache: Map<string, string>,
+): Promise<{ dataUrl: string } | { corsFailed: true }> {
+  try {
+    const blob = await withTimeout(fetch(img.src), FETCH_TIMEOUT_MS).then((r) => r.blob())
+    return { dataUrl: await blobToDataUrl(blob) }
+  } catch { /* CORS fetch failed */ }
+
+  const fallbackUrl = img.dataset.fallbackSrc
+    ?? img.closest<HTMLElement>('[data-fallback-src]')?.dataset.fallbackSrc
+
+  if (fallbackUrl && cache.has(fallbackUrl)) {
+    return { dataUrl: cache.get(fallbackUrl)! }
+  }
+
+  if (fallbackUrl) {
+    try {
+      const fallbackImg = new Image()
+      await withTimeout(new Promise<void>((resolve) => {
+        fallbackImg.onload = () => resolve()
+        fallbackImg.onerror = () => resolve()
+        fallbackImg.src = fallbackUrl
+      }), FETCH_TIMEOUT_MS)
+      if (fallbackImg.naturalWidth) {
+        const c = document.createElement('canvas')
+        const cx = c.getContext('2d')!
+        c.width = fallbackImg.naturalWidth
+        c.height = fallbackImg.naturalHeight
+        cx.drawImage(fallbackImg, 0, 0)
+        return { dataUrl: c.toDataURL() }
+      }
+    } catch { /* best-effort */ }
+  }
+
+  return { corsFailed: true }
+}
+
 /** Convert loaded images to data URIs so snapdom doesn't re-fetch them.
- *  For cross-origin images that taint the canvas, tries fetch() (works if the
- *  server sends CORS headers, e.g. imgur). If fetch also fails, falls back to
- *  the same-origin URL from data-fallback-src (handles the background blur layer).
+ *  For cross-origin images that taint the canvas, tries fetch() then a
+ *  same-origin fallback from data-fallback-src. Tainted images are resolved
+ *  in parallel to avoid sequential timeout delays.
  *  Returns the cache and a set of URLs that failed CORS — used by
  *  prepareLiveDomForCapture to decide whether to inject the default portrait. */
 async function buildImageDataUriCache(root: Element): Promise<{ cache: Map<string, string>; corsFailed: Set<string> }> {
@@ -284,6 +324,9 @@ async function buildImageDataUriCache(root: Element): Promise<{ cache: Map<strin
   const canvas = document.createElement('canvas')
   const ctx = canvas.getContext('2d')
   if (!ctx) return { cache, corsFailed }
+
+  const taintedWork: Array<{ src: string; promise: Promise<{ dataUrl: string } | { corsFailed: true }> }> = []
+
   for (const img of root.querySelectorAll<HTMLImageElement>('img')) {
     if (!img.complete || !img.naturalWidth || img.src.startsWith('data:') || cache.has(img.src)) continue
     try {
@@ -292,32 +335,22 @@ async function buildImageDataUriCache(root: Element): Promise<{ cache: Map<strin
       ctx.drawImage(img, 0, 0)
       cache.set(img.src, canvas.toDataURL())
     } catch {
-      try {
-        const blob = await withTimeout(fetch(img.src), FETCH_TIMEOUT_MS).then((r) => r.blob())
-        cache.set(img.src, await blobToDataUrl(blob))
-      } catch {
-        corsFailed.add(img.src)
-        const fallbackUrl = img.dataset.fallbackSrc
-          ?? img.closest<HTMLElement>('[data-fallback-src]')?.dataset.fallbackSrc
-        if (fallbackUrl) {
-          try {
-            const fallbackImg = new Image()
-            await new Promise<void>((resolve) => {
-              fallbackImg.onload = () => resolve()
-              fallbackImg.onerror = () => resolve()
-              fallbackImg.src = fallbackUrl
-            })
-            if (fallbackImg.naturalWidth) {
-              canvas.width = fallbackImg.naturalWidth
-              canvas.height = fallbackImg.naturalHeight
-              ctx.drawImage(fallbackImg, 0, 0)
-              cache.set(img.src, canvas.toDataURL())
-            }
-          } catch { /* best-effort */ }
-        }
-      }
+      taintedWork.push({ src: img.src, promise: resolveTaintedImage(img, cache) })
     }
   }
+
+  const results = await Promise.allSettled(taintedWork.map((w) => w.promise))
+  for (let i = 0; i < results.length; i++) {
+    const result = results[i]
+    if (result.status !== 'fulfilled') continue
+    const value = result.value
+    if ('dataUrl' in value) {
+      cache.set(taintedWork[i].src, value.dataUrl)
+    } else {
+      corsFailed.add(taintedWork[i].src)
+    }
+  }
+
   return { cache, corsFailed }
 }
 


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

- Fix screenshot capture failing for cross-origin custom portrait images by falling back to the default character portrait
- Add data-fallback-src attribute to custom portrait and background blur elements for same-origin fallback during capture
- Always emit portrait positioning data attributes on the portrait container, not just for default portraits
- Parallelize cross-origin image resolution in buildImageDataUriCache to avoid sequential timeout delays
- Extract resolveTaintedImage helper with cache-first fallback lookup and timeout on fallback image loads
- Thread defaultPortraitUrl through ShowcaseLayout to avoid redundant asset URL derivation
- Move safeNum to module scope to avoid recreating on every render
- Replace inline FileReader with shared blobToDataUrl helper

## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [ ] I have added commit messages that are descriptive and meaningful.
- [ ] I have tested the changes locally.
- [ ] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
