### PR TITLE
fix: elation conversion

### DIFF
--- a/src/lib/conditionals/character/1500/Sparxie.ts
+++ b/src/lib/conditionals/character/1500/Sparxie.ts
@@ -376,6 +376,8 @@ const conditionals: CharacterConditionalFunction = (e, withContent) => {
               if (convertibleValue < 2000) return 0
               return Math.min(0.80, floorSafe((convertibleValue - 2000) / 100) * 0.05)
             },
+            TargetTag.SelfAndPet,
+            true,
           )
         },
         gpu: function(action: OptimizerAction, context: OptimizerContext) {
@@ -390,6 +392,8 @@ const conditionals: CharacterConditionalFunction = (e, withContent) => {
             `min(0.80, floorSafe((convertibleValue - 2000.0) / 100.0) * 0.05)`,
             `${wgslTrue(r.atkToElation)}`,
             `convertibleValue >= 2000.0`,
+            TargetTag.SelfAndPet,
+            true,
           )
         },
       },

--- a/src/lib/conditionals/character/1500/Yaoguang.ts
+++ b/src/lib/conditionals/character/1500/Yaoguang.ts
@@ -402,6 +402,8 @@ const conditionals: CharacterConditionalFunction = (e, withContent) => {
               if (convertibleValue < 120) return 0
               return 0.30 + Math.min(200, convertibleValue - 120) * 0.01
             },
+            TargetTag.SelfAndPet,
+            true,
           )
         },
         gpu: function(action: OptimizerAction, context: OptimizerContext) {
@@ -416,6 +418,8 @@ const conditionals: CharacterConditionalFunction = (e, withContent) => {
             `0.30 + min(200.0, convertibleValue - 120.0) * 0.01`,
             `${wgslTrue(r.traceSpdElation)}`,
             `convertibleValue >= 120.0`,
+            TargetTag.SelfAndPet,
+            true,
           )
         },
       },

--- a/src/lib/conditionals/evaluation/statConversion.ts
+++ b/src/lib/conditionals/evaluation/statConversion.ts
@@ -33,6 +33,7 @@ export function dynamicStatConversionContainer(
   source: BuffSource,
   buffFn: (convertibleValue: number) => number,
   targetTag: TargetTag = TargetTag.SelfAndPet,
+  convertibleOutput: boolean = false,
 ) {
   const statConfig = statConversionConfig[sourceStat]
   const destConfig = statConversionConfig[destinationStat]
@@ -50,7 +51,9 @@ export function dynamicStatConversionContainer(
 
   action.conditionalState[conditional.id] = buffFull
 
-  x.buffDynamic(destConfig.unconvertibleKey, buffDelta, action, context, x.targets(targetTag).source(source))
+  if (!convertibleOutput) {
+    x.buffDynamic(destConfig.unconvertibleKey, buffDelta, action, context, x.targets(targetTag).source(source))
+  }
   x.buffDynamic(destConfig.key, buffDelta, action, context, x.targets(targetTag).source(source))
 }
 
@@ -85,6 +88,7 @@ export function gpuDynamicStatConversion(
   activeConditionWgsl: string,
   thresholdConditionWgsl: string = 'true',
   targetTag: TargetTag = TargetTag.SelfAndPet,
+  convertibleOutput: boolean = false,
 ) {
   const statConfig = statConversionConfig[sourceStat]
   const destConfig = statConversionConfig[destinationStat]
@@ -94,7 +98,7 @@ export function gpuDynamicStatConversion(
   const sourceUnconvertibleVal = containerActionVal(SELF_ENTITY_INDEX, statConfig.unconvertibleKey, config)
 
   // Generate buff lines for all entities matching the target tag
-  const destUnconvertibleBuffLines = generateMultiEntityBuffWgsl(destConfig.unconvertibleKey, 'buffDelta', action, targetTag)
+  const destUnconvertibleBuffLines = convertibleOutput ? '' : generateMultiEntityBuffWgsl(destConfig.unconvertibleKey, 'buffDelta', action, targetTag)
   const destBuffLines = generateMultiEntityBuffWgsl(destConfig.key, 'buffDelta', action, targetTag)
 
   return newConditionalWgslWrapper(


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

- Fix Yaoguang SPD -> Elation and Sparxie ATK -> Elation conversions to produce convertible elation instead of unconvertible
- Add convertibleOutput option to stat conversion helpers (CPU and GPU) to skip unconvertible buff marking

## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [ ] I have added commit messages that are descriptive and meaningful.
- [ ] I have tested the changes locally.
- [ ] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
