### PR TITLE
feat: restrict live import to existing characters

### DIFF
--- a/public/locales/en_US/importSaveTab.yaml
+++ b/public/locales/en_US/importSaveTab.yaml
@@ -26,6 +26,8 @@ Import:
     DisconnectedHint: Unable to connect to the scanner. Please check that it is running.
     Enable: Enable Live Import (Recommended)
     UpdateCharacters: Enable updating characters' equipped relics and lightcones
+    OnlyExistingCharacters: Only update existing characters
+    OnlyExistingCharactersTooltip: Prevents live import from adding characters that are not already in the Characters tab.
     UpdateWarpResources: Enable importing Warp resources (jades, passes, pity)
     AdvancedSettings:
       Title: Advanced Settings

--- a/src/lib/services/persistenceService.test.ts
+++ b/src/lib/services/persistenceService.test.ts
@@ -29,6 +29,7 @@ import {
   useRelicStore,
 } from 'lib/stores/relic/relicStore'
 import { useScoringStore } from 'lib/stores/scoring/scoringStore'
+import { useScannerState } from 'lib/tabs/tabImport/scannerStore'
 import { OptimizerMenuIds } from 'lib/tabs/tabOptimizer/optimizerForm/layout/optimizerMenuIds'
 import type {
   Character,
@@ -127,6 +128,7 @@ beforeEach(() => {
   useRelicStore.setState(useRelicStore.getInitialState())
   useCharacterStore.setState(useCharacterStore.getInitialState())
   useScoringStore.setState(useScoringStore.getInitialState())
+  useScannerState.setState(useScannerState.getInitialState())
   useOptimizerDisplayStore.setState(useOptimizerDisplayStore.getInitialState())
   useGlobalStore.setState({
     settings: DefaultSettingOptions,
@@ -340,6 +342,40 @@ describe('loadSaveData', () => {
   it('loadSaveData does not crash when relics field is not an array', () => {
     const saveData = { characters: [], relics: 'bad' } as unknown as HsrOptimizerSaveFormat
     expect(() => loadSaveData(saveData, false, false)).not.toThrow()
+  })
+
+  it('loadSaveData restores scanner only-existing-characters setting', () => {
+    const saveData = emptySaveData({
+      scannerSettings: {
+        ingest: true,
+        ingestCharacters: true,
+        ingestOnlyExistingCharacters: true,
+        ingestWarpResources: false,
+        websocketUrl: 'ws://custom:9999/ws',
+        customUrl: true,
+      },
+    })
+
+    loadSaveData(saveData, false, false)
+
+    expect(useScannerState.getState().ingestOnlyExistingCharacters).toBe(true)
+  })
+
+  it('loadSaveData defaults scanner only-existing-characters setting to false for legacy saves', () => {
+    useScannerState.setState({ ingestOnlyExistingCharacters: true })
+    const saveData = emptySaveData({
+      scannerSettings: {
+        ingest: false,
+        ingestCharacters: true,
+        ingestWarpResources: false,
+        websocketUrl: 'ws://custom:9999/ws',
+        customUrl: true,
+      },
+    })
+
+    loadSaveData(saveData, false, false)
+
+    expect(useScannerState.getState().ingestOnlyExistingCharacters).toBe(false)
   })
 })
 

--- a/src/lib/services/persistenceService.ts
+++ b/src/lib/services/persistenceService.ts
@@ -192,6 +192,7 @@ export function loadSaveData(saveData: HsrOptimizerSaveFormat, autosave = true, 
     const scannerState = useScannerState.getState()
     scannerState.setIngest(saveData.scannerSettings.ingest)
     scannerState.setIngestCharacters(saveData.scannerSettings.ingestCharacters)
+    scannerState.setIngestOnlyExistingCharacters(saveData.scannerSettings.ingestOnlyExistingCharacters ?? false)
     scannerState.setIngestWarpResources(saveData.scannerSettings.ingestWarpResources)
 
     // For security, don't restore the websocket url if we're sanitizing (manual load)

--- a/src/lib/state/saveState.ts
+++ b/src/lib/state/saveState.ts
@@ -87,6 +87,7 @@ export const SaveState = {
       scannerSettings: {
         ingest: scannerState.ingest,
         ingestCharacters: scannerState.ingestCharacters,
+        ingestOnlyExistingCharacters: scannerState.ingestOnlyExistingCharacters,
         ingestWarpResources: scannerState.ingestWarpResources,
         websocketUrl: scannerState.websocketUrl,
         customUrl: scannerState.websocketUrl !== DEFAULT_WEBSOCKET_URL,

--- a/src/lib/tabs/tabImport/ScannerImportSubmenu.tsx
+++ b/src/lib/tabs/tabImport/ScannerImportSubmenu.tsx
@@ -82,6 +82,8 @@ export function ScannerImportSubmenu() {
     setIngest,
     ingestCharacters,
     setIngestCharacters,
+    ingestOnlyExistingCharacters,
+    setIngestOnlyExistingCharacters,
     ingestWarpResources,
     setIngestWarpResources,
     websocketUrl,
@@ -92,6 +94,8 @@ export function ScannerImportSubmenu() {
     setIngest: s.setIngest,
     ingestCharacters: s.ingestCharacters,
     setIngestCharacters: s.setIngestCharacters,
+    ingestOnlyExistingCharacters: s.ingestOnlyExistingCharacters,
+    setIngestOnlyExistingCharacters: s.setIngestOnlyExistingCharacters,
     ingestWarpResources: s.ingestWarpResources,
     setIngestWarpResources: s.setIngestWarpResources,
     websocketUrl: s.websocketUrl,
@@ -386,6 +390,18 @@ export function ScannerImportSubmenu() {
                 />
 
                 <div>{t('Import.LiveImport.UpdateCharacters') /* Enable updating characters' equipped relics and lightcones */}</div>
+              </Flex>
+
+              <Flex gap={10} align='center'>
+                <Switch
+                  checked={ingestOnlyExistingCharacters}
+                  disabled={!ingestCharacters}
+                  onChange={(event) => setIngestOnlyExistingCharacters(event.currentTarget.checked)}
+                />
+
+                <Tooltip label={t('Import.LiveImport.OnlyExistingCharactersTooltip') /* Prevents live import from adding characters that are not already in the Characters tab. */}>
+                  <div>{t('Import.LiveImport.OnlyExistingCharacters') /* Only update existing characters */}</div>
+                </Tooltip>
               </Flex>
 
               <Flex gap={10} align='center'>

--- a/src/lib/tabs/tabImport/ScannerImportSubmenu.tsx
+++ b/src/lib/tabs/tabImport/ScannerImportSubmenu.tsx
@@ -392,17 +392,18 @@ export function ScannerImportSubmenu() {
                 <div>{t('Import.LiveImport.UpdateCharacters') /* Enable updating characters' equipped relics and lightcones */}</div>
               </Flex>
 
-              <Flex gap={10} align='center'>
-                <Switch
-                  checked={ingestOnlyExistingCharacters}
-                  disabled={!ingestCharacters}
-                  onChange={(event) => setIngestOnlyExistingCharacters(event.currentTarget.checked)}
-                />
+              {ingestCharacters && (
+                <Flex gap={10} align='center'>
+                  <Switch
+                    checked={ingestOnlyExistingCharacters}
+                    onChange={(event) => setIngestOnlyExistingCharacters(event.currentTarget.checked)}
+                  />
 
-                <Tooltip label={t('Import.LiveImport.OnlyExistingCharactersTooltip') /* Prevents live import from adding characters that are not already in the Characters tab. */}>
-                  <div>{t('Import.LiveImport.OnlyExistingCharacters') /* Only update existing characters */}</div>
-                </Tooltip>
-              </Flex>
+                  <Tooltip label={t('Import.LiveImport.OnlyExistingCharactersTooltip') /* Prevents live import from adding characters that are not already in the Characters tab. */}>
+                    <div>{t('Import.LiveImport.OnlyExistingCharacters') /* Only update existing characters */}</div>
+                  </Tooltip>
+                </Flex>
+              )}
 
               <Flex gap={10} align='center'>
                 <Switch

--- a/src/lib/tabs/tabImport/scannerStore.test.ts
+++ b/src/lib/tabs/tabImport/scannerStore.test.ts
@@ -9,6 +9,7 @@ import type * as KelzFormatParser from 'lib/importer/kelzFormatParser'
 import * as equipmentService from 'lib/services/equipmentService'
 import * as persistenceService from 'lib/services/persistenceService'
 import { SaveState } from 'lib/state/saveState'
+import { getCharacterById } from 'lib/stores/character/characterStore'
 import { getRelics } from 'lib/stores/relic/relicStore'
 import type { CharacterId } from 'types/character'
 import {
@@ -22,6 +23,8 @@ import {
   DEFAULT_WEBSOCKET_URL,
   handleDeleteRelic,
   handleUpdateCharacter,
+  handleUpdateRelic,
+  initialScan,
   usePrivateScannerState,
   useScannerState,
 } from './scannerStore'
@@ -41,6 +44,10 @@ vi.mock('lib/services/equipmentService', () => ({
   upsertRelicWithEquipment: vi.fn(),
   removeRelic: vi.fn(),
   equipRelic: vi.fn(),
+}))
+
+vi.mock('lib/stores/character/characterStore', () => ({
+  getCharacterById: vi.fn(),
 }))
 
 vi.mock('lib/stores/relic/relicStore', () => ({
@@ -114,6 +121,22 @@ function makeScanData(overrides: Partial<ScannerParserJson> = {}): ScannerParser
   } as ScannerParserJson
 }
 
+function makeParsedCharacter(characterId = CHAR_ID_1) {
+  return {
+    characterId,
+    characterLevel: 80,
+    lightConeLevel: 80,
+  } as any
+}
+
+function makeStoredCharacter(characterId = CHAR_ID_1) {
+  return {
+    id: characterId,
+    equipped: {},
+    form: makeParsedCharacter(characterId),
+  } as any
+}
+
 // ---- Reset ----
 
 beforeEach(() => {
@@ -130,6 +153,7 @@ describe('scannerStore', () => {
       expect(state().connected).toBe(false)
       expect(state().ingest).toBe(false)
       expect(state().ingestCharacters).toBe(false)
+      expect(state().ingestOnlyExistingCharacters).toBe(false)
       expect(state().ingestWarpResources).toBe(false)
       expect(state().lastScanData).toBeNull()
       expect(state().gachaFunds).toBeNull()
@@ -216,6 +240,53 @@ describe('scannerStore', () => {
       // Last 6 relics reversed: 7,6,5,4,3,2
       expect(state().recentRelics[0]).toBe('r-uid-007')
       expect(state().recentRelics[5]).toBe('r-uid-002')
+    })
+
+    it('initialScan only passes existing characters to mergeRelics when restricted', () => {
+      usePrivateScannerState.setState({
+        ingest: true,
+        ingestCharacters: true,
+        ingestOnlyExistingCharacters: true,
+      })
+      vi.mocked(getCharacterById).mockImplementation((id) => (id === CHAR_ID_1 ? makeStoredCharacter(CHAR_ID_1) : undefined))
+      vi.mocked(ReliquaryArchiverParser.parse).mockReturnValueOnce({
+        relics: [],
+        characters: [
+          makeParsedCharacter(CHAR_ID_1),
+          makeParsedCharacter(CHAR_ID_2),
+        ],
+      } as any)
+
+      initialScan(state(), makeScanData({
+        characters: [{ id: CHAR_ID_1 } as any, { id: CHAR_ID_2 } as any],
+      }))
+
+      expect(state().characters[CHAR_ID_1]).toBeDefined()
+      expect(state().characters[CHAR_ID_2]).toBeDefined()
+      expect(persistenceService.mergeRelics).toHaveBeenCalledWith([], [
+        expect.objectContaining({ characterId: CHAR_ID_1 }),
+      ])
+    })
+
+    it('initialScan keeps current character import behavior when restriction is off', () => {
+      usePrivateScannerState.setState({
+        ingest: true,
+        ingestCharacters: true,
+        ingestOnlyExistingCharacters: false,
+      })
+      vi.mocked(getCharacterById).mockReturnValue(undefined)
+      vi.mocked(ReliquaryArchiverParser.parse).mockReturnValueOnce({
+        relics: [],
+        characters: [makeParsedCharacter(CHAR_ID_2)],
+      } as any)
+
+      initialScan(state(), makeScanData({
+        characters: [{ id: CHAR_ID_2 } as any],
+      }))
+
+      expect(persistenceService.mergeRelics).toHaveBeenCalledWith([], [
+        expect.objectContaining({ characterId: CHAR_ID_2 }),
+      ])
     })
   })
 
@@ -375,6 +446,13 @@ describe('scannerStore', () => {
       expect(SaveState.delayedSave).toHaveBeenCalled()
     })
 
+    it('setIngestOnlyExistingCharacters updates the flag and triggers save', () => {
+      state().setIngestOnlyExistingCharacters(true)
+
+      expect(state().ingestOnlyExistingCharacters).toBe(true)
+      expect(SaveState.delayedSave).toHaveBeenCalled()
+    })
+
     it('setIngestWarpResources updates the flag and triggers save', () => {
       state().setIngestWarpResources(true)
 
@@ -416,6 +494,95 @@ describe('scannerStore', () => {
       })
 
       expect(callOrder).toEqual(['upsertCharacter', 'equipRelic'])
+    })
+  })
+
+  describe('only existing characters live ingestion', () => {
+    it('handleUpdateCharacter does not add missing characters when restricted', () => {
+      usePrivateScannerState.setState({
+        ingest: true,
+        ingestCharacters: true,
+        ingestOnlyExistingCharacters: true,
+      })
+      vi.mocked(getCharacterById).mockReturnValue(undefined)
+      vi.mocked(ReliquaryArchiverParser.parseCharacter).mockReturnValueOnce(makeParsedCharacter(CHAR_ID_2))
+
+      handleUpdateCharacter(state(), { id: CHAR_ID_2 } as V4ParserCharacter)
+
+      expect(state().characters[CHAR_ID_2]).toBeDefined()
+      expect(persistenceService.upsertCharacterFromForm).not.toHaveBeenCalled()
+    })
+
+    it('handleUpdateCharacter updates existing characters when restricted', () => {
+      usePrivateScannerState.setState({
+        ingest: true,
+        ingestCharacters: true,
+        ingestOnlyExistingCharacters: true,
+      })
+      vi.mocked(getCharacterById).mockReturnValue(makeStoredCharacter(CHAR_ID_1))
+      vi.mocked(ReliquaryArchiverParser.parseCharacter).mockReturnValueOnce(makeParsedCharacter(CHAR_ID_1))
+
+      handleUpdateCharacter(state(), { id: CHAR_ID_1 } as V4ParserCharacter)
+
+      expect(persistenceService.upsertCharacterFromForm).toHaveBeenCalledWith(
+        expect.objectContaining({ characterId: CHAR_ID_1 }),
+      )
+    })
+
+    it('handleUpdateCharacter keeps adding new characters when restriction is off', () => {
+      usePrivateScannerState.setState({
+        ingest: true,
+        ingestCharacters: true,
+        ingestOnlyExistingCharacters: false,
+      })
+      vi.mocked(getCharacterById).mockReturnValue(undefined)
+      vi.mocked(ReliquaryArchiverParser.parseCharacter).mockReturnValueOnce(makeParsedCharacter(CHAR_ID_2))
+
+      handleUpdateCharacter(state(), { id: CHAR_ID_2 } as V4ParserCharacter)
+
+      expect(persistenceService.upsertCharacterFromForm).toHaveBeenCalledWith(
+        expect.objectContaining({ characterId: CHAR_ID_2 }),
+      )
+    })
+
+    it('handleUpdateRelic clears owners for missing characters when restricted', () => {
+      usePrivateScannerState.setState({
+        ingest: true,
+        ingestCharacters: false,
+        ingestOnlyExistingCharacters: true,
+      })
+      vi.mocked(getCharacterById).mockReturnValue(undefined)
+      vi.mocked(ReliquaryArchiverParser.parseRelic).mockReturnValueOnce({
+        id: RELIC_UID_1,
+        grade: 5,
+        equippedBy: CHAR_ID_2,
+      } as any)
+
+      handleUpdateRelic(state(), makeRelic({ _uid: RELIC_UID_1 }))
+
+      expect(equipmentService.upsertRelicWithEquipment).toHaveBeenCalledWith(
+        expect.objectContaining({ equippedBy: undefined }),
+      )
+    })
+
+    it('handleUpdateRelic preserves owners for existing characters when restricted', () => {
+      usePrivateScannerState.setState({
+        ingest: true,
+        ingestCharacters: true,
+        ingestOnlyExistingCharacters: true,
+      })
+      vi.mocked(getCharacterById).mockReturnValue(makeStoredCharacter(CHAR_ID_1))
+      vi.mocked(ReliquaryArchiverParser.parseRelic).mockReturnValueOnce({
+        id: RELIC_UID_1,
+        grade: 5,
+        equippedBy: CHAR_ID_1,
+      } as any)
+
+      handleUpdateRelic(state(), makeRelic({ _uid: RELIC_UID_1 }))
+
+      expect(equipmentService.upsertRelicWithEquipment).toHaveBeenCalledWith(
+        expect.objectContaining({ equippedBy: CHAR_ID_1 }),
+      )
     })
   })
 })

--- a/src/lib/tabs/tabImport/scannerStore.ts
+++ b/src/lib/tabs/tabImport/scannerStore.ts
@@ -12,6 +12,7 @@ import {
 import * as equipmentService from 'lib/services/equipmentService'
 import * as persistenceService from 'lib/services/persistenceService'
 import { SaveState } from 'lib/state/saveState'
+import { getCharacterById } from 'lib/stores/character/characterStore'
 import { createTabAwareStore } from 'lib/stores/infrastructure/createTabAwareStore'
 import {
   getRelicById,
@@ -20,6 +21,7 @@ import {
 import { EventEmitter } from 'lib/utils/frontendUtils'
 import { objectHash } from 'lib/utils/objectUtils'
 import type { CharacterId } from 'types/character'
+import type { Form } from 'types/form'
 
 type ScannerState = {
   // The websocket url to connect to
@@ -33,6 +35,9 @@ type ScannerState = {
 
   // Whether to ingest character data from the scanner websocket
   ingestCharacters: boolean,
+
+  // Whether to restrict live character ingestion to characters that already exist in the optimizer
+  ingestOnlyExistingCharacters: boolean,
 
   // Whether to auto-import warp resources (jades, passes, pity)
   ingestWarpResources: boolean,
@@ -72,6 +77,9 @@ type ScannerActions = {
 
   // Turn on/off ingestion of character data from the scanner websocket
   setIngestCharacters: (ingest: boolean) => void,
+
+  // Turn on/off restricting live character ingestion to existing optimizer characters
+  setIngestOnlyExistingCharacters: (ingestOnlyExistingCharacters: boolean) => void,
 
   // Turn on/off auto-import of warp resources
   setIngestWarpResources: (ingest: boolean) => void,
@@ -131,6 +139,7 @@ export const usePrivateScannerState = createTabAwareStore<ScannerStore>((set, ge
   connected: false,
   ingest: false,
   ingestCharacters: false,
+  ingestOnlyExistingCharacters: false,
   ingestWarpResources: false,
 
   lastScanData: null,
@@ -159,7 +168,10 @@ export const usePrivateScannerState = createTabAwareStore<ScannerStore>((set, ge
     if (state.connected && ingest) {
       const fullScanData = state.buildFullScanData()
       if (fullScanData) {
-        ingestFullScan(fullScanData, state.ingestCharacters)
+        ingestFullScan(fullScanData, {
+          updateCharacters: state.ingestCharacters,
+          onlyExistingCharacters: state.ingestOnlyExistingCharacters,
+        })
       }
     }
 
@@ -173,7 +185,27 @@ export const usePrivateScannerState = createTabAwareStore<ScannerStore>((set, ge
     if (state.connected && state.ingest && ingestCharacters) {
       const fullScanData = state.buildFullScanData()
       if (fullScanData) {
-        ingestFullScan(fullScanData, ingestCharacters)
+        ingestFullScan(fullScanData, {
+          updateCharacters: ingestCharacters,
+          onlyExistingCharacters: state.ingestOnlyExistingCharacters,
+        })
+      }
+    }
+
+    SaveState.delayedSave()
+  },
+
+  setIngestOnlyExistingCharacters: (ingestOnlyExistingCharacters: boolean) => {
+    set({ ingestOnlyExistingCharacters })
+
+    const state = get()
+    if (state.connected && state.ingest && state.ingestCharacters) {
+      const fullScanData = state.buildFullScanData()
+      if (fullScanData) {
+        ingestFullScan(fullScanData, {
+          updateCharacters: state.ingestCharacters,
+          onlyExistingCharacters: ingestOnlyExistingCharacters,
+        })
       }
     }
 
@@ -389,13 +421,22 @@ export type ScannerEvent =
   | { event: 'DeleteRelics', data: string[] } // data: unique ids
   | { event: 'DeleteLightCones', data: string[] } // data: unique ids
 
-function ingestFullScan(data: ScannerParserJson, updateCharacters: boolean) {
+type IngestFullScanOptions = {
+  updateCharacters: boolean,
+  onlyExistingCharacters: boolean,
+}
+
+function existingCharactersOnly(characters: Form[]) {
+  return characters.filter((character) => getCharacterById(character.characterId))
+}
+
+function ingestFullScan(data: ScannerParserJson, options: IngestFullScanOptions) {
   const activatedBuffs = getActivatedBuffs(data.characters)
   usePrivateScannerState.getState().updateActivatedBuffs(activatedBuffs)
 
   const newScan = ReliquaryArchiverParser.parse(data)
   if (newScan) {
-    if (updateCharacters) {
+    if (options.updateCharacters) {
       // TODO: Merge with input form
       // We sort by the characters ingame level before setting their level to 80 for the optimizer, so the default char order is more natural
       newScan.characters = newScan.characters.sort(
@@ -405,11 +446,15 @@ function ingestFullScan(data: ScannerParserJson, updateCharacters: boolean) {
         c.characterLevel = 80
         c.lightConeLevel = 80
       })
+
+      if (options.onlyExistingCharacters) {
+        newScan.characters = existingCharactersOnly(newScan.characters)
+      }
     }
 
     persistenceService.mergeRelics(
       newScan.relics,
-      updateCharacters ? newScan.characters : [],
+      options.updateCharacters ? newScan.characters : [],
     )
     console.info('Ingested initial scan')
 
@@ -449,7 +494,10 @@ export function initialScan(state: Readonly<ScannerStore>, data: ScannerParserJs
   state.updateInitialScan(data)
 
   if (state.ingest) {
-    ingestFullScan(data, state.ingestCharacters)
+    ingestFullScan(data, {
+      updateCharacters: state.ingestCharacters,
+      onlyExistingCharacters: state.ingestOnlyExistingCharacters,
+    })
   }
 }
 
@@ -468,6 +516,10 @@ export function handleUpdateRelic(state: Readonly<ScannerStore>, relic: V4Parser
       if (oldRelic != null && !state.ingestCharacters) {
         // Keep the owner of relic as the existing owner when character ingestion is disabled
         newRelic.equippedBy = oldRelic.equippedBy
+      }
+
+      if (state.ingestOnlyExistingCharacters && !getCharacterById(newRelic.equippedBy)) {
+        newRelic.equippedBy = undefined
       }
 
       equipmentService.upsertRelicWithEquipment(newRelic)
@@ -520,6 +572,10 @@ export function handleUpdateCharacter(
       activatedBuffs,
       Object.values(freshState.lightCones),
     )
+    if (parsed && freshState.ingestOnlyExistingCharacters && !getCharacterById(parsed.characterId)) {
+      return
+    }
+
     if (parsed) {
       persistenceService.upsertCharacterFromForm(parsed)
     }

--- a/src/types/resources.d.ts
+++ b/src/types/resources.d.ts
@@ -5949,6 +5949,8 @@ interface Resources {
         "Disconnected": "Disconnected",
         "DisconnectedHint": "Unable to connect to the scanner. Please check that it is running.",
         "Enable": "Enable Live Import (Recommended)",
+        "OnlyExistingCharacters": "Only update existing characters",
+        "OnlyExistingCharactersTooltip": "Prevents live import from adding characters that are not already in the Characters tab.",
         "Title": "Live Import Controls",
         "UpdateCharacters": "Enable updating characters' equipped relics and lightcones",
         "UpdateWarpResources": "Enable importing Warp resources (jades, passes, pity)"

--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -82,6 +82,7 @@ export type HsrOptimizerSaveFormat = {
   scannerSettings?: {
     ingest: boolean,
     ingestCharacters: boolean,
+    ingestOnlyExistingCharacters?: boolean,
     ingestWarpResources: boolean,
     websocketUrl: string,
     customUrl: boolean,


### PR DESCRIPTION
# Pull Request

## Description

- Added a Live Import toggle to only update characters that already exist in the Characters tab.
- Changed live scanner ingestion so skipped missing characters are not re-added and relics do not keep phantom owners for skipped characters.
- Persisted the new scanner setting and restored legacy saves with the current default behavior.
- Added scanner store and persistence coverage for the new setting.

## Related Issue

- N/A

## Checklist

- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots

- UI change is the new Live Import toggle: `Only update existing characters`.

## Local Testing

- `npm run typecheck`
- `npm run vitest`
- `npm run lint` (0 errors, existing unrelated warnings remain)