### PR TITLE
fix: confirm character delete on enter

### DIFF
--- a/src/lib/hooks/useConfirmAction.ts
+++ b/src/lib/hooks/useConfirmAction.ts
@@ -1,20 +1,26 @@
 import { modals } from '@mantine/modals'
+import type { ConfirmModalProps } from '@mantine/modals'
 import {
   type ReactNode,
   useCallback,
 } from 'react'
 import { useTranslation } from 'react-i18next'
 
+type ConfirmActionOptions = {
+  confirmProps?: ConfirmModalProps['confirmProps'],
+}
+
 export function useConfirmAction() {
   const { t } = useTranslation('common')
 
-  return useCallback((content: ReactNode) => {
+  return useCallback((content: ReactNode, options?: ConfirmActionOptions) => {
     return new Promise<boolean>((resolve) => {
       modals.openConfirmModal({
         title: t('Confirm'),
         children: content,
         labels: { confirm: t('Confirm'), cancel: t('Cancel') },
         centered: true,
+        confirmProps: options?.confirmProps,
         onConfirm: () => resolve(true),
         onCancel: () => resolve(false),
       })

--- a/src/lib/tabs/tabCharacters/CharacterGrid.tsx
+++ b/src/lib/tabs/tabCharacters/CharacterGrid.tsx
@@ -210,6 +210,7 @@ export function CharacterGrid() {
       children: t('Messages.DeleteWarning', { charId: characterId }),
       labels: { confirm: i18next.t('common:Confirm'), cancel: i18next.t('common:Cancel') },
       centered: true,
+      confirmProps: { 'data-autofocus': true },
       onConfirm: () => CharacterTabController.removeCharacter(characterId),
     })
   }, [])
@@ -326,6 +327,7 @@ const SortableCharacterRow = memo(
       <div
         ref={mergedRef}
         className={classes.root}
+        data-character-id={character.id}
         data-selected={isFocused}
         data-scrim-mode='frosted'
         style={rootStyle}
@@ -393,9 +395,12 @@ const CharacterRowContent = memo(function CharacterRowContent({ character, rank,
   onRemove: (id: CharacterId) => void,
 }) {
   const { t } = useTranslation('common')
+  const { t: tCharactersTab } = useTranslation('charactersTab')
   const { t: tGameData } = useTranslation('gameData', { keyPrefix: 'Characters' })
   const longName = tGameData(`${character.id}.LongName`) as string
   const characterName = longName.includes('(') ? longName : tGameData(`${character.id}.Name`)
+  const editLabel = tCharactersTab('CharacterMenu.Character.Options.Edit')
+  const deleteLabel = tCharactersTab('CharacterMenu.Character.Options.Delete')
 
   // Form data for eidolon/LC
   const eidolon = character.form?.characterEidolon ?? 0
@@ -465,8 +470,9 @@ const CharacterRowContent = memo(function CharacterRowContent({ character, rank,
 
       {/* Hover action buttons — overlay on the left */}
       <div className={classes.actions}>
-        <Tooltip label='Edit' position='top' withArrow>
+        <Tooltip label={editLabel} position='top' withArrow>
           <ActionIcon
+            aria-label={`${editLabel}: ${characterName}`}
             size={24}
             variant='subtle'
             className={classes.actionBtn}
@@ -478,8 +484,9 @@ const CharacterRowContent = memo(function CharacterRowContent({ character, rank,
             <IconPencil size={12} />
           </ActionIcon>
         </Tooltip>
-        <Tooltip label='Remove' position='top' withArrow>
+        <Tooltip label={deleteLabel} position='top' withArrow>
           <ActionIcon
+            aria-label={`${deleteLabel}: ${characterName}`}
             size={24}
             variant='subtle'
             className={classes.actionBtn}

--- a/src/lib/tabs/tabCharacters/CharacterMenu.tsx
+++ b/src/lib/tabs/tabCharacters/CharacterMenu.tsx
@@ -22,7 +22,6 @@ import { CharacterTabController } from 'lib/tabs/tabCharacters/characterTabContr
 import { useCharacterTabStore } from 'lib/tabs/tabCharacters/useCharacterTabStore'
 import {
   Fragment,
-  type ReactNode,
   useMemo,
 } from 'react'
 import {
@@ -70,7 +69,7 @@ export function CharacterMenu() {
   )
 }
 
-function generateOnClickHandler(confirm: (content: ReactNode) => Promise<boolean>, t: TFunction<'charactersTab'>) {
+function generateOnClickHandler(confirm: ReturnType<typeof useConfirmAction>, t: TFunction<'charactersTab'>) {
   async function onClick(e: { key: string }) {
     const key = e.key as ReturnType<typeof generateItems>[number]['children'][number]['key']
     const { focusCharacter } = useCharacterTabStore.getState()
@@ -103,7 +102,12 @@ function generateOnClickHandler(confirm: (content: ReactNode) => Promise<boolean
         break
 
       case 'delete':
-        if (!await confirm(t('Messages.DeleteWarning', { charId: focusCharacter ?? '' }))) return
+        if (
+          !await confirm(
+            t('Messages.DeleteWarning', { charId: focusCharacter ?? '' }),
+            { confirmProps: { 'data-autofocus': true } },
+          )
+        ) return
         CharacterTabController.removeFocusCharacter()
         break
 

--- a/tests/Characters/delete-confirm-keyboard.spec.ts
+++ b/tests/Characters/delete-confirm-keyboard.spec.ts
@@ -1,0 +1,24 @@
+import {
+  expect,
+  test,
+} from '@playwright/test'
+
+test('pressing Enter confirms character deletion', async ({ page }) => {
+  await page.goto('/#main')
+  await page.getByText('Characters', { exact: true }).click()
+
+  const characterRow = page.locator('#characterGrid [data-character-id="1202"]')
+  await expect(characterRow).toContainText('Tingyun')
+
+  await characterRow.hover()
+  await characterRow.getByRole('button', { name: 'Delete character: Tingyun' }).click()
+
+  const dialog = page.getByRole('dialog')
+  await expect(dialog).toContainText('Are you sure you want to delete Tingyun?')
+  await expect(dialog.getByRole('button', { name: 'Confirm' })).toBeFocused()
+
+  await page.keyboard.press('Enter')
+
+  await expect(dialog).toBeHidden()
+  await expect(characterRow).toHaveCount(0)
+})


### PR DESCRIPTION
# Pull Request

## Description

- Fixed character delete confirmations so pressing Enter after opening the dialog confirms the deletion.
- Added accessible labels to character row edit/delete icon buttons.
- Added a Playwright regression for keyboard-confirmed character deletion.

## Related Issue

- N/A

## Checklist

- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots

N/A, behavior-only change.

## Local verification

- `npm run lint` (passes with 4 pre-existing warnings outside this change)
- `npm run typecheck:fast`
- `npm run vitest:fast`
- `npm run test`