### PR TITLE
fix: various fixes

### DIFF
--- a/src/lib/characterPreview/CharacterPreview.tsx
+++ b/src/lib/characterPreview/CharacterPreview.tsx
@@ -72,6 +72,7 @@ import { Assets } from 'lib/rendering/assets'
 import { ScoringType } from 'lib/scoring/simScoringUtils'
 import { injectBenchmarkDebuggers } from 'lib/simulations/tests/simDebuggers'
 import { useGlobalStore } from 'lib/stores/app/appStore'
+import { useCharacterStore } from 'lib/stores/character/characterStore'
 import type { ShowcaseTabCharacter } from 'lib/tabs/tabShowcase/showcaseTabTypes'
 import { useShowcaseTabStore } from 'lib/tabs/tabShowcase/useShowcaseTabStore'
 import {
@@ -388,9 +389,12 @@ const CharacterPreviewInner = memo(function CharacterPreviewInner({
     : (forceDebug ? ScoringType.SUBSTAT_SCORE : localScoringType)
   // Cache-buster: state.scoringMetadata invalidates when scoring overrides change (SPD weight, buff priority)
   const _scoringMetadataCacheBuster = state.scoringMetadata
+  // Cache-buster: portrait edits on the showcase tab wouldn't re-run the layout memo otherwise
+  const _storePortrait = useCharacterStore((s) => s.charactersById[character.id]?.portrait)
   const layout = useMemo(
     () => {
       void _scoringMetadataCacheBuster // explicit cache invalidation dependency
+      void _storePortrait
       const baseLayout = resolveShowcaseLayout({
         character,
         teamSelection: state.teamSelection,
@@ -410,6 +414,7 @@ const CharacterPreviewInner = memo(function CharacterPreviewInner({
       effectiveScoringType,
       savedBuildOverride,
       _scoringMetadataCacheBuster,
+      _storePortrait,
       t,
       forceDebug,
       editorOverrides?.forceSimScoreLayout,

--- a/src/lib/characterPreview/summary/EstimatedTbpRelicsDisplay.tsx
+++ b/src/lib/characterPreview/summary/EstimatedTbpRelicsDisplay.tsx
@@ -314,14 +314,16 @@ function RollLine({ substat, weights }: { substat: RelicSubstatMetadata | null, 
   const weight = weights?.[substat.stat] ?? 0
   const weightDisplay = `⨯ ${localeNumber_00(weight * flatReduction(substat.stat))}`
   const rolls = substat.rolls ?? { high: 0, mid: 0, low: 0 }
-  const display: ReactElement[] = []
 
-  const maxDots = 6
+  const totalRolls = Math.min(rolls.high + rolls.mid + rolls.low, 6)
+  const high = Math.min(rolls.high, totalRolls)
+  const mid = Math.min(rolls.mid, totalRolls - high)
+  const low = totalRolls - high - mid
+  const display: ReactElement[] = []
   let key = 0
-  let remaining = maxDots
-  for (let i = 0; i < rolls.high && remaining > 0; i++, remaining--) display.push(<HighRoll key={key++} />)
-  for (let i = 0; i < rolls.mid && remaining > 0; i++, remaining--) display.push(<MidRoll key={key++} />)
-  for (let i = 0; i < rolls.low && remaining > 0; i++, remaining--) display.push(<LowRoll key={key++} />)
+  for (let i = 0; i < high; i++) display.push(<HighRoll key={key++} />)
+  for (let i = 0; i < mid; i++) display.push(<MidRoll key={key++} />)
+  for (let i = 0; i < low; i++) display.push(<LowRoll key={key++} />)
 
   return (
     <div className={styles.rollLine} style={(weight || weights === null) ? undefined : { opacity: 0.05 }}>

--- a/src/lib/characterPreview/summary/EstimatedTbpRelicsDisplay.tsx
+++ b/src/lib/characterPreview/summary/EstimatedTbpRelicsDisplay.tsx
@@ -316,10 +316,12 @@ function RollLine({ substat, weights }: { substat: RelicSubstatMetadata | null, 
   const rolls = substat.rolls ?? { high: 0, mid: 0, low: 0 }
   const display: ReactElement[] = []
 
+  const maxDots = 6
   let key = 0
-  for (let i = 0; i < rolls.high; i++) display.push(<HighRoll key={key++} />)
-  for (let i = 0; i < rolls.mid; i++) display.push(<MidRoll key={key++} />)
-  for (let i = 0; i < rolls.low; i++) display.push(<LowRoll key={key++} />)
+  let remaining = maxDots
+  for (let i = 0; i < rolls.high && remaining > 0; i++, remaining--) display.push(<HighRoll key={key++} />)
+  for (let i = 0; i < rolls.mid && remaining > 0; i++, remaining--) display.push(<MidRoll key={key++} />)
+  for (let i = 0; i < rolls.low && remaining > 0; i++, remaining--) display.push(<LowRoll key={key++} />)
 
   return (
     <div className={styles.rollLine} style={(weight || weights === null) ? undefined : { opacity: 0.05 }}>

--- a/src/lib/conditionals/character/8000/TrailblazerElation.ts
+++ b/src/lib/conditionals/character/8000/TrailblazerElation.ts
@@ -107,7 +107,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     certifiedBangerStacks: 60,
     ultCdBuff: false,
     atkToElation: true,
-    e2UltElation: true,
+    e2UltElation: false,
     e4Vulnerability: true,
     e6CritDmg: true,
   }
@@ -271,7 +271,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
       const m = action.characterConditionals as Conditionals<typeof teammateContent>
 
       x.buff(StatKey.CD, (m.ultCdBuff) ? ultCdBuffValue : 0, x.targets(TargetTag.SingleTarget).source(SOURCE_ULT))
-      x.buff(StatKey.ELATION, (e >= 2 && m.e2UltElation) ? 0.12 : 0, x.targets(TargetTag.FullTeam).source(SOURCE_E2))
+      x.buff(StatKey.ELATION, (e >= 2 && m.e2UltElation) ? 0.12 : 0, x.targets(TargetTag.SingleTarget).source(SOURCE_E2))
       x.buff(StatKey.VULNERABILITY, (e >= 4 && m.e4Vulnerability) ? 0.10 : 0, x.targets(TargetTag.FullTeam).source(SOURCE_E4))
     },
 

--- a/src/lib/relics/relicRollGrader.ts
+++ b/src/lib/relics/relicRollGrader.ts
@@ -45,7 +45,6 @@ function findBestRollSplit(targetValue: number, totalRolls: number, incrementOpt
 
 function findMinimumRolls(targetValue: number, incrementOptions: IncrementOptions): { totalRolls: number, rolls: StatRolls } {
   const maxRolls = 20
-  const acceptableError = 0.01
 
   let bestTotalRolls = 1
   let bestResult = findBestRollSplit(targetValue, 1, incrementOptions)
@@ -56,7 +55,7 @@ function findMinimumRolls(targetValue: number, incrementOptions: IncrementOption
       bestResult = result
       bestTotalRolls = totalRolls
     }
-    if (bestResult.error <= acceptableError) break
+    if (bestResult.error <= 0.01) break
   }
 
   return { totalRolls: bestTotalRolls, rolls: bestResult.rolls }

--- a/src/lib/relics/relicRollGrader.ts
+++ b/src/lib/relics/relicRollGrader.ts
@@ -43,6 +43,25 @@ function findBestRollSplit(targetValue: number, totalRolls: number, incrementOpt
   return { rolls: bestRolls, error: minError }
 }
 
+function findMinimumRolls(targetValue: number, incrementOptions: IncrementOptions): { totalRolls: number, rolls: StatRolls } {
+  const maxRolls = 20
+  const acceptableError = 0.01
+
+  let bestTotalRolls = 1
+  let bestResult = findBestRollSplit(targetValue, 1, incrementOptions)
+
+  for (let totalRolls = 2; totalRolls <= maxRolls; totalRolls++) {
+    const result = findBestRollSplit(targetValue, totalRolls, incrementOptions)
+    if (result.error < bestResult.error) {
+      bestResult = result
+      bestTotalRolls = totalRolls
+    }
+    if (bestResult.error <= acceptableError) break
+  }
+
+  return { totalRolls: bestTotalRolls, rolls: bestResult.rolls }
+}
+
 export const RelicRollGrader = {
   calculateRelicSubstatRolls(relic: UnaugmentedRelic) {
     // Skip non 5 star relics for simplicity
@@ -114,6 +133,17 @@ export const RelicRollGrader = {
       for (let i = 0; i < numSubstats; i++) {
         relic.substats[i].addedRolls = bestDistResults[i].addedRolls
         relic.substats[i].rolls = bestDistResults[i].rolls
+      }
+    }
+
+    for (let i = 0; i < numSubstats; i++) {
+      const substat = relic.substats[i]
+      const incrementOptions = SubStatValues[substat.stat][relic.grade as 5 | 4 | 3 | 2]
+      const totalRolls = (substat.addedRolls ?? 0) + 1
+      if (substat.value > totalRolls * incrementOptions.high) {
+        const result = findMinimumRolls(substat.value, incrementOptions)
+        substat.addedRolls = result.totalRolls - 1
+        substat.rolls = result.rolls
       }
     }
 

--- a/src/lib/relics/tests/relicRollGrader.test.ts
+++ b/src/lib/relics/tests/relicRollGrader.test.ts
@@ -168,21 +168,22 @@ test('Regression: overcount bug — joint search respects enhance budget', () =>
 
   RelicRollGrader.calculateRelicSubstatRolls(relic)
 
+  // This relic is impossible: each substat needs 3 rolls (total 12) but budget is 9.
+  // The overflow correction assigns true roll counts, exceeding the budget.
   const sumAddedRolls = relic.substats.reduce((acc, s) => acc + (s.addedRolls ?? 0), 0)
-  expect(sumAddedRolls).toBeLessThanOrEqual(Math.floor(relic.enhance / 3))
-  expect(sumAddedRolls).toEqual(5)
+  expect(sumAddedRolls).toEqual(8)
 
-  expect(relic.substats[0].addedRolls).toEqual(1)
-  expect(relic.substats[1].addedRolls).toEqual(1)
+  expect(relic.substats[0].addedRolls).toEqual(2)
+  expect(relic.substats[1].addedRolls).toEqual(2)
   expect(relic.substats[2].addedRolls).toEqual(2)
-  expect(relic.substats[3].addedRolls).toEqual(1)
+  expect(relic.substats[3].addedRolls).toEqual(2)
 
-  expect(relic.substats[0].rolls).toEqual({ high: 2, mid: 0, low: 0 })
-  expect(relic.substats[1].rolls).toEqual({ high: 2, mid: 0, low: 0 })
+  expect(relic.substats[0].rolls).toEqual({ high: 0, mid: 1, low: 2 })
+  expect(relic.substats[1].rolls).toEqual({ high: 0, mid: 0, low: 3 })
   expect(relic.substats[2].rolls).toEqual({ high: 0, mid: 0, low: 3 })
-  expect(relic.substats[3].rolls).toEqual({ high: 2, mid: 0, low: 0 })
+  expect(relic.substats[3].rolls).toEqual({ high: 0, mid: 0, low: 3 })
 
-  expect(relic.initialRolls).toEqual(4)
+  expect(relic.initialRolls).toEqual(7)
 })
 
 test('Tiebreaker: equal-error budgets favor higher addedRolls', () => {

--- a/src/lib/simulations/statSimulationController.ts
+++ b/src/lib/simulations/statSimulationController.ts
@@ -177,14 +177,17 @@ export function startOptimizerStatSimulation() {
     optimizerDisplayData.push(transformedData[0])
   }
 
+  const sortOption = SortOption[form.resultSort!]
+  const gridSortColumn = (form.statDisplay === 'combat' ? sortOption.combatGridColumn : sortOption.basicGridColumn) as keyof OptimizerDisplayData
+
+  optimizerDisplayData.sort((a, b) => (b[gridSortColumn] as number) - (a[gridSortColumn] as number))
   OptimizerTabController.setRows(optimizerDisplayData)
 
   calculateCurrentlyEquippedRow(form)
-  gridStore.optimizerGridApi()?.updateGridOptions({ datasource: OptimizerTabController.getDataSource() })
-
-  const sortOption = SortOption[form.resultSort!]
-  const gridSortColumn = form.statDisplay === 'combat' ? sortOption.combatGridColumn : sortOption.basicGridColumn
   setSortColumn(gridSortColumn)
+  gridStore.optimizerGridApi()?.updateGridOptions({
+    datasource: OptimizerTabController.getDataSource({ colId: gridSortColumn, sort: 'desc' }),
+  })
 
   autosave()
 }

--- a/src/lib/tabs/tabRelics/relicPreview/RelicStatRow.tsx
+++ b/src/lib/tabs/tabRelics/relicPreview/RelicStatRow.tsx
@@ -135,5 +135,6 @@ const CHEVRON_SVGS: Record<number, React.JSX.Element> = {
 }
 
 function generateRolls(stat: SubstatDetails) {
-  return stat.addedRolls ? CHEVRON_SVGS[stat.addedRolls] : null
+  if (!stat.addedRolls) return null
+  return CHEVRON_SVGS[Math.min(stat.addedRolls, 5)]
 }


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

- Fix Est TBP calculation returning finite values for impossible relics by uncapping roll grading when substat values exceed what assigned rolls can produce
- Fix Trailblazer Elation E2 ult buff targeting single target instead of full team, and default to disabled
- Fix sim results sorting by pre-sorting data before setting grid rows
- Fix showcase tab not re-rendering on portrait edits
- Cap relic roll chevron display at max real values to prevent visual overflow from impossible relics

## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [ ] I have added commit messages that are descriptive and meaningful.
- [ ] I have tested the changes locally.
- [ ] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
