### PR TITLE
fix: Cyrene E1 extra bounces included at E0

### DIFF
--- a/src/lib/conditionals/character/1400/Cyrene.ts
+++ b/src/lib/conditionals/character/1400/Cyrene.ts
@@ -318,7 +318,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
       const memoSkillScalingIndividual = memoSkillDmgScaling + (e >= 4 ? r.e4BounceStacks * 0.06 : 0)
       const memoSkillTotalHpScaling = memoSkillDmgScaling
         + r.odeToEgoExtraBounces * memoSkillScalingIndividual
-        + r.e1ExtraBounces * memoSkillScalingIndividual
+        + (e >= 1 ? r.e1ExtraBounces * memoSkillScalingIndividual : 0)
       const memoSkillToughness = 10
         + 5 / 3 * r.odeToEgoExtraBounces
         + (e >= 1 ? 5 / 3 * r.e1ExtraBounces : 0)


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

-Fixed Cyrene E1 extra bounces being applied irrespective of eidolon level

## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [ ] I have added commit messages that are descriptive and meaningful.
- [ ] I have tested the changes locally.
- [ ] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
