### PR TITLE
fix: replace dmg% with err for eva

### DIFF
--- a/src/lib/characterPreview/scoring/CharacterCardCombatStats.tsx
+++ b/src/lib/characterPreview/scoring/CharacterCardCombatStats.tsx
@@ -156,7 +156,25 @@ function pickCombatStats(characterMetadata: DBMetadataCharacter) {
   // Dedupe, remove flats, standardize order
   substats = filterUnique(substats).filter((x) => !percentFlatStats[x])
   substats.sort((a, b) => getIndexOf(SubStats, a) - getIndexOf(SubStats, b))
-  substats.push(elementalDmgValue)
+
+  let includeElementalDmg = true
+  const config = simulationMetadata.combatStatsConfig
+  if (config) {
+    for (const entry of config) {
+      if (entry.remove === 'ELEMENTAL_DMG') {
+        includeElementalDmg = false
+      } else if (entry.remove) {
+        substats = substats.filter((s) => s !== entry.remove)
+      }
+      if (entry.add) {
+        substats.push(entry.add)
+      }
+    }
+  }
+
+  if (includeElementalDmg) {
+    substats.push(elementalDmgValue)
+  }
 
   if (characterMetadata.path === PathNames.Elation) {
     substats.push(Stats.Elation)

--- a/src/lib/characterPreview/summary/DpsScoreMainStatUpgradesTable.tsx
+++ b/src/lib/characterPreview/summary/DpsScoreMainStatUpgradesTable.tsx
@@ -281,6 +281,18 @@ export type SharedScoreColumn = {
 export function sharedScoreUpgradeColumns(t: TFunction<'charactersTab', 'CharacterPreview.SubstatUpgradeComparisons'>): SharedScoreColumn[] {
   return [
     {
+      key: 'damagePercentUpgrade',
+      title: t('ComboDmgPercentUpgrade'), // Combo DMG Δ %
+      dataIndex: 'damagePercentUpgrade',
+      type: 'damageUpgrade',
+      render: (n: number) => (
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 5 }}>
+          <Arrow up={n >= 0} />
+          {` ${localeNumber_00(n)}%`}
+        </div>
+      ),
+    },
+    {
       key: 'scorePercentUpgrade',
       title: t('DpsScorePercentUpgrade'), // DPS Score Δ %
       dataIndex: 'scorePercentUpgrade',
@@ -295,15 +307,14 @@ export function sharedScoreUpgradeColumns(t: TFunction<'charactersTab', 'Charact
       ),
     },
     {
-      key: 'damagePercentUpgrade',
-      title: t('ComboDmgPercentUpgrade'), // Combo DMG Δ %
-      dataIndex: 'damagePercentUpgrade',
+      key: 'damageValueUpgrade',
+      title: t('ComboDmgUpgrade'), // Combo DMG Δ
+      dataIndex: 'damageValueUpgrade',
       type: 'damageUpgrade',
       render: (n: number) => (
-        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 5 }}>
-          <Arrow up={n >= 0} />
-          {` ${localeNumber_00(n)}%`}
-        </div>
+        <>
+          {localeNumber_0(n)}
+        </>
       ),
     },
     {
@@ -317,17 +328,6 @@ export function sharedScoreUpgradeColumns(t: TFunction<'charactersTab', 'Charact
             {`${localeNumber_0(Math.max(0, n))}%`}
           </>
         )
-      ),
-    },
-    {
-      key: 'damageValueUpgrade',
-      title: t('ComboDmgUpgrade'), // Combo DMG Δ
-      dataIndex: 'damageValueUpgrade',
-      type: 'damageUpgrade',
-      render: (n: number) => (
-        <>
-          {localeNumber_0(n)}
-        </>
       ),
     },
   ]

--- a/src/lib/conditionals/character/1500/Evanescia.ts
+++ b/src/lib/conditionals/character/1500/Evanescia.ts
@@ -434,6 +434,9 @@ const simulation = (): SimulationMetadata => ({
   ],
   comboDot: 0,
   errRopeEidolon: 0,
+  combatStatsConfig: [
+    { add: Stats.ERR, remove: 'ELEMENTAL_DMG' },
+  ],
   relicSets: [
     [Sets.EverGloriousMagicalGirl, Sets.EverGloriousMagicalGirl],
     ...SPREAD_RELICS_4P_GENERAL_CONDITIONALS,

--- a/src/types/metadata.ts
+++ b/src/types/metadata.ts
@@ -77,6 +77,10 @@ export type SimulationMetadata = {
   breakpoints?: {
     [stat: string]: number,
   },
+  combatStatsConfig?: Array<{
+    add?: StatsValues,
+    remove?: StatsValues | 'ELEMENTAL_DMG',
+  }>,
 }
 
 export type ElementalResPenType =


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

- Add per-character combat stats config to add or remove stats from the combat stats card display
- Replace Elemental DMG with Energy Regen in Evanescia's combat stats

## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [ ] I have added commit messages that are descriptive and meaningful.
- [ ] I have tested the changes locally.
- [ ] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
