### PR TITLE
fix: remove substat sorting

### DIFF
--- a/src/lib/relics/relicAugmenter.ts
+++ b/src/lib/relics/relicAugmenter.ts
@@ -34,8 +34,6 @@ export const RelicAugmenter = {
     augmentedStats.mainStat = mainStat
     augmentedStats.mainValue = mainMaxValue
 
-    sortSubstats(relic)
-
     for (const substat of relic.substats) {
       const stat = substat.stat
       substat.value = precisionRound(substat.value)
@@ -56,26 +54,6 @@ export const RelicAugmenter = {
     RelicRollGrader.calculateRelicSubstatRolls(relic)
     return relic as Relic
   },
-}
-
-const substatToOrder: Record<string, number> = {
-  [Stats.HP]: 0,
-  [Stats.ATK]: 1,
-  [Stats.DEF]: 2,
-  [Stats.HP_P]: 3,
-  [Stats.ATK_P]: 4,
-  [Stats.DEF_P]: 5,
-  [Stats.SPD]: 6,
-  [Stats.CR]: 7,
-  [Stats.CD]: 8,
-  [Stats.EHR]: 9,
-  [Stats.RES]: 10,
-  [Stats.BE]: 11,
-}
-
-// Relic substats are always sorted in the predefined order above when the user logs out.
-function sortSubstats(relic: UnaugmentedRelic) {
-  relic.substats = relic.substats.sort((a, b) => substatToOrder[a.stat] - substatToOrder[b.stat])
 }
 
 // Changes the augmented stats percents to decimals


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

- Removed substat sorting on relic import, the game no longer does this following the addition of preview substats

## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
