### PR TITLE
feat: all ashblazing ult multis

### DIFF
--- a/src/lib/conditionals/ashblazingCompute.test.ts
+++ b/src/lib/conditionals/ashblazingCompute.test.ts
@@ -1,0 +1,218 @@
+import { ASHBLAZING_ATK_STACK } from 'lib/conditionals/conditionalConstants'
+import {
+  aoe,
+  ashblazingMulti,
+  blast,
+  single,
+} from 'lib/conditionals/ashblazingCompute'
+import { describe, expect, it } from 'vitest'
+
+function context(enemyCount: number) {
+  return { enemyCount }
+}
+
+describe('ashblazingMulti', () => {
+  describe('single-target hits', () => {
+    it('1 single hit — constant across enemy counts', () => {
+      const hitMulti = ashblazingMulti([single(1.00)])
+
+      expect(hitMulti(context(1))).toBeCloseTo(0.06, 6)
+      expect(hitMulti(context(3))).toBeCloseTo(0.06, 6)
+      expect(hitMulti(context(5))).toBeCloseTo(0.06, 6)
+    })
+
+    it('Hook ULT — 2 single hits: 30%/70%', () => {
+      const hitMulti = ashblazingMulti([single(0.30), single(0.70)])
+
+      // stacks: 1, 2
+      const expected = ASHBLAZING_ATK_STACK * (1 * 0.30 + 2 * 0.70)
+      expect(hitMulti(context(1))).toBeCloseTo(expected, 6)
+      expect(hitMulti(context(3))).toBeCloseTo(expected, 6)
+      expect(hitMulti(context(5))).toBeCloseTo(expected, 6)
+    })
+
+    it('Moze FUA — 6 single hits', () => {
+      const hitMulti = ashblazingMulti([
+        single(0.08), single(0.08), single(0.08),
+        single(0.08), single(0.08), single(0.60),
+      ])
+
+      // stacks: 1, 2, 3, 4, 5, 6
+      const expected = ASHBLAZING_ATK_STACK * (
+        1 * 0.08 + 2 * 0.08 + 3 * 0.08 + 4 * 0.08 + 5 * 0.08 + 6 * 0.60
+      )
+      expect(hitMulti(context(1))).toBeCloseTo(expected, 6)
+      expect(hitMulti(context(3))).toBeCloseTo(expected, 6)
+      expect(hitMulti(context(5))).toBeCloseTo(expected, 6)
+    })
+
+    it('Archer ULT — 15 single hits: 4%×14 + 44%', () => {
+      const hitMulti = ashblazingMulti([
+        ...Array(14).fill(single(0.04)),
+        single(0.44),
+      ])
+
+      // stacks: 1,2,3,4,5,6,7,8,8,8,8,8,8,8,8 — caps at hit 8
+      const expected = ASHBLAZING_ATK_STACK * (
+        1 * 0.04 + 2 * 0.04 + 3 * 0.04 + 4 * 0.04
+        + 5 * 0.04 + 6 * 0.04 + 7 * 0.04
+        + 8 * 0.04 * 7
+        + 8 * 0.44
+      )
+      expect(hitMulti(context(1))).toBeCloseTo(expected, 6)
+      expect(hitMulti(context(5))).toBeCloseTo(expected, 6)
+    })
+
+    it('Ashveil ULT — 20 single hits: 5%×20', () => {
+      const hitMulti = ashblazingMulti(Array(20).fill(single(0.05)))
+
+      // stacks: 1,2,3,4,5,6,7 then 13×8 — caps at hit 8
+      const expected = ASHBLAZING_ATK_STACK * (
+        (1 + 2 + 3 + 4 + 5 + 6 + 7) * 0.05 + 8 * 0.05 * 13
+      )
+      expect(hitMulti(context(1))).toBeCloseTo(expected, 6)
+      expect(hitMulti(context(5))).toBeCloseTo(expected, 6)
+    })
+  })
+
+  describe('AoE hits', () => {
+    it('1 AoE hit — scales with enemy count', () => {
+      const hitMulti = ashblazingMulti([aoe(1.00)])
+
+      expect(hitMulti(context(1))).toBeCloseTo(ASHBLAZING_ATK_STACK * 1, 6)
+      expect(hitMulti(context(3))).toBeCloseTo(ASHBLAZING_ATK_STACK * 2, 6)
+      expect(hitMulti(context(5))).toBeCloseTo(ASHBLAZING_ATK_STACK * 3, 6)
+    })
+
+    it('Himeko FUA — 4 AoE hits: 20%/20%/20%/40%', () => {
+      const hitMulti = ashblazingMulti([aoe(0.20), aoe(0.20), aoe(0.20), aoe(0.40)])
+
+      // 1 enemy: stacks 1, 2, 3, 4
+      expect(hitMulti(context(1))).toBeCloseTo(
+        ASHBLAZING_ATK_STACK * (1 * 0.20 + 2 * 0.20 + 3 * 0.20 + 4 * 0.40), 6,
+      )
+      // 3 enemies: stacks 2, 5, 8, 8
+      expect(hitMulti(context(3))).toBeCloseTo(
+        ASHBLAZING_ATK_STACK * (2 * 0.20 + 5 * 0.20 + 8 * 0.20 + 8 * 0.40), 6,
+      )
+      // 5 enemies: stacks 3, 8, 8, 8
+      expect(hitMulti(context(5))).toBeCloseTo(
+        ASHBLAZING_ATK_STACK * (3 * 0.20 + 8 * 0.20 + 8 * 0.20 + 8 * 0.40), 6,
+      )
+    })
+
+    it('Sampo ULT — 4 AoE hits: 25%×4', () => {
+      const hitMulti = ashblazingMulti([aoe(0.25), aoe(0.25), aoe(0.25), aoe(0.25)])
+
+      expect(hitMulti(context(1))).toBeCloseTo(
+        ASHBLAZING_ATK_STACK * (1 * 0.25 + 2 * 0.25 + 3 * 0.25 + 4 * 0.25), 6,
+      )
+      expect(hitMulti(context(3))).toBeCloseTo(
+        ASHBLAZING_ATK_STACK * (2 * 0.25 + 5 * 0.25 + 8 * 0.25 + 8 * 0.25), 6,
+      )
+      expect(hitMulti(context(5))).toBeCloseTo(
+        ASHBLAZING_ATK_STACK * (3 * 0.25 + 8 * 0.25 + 8 * 0.25 + 8 * 0.25), 6,
+      )
+    })
+  })
+
+  describe('blast hits', () => {
+    it('1 blast hit — caps at 3 targets', () => {
+      const hitMulti = ashblazingMulti([blast(1.00)])
+
+      expect(hitMulti(context(1))).toBeCloseTo(ASHBLAZING_ATK_STACK * 1, 6)
+      expect(hitMulti(context(3))).toBeCloseTo(ASHBLAZING_ATK_STACK * 2, 6)
+      // blast hits max 3 at 5 enemies → starting stacks = ceil(3/2) = 2
+      expect(hitMulti(context(5))).toBeCloseTo(ASHBLAZING_ATK_STACK * 2, 6)
+    })
+
+    it('3 blast hits — 5-enemy case matches 3-enemy case', () => {
+      // Arlan ULT: 3 blast 30%/10%/60%
+      const hitMulti = ashblazingMulti([blast(0.30), blast(0.10), blast(0.60)])
+
+      // 1 enemy: stacks 1, 2, 3
+      expect(hitMulti(context(1))).toBeCloseTo(
+        ASHBLAZING_ATK_STACK * (1 * 0.30 + 2 * 0.10 + 3 * 0.60), 6,
+      )
+      // 3 enemies: stacks 2, 5, 8
+      expect(hitMulti(context(3))).toBeCloseTo(
+        ASHBLAZING_ATK_STACK * (2 * 0.30 + 5 * 0.10 + 8 * 0.60), 6,
+      )
+      // 5 enemies: blast only hits 3, so stacks 2, 5, 8 — same as 3 enemies
+      expect(hitMulti(context(5))).toBeCloseTo(hitMulti(context(3)), 6)
+    })
+  })
+
+  describe('mixed hit types', () => {
+    it('Himeko ULT E6 — 1 AoE + 2 single', () => {
+      const hitMulti = ashblazingMulti([aoe(5 / 9), single(2 / 9), single(2 / 9)])
+
+      // 1 enemy: start=1(aoe), stacks 1, 2, 3
+      expect(hitMulti(context(1))).toBeCloseTo(
+        ASHBLAZING_ATK_STACK * (1 * 5 / 9 + 2 * 2 / 9 + 3 * 2 / 9), 6,
+      )
+      // 3 enemies: start=2(aoe at 3), growth aoe→+3, single→+1 → stacks 2, 5, 6
+      expect(hitMulti(context(3))).toBeCloseTo(
+        ASHBLAZING_ATK_STACK * (2 * 5 / 9 + 5 * 2 / 9 + 6 * 2 / 9), 6,
+      )
+      // 5 enemies: start=3(aoe at 5), growth aoe→+5, single→+1 → stacks 3, 8, 8
+      expect(hitMulti(context(5))).toBeCloseTo(
+        ASHBLAZING_ATK_STACK * (3 * 5 / 9 + 8 * 2 / 9 + 8 * 2 / 9), 6,
+      )
+    })
+
+    it('Saber ULT — 1 AoE + 10 single', () => {
+      const hitMulti = ashblazingMulti([
+        aoe(0.2029),
+        ...Array(10).fill(single(0.0797)),
+      ])
+
+      // Saber weights sum to 0.9999 — normalization adjusts them slightly
+      // Use precision 4 to account for the intentional normalization shift
+
+      // 1 enemy: start=1(aoe), all growth +1 → stacks 1,2,3,4,5,6,7,8,8,8,8
+      expect(hitMulti(context(1))).toBeCloseTo(
+        ASHBLAZING_ATK_STACK * (
+          1 * 0.2029
+          + 2 * 0.0797 + 3 * 0.0797 + 4 * 0.0797 + 5 * 0.0797
+          + 6 * 0.0797 + 7 * 0.0797 + 8 * 0.0797 + 8 * 0.0797
+          + 8 * 0.0797 + 8 * 0.0797
+        ), 4,
+      )
+
+      // 3 enemies: start=2(aoe at 3), aoe growth +3→5, then single +1 each
+      // stacks: 2, 5, 6, 7, 8, 8, 8, 8, 8, 8, 8
+      expect(hitMulti(context(3))).toBeCloseTo(
+        ASHBLAZING_ATK_STACK * (
+          2 * 0.2029 + 5 * 0.0797 + 6 * 0.0797 + 7 * 0.0797 + 8 * 0.0797 * 7
+        ), 4,
+      )
+
+      // 5 enemies: start=3(aoe at 5), aoe growth +5→8, then all at 8
+      // stacks: 3, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8
+      expect(hitMulti(context(5))).toBeCloseTo(
+        ASHBLAZING_ATK_STACK * (3 * 0.2029 + 8 * 0.0797 * 10), 4,
+      )
+    })
+  })
+
+  describe('weight normalization', () => {
+    it('normalizes weights that do not sum to 1', () => {
+      const unnormalized = ashblazingMulti([single(3), single(7)])
+      const normalized = ashblazingMulti([single(0.30), single(0.70)])
+
+      expect(unnormalized(context(1))).toBeCloseTo(normalized(context(1)), 6)
+      expect(unnormalized(context(3))).toBeCloseTo(normalized(context(3)), 6)
+      expect(unnormalized(context(5))).toBeCloseTo(normalized(context(5)), 6)
+    })
+
+    it('leaves weights that already sum to 1 unchanged', () => {
+      const hitMulti = ashblazingMulti([aoe(0.60), aoe(0.40)])
+
+      // 1 enemy: stacks 1, 2
+      expect(hitMulti(context(1))).toBeCloseTo(
+        ASHBLAZING_ATK_STACK * (1 * 0.60 + 2 * 0.40), 6,
+      )
+    })
+  })
+})

--- a/src/lib/conditionals/ashblazingCompute.ts
+++ b/src/lib/conditionals/ashblazingCompute.ts
@@ -1,0 +1,75 @@
+import { ASHBLAZING_ATK_STACK } from 'lib/conditionals/conditionalConstants'
+
+const MAX_STACKS = 8
+const ENEMY_COUNTS = [1, 3, 5] as const
+
+type TargetType = 'single' | 'aoe' | 'blast'
+
+export interface AshblazingHit {
+  targetType: TargetType
+  weight: number
+}
+
+export type AshblazingMultiFn = (context: { enemyCount: number }) => number
+
+export function single(weight: number): AshblazingHit {
+  return { targetType: 'single', weight }
+}
+
+export function aoe(weight: number): AshblazingHit {
+  return { targetType: 'aoe', weight }
+}
+
+export function blast(weight: number): AshblazingHit {
+  return { targetType: 'blast', weight }
+}
+
+function getTargetsHit(targetType: TargetType, enemyCount: number): number {
+  switch (targetType) {
+    case 'single':
+      return 1
+    case 'aoe':
+      return enemyCount
+    case 'blast':
+      return Math.min(3, enemyCount)
+  }
+}
+
+function normalizeWeights(hits: AshblazingHit[]): AshblazingHit[] {
+  const totalWeight = hits.reduce((sum, hit) => sum + hit.weight, 0)
+
+  if (Math.abs(totalWeight - 1.0) < 1e-6) {
+    return hits
+  }
+
+  return hits.map((hit) => ({
+    targetType: hit.targetType,
+    weight: hit.weight / totalWeight,
+  }))
+}
+
+function computeForEnemyCount(hits: AshblazingHit[], enemyCount: number): number {
+  const firstHitTargets = getTargetsHit(hits[0].targetType, enemyCount)
+  let stacks = Math.ceil(firstHitTargets / 2)
+  let weightedStackTotal = 0
+
+  for (const hit of hits) {
+    weightedStackTotal += stacks * hit.weight
+
+    const stackGrowth = getTargetsHit(hit.targetType, enemyCount)
+    stacks = Math.min(MAX_STACKS, stacks + stackGrowth)
+  }
+
+  return ASHBLAZING_ATK_STACK * weightedStackTotal
+}
+
+export function ashblazingMulti(hits: AshblazingHit[]): AshblazingMultiFn {
+  const normalizedHits = normalizeWeights(hits)
+  const hitMultiByEnemyCount: Record<number, number> = {}
+
+  for (const enemyCount of ENEMY_COUNTS) {
+    hitMultiByEnemyCount[enemyCount] = computeForEnemyCount(normalizedHits, enemyCount)
+  }
+
+  return (context) => hitMultiByEnemyCount[context.enemyCount]
+}

--- a/src/lib/conditionals/character/1000/Archer.ts
+++ b/src/lib/conditionals/character/1000/Archer.ts
@@ -1,7 +1,7 @@
 import { SparkleB1 } from 'lib/conditionals/character/1300/SparkleB1'
 import { Cipher } from 'lib/conditionals/character/1400/Cipher'
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
-import { ASHBLAZING_ATK_STACK } from 'lib/conditionals/conditionalConstants'
+import { ashblazingMulti, single } from 'lib/conditionals/ashblazingCompute'
 import {
   boostUltAshblazingAtk,
   gpuBoostUltAshblazingAtk,
@@ -81,7 +81,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     SOURCE_E6,
   } = Source.character(Archer.id)
 
-  const ultHitMulti = ASHBLAZING_ATK_STACK * (1 * 0.04 + 2 * 0.04 + 3 * 0.04 + 4 * 0.04 + 5 * 0.04 + 6 * 0.04 + 7 * 0.04 + 8 * 0.04 * 7 + 8 * 0.44)
+  const ultHitMulti = ashblazingMulti([...Array(14).fill(single(0.04)), single(0.44)])
 
   const basicScaling = basic(e, 1.00, 1.10)
 
@@ -229,10 +229,10 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
-      boostUltAshblazingAtk(x, action, ultHitMulti)
+      boostUltAshblazingAtk(x, action, ultHitMulti(context))
     },
     newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
-      return gpuBoostUltAshblazingAtk(action, ultHitMulti)
+      return gpuBoostUltAshblazingAtk(action, ultHitMulti(context))
     },
   }
 }

--- a/src/lib/conditionals/character/1000/Archer.ts
+++ b/src/lib/conditionals/character/1000/Archer.ts
@@ -351,6 +351,7 @@ const scoring = (): ScoringMetadata => ({
   presets: [
     PresetEffects.fnPioneerSet(4),
     PresetEffects.TENGOKU_SET,
+    PresetEffects.fnMortenaxAshblazingSet(8),
   ],
   sortOption: SortOption.SKILL,
   hiddenColumns: [

--- a/src/lib/conditionals/character/1000/Archer.ts
+++ b/src/lib/conditionals/character/1000/Archer.ts
@@ -1,7 +1,10 @@
+import {
+  ashblazingMulti,
+  single,
+} from 'lib/conditionals/ashblazingCompute'
 import { SparkleB1 } from 'lib/conditionals/character/1300/SparkleB1'
 import { Cipher } from 'lib/conditionals/character/1400/Cipher'
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
-import { ashblazingMulti, single } from 'lib/conditionals/ashblazingCompute'
 import {
   boostUltAshblazingAtk,
   gpuBoostUltAshblazingAtk,
@@ -81,7 +84,10 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     SOURCE_E6,
   } = Source.character(Archer.id)
 
-  const ultHitMulti = ashblazingMulti([...Array(14).fill(single(0.04)), single(0.44)])
+  const ultHitMulti = ashblazingMulti([
+    ...Array(14).fill(single(0.04)),
+    single(0.44),
+  ])
 
   const basicScaling = basic(e, 1.00, 1.10)
 

--- a/src/lib/conditionals/character/1000/Archer.ts
+++ b/src/lib/conditionals/character/1000/Archer.ts
@@ -1,6 +1,11 @@
 import { SparkleB1 } from 'lib/conditionals/character/1300/SparkleB1'
 import { Cipher } from 'lib/conditionals/character/1400/Cipher'
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
+import { ASHBLAZING_ATK_STACK } from 'lib/conditionals/conditionalConstants'
+import {
+  boostUltAshblazingAtk,
+  gpuBoostUltAshblazingAtk,
+} from 'lib/conditionals/conditionalFinalizers'
 import {
   AbilityEidolon,
   type Conditionals,
@@ -75,6 +80,8 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     SOURCE_E4,
     SOURCE_E6,
   } = Source.character(Archer.id)
+
+  const ultHitMulti = ASHBLAZING_ATK_STACK * (1 * 0.04 + 2 * 0.04 + 3 * 0.04 + 4 * 0.04 + 5 * 0.04 + 6 * 0.04 + 7 * 0.04 + 8 * 0.04 * 7 + 8 * 0.44)
 
   const basicScaling = basic(e, 1.00, 1.10)
 
@@ -222,6 +229,10 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
+      boostUltAshblazingAtk(x, action, ultHitMulti)
+    },
+    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
+      return gpuBoostUltAshblazingAtk(action, ultHitMulti)
     },
   }
 }

--- a/src/lib/conditionals/character/1000/Arlan.ts
+++ b/src/lib/conditionals/character/1000/Arlan.ts
@@ -1,7 +1,10 @@
+import {
+  ashblazingMulti,
+  blast,
+} from 'lib/conditionals/ashblazingCompute'
 import { Robin } from 'lib/conditionals/character/1300/Robin'
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
 import { Tribbie } from 'lib/conditionals/character/1400/Tribbie'
-import { ashblazingMulti, blast } from 'lib/conditionals/ashblazingCompute'
 import {
   boostUltAshblazingAtk,
   gpuBoostUltAshblazingAtk,
@@ -84,7 +87,11 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   const skillScaling = skill(e, 2.40, 2.64)
   const ultScaling = ult(e, 3.20, 3.456)
 
-  const ultHitMulti = ashblazingMulti([blast(0.30), blast(0.10), blast(0.60)])
+  const ultHitMulti = ashblazingMulti([
+    blast(0.30),
+    blast(0.10),
+    blast(0.60),
+  ])
 
   const talentMissingHpDmgBoostMax = talent(e, 0.72, 0.792)
 

--- a/src/lib/conditionals/character/1000/Arlan.ts
+++ b/src/lib/conditionals/character/1000/Arlan.ts
@@ -1,6 +1,11 @@
 import { Robin } from 'lib/conditionals/character/1300/Robin'
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
 import { Tribbie } from 'lib/conditionals/character/1400/Tribbie'
+import { ashblazingMulti, blast } from 'lib/conditionals/ashblazingCompute'
+import {
+  boostUltAshblazingAtk,
+  gpuBoostUltAshblazingAtk,
+} from 'lib/conditionals/conditionalFinalizers'
 import {
   AbilityEidolon,
   type Conditionals,
@@ -78,6 +83,8 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   const basicScaling = basic(e, 1.00, 1.10)
   const skillScaling = skill(e, 2.40, 2.64)
   const ultScaling = ult(e, 3.20, 3.456)
+
+  const ultHitMulti = ashblazingMulti([blast(0.30), blast(0.10), blast(0.60)])
 
   const talentMissingHpDmgBoostMax = talent(e, 0.72, 0.792)
 
@@ -161,6 +168,10 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
+      boostUltAshblazingAtk(x, action, ultHitMulti(context))
+    },
+    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
+      return gpuBoostUltAshblazingAtk(action, ultHitMulti(context))
     },
   }
 }

--- a/src/lib/conditionals/character/1000/Arlan.ts
+++ b/src/lib/conditionals/character/1000/Arlan.ts
@@ -43,6 +43,7 @@ import {
   SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
   SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
 } from 'lib/scoring/scoringConstants'
+import { PresetEffects } from 'lib/scoring/presetEffects'
 import { wrappedFixedT } from 'lib/utils/i18nUtils'
 
 import { precisionRound } from 'lib/utils/mathUtils'
@@ -277,7 +278,9 @@ const scoring = (): ScoringMetadata => ({
       Stats.ATK_P,
     ],
   },
-  presets: [],
+  presets: [
+    PresetEffects.fnMortenaxAshblazingSet(8),
+  ],
   sortOption: SortOption.SKILL,
   hiddenColumns: [
     SortOption.FUA,

--- a/src/lib/conditionals/character/1000/DanHeng.ts
+++ b/src/lib/conditionals/character/1000/DanHeng.ts
@@ -1,7 +1,7 @@
 import { Bronya } from 'lib/conditionals/character/1100/Bronya'
 import { HuohuoB1 } from 'lib/conditionals/character/1200/HuohuoB1'
 import { Robin } from 'lib/conditionals/character/1300/Robin'
-import { ULT_ASHBLAZING_1_SINGLE } from 'lib/conditionals/conditionalConstants'
+import { ashblazingMulti, single } from 'lib/conditionals/ashblazingCompute'
 import {
   boostUltAshblazingAtk,
   gpuBoostUltAshblazingAtk,
@@ -80,6 +80,8 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     SOURCE_E4,
     SOURCE_E6,
   } = Source.character(DanHeng.id)
+
+  const ultHitMulti = ashblazingMulti([single(1.00)])
 
   const extraPenValue = talent(e, 0.36, 0.396)
 
@@ -190,10 +192,10 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
-      boostUltAshblazingAtk(x, action, ULT_ASHBLAZING_1_SINGLE)
+      boostUltAshblazingAtk(x, action, ultHitMulti(context))
     },
     newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
-      return gpuBoostUltAshblazingAtk(action, ULT_ASHBLAZING_1_SINGLE)
+      return gpuBoostUltAshblazingAtk(action, ultHitMulti(context))
     },
   }
 }

--- a/src/lib/conditionals/character/1000/DanHeng.ts
+++ b/src/lib/conditionals/character/1000/DanHeng.ts
@@ -1,6 +1,11 @@
 import { Bronya } from 'lib/conditionals/character/1100/Bronya'
 import { HuohuoB1 } from 'lib/conditionals/character/1200/HuohuoB1'
 import { Robin } from 'lib/conditionals/character/1300/Robin'
+import { ULT_ASHBLAZING_1_SINGLE } from 'lib/conditionals/conditionalConstants'
+import {
+  boostUltAshblazingAtk,
+  gpuBoostUltAshblazingAtk,
+} from 'lib/conditionals/conditionalFinalizers'
 import {
   AbilityEidolon,
   type Conditionals,
@@ -185,6 +190,10 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
+      boostUltAshblazingAtk(x, action, ULT_ASHBLAZING_1_SINGLE)
+    },
+    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
+      return gpuBoostUltAshblazingAtk(action, ULT_ASHBLAZING_1_SINGLE)
     },
   }
 }

--- a/src/lib/conditionals/character/1000/DanHeng.ts
+++ b/src/lib/conditionals/character/1000/DanHeng.ts
@@ -297,6 +297,7 @@ const scoring = (): ScoringMetadata => ({
   },
   presets: [
     PresetEffects.fnPioneerSet(4),
+    PresetEffects.fnMortenaxAshblazingSet(1),
   ],
   sortOption: SortOption.ULT,
   hiddenColumns: [

--- a/src/lib/conditionals/character/1000/Herta.ts
+++ b/src/lib/conditionals/character/1000/Herta.ts
@@ -1,7 +1,8 @@
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
 import { TheHerta } from 'lib/conditionals/character/1400/TheHerta'
 import { Tribbie } from 'lib/conditionals/character/1400/Tribbie'
-import { ASHBLAZING_ATK_STACK, ULT_ASHBLAZING_1_AOE } from 'lib/conditionals/conditionalConstants'
+import { aoe, ashblazingMulti } from 'lib/conditionals/ashblazingCompute'
+import { ASHBLAZING_ATK_STACK } from 'lib/conditionals/conditionalConstants'
 import {
   boostAshblazingAtkContainer,
   gpuBoostAshblazingAtkContainer,
@@ -89,6 +90,8 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   const ultScaling = ult(e, 2.00, 2.16)
   const fuaScaling = talent(e, 0.40, 0.43)
 
+  const ultHitMulti = ashblazingMulti([aoe(1.00)])
+
   function getHitMultiByTargetsAndHits(hits: number, context: OptimizerContext) {
     const div = 1 / hits
 
@@ -127,7 +130,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 
   function getHitMulti(action: OptimizerAction, context: OptimizerContext) {
     if (action.actionType === AbilityKind.ULT) {
-      return ULT_ASHBLAZING_1_AOE[context.enemyCount]
+      return ultHitMulti(context)
     }
 
     const r = action.characterConditionals as Conditionals<typeof content>

--- a/src/lib/conditionals/character/1000/Herta.ts
+++ b/src/lib/conditionals/character/1000/Herta.ts
@@ -1,7 +1,7 @@
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
 import { TheHerta } from 'lib/conditionals/character/1400/TheHerta'
 import { Tribbie } from 'lib/conditionals/character/1400/Tribbie'
-import { ASHBLAZING_ATK_STACK } from 'lib/conditionals/conditionalConstants'
+import { ASHBLAZING_ATK_STACK, ULT_ASHBLAZING_1_AOE } from 'lib/conditionals/conditionalConstants'
 import {
   boostAshblazingAtkContainer,
   gpuBoostAshblazingAtkContainer,
@@ -126,6 +126,10 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   }
 
   function getHitMulti(action: OptimizerAction, context: OptimizerContext) {
+    if (action.actionType === AbilityKind.ULT) {
+      return ULT_ASHBLAZING_1_AOE[context.enemyCount]
+    }
+
     const r = action.characterConditionals as Conditionals<typeof content>
 
     const hitMultiStacks = getHitMultiByTargetsAndHits(r.fuaStacks, context)

--- a/src/lib/conditionals/character/1000/Himeko.ts
+++ b/src/lib/conditionals/character/1000/Himeko.ts
@@ -97,6 +97,27 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     5: ASHBLAZING_ATK_STACK * (3 * 0.20 + 8 * 0.20 + 8 * 0.20 + 8 * 0.40), // 0.42
   }
 
+  // ULT: 1 aoe hit
+  const ultHitMultiByTargets: NumberToNumberMap = {
+    1: ASHBLAZING_ATK_STACK * (1 * 1.00),
+    3: ASHBLAZING_ATK_STACK * (2 * 1.00),
+    5: ASHBLAZING_ATK_STACK * (3 * 1.00),
+  }
+
+  // ULT E6: 1 aoe hit (weight 5/9) + 2 single hits (weight 2/9 each)
+  const ultE6HitMultiByTargets: NumberToNumberMap = {
+    1: ASHBLAZING_ATK_STACK * (1 * 5 / 9 + 2 * 2 / 9 + 3 * 2 / 9),
+    3: ASHBLAZING_ATK_STACK * (2 * 5 / 9 + 5 * 2 / 9 + 6 * 2 / 9),
+    5: ASHBLAZING_ATK_STACK * (3 * 5 / 9 + 8 * 2 / 9 + 8 * 2 / 9),
+  }
+
+  function getHitMulti(action: OptimizerAction, context: OptimizerContext) {
+    if (action.actionType === AbilityKind.ULT) {
+      return (e >= 6 ? ultE6HitMultiByTargets : ultHitMultiByTargets)[context.enemyCount]
+    }
+    return hitMultiByTargets[context.enemyCount]
+  }
+
   const defaults = {
     targetBurned: true,
     selfCurrentHp80Percent: true,
@@ -228,10 +249,10 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
-      boostAshblazingAtkContainer(x, action, hitMultiByTargets[context.enemyCount])
+      boostAshblazingAtkContainer(x, action, getHitMulti(action, context))
     },
     newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
-      return gpuBoostAshblazingAtkContainer(hitMultiByTargets[context.enemyCount], action)
+      return gpuBoostAshblazingAtkContainer(getHitMulti(action, context), action)
     },
   }
 }

--- a/src/lib/conditionals/character/1000/Kafka.ts
+++ b/src/lib/conditionals/character/1000/Kafka.ts
@@ -1,7 +1,7 @@
 import { BlackSwanB1 } from 'lib/conditionals/character/1300/BlackSwanB1'
 import { Hysilens } from 'lib/conditionals/character/1400/Hysilens'
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
-import { ASHBLAZING_ATK_STACK } from 'lib/conditionals/conditionalConstants'
+import { ASHBLAZING_ATK_STACK, ULT_ASHBLAZING_1_AOE } from 'lib/conditionals/conditionalConstants'
 import {
   boostAshblazingAtkContainer,
   gpuBoostAshblazingAtkContainer,
@@ -91,8 +91,15 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   const dotScaling = ult(e, 2.90, 3.183)
   const e6DotScaling = 1.56
 
-  const hitMulti = ASHBLAZING_ATK_STACK
+  const fuaHitMulti = ASHBLAZING_ATK_STACK
     * (1 * 0.15 + 2 * 0.15 + 3 * 0.15 + 4 * 0.15 + 5 * 0.15 + 6 * 0.25)
+
+  function getHitMulti(action: OptimizerAction, context: OptimizerContext) {
+    if (action.actionType === AbilityKind.ULT) {
+      return ULT_ASHBLAZING_1_AOE[context.enemyCount]
+    }
+    return fuaHitMulti
+  }
 
   const defaults = {
     dotTickCoefficient: 4,
@@ -221,10 +228,10 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
-      boostAshblazingAtkContainer(x, action, hitMulti)
+      boostAshblazingAtkContainer(x, action, getHitMulti(action, context))
     },
     newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
-      return gpuBoostAshblazingAtkContainer(hitMulti, action)
+      return gpuBoostAshblazingAtkContainer(getHitMulti(action, context), action)
     },
   }
 }

--- a/src/lib/conditionals/character/1000/Kafka.ts
+++ b/src/lib/conditionals/character/1000/Kafka.ts
@@ -1,7 +1,8 @@
 import { BlackSwanB1 } from 'lib/conditionals/character/1300/BlackSwanB1'
 import { Hysilens } from 'lib/conditionals/character/1400/Hysilens'
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
-import { ASHBLAZING_ATK_STACK, ULT_ASHBLAZING_1_AOE } from 'lib/conditionals/conditionalConstants'
+import { aoe, ashblazingMulti } from 'lib/conditionals/ashblazingCompute'
+import { ASHBLAZING_ATK_STACK } from 'lib/conditionals/conditionalConstants'
 import {
   boostAshblazingAtkContainer,
   gpuBoostAshblazingAtkContainer,
@@ -94,9 +95,11 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   const fuaHitMulti = ASHBLAZING_ATK_STACK
     * (1 * 0.15 + 2 * 0.15 + 3 * 0.15 + 4 * 0.15 + 5 * 0.15 + 6 * 0.25)
 
+  const ultHitMulti = ashblazingMulti([aoe(1.00)])
+
   function getHitMulti(action: OptimizerAction, context: OptimizerContext) {
     if (action.actionType === AbilityKind.ULT) {
-      return ULT_ASHBLAZING_1_AOE[context.enemyCount]
+      return ultHitMulti(context)
     }
     return fuaHitMulti
   }

--- a/src/lib/conditionals/character/1000/KafkaB1.ts
+++ b/src/lib/conditionals/character/1000/KafkaB1.ts
@@ -1,7 +1,7 @@
 import { BlackSwanB1 } from 'lib/conditionals/character/1300/BlackSwanB1'
 import { Hysilens } from 'lib/conditionals/character/1400/Hysilens'
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
-import { ASHBLAZING_ATK_STACK } from 'lib/conditionals/conditionalConstants'
+import { ASHBLAZING_ATK_STACK, ULT_ASHBLAZING_1_AOE } from 'lib/conditionals/conditionalConstants'
 import {
   boostAshblazingAtkContainer,
   gpuBoostAshblazingAtkContainer,
@@ -108,8 +108,15 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   const fuaScaling = talent(e, 1.40, 1.596)
   const dotScaling = ult(e, 2.90, 3.183)
 
-  const hitMulti = ASHBLAZING_ATK_STACK
+  const fuaHitMulti = ASHBLAZING_ATK_STACK
     * (1 * 0.15 + 2 * 0.15 + 3 * 0.15 + 4 * 0.15 + 5 * 0.15 + 6 * 0.25)
+
+  function getHitMulti(action: OptimizerAction, context: OptimizerContext) {
+    if (action.actionType === AbilityKind.ULT) {
+      return ULT_ASHBLAZING_1_AOE[context.enemyCount]
+    }
+    return fuaHitMulti
+  }
 
   const defaults = {
     dotTickCoefficient: 4,
@@ -262,7 +269,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
         x.buff(StatKey.ATK, 1.00 * context.baseATK, x.source(SOURCE_TRACE))
       }
 
-      boostAshblazingAtkContainer(x, action, hitMulti)
+      boostAshblazingAtkContainer(x, action, getHitMulti(action, context))
     },
     newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
       const r = action.characterConditionals as Conditionals<typeof content>
@@ -271,7 +278,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 if (${wgslTrue(r.ehrBasedBuff)} && ${containerActionVal(SELF_ENTITY_INDEX, StatKey.EHR, action.config)} >= 0.75) {
   ${buff.action(AKey.ATK, `1.00 * baseATK`).wgsl(action)}
 }
-      ` + gpuBoostAshblazingAtkContainer(hitMulti, action)
+      ` + gpuBoostAshblazingAtkContainer(getHitMulti(action, context), action)
     },
 
     teammateDynamicConditionals: [

--- a/src/lib/conditionals/character/1000/KafkaB1.ts
+++ b/src/lib/conditionals/character/1000/KafkaB1.ts
@@ -1,7 +1,8 @@
 import { BlackSwanB1 } from 'lib/conditionals/character/1300/BlackSwanB1'
 import { Hysilens } from 'lib/conditionals/character/1400/Hysilens'
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
-import { ASHBLAZING_ATK_STACK, ULT_ASHBLAZING_1_AOE } from 'lib/conditionals/conditionalConstants'
+import { aoe, ashblazingMulti } from 'lib/conditionals/ashblazingCompute'
+import { ASHBLAZING_ATK_STACK } from 'lib/conditionals/conditionalConstants'
 import {
   boostAshblazingAtkContainer,
   gpuBoostAshblazingAtkContainer,
@@ -111,9 +112,11 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   const fuaHitMulti = ASHBLAZING_ATK_STACK
     * (1 * 0.15 + 2 * 0.15 + 3 * 0.15 + 4 * 0.15 + 5 * 0.15 + 6 * 0.25)
 
+  const ultHitMulti = ashblazingMulti([aoe(1.00)])
+
   function getHitMulti(action: OptimizerAction, context: OptimizerContext) {
     if (action.actionType === AbilityKind.ULT) {
-      return ULT_ASHBLAZING_1_AOE[context.enemyCount]
+      return ultHitMulti(context)
     }
     return fuaHitMulti
   }

--- a/src/lib/conditionals/character/1000/March7th.ts
+++ b/src/lib/conditionals/character/1000/March7th.ts
@@ -1,6 +1,7 @@
 import { Jiaoqiu } from 'lib/conditionals/character/1200/Jiaoqiu'
 import { Acheron } from 'lib/conditionals/character/1300/Acheron'
 import { Cipher } from 'lib/conditionals/character/1400/Cipher'
+import { ashblazingMulti, aoe } from 'lib/conditionals/ashblazingCompute'
 import { ASHBLAZING_ATK_STACK } from 'lib/conditionals/conditionalConstants'
 import {
   boostAshblazingAtkContainer,
@@ -76,6 +77,15 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 
   const hitMulti = ASHBLAZING_ATK_STACK * (1 * 1 / 1)
 
+  const ultHitMulti = ashblazingMulti([aoe(0.25), aoe(0.25), aoe(0.25), aoe(0.25)])
+
+  function getHitMulti(action: OptimizerAction, context: OptimizerContext) {
+    if (action.actionType === AbilityKind.ULT) {
+      return ultHitMulti(context)
+    }
+    return hitMulti
+  }
+
   const skillShieldScaling = skill(e, 0.57, 0.608)
   const skillShieldFlat = skill(e, 760, 845.5)
 
@@ -147,9 +157,9 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
-      boostAshblazingAtkContainer(x, action, hitMulti)
+      boostAshblazingAtkContainer(x, action, getHitMulti(action, context))
     },
-    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => gpuBoostAshblazingAtkContainer(hitMulti, action),
+    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => gpuBoostAshblazingAtkContainer(getHitMulti(action, context), action),
   }
 }
 

--- a/src/lib/conditionals/character/1000/March7th.ts
+++ b/src/lib/conditionals/character/1000/March7th.ts
@@ -1,7 +1,10 @@
+import {
+  aoe,
+  ashblazingMulti,
+} from 'lib/conditionals/ashblazingCompute'
 import { Jiaoqiu } from 'lib/conditionals/character/1200/Jiaoqiu'
 import { Acheron } from 'lib/conditionals/character/1300/Acheron'
 import { Cipher } from 'lib/conditionals/character/1400/Cipher'
-import { ashblazingMulti, aoe } from 'lib/conditionals/ashblazingCompute'
 import { ASHBLAZING_ATK_STACK } from 'lib/conditionals/conditionalConstants'
 import {
   boostAshblazingAtkContainer,
@@ -77,7 +80,12 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 
   const hitMulti = ASHBLAZING_ATK_STACK * (1 * 1 / 1)
 
-  const ultHitMulti = ashblazingMulti([aoe(0.25), aoe(0.25), aoe(0.25), aoe(0.25)])
+  const ultHitMulti = ashblazingMulti([
+    aoe(0.25),
+    aoe(0.25),
+    aoe(0.25),
+    aoe(0.25),
+  ])
 
   function getHitMulti(action: OptimizerAction, context: OptimizerContext) {
     if (action.actionType === AbilityKind.ULT) {

--- a/src/lib/conditionals/character/1000/March7th.ts
+++ b/src/lib/conditionals/character/1000/March7th.ts
@@ -257,6 +257,7 @@ const scoring = (): ScoringMetadata => ({
   presets: [
     PresetEffects.VALOROUS_SET,
     PresetEffects.WARRIOR_SET,
+    PresetEffects.fnMortenaxAshblazingSet(8),
   ],
   sortOption: SortOption.SKILL_SHIELD,
   addedColumns: [],

--- a/src/lib/conditionals/character/1000/Saber.ts
+++ b/src/lib/conditionals/character/1000/Saber.ts
@@ -44,6 +44,7 @@ import {
   SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
   SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
 } from 'lib/scoring/scoringConstants'
+import { PresetEffects } from 'lib/scoring/presetEffects'
 import { wrappedFixedT } from 'lib/utils/i18nUtils'
 import { precisionRound } from 'lib/utils/mathUtils'
 import { type Eidolon } from 'types/character'
@@ -398,7 +399,9 @@ const scoring = (): ScoringMetadata => ({
       Stats.ERR,
     ],
   },
-  presets: [],
+  presets: [
+    PresetEffects.fnMortenaxAshblazingSet(8),
+  ],
   sortOption: SortOption.ULT,
   hiddenColumns: [
     SortOption.DOT,

--- a/src/lib/conditionals/character/1000/Saber.ts
+++ b/src/lib/conditionals/character/1000/Saber.ts
@@ -87,7 +87,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   const ultScaling = ult(e, 2.80, 3.08)
   const ultBounceScaling = ult(e, 1.10, 1.21)
 
-  const ultHitMulti = ashblazingMulti([aoe(0.2029), ...Array(10).fill(single(0.0797))])
+  const ultHitMulti = ashblazingMulti([aoe(ultScaling), ...Array(10).fill(single(ultBounceScaling))])
 
   const talentDmgBuffScaling = talent(e, 0.60, 0.66)
 

--- a/src/lib/conditionals/character/1000/Saber.ts
+++ b/src/lib/conditionals/character/1000/Saber.ts
@@ -1,7 +1,11 @@
+import {
+  aoe,
+  ashblazingMulti,
+  single,
+} from 'lib/conditionals/ashblazingCompute'
 import { HuohuoB1 } from 'lib/conditionals/character/1200/HuohuoB1'
 import { Tingyun } from 'lib/conditionals/character/1200/Tingyun'
 import { Sunday } from 'lib/conditionals/character/1300/Sunday'
-import { aoe, ashblazingMulti, single } from 'lib/conditionals/ashblazingCompute'
 import {
   boostUltAshblazingAtk,
   gpuBoostUltAshblazingAtk,
@@ -87,7 +91,10 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   const ultScaling = ult(e, 2.80, 3.08)
   const ultBounceScaling = ult(e, 1.10, 1.21)
 
-  const ultHitMulti = ashblazingMulti([aoe(ultScaling), ...Array(10).fill(single(ultBounceScaling))])
+  const ultHitMulti = ashblazingMulti([
+    aoe(ultScaling),
+    ...Array(10).fill(single(ultBounceScaling)),
+  ])
 
   const talentDmgBuffScaling = talent(e, 0.60, 0.66)
 

--- a/src/lib/conditionals/character/1000/Saber.ts
+++ b/src/lib/conditionals/character/1000/Saber.ts
@@ -1,6 +1,11 @@
 import { HuohuoB1 } from 'lib/conditionals/character/1200/HuohuoB1'
 import { Tingyun } from 'lib/conditionals/character/1200/Tingyun'
 import { Sunday } from 'lib/conditionals/character/1300/Sunday'
+import { aoe, ashblazingMulti, single } from 'lib/conditionals/ashblazingCompute'
+import {
+  boostUltAshblazingAtk,
+  gpuBoostUltAshblazingAtk,
+} from 'lib/conditionals/conditionalFinalizers'
 import {
   AbilityEidolon,
   type Conditionals,
@@ -81,6 +86,8 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 
   const ultScaling = ult(e, 2.80, 3.08)
   const ultBounceScaling = ult(e, 1.10, 1.21)
+
+  const ultHitMulti = ashblazingMulti([aoe(0.2029), ...Array(10).fill(single(0.0797))])
 
   const talentDmgBuffScaling = talent(e, 0.60, 0.66)
 
@@ -276,8 +283,11 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
+      boostUltAshblazingAtk(x, action, ultHitMulti(context))
     },
-    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => '',
+    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
+      return gpuBoostUltAshblazingAtk(action, ultHitMulti(context))
+    },
   }
 }
 

--- a/src/lib/conditionals/character/1000/SilverWolf.ts
+++ b/src/lib/conditionals/character/1000/SilverWolf.ts
@@ -1,3 +1,8 @@
+import { ULT_ASHBLAZING_1_SINGLE } from 'lib/conditionals/conditionalConstants'
+import {
+  boostUltAshblazingAtk,
+  gpuBoostUltAshblazingAtk,
+} from 'lib/conditionals/conditionalFinalizers'
 import {
   AbilityEidolon,
   type Conditionals,
@@ -208,8 +213,11 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
+      boostUltAshblazingAtk(x, action, ULT_ASHBLAZING_1_SINGLE)
     },
-    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => '',
+    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
+      return gpuBoostUltAshblazingAtk(action, ULT_ASHBLAZING_1_SINGLE)
+    },
   }
 }
 

--- a/src/lib/conditionals/character/1000/SilverWolf.ts
+++ b/src/lib/conditionals/character/1000/SilverWolf.ts
@@ -1,4 +1,4 @@
-import { ULT_ASHBLAZING_1_AOE } from 'lib/conditionals/conditionalConstants'
+import { aoe, ashblazingMulti } from 'lib/conditionals/ashblazingCompute'
 import {
   boostUltAshblazingAtk,
   gpuBoostUltAshblazingAtk,
@@ -60,6 +60,8 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     SOURCE_E4,
     SOURCE_E6,
   } = Source.character(SilverWolf.id)
+
+  const ultHitMulti = ashblazingMulti([aoe(1.00)])
 
   const skillResShredValue = skill(e, 0.10, 0.105)
   const talentDefShredDebuffValue = talent(e, 0.08, 0.088)
@@ -213,10 +215,10 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
-      boostUltAshblazingAtk(x, action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
+      boostUltAshblazingAtk(x, action, ultHitMulti(context))
     },
     newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
-      return gpuBoostUltAshblazingAtk(action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
+      return gpuBoostUltAshblazingAtk(action, ultHitMulti(context))
     },
   }
 }

--- a/src/lib/conditionals/character/1000/SilverWolf.ts
+++ b/src/lib/conditionals/character/1000/SilverWolf.ts
@@ -261,6 +261,7 @@ const scoring = (): ScoringMetadata => ({
   },
   presets: [
     PresetEffects.fnPioneerSet(4),
+    PresetEffects.fnMortenaxAshblazingSet(1),
   ],
   sortOption: SortOption.ULT,
   hiddenColumns: [

--- a/src/lib/conditionals/character/1000/SilverWolf.ts
+++ b/src/lib/conditionals/character/1000/SilverWolf.ts
@@ -1,4 +1,4 @@
-import { ULT_ASHBLAZING_1_SINGLE } from 'lib/conditionals/conditionalConstants'
+import { ULT_ASHBLAZING_1_AOE } from 'lib/conditionals/conditionalConstants'
 import {
   boostUltAshblazingAtk,
   gpuBoostUltAshblazingAtk,
@@ -213,10 +213,10 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
-      boostUltAshblazingAtk(x, action, ULT_ASHBLAZING_1_SINGLE)
+      boostUltAshblazingAtk(x, action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
     },
     newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
-      return gpuBoostUltAshblazingAtk(action, ULT_ASHBLAZING_1_SINGLE)
+      return gpuBoostUltAshblazingAtk(action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
     },
   }
 }

--- a/src/lib/conditionals/character/1000/Welt.ts
+++ b/src/lib/conditionals/character/1000/Welt.ts
@@ -1,7 +1,10 @@
+import {
+  aoe,
+  ashblazingMulti,
+} from 'lib/conditionals/ashblazingCompute'
 import { Jiaoqiu } from 'lib/conditionals/character/1200/Jiaoqiu'
 import { Acheron } from 'lib/conditionals/character/1300/Acheron'
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
-import { ashblazingMulti, aoe } from 'lib/conditionals/ashblazingCompute'
 import {
   boostUltAshblazingAtk,
   gpuBoostUltAshblazingAtk,
@@ -88,7 +91,10 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   const ultScaling = ult(e, 1.50, 1.62)
   const talentScaling = talent(e, 0.60, 0.66)
 
-  const ultHitMulti = ashblazingMulti([aoe(0.10), aoe(0.90)])
+  const ultHitMulti = ashblazingMulti([
+    aoe(0.10),
+    aoe(0.90),
+  ])
 
   const content: ContentDefinition<typeof defaults> = {
     enemyDmgTakenDebuff: {

--- a/src/lib/conditionals/character/1000/Welt.ts
+++ b/src/lib/conditionals/character/1000/Welt.ts
@@ -1,6 +1,11 @@
 import { Jiaoqiu } from 'lib/conditionals/character/1200/Jiaoqiu'
 import { Acheron } from 'lib/conditionals/character/1300/Acheron'
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
+import { ashblazingMulti, aoe } from 'lib/conditionals/ashblazingCompute'
+import {
+  boostUltAshblazingAtk,
+  gpuBoostUltAshblazingAtk,
+} from 'lib/conditionals/conditionalFinalizers'
 import {
   AbilityEidolon,
   type Conditionals,
@@ -82,6 +87,8 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   const skillScaling = skill(e, 0.72, 0.792)
   const ultScaling = ult(e, 1.50, 1.62)
   const talentScaling = talent(e, 0.60, 0.66)
+
+  const ultHitMulti = ashblazingMulti([aoe(0.10), aoe(0.90)])
 
   const content: ContentDefinition<typeof defaults> = {
     enemyDmgTakenDebuff: {
@@ -236,8 +243,11 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
+      boostUltAshblazingAtk(x, action, ultHitMulti(context))
     },
-    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => '',
+    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
+      return gpuBoostUltAshblazingAtk(action, ultHitMulti(context))
+    },
   }
 }
 

--- a/src/lib/conditionals/character/1000/Welt.ts
+++ b/src/lib/conditionals/character/1000/Welt.ts
@@ -359,6 +359,7 @@ const scoring = (): ScoringMetadata => ({
   presets: [
     PresetEffects.WASTELANDER_SET,
     PresetEffects.fnPioneerSet(4),
+    PresetEffects.fnMortenaxAshblazingSet(8),
   ],
   sortOption: SortOption.SKILL,
   hiddenColumns: [

--- a/src/lib/conditionals/character/1100/Hook.ts
+++ b/src/lib/conditionals/character/1100/Hook.ts
@@ -1,6 +1,11 @@
 import { SparkleB1 } from 'lib/conditionals/character/1300/SparkleB1'
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
 import { Tribbie } from 'lib/conditionals/character/1400/Tribbie'
+import { ASHBLAZING_ATK_STACK } from 'lib/conditionals/conditionalConstants'
+import {
+  boostUltAshblazingAtk,
+  gpuBoostUltAshblazingAtk,
+} from 'lib/conditionals/conditionalFinalizers'
 import {
   AbilityEidolon,
   type Conditionals,
@@ -77,6 +82,8 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     SOURCE_E4,
     SOURCE_E6,
   } = Source.character(Hook.id)
+
+  const ultHitMulti = ASHBLAZING_ATK_STACK * (1 * 0.30 + 2 * 0.70)
 
   const targetBurnedExtraScaling = talent(e, 1.00, 1.10)
 
@@ -201,8 +208,11 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
+      boostUltAshblazingAtk(x, action, ultHitMulti)
     },
-    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => '',
+    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
+      return gpuBoostUltAshblazingAtk(action, ultHitMulti)
+    },
   }
 }
 

--- a/src/lib/conditionals/character/1100/Hook.ts
+++ b/src/lib/conditionals/character/1100/Hook.ts
@@ -321,6 +321,7 @@ const scoring = (): ScoringMetadata => ({
   },
   presets: [
     PresetEffects.fnPioneerSet(4),
+    PresetEffects.fnMortenaxAshblazingSet(2),
   ],
   sortOption: SortOption.SKILL,
   hiddenColumns: [

--- a/src/lib/conditionals/character/1100/Hook.ts
+++ b/src/lib/conditionals/character/1100/Hook.ts
@@ -1,7 +1,10 @@
+import {
+  ashblazingMulti,
+  single,
+} from 'lib/conditionals/ashblazingCompute'
 import { SparkleB1 } from 'lib/conditionals/character/1300/SparkleB1'
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
 import { Tribbie } from 'lib/conditionals/character/1400/Tribbie'
-import { ashblazingMulti, single } from 'lib/conditionals/ashblazingCompute'
 import {
   boostUltAshblazingAtk,
   gpuBoostUltAshblazingAtk,
@@ -83,7 +86,10 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     SOURCE_E6,
   } = Source.character(Hook.id)
 
-  const ultHitMulti = ashblazingMulti([single(0.30), single(0.70)])
+  const ultHitMulti = ashblazingMulti([
+    single(0.30),
+    single(0.70),
+  ])
 
   const targetBurnedExtraScaling = talent(e, 1.00, 1.10)
 

--- a/src/lib/conditionals/character/1100/Hook.ts
+++ b/src/lib/conditionals/character/1100/Hook.ts
@@ -1,7 +1,7 @@
 import { SparkleB1 } from 'lib/conditionals/character/1300/SparkleB1'
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
 import { Tribbie } from 'lib/conditionals/character/1400/Tribbie'
-import { ASHBLAZING_ATK_STACK } from 'lib/conditionals/conditionalConstants'
+import { ashblazingMulti, single } from 'lib/conditionals/ashblazingCompute'
 import {
   boostUltAshblazingAtk,
   gpuBoostUltAshblazingAtk,
@@ -83,7 +83,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     SOURCE_E6,
   } = Source.character(Hook.id)
 
-  const ultHitMulti = ASHBLAZING_ATK_STACK * (1 * 0.30 + 2 * 0.70)
+  const ultHitMulti = ashblazingMulti([single(0.30), single(0.70)])
 
   const targetBurnedExtraScaling = talent(e, 1.00, 1.10)
 
@@ -208,10 +208,10 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
-      boostUltAshblazingAtk(x, action, ultHitMulti)
+      boostUltAshblazingAtk(x, action, ultHitMulti(context))
     },
     newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
-      return gpuBoostUltAshblazingAtk(action, ultHitMulti)
+      return gpuBoostUltAshblazingAtk(action, ultHitMulti(context))
     },
   }
 }

--- a/src/lib/conditionals/character/1100/Luka.ts
+++ b/src/lib/conditionals/character/1100/Luka.ts
@@ -358,6 +358,7 @@ const scoring = (): ScoringMetadata => ({
   },
   presets: [
     PresetEffects.PRISONER_SET,
+    PresetEffects.fnMortenaxAshblazingSet(1),
   ],
   sortOption: SortOption.DOT,
   hiddenColumns: [

--- a/src/lib/conditionals/character/1100/Luka.ts
+++ b/src/lib/conditionals/character/1100/Luka.ts
@@ -1,6 +1,11 @@
 import { Fugue } from 'lib/conditionals/character/1200/Fugue'
 import { Lingsha } from 'lib/conditionals/character/1200/Lingsha'
 import { RuanMei } from 'lib/conditionals/character/1300/RuanMei'
+import { ULT_ASHBLAZING_1_SINGLE } from 'lib/conditionals/conditionalConstants'
+import {
+  boostUltAshblazingAtk,
+  gpuBoostUltAshblazingAtk,
+} from 'lib/conditionals/conditionalFinalizers'
 import {
   AbilityEidolon,
   type Conditionals,
@@ -238,8 +243,11 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
+      boostUltAshblazingAtk(x, action, ULT_ASHBLAZING_1_SINGLE)
     },
-    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => '',
+    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
+      return gpuBoostUltAshblazingAtk(action, ULT_ASHBLAZING_1_SINGLE)
+    },
   }
 }
 

--- a/src/lib/conditionals/character/1100/Luka.ts
+++ b/src/lib/conditionals/character/1100/Luka.ts
@@ -1,7 +1,7 @@
 import { Fugue } from 'lib/conditionals/character/1200/Fugue'
 import { Lingsha } from 'lib/conditionals/character/1200/Lingsha'
 import { RuanMei } from 'lib/conditionals/character/1300/RuanMei'
-import { ULT_ASHBLAZING_1_SINGLE } from 'lib/conditionals/conditionalConstants'
+import { ashblazingMulti, single } from 'lib/conditionals/ashblazingCompute'
 import {
   boostUltAshblazingAtk,
   gpuBoostUltAshblazingAtk,
@@ -84,6 +84,8 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     SOURCE_E4,
     SOURCE_E6,
   } = Source.character(Luka.id)
+
+  const ultHitMulti = ashblazingMulti([single(1.00)])
 
   const basicEnhancedHitValue = basic(e, 0.20, 0.22)
   const targetUltDebuffDmgTakenValue = ult(e, 0.20, 0.216)
@@ -243,10 +245,10 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
-      boostUltAshblazingAtk(x, action, ULT_ASHBLAZING_1_SINGLE)
+      boostUltAshblazingAtk(x, action, ultHitMulti(context))
     },
     newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
-      return gpuBoostUltAshblazingAtk(action, ULT_ASHBLAZING_1_SINGLE)
+      return gpuBoostUltAshblazingAtk(action, ultHitMulti(context))
     },
   }
 }

--- a/src/lib/conditionals/character/1100/Pela.ts
+++ b/src/lib/conditionals/character/1100/Pela.ts
@@ -1,4 +1,4 @@
-import { ULT_ASHBLAZING_1_AOE } from 'lib/conditionals/conditionalConstants'
+import { aoe, ashblazingMulti } from 'lib/conditionals/ashblazingCompute'
 import {
   boostUltAshblazingAtk,
   gpuBoostUltAshblazingAtk,
@@ -55,6 +55,8 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     SOURCE_E2,
     SOURCE_E4,
   } = Source.character(Pela.id)
+
+  const ultHitMulti = ashblazingMulti([aoe(1.00)])
 
   const ultDefPenValue = ult(e, 0.40, 0.42)
 
@@ -223,10 +225,10 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
-      boostUltAshblazingAtk(x, action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
+      boostUltAshblazingAtk(x, action, ultHitMulti(context))
     },
     newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
-      return gpuBoostUltAshblazingAtk(action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
+      return gpuBoostUltAshblazingAtk(action, ultHitMulti(context))
     },
   }
 }

--- a/src/lib/conditionals/character/1100/Pela.ts
+++ b/src/lib/conditionals/character/1100/Pela.ts
@@ -1,3 +1,8 @@
+import { ULT_ASHBLAZING_1_AOE } from 'lib/conditionals/conditionalConstants'
+import {
+  boostUltAshblazingAtk,
+  gpuBoostUltAshblazingAtk,
+} from 'lib/conditionals/conditionalFinalizers'
 import {
   AbilityEidolon,
   type Conditionals,
@@ -217,8 +222,12 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
       x.buff(StatKey.RES_PEN, (e >= 4 && m.e4SkillResShred) ? 0.12 : 0, x.elements(ElementTag.Ice).targets(TargetTag.FullTeam).source(SOURCE_E4))
     },
 
-    finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {},
-    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => '',
+    finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
+      boostUltAshblazingAtk(x, action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
+    },
+    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
+      return gpuBoostUltAshblazingAtk(action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
+    },
   }
 }
 

--- a/src/lib/conditionals/character/1100/Pela.ts
+++ b/src/lib/conditionals/character/1100/Pela.ts
@@ -268,6 +268,7 @@ const scoring = (): ScoringMetadata => ({
   },
   presets: [
     PresetEffects.fnPioneerSet(4),
+    PresetEffects.fnMortenaxAshblazingSet(5),
   ],
   sortOption: SortOption.SPD,
   hiddenColumns: [

--- a/src/lib/conditionals/character/1100/Sampo.ts
+++ b/src/lib/conditionals/character/1100/Sampo.ts
@@ -1,7 +1,10 @@
+import {
+  aoe,
+  ashblazingMulti,
+} from 'lib/conditionals/ashblazingCompute'
 import { KafkaB1 } from 'lib/conditionals/character/1000/KafkaB1'
 import { Hysilens } from 'lib/conditionals/character/1400/Hysilens'
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
-import { ashblazingMulti, aoe } from 'lib/conditionals/ashblazingCompute'
 import {
   boostUltAshblazingAtk,
   gpuBoostUltAshblazingAtk,
@@ -83,7 +86,12 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   const ultScaling = ult(e, 1.60, 1.728)
   const dotScaling = talent(e, 0.52, 0.572)
 
-  const ultHitMulti = ashblazingMulti([aoe(0.25), aoe(0.25), aoe(0.25), aoe(0.25)])
+  const ultHitMulti = ashblazingMulti([
+    aoe(0.25),
+    aoe(0.25),
+    aoe(0.25),
+    aoe(0.25),
+  ])
 
   const maxExtraHits = e < 1 ? 4 : 5
   const defaults = {

--- a/src/lib/conditionals/character/1100/Sampo.ts
+++ b/src/lib/conditionals/character/1100/Sampo.ts
@@ -1,6 +1,11 @@
 import { KafkaB1 } from 'lib/conditionals/character/1000/KafkaB1'
 import { Hysilens } from 'lib/conditionals/character/1400/Hysilens'
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
+import { ashblazingMulti, aoe } from 'lib/conditionals/ashblazingCompute'
+import {
+  boostUltAshblazingAtk,
+  gpuBoostUltAshblazingAtk,
+} from 'lib/conditionals/conditionalFinalizers'
 import {
   AbilityEidolon,
   type Conditionals,
@@ -77,6 +82,8 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   const skillScaling = skill(e, 0.56, 0.616)
   const ultScaling = ult(e, 1.60, 1.728)
   const dotScaling = talent(e, 0.52, 0.572)
+
+  const ultHitMulti = ashblazingMulti([aoe(0.25), aoe(0.25), aoe(0.25), aoe(0.25)])
 
   const maxExtraHits = e < 1 ? 4 : 5
   const defaults = {
@@ -215,8 +222,12 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
       )
     },
 
-    finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {},
-    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => '',
+    finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
+      boostUltAshblazingAtk(x, action, ultHitMulti(context))
+    },
+    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
+      return gpuBoostUltAshblazingAtk(action, ultHitMulti(context))
+    },
   }
 }
 

--- a/src/lib/conditionals/character/1100/Sampo.ts
+++ b/src/lib/conditionals/character/1100/Sampo.ts
@@ -339,6 +339,7 @@ const scoring = (): ScoringMetadata => ({
   },
   presets: [
     PresetEffects.PRISONER_SET,
+    PresetEffects.fnMortenaxAshblazingSet(8),
   ],
   sortOption: SortOption.DOT,
   hiddenColumns: [

--- a/src/lib/conditionals/character/1100/Seele.ts
+++ b/src/lib/conditionals/character/1100/Seele.ts
@@ -1,7 +1,7 @@
 import { SilverWolfB1 } from 'lib/conditionals/character/1000/SilverWolfB1'
 import { SparkleB1 } from 'lib/conditionals/character/1300/SparkleB1'
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
-import { ULT_ASHBLAZING_1_SINGLE } from 'lib/conditionals/conditionalConstants'
+import { ashblazingMulti, single } from 'lib/conditionals/ashblazingCompute'
 import {
   boostUltAshblazingAtk,
   gpuBoostUltAshblazingAtk,
@@ -71,6 +71,8 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     SOURCE_TRACE,
     SOURCE_E1,
   } = Source.character(Seele.id)
+
+  const ultHitMulti = ashblazingMulti([single(1.00)])
 
   const buffedStateDmgBuff = talent(e, 0.80, 0.88)
   const speedBoostStacksMax = e >= 2 ? 2 : 1
@@ -215,10 +217,10 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
-      boostUltAshblazingAtk(x, action, ULT_ASHBLAZING_1_SINGLE)
+      boostUltAshblazingAtk(x, action, ultHitMulti(context))
     },
     newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
-      return gpuBoostUltAshblazingAtk(action, ULT_ASHBLAZING_1_SINGLE)
+      return gpuBoostUltAshblazingAtk(action, ultHitMulti(context))
     },
   }
 }

--- a/src/lib/conditionals/character/1100/Seele.ts
+++ b/src/lib/conditionals/character/1100/Seele.ts
@@ -1,6 +1,11 @@
 import { SilverWolfB1 } from 'lib/conditionals/character/1000/SilverWolfB1'
 import { SparkleB1 } from 'lib/conditionals/character/1300/SparkleB1'
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
+import { ULT_ASHBLAZING_1_SINGLE } from 'lib/conditionals/conditionalConstants'
+import {
+  boostUltAshblazingAtk,
+  gpuBoostUltAshblazingAtk,
+} from 'lib/conditionals/conditionalFinalizers'
 import {
   AbilityEidolon,
   type Conditionals,
@@ -209,8 +214,12 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
       // TODO: Seele's E6 should have a teammate effect but its kinda hard to calc
     },
 
-    finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {},
-    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => '',
+    finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
+      boostUltAshblazingAtk(x, action, ULT_ASHBLAZING_1_SINGLE)
+    },
+    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
+      return gpuBoostUltAshblazingAtk(action, ULT_ASHBLAZING_1_SINGLE)
+    },
   }
 }
 

--- a/src/lib/conditionals/character/1100/Seele.ts
+++ b/src/lib/conditionals/character/1100/Seele.ts
@@ -324,6 +324,7 @@ const scoring = (): ScoringMetadata => ({
   },
   presets: [
     PresetEffects.TENGOKU_SET,
+    PresetEffects.fnMortenaxAshblazingSet(1),
   ],
   sortOption: SortOption.SKILL,
   hiddenColumns: [

--- a/src/lib/conditionals/character/1100/Serval.ts
+++ b/src/lib/conditionals/character/1100/Serval.ts
@@ -1,6 +1,11 @@
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
 import { TheHerta } from 'lib/conditionals/character/1400/TheHerta'
 import { Tribbie } from 'lib/conditionals/character/1400/Tribbie'
+import { ULT_ASHBLAZING_1_AOE } from 'lib/conditionals/conditionalConstants'
+import {
+  boostUltAshblazingAtk,
+  gpuBoostUltAshblazingAtk,
+} from 'lib/conditionals/conditionalFinalizers'
 import {
   AbilityEidolon,
   type Conditionals,
@@ -193,8 +198,12 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
       x.buff(StatKey.BOOST, (e >= 6 && r.targetShocked) ? 0.30 : 0, x.source(SOURCE_E6))
     },
 
-    finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {},
-    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => '',
+    finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
+      boostUltAshblazingAtk(x, action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
+    },
+    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
+      return gpuBoostUltAshblazingAtk(action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
+    },
   }
 }
 

--- a/src/lib/conditionals/character/1100/Serval.ts
+++ b/src/lib/conditionals/character/1100/Serval.ts
@@ -314,6 +314,7 @@ const scoring = (): ScoringMetadata => ({
   },
   presets: [
     PresetEffects.fnPioneerSet(4),
+    PresetEffects.fnMortenaxAshblazingSet(5),
   ],
   sortOption: SortOption.ULT,
   hiddenColumns: [

--- a/src/lib/conditionals/character/1100/Serval.ts
+++ b/src/lib/conditionals/character/1100/Serval.ts
@@ -1,7 +1,7 @@
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
 import { TheHerta } from 'lib/conditionals/character/1400/TheHerta'
 import { Tribbie } from 'lib/conditionals/character/1400/Tribbie'
-import { ULT_ASHBLAZING_1_AOE } from 'lib/conditionals/conditionalConstants'
+import { aoe, ashblazingMulti } from 'lib/conditionals/ashblazingCompute'
 import {
   boostUltAshblazingAtk,
   gpuBoostUltAshblazingAtk,
@@ -76,6 +76,8 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     SOURCE_TRACE,
     SOURCE_E6,
   } = Source.character(Serval.id)
+
+  const ultHitMulti = ashblazingMulti([aoe(1.00)])
 
   const talentExtraDmgScaling = talent(e, 0.72, 0.792)
 
@@ -199,10 +201,10 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
-      boostUltAshblazingAtk(x, action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
+      boostUltAshblazingAtk(x, action, ultHitMulti(context))
     },
     newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
-      return gpuBoostUltAshblazingAtk(action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
+      return gpuBoostUltAshblazingAtk(action, ultHitMulti(context))
     },
   }
 }

--- a/src/lib/conditionals/character/1200/Feixiao.ts
+++ b/src/lib/conditionals/character/1200/Feixiao.ts
@@ -1,6 +1,7 @@
 import { Robin } from 'lib/conditionals/character/1300/Robin'
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
 import { Tribbie } from 'lib/conditionals/character/1400/Tribbie'
+import { ashblazingMulti, single } from 'lib/conditionals/ashblazingCompute'
 import {
   ASHBLAZING_ATK_STACK,
 } from 'lib/conditionals/conditionalConstants'
@@ -97,21 +98,22 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   const fuaScaling = talent(e, 1.10, 1.21)
   const talentDmgBuff = talent(e, 0.60, 0.66)
 
-  const ultHitCountMulti = 1 * 0.1285 + 2 * 0.1285 + 3 * 0.1285 + 4 * 0.1285 + 5 * 0.1285 + 6 * 0.1285 + 7 * 0.2285
-  const ultBrokenHitCountMulti = 1 * 0.1285 * 0.1 + 2 * 0.1285 * 0.9
-    + 3 * 0.1285 * 0.1 + 4 * 0.1285 * 0.9
-    + 5 * 0.1285 * 0.1 + 6 * 0.1285 * 0.9
-    + 7 * 0.1285 * 0.1 + 8 * 0.1285 * 0.9
-    + 8 * 0.1285 * 0.1 + 8 * 0.1285 * 0.9
-    + 8 * 0.1285 * 0.1 + 8 * 0.1285 * 0.9
-    + 8 * 0.2285
+  const ultHitMulti = ashblazingMulti([
+    ...Array(6).fill(single(0.1285)),
+    single(0.2285),
+  ])
+
+  const ultBrokenHitMulti = ashblazingMulti([
+    ...Array(6).flatMap(() => [single(0.1285 * 0.1), single(0.1285 * 0.9)]),
+    single(0.2285),
+  ])
 
   function getUltHitMulti(action: OptimizerAction, context: OptimizerContext) {
     const r = action.characterConditionals as Conditionals<typeof content>
 
     return r.weaknessBrokenUlt
-      ? ASHBLAZING_ATK_STACK * ultBrokenHitCountMulti
-      : ASHBLAZING_ATK_STACK * ultHitCountMulti
+      ? ultBrokenHitMulti(context)
+      : ultHitMulti(context)
   }
 
   const defaults = {
@@ -271,12 +273,16 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
-      const fuaHitMulti = ASHBLAZING_ATK_STACK * (1 * 1.00)
-      boostAshblazingAtkContainer(x, action, fuaHitMulti)
+      const hitMulti = action.actionType === AbilityKind.ULT
+        ? getUltHitMulti(action, context)
+        : ASHBLAZING_ATK_STACK * (1 * 1.00)
+      boostAshblazingAtkContainer(x, action, hitMulti)
     },
     newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
-      const fuaHitMulti = ASHBLAZING_ATK_STACK * (1 * 1.00)
-      return gpuBoostAshblazingAtkContainer(fuaHitMulti, action)
+      const hitMulti = action.actionType === AbilityKind.ULT
+        ? getUltHitMulti(action, context)
+        : ASHBLAZING_ATK_STACK * (1 * 1.00)
+      return gpuBoostAshblazingAtkContainer(hitMulti, action)
     },
   }
 }

--- a/src/lib/conditionals/character/1200/Feixiao.ts
+++ b/src/lib/conditionals/character/1200/Feixiao.ts
@@ -1,7 +1,10 @@
+import {
+  ashblazingMulti,
+  single,
+} from 'lib/conditionals/ashblazingCompute'
 import { Robin } from 'lib/conditionals/character/1300/Robin'
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
 import { Tribbie } from 'lib/conditionals/character/1400/Tribbie'
-import { ashblazingMulti, single } from 'lib/conditionals/ashblazingCompute'
 import {
   ASHBLAZING_ATK_STACK,
 } from 'lib/conditionals/conditionalConstants'
@@ -104,7 +107,10 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   ])
 
   const ultBrokenHitMulti = ashblazingMulti([
-    ...Array(6).flatMap(() => [single(0.1285 * 0.1), single(0.1285 * 0.9)]),
+    ...Array(6).flatMap(() => [
+      single(0.1285 * 0.1),
+      single(0.1285 * 0.9),
+    ]),
     single(0.2285),
   ])
 

--- a/src/lib/conditionals/character/1200/Fugue.ts
+++ b/src/lib/conditionals/character/1200/Fugue.ts
@@ -1,6 +1,11 @@
 import { Lingsha } from 'lib/conditionals/character/1200/Lingsha'
 import { FireflyB1 } from 'lib/conditionals/character/1300/FireflyB1'
 import { TheDahlia } from 'lib/conditionals/character/1300/TheDahlia'
+import { ashblazingMulti, aoe } from 'lib/conditionals/ashblazingCompute'
+import {
+  boostUltAshblazingAtk,
+  gpuBoostUltAshblazingAtk,
+} from 'lib/conditionals/conditionalFinalizers'
 import {
   AbilityEidolon,
   addSuperBreakHits,
@@ -87,6 +92,8 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   const basicScaling = basic(e, 1.00, 1.10)
   const ultScaling = ult(e, 2.00, 2.20)
   const superBreakScaling = talent(e, 1.00, 1.10)
+
+  const ultHitMulti = ashblazingMulti([aoe(0.60), aoe(0.10), aoe(0.10), aoe(0.10), aoe(0.10)])
 
   const defaults = {
     torridScorch: true,
@@ -259,7 +266,12 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
       x.buff(StatKey.BE, t.weaknessBreakBeStacks * (0.06 + (t.be220Buff ? 0.12 : 0)), x.targets(TargetTag.FullTeam).source(SOURCE_TRACE))
     },
 
-    finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {},
+    finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
+      boostUltAshblazingAtk(x, action, ultHitMulti(context))
+    },
+    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
+      return gpuBoostUltAshblazingAtk(action, ultHitMulti(context))
+    },
   }
 }
 

--- a/src/lib/conditionals/character/1200/Fugue.ts
+++ b/src/lib/conditionals/character/1200/Fugue.ts
@@ -48,6 +48,7 @@ import {
   SPREAD_ORNAMENTS_2P_SUPPORT,
   SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
 } from 'lib/scoring/scoringConstants'
+import { PresetEffects } from 'lib/scoring/presetEffects'
 import { relics2pByStats } from 'lib/sets/setConfigRegistry'
 import { wrappedFixedT } from 'lib/utils/i18nUtils'
 
@@ -385,7 +386,9 @@ const scoring = (): ScoringMetadata => ({
       Stats.BE,
     ],
   },
-  presets: [],
+  presets: [
+    PresetEffects.fnMortenaxAshblazingSet(8),
+  ],
   sortOption: SortOption.BASIC,
   hiddenColumns: [
     SortOption.SKILL,

--- a/src/lib/conditionals/character/1200/Fugue.ts
+++ b/src/lib/conditionals/character/1200/Fugue.ts
@@ -1,7 +1,10 @@
+import {
+  aoe,
+  ashblazingMulti,
+} from 'lib/conditionals/ashblazingCompute'
 import { Lingsha } from 'lib/conditionals/character/1200/Lingsha'
 import { FireflyB1 } from 'lib/conditionals/character/1300/FireflyB1'
 import { TheDahlia } from 'lib/conditionals/character/1300/TheDahlia'
-import { ashblazingMulti, aoe } from 'lib/conditionals/ashblazingCompute'
 import {
   boostUltAshblazingAtk,
   gpuBoostUltAshblazingAtk,
@@ -93,7 +96,13 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   const ultScaling = ult(e, 2.00, 2.20)
   const superBreakScaling = talent(e, 1.00, 1.10)
 
-  const ultHitMulti = ashblazingMulti([aoe(0.60), aoe(0.10), aoe(0.10), aoe(0.10), aoe(0.10)])
+  const ultHitMulti = ashblazingMulti([
+    aoe(0.60),
+    aoe(0.10),
+    aoe(0.10),
+    aoe(0.10),
+    aoe(0.10),
+  ])
 
   const defaults = {
     torridScorch: true,

--- a/src/lib/conditionals/character/1200/Guinaifen.ts
+++ b/src/lib/conditionals/character/1200/Guinaifen.ts
@@ -1,3 +1,8 @@
+import { ULT_ASHBLAZING_1_AOE } from 'lib/conditionals/conditionalConstants'
+import {
+  boostUltAshblazingAtk,
+  gpuBoostUltAshblazingAtk,
+} from 'lib/conditionals/conditionalFinalizers'
 import {
   AbilityEidolon,
   type Conditionals,
@@ -212,8 +217,11 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
+      boostUltAshblazingAtk(x, action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
     },
-    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => '',
+    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
+      return gpuBoostUltAshblazingAtk(action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
+    },
   }
 }
 

--- a/src/lib/conditionals/character/1200/Guinaifen.ts
+++ b/src/lib/conditionals/character/1200/Guinaifen.ts
@@ -1,4 +1,4 @@
-import { ULT_ASHBLAZING_1_AOE } from 'lib/conditionals/conditionalConstants'
+import { aoe, ashblazingMulti } from 'lib/conditionals/ashblazingCompute'
 import {
   boostUltAshblazingAtk,
   gpuBoostUltAshblazingAtk,
@@ -62,6 +62,8 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     SOURCE_E4,
     SOURCE_E6,
   } = Source.character('1210')
+
+  const ultHitMulti = ashblazingMulti([aoe(1.00)])
 
   const talentDebuffDmgIncreaseValue = talent(e, 0.07, 0.076)
   const talentDebuffMax = (e >= 6) ? 4 : 3
@@ -217,10 +219,10 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
-      boostUltAshblazingAtk(x, action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
+      boostUltAshblazingAtk(x, action, ultHitMulti(context))
     },
     newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
-      return gpuBoostUltAshblazingAtk(action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
+      return gpuBoostUltAshblazingAtk(action, ultHitMulti(context))
     },
   }
 }

--- a/src/lib/conditionals/character/1200/Guinaifen.ts
+++ b/src/lib/conditionals/character/1200/Guinaifen.ts
@@ -261,6 +261,7 @@ const scoring = (): ScoringMetadata => ({
   },
   presets: [
     PresetEffects.PRISONER_SET,
+    PresetEffects.fnMortenaxAshblazingSet(5),
   ],
   sortOption: SortOption.SPD,
   hiddenColumns: [

--- a/src/lib/conditionals/character/1200/ImbibitorLunae.ts
+++ b/src/lib/conditionals/character/1200/ImbibitorLunae.ts
@@ -1,7 +1,10 @@
+import {
+  ashblazingMulti,
+  blast,
+} from 'lib/conditionals/ashblazingCompute'
 import { SparkleB1 } from 'lib/conditionals/character/1300/SparkleB1'
 import { Cipher } from 'lib/conditionals/character/1400/Cipher'
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
-import { ashblazingMulti, blast } from 'lib/conditionals/ashblazingCompute'
 import {
   boostUltAshblazingAtk,
   gpuBoostUltAshblazingAtk,
@@ -91,7 +94,11 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   const basicEnhanced3Scaling = basic(e, 5.00, 5.50)
   const ultScaling = ult(e, 3.00, 3.24)
 
-  const ultHitMulti = ashblazingMulti([blast(0.30), blast(0.30), blast(0.40)])
+  const ultHitMulti = ashblazingMulti([
+    blast(0.30),
+    blast(0.30),
+    blast(0.40),
+  ])
 
   const defaults = {
     basicEnhanced: 3,

--- a/src/lib/conditionals/character/1200/ImbibitorLunae.ts
+++ b/src/lib/conditionals/character/1200/ImbibitorLunae.ts
@@ -330,6 +330,7 @@ const scoring = (): ScoringMetadata => ({
   presets: [
     PresetEffects.WASTELANDER_SET,
     PresetEffects.TENGOKU_SET,
+    PresetEffects.fnMortenaxAshblazingSet(8),
   ],
   sortOption: SortOption.BASIC,
   hiddenColumns: [

--- a/src/lib/conditionals/character/1200/ImbibitorLunae.ts
+++ b/src/lib/conditionals/character/1200/ImbibitorLunae.ts
@@ -1,6 +1,11 @@
 import { SparkleB1 } from 'lib/conditionals/character/1300/SparkleB1'
 import { Cipher } from 'lib/conditionals/character/1400/Cipher'
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
+import { ashblazingMulti, blast } from 'lib/conditionals/ashblazingCompute'
+import {
+  boostUltAshblazingAtk,
+  gpuBoostUltAshblazingAtk,
+} from 'lib/conditionals/conditionalFinalizers'
 import {
   AbilityEidolon,
   type Conditionals,
@@ -85,6 +90,8 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   const basicEnhanced2Scaling = basic(e, 3.80, 4.18)
   const basicEnhanced3Scaling = basic(e, 5.00, 5.50)
   const ultScaling = ult(e, 3.00, 3.24)
+
+  const ultHitMulti = ashblazingMulti([blast(0.30), blast(0.30), blast(0.40)])
 
   const defaults = {
     basicEnhanced: 3,
@@ -208,8 +215,11 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
+      boostUltAshblazingAtk(x, action, ultHitMulti(context))
     },
-    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => '',
+    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
+      return gpuBoostUltAshblazingAtk(action, ultHitMulti(context))
+    },
   }
 }
 

--- a/src/lib/conditionals/character/1200/Jiaoqiu.ts
+++ b/src/lib/conditionals/character/1200/Jiaoqiu.ts
@@ -1,3 +1,8 @@
+import { ULT_ASHBLAZING_1_AOE } from 'lib/conditionals/conditionalConstants'
+import {
+  boostUltAshblazingAtk,
+  gpuBoostUltAshblazingAtk,
+} from 'lib/conditionals/conditionalFinalizers'
 import {
   AbilityEidolon,
   type Conditionals,
@@ -253,8 +258,11 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
+      boostUltAshblazingAtk(x, action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
     },
-    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => '',
+    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
+      return gpuBoostUltAshblazingAtk(action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
+    },
 
     dynamicConditionals: [{
       id: 'JiaoqiuConversionConditional',

--- a/src/lib/conditionals/character/1200/Jiaoqiu.ts
+++ b/src/lib/conditionals/character/1200/Jiaoqiu.ts
@@ -336,6 +336,7 @@ const scoring = (): ScoringMetadata => ({
   },
   presets: [
     PresetEffects.PRISONER_SET,
+    PresetEffects.fnMortenaxAshblazingSet(5),
   ],
   sortOption: SortOption.EHR,
   hiddenColumns: [

--- a/src/lib/conditionals/character/1200/Jiaoqiu.ts
+++ b/src/lib/conditionals/character/1200/Jiaoqiu.ts
@@ -1,4 +1,4 @@
-import { ULT_ASHBLAZING_1_AOE } from 'lib/conditionals/conditionalConstants'
+import { aoe, ashblazingMulti } from 'lib/conditionals/ashblazingCompute'
 import {
   boostUltAshblazingAtk,
   gpuBoostUltAshblazingAtk,
@@ -74,6 +74,8 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     SOURCE_E4,
     SOURCE_E6,
   } = Source.character('1218')
+
+  const ultHitMulti = ashblazingMulti([aoe(1.00)])
 
   const basicScaling = basic(e, 1.00, 1.10)
   const skillScaling = skill(e, 1.50, 1.65)
@@ -258,10 +260,10 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
-      boostUltAshblazingAtk(x, action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
+      boostUltAshblazingAtk(x, action, ultHitMulti(context))
     },
     newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
-      return gpuBoostUltAshblazingAtk(action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
+      return gpuBoostUltAshblazingAtk(action, ultHitMulti(context))
     },
 
     dynamicConditionals: [{

--- a/src/lib/conditionals/character/1200/JingYuan.ts
+++ b/src/lib/conditionals/character/1200/JingYuan.ts
@@ -1,5 +1,6 @@
 import {
   ASHBLAZING_ATK_STACK,
+  ULT_ASHBLAZING_1_AOE,
 } from 'lib/conditionals/conditionalConstants'
 import {
   boostAshblazingAtkContainer,
@@ -92,6 +93,10 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   const fuaScaling = talent(e, 0.66, 0.726)
 
   function getHitMulti(action: OptimizerAction, context: OptimizerContext) {
+    if (action.actionType === AbilityKind.ULT) {
+      return ULT_ASHBLAZING_1_AOE[context.enemyCount]
+    }
+
     const r = action.characterConditionals as Conditionals<typeof content>
 
     let hitMulti = 0

--- a/src/lib/conditionals/character/1200/JingYuan.ts
+++ b/src/lib/conditionals/character/1200/JingYuan.ts
@@ -1,7 +1,5 @@
-import {
-  ASHBLAZING_ATK_STACK,
-  ULT_ASHBLAZING_1_AOE,
-} from 'lib/conditionals/conditionalConstants'
+import { aoe, ashblazingMulti } from 'lib/conditionals/ashblazingCompute'
+import { ASHBLAZING_ATK_STACK } from 'lib/conditionals/conditionalConstants'
 import {
   boostAshblazingAtkContainer,
   gpuBoostAshblazingAtkContainer,
@@ -92,9 +90,11 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   const ultScaling = ult(e, 2.00, 2.16)
   const fuaScaling = talent(e, 0.66, 0.726)
 
+  const ultHitMulti = ashblazingMulti([aoe(1.00)])
+
   function getHitMulti(action: OptimizerAction, context: OptimizerContext) {
     if (action.actionType === AbilityKind.ULT) {
-      return ULT_ASHBLAZING_1_AOE[context.enemyCount]
+      return ultHitMulti(context)
     }
 
     const r = action.characterConditionals as Conditionals<typeof content>

--- a/src/lib/conditionals/character/1200/Jingliu.ts
+++ b/src/lib/conditionals/character/1200/Jingliu.ts
@@ -27,6 +27,7 @@ import {
   SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
   SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
 } from 'lib/scoring/scoringConstants'
+import { PresetEffects } from 'lib/scoring/presetEffects'
 import { wrappedFixedT } from 'lib/utils/i18nUtils'
 import { type Eidolon } from 'types/character'
 import { type CharacterConfig } from 'types/characterConfig'
@@ -318,7 +319,9 @@ const scoring = (): ScoringMetadata => ({
       Stats.ERR,
     ],
   },
-  presets: [],
+  presets: [
+    PresetEffects.fnMortenaxAshblazingSet(3),
+  ],
   sortOption: SortOption.SKILL,
   hiddenColumns: [SortOption.FUA, SortOption.DOT],
   simulation: simulation(),

--- a/src/lib/conditionals/character/1200/Jingliu.ts
+++ b/src/lib/conditionals/character/1200/Jingliu.ts
@@ -1,3 +1,8 @@
+import { ULT_ASHBLAZING_1_BLAST } from 'lib/conditionals/conditionalConstants'
+import {
+  boostUltAshblazingAtk,
+  gpuBoostUltAshblazingAtk,
+} from 'lib/conditionals/conditionalFinalizers'
 import {
   AbilityEidolon,
   type Conditionals,
@@ -205,8 +210,11 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
+      boostUltAshblazingAtk(x, action, ULT_ASHBLAZING_1_BLAST[context.enemyCount])
     },
-    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => '',
+    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
+      return gpuBoostUltAshblazingAtk(action, ULT_ASHBLAZING_1_BLAST[context.enemyCount])
+    },
   }
 }
 

--- a/src/lib/conditionals/character/1200/Jingliu.ts
+++ b/src/lib/conditionals/character/1200/Jingliu.ts
@@ -1,4 +1,4 @@
-import { ULT_ASHBLAZING_1_BLAST } from 'lib/conditionals/conditionalConstants'
+import { ashblazingMulti, blast } from 'lib/conditionals/ashblazingCompute'
 import {
   boostUltAshblazingAtk,
   gpuBoostUltAshblazingAtk,
@@ -80,6 +80,8 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     SOURCE_E4,
     SOURCE_E6,
   } = Source.character('1212')
+
+  const ultHitMulti = ashblazingMulti([blast(1.00)])
 
   const talentCrBuff = talent(e, 0.50, 0.52)
   const basicScaling = basic(e, 1.00, 1.10)
@@ -210,10 +212,10 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
-      boostUltAshblazingAtk(x, action, ULT_ASHBLAZING_1_BLAST[context.enemyCount])
+      boostUltAshblazingAtk(x, action, ultHitMulti(context))
     },
     newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
-      return gpuBoostUltAshblazingAtk(action, ULT_ASHBLAZING_1_BLAST[context.enemyCount])
+      return gpuBoostUltAshblazingAtk(action, ultHitMulti(context))
     },
   }
 }

--- a/src/lib/conditionals/character/1200/Lingsha.ts
+++ b/src/lib/conditionals/character/1200/Lingsha.ts
@@ -1,7 +1,7 @@
 import { FireflyB1 } from 'lib/conditionals/character/1300/FireflyB1'
 import { RuanMei } from 'lib/conditionals/character/1300/RuanMei'
 import { TheDahlia } from 'lib/conditionals/character/1300/TheDahlia'
-import { ASHBLAZING_ATK_STACK } from 'lib/conditionals/conditionalConstants'
+import { ASHBLAZING_ATK_STACK, ULT_ASHBLAZING_1_AOE } from 'lib/conditionals/conditionalConstants'
 import {
   boostAshblazingAtkContainer,
   gpuBoostAshblazingAtkContainer,
@@ -113,6 +113,13 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     1: ASHBLAZING_ATK_STACK * (1 * 1 / 2 + 2 * 1 / 2),
     3: ASHBLAZING_ATK_STACK * (2 * 1 / 2 + 3 * 1 / 2),
     5: ASHBLAZING_ATK_STACK * (3 * 1 / 2 + 4 * 1 / 2),
+  }
+
+  function getHitMulti(action: OptimizerAction, context: OptimizerContext) {
+    if (action.actionType === AbilityKind.ULT) {
+      return ULT_ASHBLAZING_1_AOE[context.enemyCount]
+    }
+    return hitMultiByTargets[context.enemyCount]
   }
 
   const defaults = {
@@ -291,11 +298,11 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
-      boostAshblazingAtkContainer(x, action, hitMultiByTargets[context.enemyCount])
+      boostAshblazingAtkContainer(x, action, getHitMulti(action, context))
     },
 
     newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
-      return gpuBoostAshblazingAtkContainer(hitMultiByTargets[context.enemyCount], action)
+      return gpuBoostAshblazingAtkContainer(getHitMulti(action, context), action)
     },
 
     dynamicConditionals: [

--- a/src/lib/conditionals/character/1200/Lingsha.ts
+++ b/src/lib/conditionals/character/1200/Lingsha.ts
@@ -1,7 +1,8 @@
 import { FireflyB1 } from 'lib/conditionals/character/1300/FireflyB1'
 import { RuanMei } from 'lib/conditionals/character/1300/RuanMei'
 import { TheDahlia } from 'lib/conditionals/character/1300/TheDahlia'
-import { ASHBLAZING_ATK_STACK, ULT_ASHBLAZING_1_AOE } from 'lib/conditionals/conditionalConstants'
+import { aoe, ashblazingMulti } from 'lib/conditionals/ashblazingCompute'
+import { ASHBLAZING_ATK_STACK } from 'lib/conditionals/conditionalConstants'
 import {
   boostAshblazingAtkContainer,
   gpuBoostAshblazingAtkContainer,
@@ -115,9 +116,11 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     5: ASHBLAZING_ATK_STACK * (3 * 1 / 2 + 4 * 1 / 2),
   }
 
+  const ultHitMulti = ashblazingMulti([aoe(1.00)])
+
   function getHitMulti(action: OptimizerAction, context: OptimizerContext) {
     if (action.actionType === AbilityKind.ULT) {
-      return ULT_ASHBLAZING_1_AOE[context.enemyCount]
+      return ultHitMulti(context)
     }
     return hitMultiByTargets[context.enemyCount]
   }

--- a/src/lib/conditionals/character/1200/Luocha.ts
+++ b/src/lib/conditionals/character/1200/Luocha.ts
@@ -1,7 +1,7 @@
 import { Castorice } from 'lib/conditionals/character/1400/Castorice'
 import { Cipher } from 'lib/conditionals/character/1400/Cipher'
 import { Tribbie } from 'lib/conditionals/character/1400/Tribbie'
-import { ULT_ASHBLAZING_1_AOE } from 'lib/conditionals/conditionalConstants'
+import { aoe, ashblazingMulti } from 'lib/conditionals/ashblazingCompute'
 import {
   boostUltAshblazingAtk,
   gpuBoostUltAshblazingAtk,
@@ -78,6 +78,8 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     SOURCE_E4,
     SOURCE_E6,
   } = Source.character('1203')
+
+  const ultHitMulti = ashblazingMulti([aoe(1.00)])
 
   const basicScaling = basic(e, 1.00, 1.10)
   const ultScaling = ult(e, 2.00, 2.16)
@@ -192,10 +194,10 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
-      boostUltAshblazingAtk(x, action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
+      boostUltAshblazingAtk(x, action, ultHitMulti(context))
     },
     newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
-      return gpuBoostUltAshblazingAtk(action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
+      return gpuBoostUltAshblazingAtk(action, ultHitMulti(context))
     },
   }
 }

--- a/src/lib/conditionals/character/1200/Luocha.ts
+++ b/src/lib/conditionals/character/1200/Luocha.ts
@@ -1,6 +1,11 @@
 import { Castorice } from 'lib/conditionals/character/1400/Castorice'
 import { Cipher } from 'lib/conditionals/character/1400/Cipher'
 import { Tribbie } from 'lib/conditionals/character/1400/Tribbie'
+import { ULT_ASHBLAZING_1_AOE } from 'lib/conditionals/conditionalConstants'
+import {
+  boostUltAshblazingAtk,
+  gpuBoostUltAshblazingAtk,
+} from 'lib/conditionals/conditionalFinalizers'
 import {
   AbilityEidolon,
   type Conditionals,
@@ -187,8 +192,11 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
+      boostUltAshblazingAtk(x, action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
     },
-    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => '',
+    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
+      return gpuBoostUltAshblazingAtk(action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
+    },
   }
 }
 

--- a/src/lib/conditionals/character/1200/Luocha.ts
+++ b/src/lib/conditionals/character/1200/Luocha.ts
@@ -291,6 +291,7 @@ const scoring = (): ScoringMetadata => ({
   presets: [
     PresetEffects.WASTELANDER_SET,
     PresetEffects.WARRIOR_SET,
+    PresetEffects.fnMortenaxAshblazingSet(5),
   ],
   sortOption: SortOption.SPD,
   addedColumns: [SortOption.OHB],

--- a/src/lib/conditionals/character/1200/March7thImaginary.ts
+++ b/src/lib/conditionals/character/1200/March7thImaginary.ts
@@ -1,7 +1,5 @@
-import {
-  ASHBLAZING_ATK_STACK,
-  ULT_ASHBLAZING_1_SINGLE,
-} from 'lib/conditionals/conditionalConstants'
+import { ashblazingMulti, single } from 'lib/conditionals/ashblazingCompute'
+import { ASHBLAZING_ATK_STACK } from 'lib/conditionals/conditionalConstants'
 import {
   boostAshblazingAtkContainer,
   gpuBoostAshblazingAtkContainer,
@@ -99,9 +97,11 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   // 0.06
   const fuaHitCountMulti = ASHBLAZING_ATK_STACK * (1 * 0.40 + 2 * 0.60)
 
+  const ultHitMulti = ashblazingMulti([single(1.00)])
+
   function getHitMulti(action: OptimizerAction, context: OptimizerContext) {
     if (action.actionType === AbilityKind.ULT) {
-      return ULT_ASHBLAZING_1_SINGLE
+      return ultHitMulti(context)
     }
     return fuaHitCountMulti
   }

--- a/src/lib/conditionals/character/1200/March7thImaginary.ts
+++ b/src/lib/conditionals/character/1200/March7thImaginary.ts
@@ -1,5 +1,6 @@
 import {
   ASHBLAZING_ATK_STACK,
+  ULT_ASHBLAZING_1_SINGLE,
 } from 'lib/conditionals/conditionalConstants'
 import {
   boostAshblazingAtkContainer,
@@ -97,6 +98,13 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 
   // 0.06
   const fuaHitCountMulti = ASHBLAZING_ATK_STACK * (1 * 0.40 + 2 * 0.60)
+
+  function getHitMulti(action: OptimizerAction, context: OptimizerContext) {
+    if (action.actionType === AbilityKind.ULT) {
+      return ULT_ASHBLAZING_1_SINGLE
+    }
+    return fuaHitCountMulti
+  }
 
   const defaults = {
     enhancedBasic: true,
@@ -283,10 +291,10 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
-      boostAshblazingAtkContainer(x, action, fuaHitCountMulti)
+      boostAshblazingAtkContainer(x, action, getHitMulti(action, context))
     },
     newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
-      return gpuBoostAshblazingAtkContainer(fuaHitCountMulti, action)
+      return gpuBoostAshblazingAtkContainer(getHitMulti(action, context), action)
     },
   }
 }

--- a/src/lib/conditionals/character/1200/Moze.ts
+++ b/src/lib/conditionals/character/1200/Moze.ts
@@ -1,5 +1,6 @@
 import {
   ASHBLAZING_ATK_STACK,
+  ULT_ASHBLAZING_1_SINGLE,
 } from 'lib/conditionals/conditionalConstants'
 import {
   boostAshblazingAtkContainer,
@@ -96,6 +97,13 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   const additionalDmgScaling = talent(e, 0.30, 0.33)
 
   const fuaHitCountMulti = ASHBLAZING_ATK_STACK * (1 * 0.08 + 2 * 0.08 + 3 * 0.08 + 4 * 0.08 + 5 * 0.08 + 6 * 0.6)
+
+  function getHitMulti(action: OptimizerAction, context: OptimizerContext) {
+    if (action.actionType === AbilityKind.ULT) {
+      return ULT_ASHBLAZING_1_SINGLE
+    }
+    return fuaHitCountMulti
+  }
 
   const defaults = {
     preyMark: true,
@@ -269,10 +277,10 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
-      boostAshblazingAtkContainer(x, action, fuaHitCountMulti)
+      boostAshblazingAtkContainer(x, action, getHitMulti(action, context))
     },
     newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
-      return gpuBoostAshblazingAtkContainer(fuaHitCountMulti, action)
+      return gpuBoostAshblazingAtkContainer(getHitMulti(action, context), action)
     },
   }
 }

--- a/src/lib/conditionals/character/1200/Moze.ts
+++ b/src/lib/conditionals/character/1200/Moze.ts
@@ -1,7 +1,5 @@
-import {
-  ASHBLAZING_ATK_STACK,
-  ULT_ASHBLAZING_1_SINGLE,
-} from 'lib/conditionals/conditionalConstants'
+import { ashblazingMulti, single } from 'lib/conditionals/ashblazingCompute'
+import { ASHBLAZING_ATK_STACK } from 'lib/conditionals/conditionalConstants'
 import {
   boostAshblazingAtkContainer,
   gpuBoostAshblazingAtkContainer,
@@ -98,9 +96,11 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 
   const fuaHitCountMulti = ASHBLAZING_ATK_STACK * (1 * 0.08 + 2 * 0.08 + 3 * 0.08 + 4 * 0.08 + 5 * 0.08 + 6 * 0.6)
 
+  const ultHitMulti = ashblazingMulti([single(1.00)])
+
   function getHitMulti(action: OptimizerAction, context: OptimizerContext) {
     if (action.actionType === AbilityKind.ULT) {
-      return ULT_ASHBLAZING_1_SINGLE
+      return ultHitMulti(context)
     }
     return fuaHitCountMulti
   }

--- a/src/lib/conditionals/character/1200/Qingque.ts
+++ b/src/lib/conditionals/character/1200/Qingque.ts
@@ -1,5 +1,6 @@
 import {
   ASHBLAZING_ATK_STACK,
+  ULT_ASHBLAZING_1_AOE,
 } from 'lib/conditionals/conditionalConstants'
 import {
   boostAshblazingAtkContainer,
@@ -102,6 +103,9 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   const hitMultiSingle = ASHBLAZING_ATK_STACK * (1 * 1 / 1)
 
   function getHitMulti(action: OptimizerAction, context: OptimizerContext) {
+    if (action.actionType === AbilityKind.ULT) {
+      return ULT_ASHBLAZING_1_AOE[context.enemyCount]
+    }
     const r = action.characterConditionals as Conditionals<typeof content>
     return r.basicEnhanced
       ? hitMultiByTargetsBlast[context.enemyCount]

--- a/src/lib/conditionals/character/1200/Qingque.ts
+++ b/src/lib/conditionals/character/1200/Qingque.ts
@@ -330,6 +330,7 @@ const scoring = (): ScoringMetadata => ({
     PresetEffects.VALOROUS_SET,
     PresetEffects.TENGOKU_SET,
     PresetEffects.fnSacerdosSet(2),
+    PresetEffects.fnMortenaxAshblazingSet(5),
   ],
   sortOption: SortOption.BASIC,
   hiddenColumns: [SortOption.SKILL, SortOption.DOT],

--- a/src/lib/conditionals/character/1200/Qingque.ts
+++ b/src/lib/conditionals/character/1200/Qingque.ts
@@ -1,7 +1,5 @@
-import {
-  ASHBLAZING_ATK_STACK,
-  ULT_ASHBLAZING_1_AOE,
-} from 'lib/conditionals/conditionalConstants'
+import { aoe, ashblazingMulti } from 'lib/conditionals/ashblazingCompute'
+import { ASHBLAZING_ATK_STACK } from 'lib/conditionals/conditionalConstants'
 import {
   boostAshblazingAtkContainer,
   gpuBoostAshblazingAtkContainer,
@@ -94,6 +92,8 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   const basicEnhancedScaling = basic(e, 2.40, 2.64)
   const ultScaling = ult(e, 2.00, 2.16)
 
+  const ultHitMulti = ashblazingMulti([aoe(1.00)])
+
   const hitMultiByTargetsBlast: NumberToNumberMap = {
     1: ASHBLAZING_ATK_STACK * (1 * 1 / 1), // 0.06
     3: ASHBLAZING_ATK_STACK * (2 * 1 / 1), // 0.12
@@ -104,7 +104,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 
   function getHitMulti(action: OptimizerAction, context: OptimizerContext) {
     if (action.actionType === AbilityKind.ULT) {
-      return ULT_ASHBLAZING_1_AOE[context.enemyCount]
+      return ultHitMulti(context)
     }
     const r = action.characterConditionals as Conditionals<typeof content>
     return r.basicEnhanced

--- a/src/lib/conditionals/character/1200/Sushang.ts
+++ b/src/lib/conditionals/character/1200/Sushang.ts
@@ -1,3 +1,8 @@
+import { ULT_ASHBLAZING_1_SINGLE } from 'lib/conditionals/conditionalConstants'
+import {
+  boostUltAshblazingAtk,
+  gpuBoostUltAshblazingAtk,
+} from 'lib/conditionals/conditionalFinalizers'
 import {
   AbilityEidolon,
   type Conditionals,
@@ -223,9 +228,12 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
+      boostUltAshblazingAtk(x, action, ULT_ASHBLAZING_1_SINGLE)
     },
 
-    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => '',
+    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
+      return gpuBoostUltAshblazingAtk(action, ULT_ASHBLAZING_1_SINGLE)
+    },
   }
 }
 

--- a/src/lib/conditionals/character/1200/Sushang.ts
+++ b/src/lib/conditionals/character/1200/Sushang.ts
@@ -27,6 +27,7 @@ import {
   SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
   SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
 } from 'lib/scoring/scoringConstants'
+import { PresetEffects } from 'lib/scoring/presetEffects'
 import { wrappedFixedT } from 'lib/utils/i18nUtils'
 
 import { type Eidolon } from 'types/character'
@@ -342,7 +343,9 @@ const scoring = (): ScoringMetadata => ({
       Stats.BE,
     ],
   },
-  presets: [],
+  presets: [
+    PresetEffects.fnMortenaxAshblazingSet(1),
+  ],
   sortOption: SortOption.SKILL,
   hiddenColumns: [SortOption.FUA, SortOption.DOT],
   simulation: simulation(),

--- a/src/lib/conditionals/character/1200/Sushang.ts
+++ b/src/lib/conditionals/character/1200/Sushang.ts
@@ -1,4 +1,4 @@
-import { ULT_ASHBLAZING_1_SINGLE } from 'lib/conditionals/conditionalConstants'
+import { ashblazingMulti, single } from 'lib/conditionals/ashblazingCompute'
 import {
   boostUltAshblazingAtk,
   gpuBoostUltAshblazingAtk,
@@ -81,6 +81,8 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     SOURCE_E4,
     SOURCE_E6,
   } = Source.character('1206')
+
+  const ultHitMulti = ashblazingMulti([single(1.00)])
 
   const talentSpdBuffValue = talent(e, 0.20, 0.21)
   const ultBuffedAtk = ult(e, 0.30, 0.324)
@@ -228,11 +230,11 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
-      boostUltAshblazingAtk(x, action, ULT_ASHBLAZING_1_SINGLE)
+      boostUltAshblazingAtk(x, action, ultHitMulti(context))
     },
 
     newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
-      return gpuBoostUltAshblazingAtk(action, ULT_ASHBLAZING_1_SINGLE)
+      return gpuBoostUltAshblazingAtk(action, ultHitMulti(context))
     },
   }
 }

--- a/src/lib/conditionals/character/1200/Xueyi.ts
+++ b/src/lib/conditionals/character/1200/Xueyi.ts
@@ -1,5 +1,6 @@
 import {
   ASHBLAZING_ATK_STACK,
+  ULT_ASHBLAZING_1_SINGLE,
 } from 'lib/conditionals/conditionalConstants'
 import {
   boostAshblazingAtkContainer,
@@ -106,6 +107,14 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     1: ASHBLAZING_ATK_STACK * (1 * 1 / 1), // 0.06
     2: ASHBLAZING_ATK_STACK * (1 * 1 / 2 + 2 * 1 / 2), // 0.09
     3: ASHBLAZING_ATK_STACK * (1 * 1 / 3 + 2 * 1 / 3 + 3 * 1 / 3), // 0.12
+  }
+
+  function getHitMulti(action: OptimizerAction, context: OptimizerContext) {
+    if (action.actionType === AbilityKind.ULT) {
+      return ULT_ASHBLAZING_1_SINGLE
+    }
+    const r = action.characterConditionals as Conditionals<typeof content>
+    return hitMultiByFuaHits[r.fuaHits]
   }
 
   const defaults = {
@@ -241,7 +250,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
       const be = x.getActionValue(StatKey.BE, XueyiEntities.Xueyi)
       x.buff(StatKey.BOOST, (r.beToDmgBoost) ? Math.min(2.40, be) : 0, x.source(SOURCE_TRACE))
 
-      boostAshblazingAtkContainer(x, action, hitMultiByFuaHits[r.fuaHits])
+      boostAshblazingAtkContainer(x, action, getHitMulti(action, context))
     },
 
     newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
@@ -252,7 +261,7 @@ if (${wgslTrue(r.beToDmgBoost)}) {
   let dmgBuff = min(2.40, ${containerActionVal(SELF_ENTITY_INDEX, StatKey.BE, action.config)});
   ${buff.action(AKey.BOOST, 'dmgBuff').wgsl(action)}
 }
-      ` + gpuBoostAshblazingAtkContainer(hitMultiByFuaHits[r.fuaHits], action)
+      ` + gpuBoostAshblazingAtkContainer(getHitMulti(action, context), action)
     },
   }
 }

--- a/src/lib/conditionals/character/1200/Xueyi.ts
+++ b/src/lib/conditionals/character/1200/Xueyi.ts
@@ -1,7 +1,5 @@
-import {
-  ASHBLAZING_ATK_STACK,
-  ULT_ASHBLAZING_1_SINGLE,
-} from 'lib/conditionals/conditionalConstants'
+import { ashblazingMulti, single } from 'lib/conditionals/ashblazingCompute'
+import { ASHBLAZING_ATK_STACK } from 'lib/conditionals/conditionalConstants'
 import {
   boostAshblazingAtkContainer,
   gpuBoostAshblazingAtkContainer,
@@ -102,6 +100,8 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   const ultScaling = ult(e, 2.50, 2.70)
   const fuaScaling = talent(e, 0.90, 0.99)
 
+  const ultHitMulti = ashblazingMulti([single(1.00)])
+
   const hitMultiByFuaHits: NumberToNumberMap = {
     0: 0,
     1: ASHBLAZING_ATK_STACK * (1 * 1 / 1), // 0.06
@@ -111,7 +111,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 
   function getHitMulti(action: OptimizerAction, context: OptimizerContext) {
     if (action.actionType === AbilityKind.ULT) {
-      return ULT_ASHBLAZING_1_SINGLE
+      return ultHitMulti(context)
     }
     const r = action.characterConditionals as Conditionals<typeof content>
     return hitMultiByFuaHits[r.fuaHits]

--- a/src/lib/conditionals/character/1200/Yanqing.ts
+++ b/src/lib/conditionals/character/1200/Yanqing.ts
@@ -1,7 +1,5 @@
-import {
-  ASHBLAZING_ATK_STACK,
-  ULT_ASHBLAZING_1_SINGLE,
-} from 'lib/conditionals/conditionalConstants'
+import { ashblazingMulti, single } from 'lib/conditionals/ashblazingCompute'
+import { ASHBLAZING_ATK_STACK } from 'lib/conditionals/conditionalConstants'
 import {
   boostAshblazingAtkContainer,
   gpuBoostAshblazingAtkContainer,
@@ -95,9 +93,11 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 
   const hitMulti = ASHBLAZING_ATK_STACK * (1 * 1 / 1)
 
+  const ultHitMulti = ashblazingMulti([single(1.00)])
+
   function getHitMulti(action: OptimizerAction, context: OptimizerContext) {
     if (action.actionType === AbilityKind.ULT) {
-      return ULT_ASHBLAZING_1_SINGLE
+      return ultHitMulti(context)
     }
     return hitMulti
   }

--- a/src/lib/conditionals/character/1200/Yanqing.ts
+++ b/src/lib/conditionals/character/1200/Yanqing.ts
@@ -1,5 +1,6 @@
 import {
   ASHBLAZING_ATK_STACK,
+  ULT_ASHBLAZING_1_SINGLE,
 } from 'lib/conditionals/conditionalConstants'
 import {
   boostAshblazingAtkContainer,
@@ -93,6 +94,13 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   const fuaScaling = talent(e, 0.50, 0.55)
 
   const hitMulti = ASHBLAZING_ATK_STACK * (1 * 1 / 1)
+
+  function getHitMulti(action: OptimizerAction, context: OptimizerContext) {
+    if (action.actionType === AbilityKind.ULT) {
+      return ULT_ASHBLAZING_1_SINGLE
+    }
+    return hitMulti
+  }
 
   const defaults = {
     ultBuffActive: true,
@@ -271,11 +279,11 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
-      boostAshblazingAtkContainer(x, action, hitMulti)
+      boostAshblazingAtkContainer(x, action, getHitMulti(action, context))
     },
 
     newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
-      return gpuBoostAshblazingAtkContainer(hitMulti, action)
+      return gpuBoostAshblazingAtkContainer(getHitMulti(action, context), action)
     },
   }
 }

--- a/src/lib/conditionals/character/1200/Yukong.ts
+++ b/src/lib/conditionals/character/1200/Yukong.ts
@@ -1,3 +1,8 @@
+import { ULT_ASHBLAZING_1_SINGLE } from 'lib/conditionals/conditionalConstants'
+import {
+  boostUltAshblazingAtk,
+  gpuBoostUltAshblazingAtk,
+} from 'lib/conditionals/conditionalFinalizers'
 import {
   AbilityEidolon,
   type Conditionals,
@@ -186,9 +191,12 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
+      boostUltAshblazingAtk(x, action, ULT_ASHBLAZING_1_SINGLE)
     },
 
-    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => '',
+    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
+      return gpuBoostUltAshblazingAtk(action, ULT_ASHBLAZING_1_SINGLE)
+    },
   }
 }
 

--- a/src/lib/conditionals/character/1200/Yukong.ts
+++ b/src/lib/conditionals/character/1200/Yukong.ts
@@ -1,4 +1,4 @@
-import { ULT_ASHBLAZING_1_SINGLE } from 'lib/conditionals/conditionalConstants'
+import { ashblazingMulti, single } from 'lib/conditionals/ashblazingCompute'
 import {
   boostUltAshblazingAtk,
   gpuBoostUltAshblazingAtk,
@@ -59,6 +59,8 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     SOURCE_E4,
     SOURCE_E6,
   } = Source.character('1207')
+
+  const ultHitMulti = ashblazingMulti([single(1.00)])
 
   const skillAtkBuffValue = skill(e, 0.80, 0.88)
   const ultCdBuffValue = skill(e, 0.65, 0.702)
@@ -191,11 +193,11 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
-      boostUltAshblazingAtk(x, action, ULT_ASHBLAZING_1_SINGLE)
+      boostUltAshblazingAtk(x, action, ultHitMulti(context))
     },
 
     newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
-      return gpuBoostUltAshblazingAtk(action, ULT_ASHBLAZING_1_SINGLE)
+      return gpuBoostUltAshblazingAtk(action, ultHitMulti(context))
     },
   }
 }

--- a/src/lib/conditionals/character/1200/Yukong.ts
+++ b/src/lib/conditionals/character/1200/Yukong.ts
@@ -238,6 +238,7 @@ const scoring = (): ScoringMetadata => ({
   presets: [
     PresetEffects.WASTELANDER_SET,
     PresetEffects.fnSacerdosSet(1),
+    PresetEffects.fnMortenaxAshblazingSet(1),
   ],
   sortOption: SortOption.ULT,
   hiddenColumns: [SortOption.SKILL, SortOption.FUA, SortOption.DOT],

--- a/src/lib/conditionals/character/1300/Acheron.ts
+++ b/src/lib/conditionals/character/1300/Acheron.ts
@@ -1,6 +1,7 @@
 import { SilverWolfB1 } from 'lib/conditionals/character/1000/SilverWolfB1'
 import { Cipher } from 'lib/conditionals/character/1400/Cipher'
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
+import { aoe, ashblazingMulti, single } from 'lib/conditionals/ashblazingCompute'
 import {
   AbilityEidolon,
   type Conditionals,
@@ -8,6 +9,10 @@ import {
   countTeamPath,
   createEnum,
 } from 'lib/conditionals/conditionalUtils'
+import {
+  boostUltAshblazingAtk,
+  gpuBoostUltAshblazingAtk,
+} from 'lib/conditionals/conditionalFinalizers'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
 import { BeforeTheTutorialMissionStarts } from 'lib/conditionals/lightcone/4star/BeforeTheTutorialMissionStarts'
 import { LiesAflutterInTheWind } from 'lib/conditionals/lightcone/5star/LiesAflutterInTheWind'
@@ -88,6 +93,19 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   const talentResPen = talent(e, 0.2, 0.22)
 
   const maxCrimsonKnotStacks = 9
+
+  // Precompute ashblazing hitMulti for each possible knot stack count (0-9)
+  // ULT sequence: 3 Rainblades (single + AoE knot removal each) → Stygian Resurge (AoE) → 6 Thunder Core (single)
+  const ultHitMultis = Array.from({ length: maxCrimsonKnotStacks + 1 }, (_, knotStacks) => {
+    const knotAoePerRainblade = ultCrimsonKnotScaling * (1 + knotStacks / 3)
+    return ashblazingMulti([
+      single(0.50 * ultRainbladeScaling), single(0.50 * ultRainbladeScaling), aoe(knotAoePerRainblade),
+      single(0.30 * ultRainbladeScaling), single(0.30 * ultRainbladeScaling), single(0.40 * ultRainbladeScaling), aoe(knotAoePerRainblade),
+      single(ultRainbladeScaling), aoe(knotAoePerRainblade),
+      aoe(0.10 * ultStygianResurgeScaling), aoe(0.90 * ultStygianResurgeScaling),
+      ...Array(6).fill(single(ultThunderCoreScaling)),
+    ])
+  })
 
   const nihilityTeammateScaling: Record<number, number> = {
     0: 0,
@@ -262,9 +280,13 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
+      const r = action.characterConditionals as Conditionals<typeof content>
+      boostUltAshblazingAtk(x, action, ultHitMultis[r.crimsonKnotStacks](context))
     },
-
-    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => '',
+    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
+      const r = action.characterConditionals as Conditionals<typeof content>
+      return gpuBoostUltAshblazingAtk(action, ultHitMultis[r.crimsonKnotStacks](context))
+    },
   }
 }
 

--- a/src/lib/conditionals/character/1300/Acheron.ts
+++ b/src/lib/conditionals/character/1300/Acheron.ts
@@ -387,6 +387,7 @@ const scoring = (): ScoringMetadata => ({
   },
   presets: [
     PresetEffects.fnPioneerSet(4),
+    PresetEffects.fnMortenaxAshblazingSet(8),
   ],
   sortOption: SortOption.ULT,
   hiddenColumns: [

--- a/src/lib/conditionals/character/1300/Argenti.ts
+++ b/src/lib/conditionals/character/1300/Argenti.ts
@@ -1,7 +1,11 @@
+import {
+  aoe,
+  ashblazingMulti,
+  single,
+} from 'lib/conditionals/ashblazingCompute'
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
 import { TheHerta } from 'lib/conditionals/character/1400/TheHerta'
 import { Tribbie } from 'lib/conditionals/character/1400/Tribbie'
-import { aoe, ashblazingMulti, single } from 'lib/conditionals/ashblazingCompute'
 import {
   boostUltAshblazingAtk,
   gpuBoostUltAshblazingAtk,
@@ -90,7 +94,10 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   const talentCrStackValue = talent(e, 0.025, 0.028)
 
   const ultHitMulti = ashblazingMulti([aoe(1.00)])
-  const ultEnhancedHitMulti = ashblazingMulti([aoe(ultEnhancedScaling), ...Array(6).fill(single(ultEnhancedExtraHitScaling))])
+  const ultEnhancedHitMulti = ashblazingMulti([
+    aoe(ultEnhancedScaling),
+    ...Array(6).fill(single(ultEnhancedExtraHitScaling)),
+  ])
 
   const defaults = {
     ultEnhanced: false,

--- a/src/lib/conditionals/character/1300/Argenti.ts
+++ b/src/lib/conditionals/character/1300/Argenti.ts
@@ -1,6 +1,11 @@
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
 import { TheHerta } from 'lib/conditionals/character/1400/TheHerta'
 import { Tribbie } from 'lib/conditionals/character/1400/Tribbie'
+import { aoe, ashblazingMulti, single } from 'lib/conditionals/ashblazingCompute'
+import {
+  boostUltAshblazingAtk,
+  gpuBoostUltAshblazingAtk,
+} from 'lib/conditionals/conditionalFinalizers'
 import {
   AbilityEidolon,
   type Conditionals,
@@ -83,6 +88,9 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   const ultEnhancedScaling = ult(e, 2.80, 3.024)
   const ultEnhancedExtraHitScaling = ult(e, 0.95, 1.026)
   const talentCrStackValue = talent(e, 0.025, 0.028)
+
+  const ultHitMulti = ashblazingMulti([aoe(1.00)])
+  const ultEnhancedHitMulti = ashblazingMulti([aoe(ultEnhancedScaling), ...Array(6).fill(single(ultEnhancedExtraHitScaling))])
 
   const defaults = {
     ultEnhanced: false,
@@ -215,9 +223,13 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
+      const r = action.characterConditionals as Conditionals<typeof content>
+      boostUltAshblazingAtk(x, action, (r.ultEnhanced ? ultEnhancedHitMulti : ultHitMulti)(context))
     },
-
-    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => '',
+    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
+      const r = action.characterConditionals as Conditionals<typeof content>
+      return gpuBoostUltAshblazingAtk(action, (r.ultEnhanced ? ultEnhancedHitMulti : ultHitMulti)(context))
+    },
   }
 }
 

--- a/src/lib/conditionals/character/1300/Argenti.ts
+++ b/src/lib/conditionals/character/1300/Argenti.ts
@@ -44,6 +44,7 @@ import {
   SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
   SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
 } from 'lib/scoring/scoringConstants'
+import { PresetEffects } from 'lib/scoring/presetEffects'
 import { wrappedFixedT } from 'lib/utils/i18nUtils'
 
 import { precisionRound } from 'lib/utils/mathUtils'
@@ -341,7 +342,9 @@ const scoring = (): ScoringMetadata => ({
       Stats.ERR,
     ],
   },
-  presets: [],
+  presets: [
+    PresetEffects.fnMortenaxAshblazingSet(8),
+  ],
   sortOption: SortOption.ULT,
   hiddenColumns: [
     SortOption.FUA,

--- a/src/lib/conditionals/character/1300/Aventurine.ts
+++ b/src/lib/conditionals/character/1300/Aventurine.ts
@@ -2,11 +2,6 @@ import { Topaz } from 'lib/conditionals/character/1100/Topaz'
 import { Feixiao } from 'lib/conditionals/character/1200/Feixiao'
 import { Robin } from 'lib/conditionals/character/1300/Robin'
 import { Tribbie } from 'lib/conditionals/character/1400/Tribbie'
-import { ashblazingMulti, single } from 'lib/conditionals/ashblazingCompute'
-import {
-  boostUltAshblazingAtk,
-  gpuBoostUltAshblazingAtk,
-} from 'lib/conditionals/conditionalFinalizers'
 import {
   AbilityEidolon,
   type Conditionals,
@@ -96,8 +91,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     SOURCE_E4,
     SOURCE_E6,
   } = Source.character(Aventurine.id)
-
-  const ultHitMulti = ashblazingMulti([single(1.00)])
 
   const basicScaling = basic(e, 1.00, 1.10)
   const ultScaling = ult(e, 2.70, 2.916)
@@ -275,10 +268,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
-      boostUltAshblazingAtk(x, action, ultHitMulti(context))
-    },
-    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
-      return gpuBoostUltAshblazingAtk(action, ultHitMulti(context))
     },
 
     dynamicConditionals: [{

--- a/src/lib/conditionals/character/1300/Aventurine.ts
+++ b/src/lib/conditionals/character/1300/Aventurine.ts
@@ -2,6 +2,11 @@ import { Topaz } from 'lib/conditionals/character/1100/Topaz'
 import { Feixiao } from 'lib/conditionals/character/1200/Feixiao'
 import { Robin } from 'lib/conditionals/character/1300/Robin'
 import { Tribbie } from 'lib/conditionals/character/1400/Tribbie'
+import { ULT_ASHBLAZING_1_SINGLE } from 'lib/conditionals/conditionalConstants'
+import {
+  boostUltAshblazingAtk,
+  gpuBoostUltAshblazingAtk,
+} from 'lib/conditionals/conditionalFinalizers'
 import {
   AbilityEidolon,
   type Conditionals,
@@ -268,8 +273,11 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
+      boostUltAshblazingAtk(x, action, ULT_ASHBLAZING_1_SINGLE)
     },
-    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => '',
+    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
+      return gpuBoostUltAshblazingAtk(action, ULT_ASHBLAZING_1_SINGLE)
+    },
 
     dynamicConditionals: [{
       id: 'AventurineConversionConditional',

--- a/src/lib/conditionals/character/1300/Aventurine.ts
+++ b/src/lib/conditionals/character/1300/Aventurine.ts
@@ -2,7 +2,7 @@ import { Topaz } from 'lib/conditionals/character/1100/Topaz'
 import { Feixiao } from 'lib/conditionals/character/1200/Feixiao'
 import { Robin } from 'lib/conditionals/character/1300/Robin'
 import { Tribbie } from 'lib/conditionals/character/1400/Tribbie'
-import { ULT_ASHBLAZING_1_SINGLE } from 'lib/conditionals/conditionalConstants'
+import { ashblazingMulti, single } from 'lib/conditionals/ashblazingCompute'
 import {
   boostUltAshblazingAtk,
   gpuBoostUltAshblazingAtk,
@@ -96,6 +96,8 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     SOURCE_E4,
     SOURCE_E6,
   } = Source.character(Aventurine.id)
+
+  const ultHitMulti = ashblazingMulti([single(1.00)])
 
   const basicScaling = basic(e, 1.00, 1.10)
   const ultScaling = ult(e, 2.70, 2.916)
@@ -273,10 +275,10 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
-      boostUltAshblazingAtk(x, action, ULT_ASHBLAZING_1_SINGLE)
+      boostUltAshblazingAtk(x, action, ultHitMulti(context))
     },
     newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
-      return gpuBoostUltAshblazingAtk(action, ULT_ASHBLAZING_1_SINGLE)
+      return gpuBoostUltAshblazingAtk(action, ultHitMulti(context))
     },
 
     dynamicConditionals: [{

--- a/src/lib/conditionals/character/1300/BlackSwan.ts
+++ b/src/lib/conditionals/character/1300/BlackSwan.ts
@@ -1,6 +1,11 @@
 import { KafkaB1 } from 'lib/conditionals/character/1000/KafkaB1'
 import { Hysilens } from 'lib/conditionals/character/1400/Hysilens'
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
+import { ULT_ASHBLAZING_1_AOE } from 'lib/conditionals/conditionalConstants'
+import {
+  boostUltAshblazingAtk,
+  gpuBoostUltAshblazingAtk,
+} from 'lib/conditionals/conditionalFinalizers'
 import {
   AbilityEidolon,
   type Conditionals,
@@ -273,6 +278,8 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 
       const ehrValue = x.getActionValueByIndex(StatKey.EHR, SELF_ENTITY_INDEX)
       x.buff(StatKey.BOOST, (r.ehrToDmgBoost) ? Math.min(0.72, 0.60 * ehrValue) : 0, x.source(SOURCE_TRACE))
+
+      boostUltAshblazingAtk(x, action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
     },
     newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
       const r = action.characterConditionals as Conditionals<typeof content>
@@ -282,7 +289,7 @@ if (${wgslTrue(r.ehrToDmgBoost)}) {
   let dmgBuff = min(0.72, 0.60 * ${containerActionVal(SELF_ENTITY_INDEX, StatKey.EHR, action.config)});
   ${buff.action(AKey.BOOST, 'dmgBuff').wgsl(action)}
 }
-      `
+      ` + gpuBoostUltAshblazingAtk(action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
     },
   }
 }

--- a/src/lib/conditionals/character/1300/BlackSwan.ts
+++ b/src/lib/conditionals/character/1300/BlackSwan.ts
@@ -1,7 +1,7 @@
 import { KafkaB1 } from 'lib/conditionals/character/1000/KafkaB1'
 import { Hysilens } from 'lib/conditionals/character/1400/Hysilens'
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
-import { ULT_ASHBLAZING_1_AOE } from 'lib/conditionals/conditionalConstants'
+import { aoe, ashblazingMulti } from 'lib/conditionals/ashblazingCompute'
 import {
   boostUltAshblazingAtk,
   gpuBoostUltAshblazingAtk,
@@ -94,6 +94,8 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     SOURCE_E4,
     SOURCE_E6,
   } = Source.character(BlackSwan.id)
+
+  const ultHitMulti = ashblazingMulti([aoe(1.00)])
 
   const arcanaStackMultiplier = talent(e, 0.12, 0.132)
   const epiphanyDmgTakenBoost = ult(e, 0.25, 0.27)
@@ -279,7 +281,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
       const ehrValue = x.getActionValueByIndex(StatKey.EHR, SELF_ENTITY_INDEX)
       x.buff(StatKey.BOOST, (r.ehrToDmgBoost) ? Math.min(0.72, 0.60 * ehrValue) : 0, x.source(SOURCE_TRACE))
 
-      boostUltAshblazingAtk(x, action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
+      boostUltAshblazingAtk(x, action, ultHitMulti(context))
     },
     newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
       const r = action.characterConditionals as Conditionals<typeof content>
@@ -289,7 +291,7 @@ if (${wgslTrue(r.ehrToDmgBoost)}) {
   let dmgBuff = min(0.72, 0.60 * ${containerActionVal(SELF_ENTITY_INDEX, StatKey.EHR, action.config)});
   ${buff.action(AKey.BOOST, 'dmgBuff').wgsl(action)}
 }
-      ` + gpuBoostUltAshblazingAtk(action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
+      ` + gpuBoostUltAshblazingAtk(action, ultHitMulti(context))
     },
   }
 }

--- a/src/lib/conditionals/character/1300/BlackSwan.ts
+++ b/src/lib/conditionals/character/1300/BlackSwan.ts
@@ -401,6 +401,7 @@ const scoring = (): ScoringMetadata => ({
   },
   presets: [
     PresetEffects.PRISONER_SET,
+    PresetEffects.fnMortenaxAshblazingSet(5),
   ],
   sortOption: SortOption.DOT,
   hiddenColumns: [

--- a/src/lib/conditionals/character/1300/Boothill.ts
+++ b/src/lib/conditionals/character/1300/Boothill.ts
@@ -1,6 +1,11 @@
 import { Fugue } from 'lib/conditionals/character/1200/Fugue'
 import { Lingsha } from 'lib/conditionals/character/1200/Lingsha'
 import { TheDahlia } from 'lib/conditionals/character/1300/TheDahlia'
+import { ASHBLAZING_ATK_STACK } from 'lib/conditionals/conditionalConstants'
+import {
+  boostUltAshblazingAtk,
+  gpuBoostUltAshblazingAtk,
+} from 'lib/conditionals/conditionalFinalizers'
 import {
   AbilityEidolon,
   type Conditionals,
@@ -86,6 +91,8 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     SOURCE_E4,
     SOURCE_E6,
   } = Source.character(Boothill.id)
+
+  const ultHitMulti = ASHBLAZING_ATK_STACK * (1 * 0.20 + 2 * 0.80)
 
   const standoffVulnerabilityBoost = skill(e, 0.30, 0.33)
 
@@ -274,7 +281,12 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
       x.buff(StatKey.VULNERABILITY, (e >= 4 && r.standoffActive && r.e4TargetStandoffVulnerability) ? 0.12 : 0, x.source(SOURCE_E4))
     },
 
-    finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {},
+    finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
+      boostUltAshblazingAtk(x, action, ultHitMulti)
+    },
+    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
+      return gpuBoostUltAshblazingAtk(action, ultHitMulti)
+    },
     dynamicConditionals: [{
       id: 'BoothillConversionConditional',
       type: ConditionalType.ABILITY,

--- a/src/lib/conditionals/character/1300/Boothill.ts
+++ b/src/lib/conditionals/character/1300/Boothill.ts
@@ -1,7 +1,10 @@
+import {
+  ashblazingMulti,
+  single,
+} from 'lib/conditionals/ashblazingCompute'
 import { Fugue } from 'lib/conditionals/character/1200/Fugue'
 import { Lingsha } from 'lib/conditionals/character/1200/Lingsha'
 import { TheDahlia } from 'lib/conditionals/character/1300/TheDahlia'
-import { ashblazingMulti, single } from 'lib/conditionals/ashblazingCompute'
 import {
   boostUltAshblazingAtk,
   gpuBoostUltAshblazingAtk,
@@ -92,7 +95,10 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     SOURCE_E6,
   } = Source.character(Boothill.id)
 
-  const ultHitMulti = ashblazingMulti([single(0.20), single(0.80)])
+  const ultHitMulti = ashblazingMulti([
+    single(0.20),
+    single(0.80),
+  ])
 
   const standoffVulnerabilityBoost = skill(e, 0.30, 0.33)
 

--- a/src/lib/conditionals/character/1300/Boothill.ts
+++ b/src/lib/conditionals/character/1300/Boothill.ts
@@ -1,7 +1,7 @@
 import { Fugue } from 'lib/conditionals/character/1200/Fugue'
 import { Lingsha } from 'lib/conditionals/character/1200/Lingsha'
 import { TheDahlia } from 'lib/conditionals/character/1300/TheDahlia'
-import { ASHBLAZING_ATK_STACK } from 'lib/conditionals/conditionalConstants'
+import { ashblazingMulti, single } from 'lib/conditionals/ashblazingCompute'
 import {
   boostUltAshblazingAtk,
   gpuBoostUltAshblazingAtk,
@@ -92,7 +92,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     SOURCE_E6,
   } = Source.character(Boothill.id)
 
-  const ultHitMulti = ASHBLAZING_ATK_STACK * (1 * 0.20 + 2 * 0.80)
+  const ultHitMulti = ashblazingMulti([single(0.20), single(0.80)])
 
   const standoffVulnerabilityBoost = skill(e, 0.30, 0.33)
 
@@ -282,10 +282,10 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
-      boostUltAshblazingAtk(x, action, ultHitMulti)
+      boostUltAshblazingAtk(x, action, ultHitMulti(context))
     },
     newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
-      return gpuBoostUltAshblazingAtk(action, ultHitMulti)
+      return gpuBoostUltAshblazingAtk(action, ultHitMulti(context))
     },
     dynamicConditionals: [{
       id: 'BoothillConversionConditional',

--- a/src/lib/conditionals/character/1300/Boothill.ts
+++ b/src/lib/conditionals/character/1300/Boothill.ts
@@ -53,6 +53,7 @@ import { SortOption } from 'lib/optimization/sortOptions'
 import {
   SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
 } from 'lib/scoring/scoringConstants'
+import { PresetEffects } from 'lib/scoring/presetEffects'
 import { relics2pByStats } from 'lib/sets/setConfigRegistry'
 import { wrappedFixedT } from 'lib/utils/i18nUtils'
 
@@ -450,7 +451,9 @@ const scoring = (): ScoringMetadata => ({
       Stats.BE,
     ],
   },
-  presets: [],
+  presets: [
+    PresetEffects.fnMortenaxAshblazingSet(2),
+  ],
   sortOption: SortOption.BASIC,
   hiddenColumns: [
     SortOption.SKILL,

--- a/src/lib/conditionals/character/1300/DrRatio.ts
+++ b/src/lib/conditionals/character/1300/DrRatio.ts
@@ -3,6 +3,7 @@ import { Robin } from 'lib/conditionals/character/1300/Robin'
 import { Cipher } from 'lib/conditionals/character/1400/Cipher'
 import {
   ASHBLAZING_ATK_STACK,
+  ULT_ASHBLAZING_1_SINGLE,
 } from 'lib/conditionals/conditionalConstants'
 import {
   boostAshblazingAtkContainer,
@@ -111,6 +112,9 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   }
 
   function getHitMulti(action: OptimizerAction, context: OptimizerContext) {
+    if (action.actionType === AbilityKind.ULT) {
+      return ULT_ASHBLAZING_1_SINGLE
+    }
     const r = action.characterConditionals as Conditionals<typeof content>
     return e >= 2
       ? fuaMultiByDebuffs[Math.min(4, r.enemyDebuffStacks)]

--- a/src/lib/conditionals/character/1300/DrRatio.ts
+++ b/src/lib/conditionals/character/1300/DrRatio.ts
@@ -1,10 +1,8 @@
 import { Aventurine } from 'lib/conditionals/character/1300/Aventurine'
 import { Robin } from 'lib/conditionals/character/1300/Robin'
 import { Cipher } from 'lib/conditionals/character/1400/Cipher'
-import {
-  ASHBLAZING_ATK_STACK,
-  ULT_ASHBLAZING_1_SINGLE,
-} from 'lib/conditionals/conditionalConstants'
+import { ashblazingMulti, single } from 'lib/conditionals/ashblazingCompute'
+import { ASHBLAZING_ATK_STACK } from 'lib/conditionals/conditionalConstants'
 import {
   boostAshblazingAtkContainer,
   gpuBoostAshblazingAtkContainer,
@@ -102,6 +100,8 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
       : 0.20 / (fuaScaling + 0.20 * procs) // for each e2 proc
   }
 
+  const ultHitMulti = ashblazingMulti([single(1.00)])
+
   const baseHitMulti = ASHBLAZING_ATK_STACK * (1 * 1 / 1)
   const fuaMultiByDebuffs: Record<number, number> = {
     0: ASHBLAZING_ATK_STACK * (1 * 1 / 1), // 0
@@ -113,7 +113,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 
   function getHitMulti(action: OptimizerAction, context: OptimizerContext) {
     if (action.actionType === AbilityKind.ULT) {
-      return ULT_ASHBLAZING_1_SINGLE
+      return ultHitMulti(context)
     }
     const r = action.characterConditionals as Conditionals<typeof content>
     return e >= 2

--- a/src/lib/conditionals/character/1300/Gallagher.ts
+++ b/src/lib/conditionals/character/1300/Gallagher.ts
@@ -324,6 +324,7 @@ const scoring = (): ScoringMetadata => ({
   },
   presets: [
     PresetEffects.WARRIOR_SET,
+    PresetEffects.fnMortenaxAshblazingSet(5),
   ],
   sortOption: SortOption.BE,
   addedColumns: [

--- a/src/lib/conditionals/character/1300/Gallagher.ts
+++ b/src/lib/conditionals/character/1300/Gallagher.ts
@@ -1,8 +1,8 @@
 import { RuanMei } from 'lib/conditionals/character/1300/RuanMei'
+import { aoe, ashblazingMulti } from 'lib/conditionals/ashblazingCompute'
 import {
   NONE_TYPE,
   SKILL_DMG_TYPE,
-  ULT_ASHBLAZING_1_AOE,
 } from 'lib/conditionals/conditionalConstants'
 import {
   boostUltAshblazingAtk,
@@ -80,6 +80,8 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     SOURCE_E4,
     SOURCE_E6,
   } = Source.character(Gallagher.id)
+
+  const ultHitMulti = ashblazingMulti([aoe(1.00)])
 
   const basicScaling = basic(e, 1.00, 1.10)
   const basicEnhancedScaling = basic(e, 2.50, 2.75)
@@ -243,11 +245,11 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
-      boostUltAshblazingAtk(x, action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
+      boostUltAshblazingAtk(x, action, ultHitMulti(context))
     },
 
     newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
-      return gpuBoostUltAshblazingAtk(action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
+      return gpuBoostUltAshblazingAtk(action, ultHitMulti(context))
     },
 
     dynamicConditionals: [

--- a/src/lib/conditionals/character/1300/Gallagher.ts
+++ b/src/lib/conditionals/character/1300/Gallagher.ts
@@ -2,7 +2,12 @@ import { RuanMei } from 'lib/conditionals/character/1300/RuanMei'
 import {
   NONE_TYPE,
   SKILL_DMG_TYPE,
+  ULT_ASHBLAZING_1_AOE,
 } from 'lib/conditionals/conditionalConstants'
+import {
+  boostUltAshblazingAtk,
+  gpuBoostUltAshblazingAtk,
+} from 'lib/conditionals/conditionalFinalizers'
 import {
   AbilityEidolon,
   type Conditionals,
@@ -238,9 +243,12 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
+      boostUltAshblazingAtk(x, action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
     },
 
-    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => '',
+    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
+      return gpuBoostUltAshblazingAtk(action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
+    },
 
     dynamicConditionals: [
       {

--- a/src/lib/conditionals/character/1300/Jade.ts
+++ b/src/lib/conditionals/character/1300/Jade.ts
@@ -3,6 +3,7 @@ import { TheHerta } from 'lib/conditionals/character/1400/TheHerta'
 import { Tribbie } from 'lib/conditionals/character/1400/Tribbie'
 import {
   ASHBLAZING_ATK_STACK,
+  ULT_ASHBLAZING_1_AOE,
 } from 'lib/conditionals/conditionalConstants'
 import {
   boostAshblazingAtkContainer,
@@ -107,6 +108,9 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   }
 
   function getHitMulti(action: OptimizerAction, context: OptimizerContext) {
+    if (action.actionType === AbilityKind.ULT) {
+      return ULT_ASHBLAZING_1_AOE[context.enemyCount]
+    }
     const r = action.characterConditionals as Conditionals<typeof content>
     return r.enhancedFollowUp
       ? enhancedHitMultiByTargets[context.enemyCount]

--- a/src/lib/conditionals/character/1300/Jade.ts
+++ b/src/lib/conditionals/character/1300/Jade.ts
@@ -1,10 +1,8 @@
 import { Lingsha } from 'lib/conditionals/character/1200/Lingsha'
 import { TheHerta } from 'lib/conditionals/character/1400/TheHerta'
 import { Tribbie } from 'lib/conditionals/character/1400/Tribbie'
-import {
-  ASHBLAZING_ATK_STACK,
-  ULT_ASHBLAZING_1_AOE,
-} from 'lib/conditionals/conditionalConstants'
+import { aoe, ashblazingMulti } from 'lib/conditionals/ashblazingCompute'
+import { ASHBLAZING_ATK_STACK } from 'lib/conditionals/conditionalConstants'
 import {
   boostAshblazingAtkContainer,
   gpuBoostAshblazingAtkContainer,
@@ -95,6 +93,8 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   const fuaScaling = talent(e, 1.20, 1.32)
   const pawnedAssetCdScaling = talent(e, 0.024, 0.0264)
 
+  const ultHitMulti = ashblazingMulti([aoe(1.00)])
+
   const unenhancedHitMultiByTargets: Record<number, number> = {
     1: ASHBLAZING_ATK_STACK * (1 * 0.25 + 2 * 0.25 + 3 * 0.25 + 4 * 0.25), // 0.15
     3: ASHBLAZING_ATK_STACK * (2 * 0.25 + 5 * 0.25 + 8 * 0.25 + 8 * 0.25), // 0.345
@@ -109,7 +109,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 
   function getHitMulti(action: OptimizerAction, context: OptimizerContext) {
     if (action.actionType === AbilityKind.ULT) {
-      return ULT_ASHBLAZING_1_AOE[context.enemyCount]
+      return ultHitMulti(context)
     }
     const r = action.characterConditionals as Conditionals<typeof content>
     return r.enhancedFollowUp

--- a/src/lib/conditionals/character/1300/Misha.ts
+++ b/src/lib/conditionals/character/1300/Misha.ts
@@ -1,12 +1,17 @@
 import { HuohuoB1 } from 'lib/conditionals/character/1200/HuohuoB1'
 import { RuanMei } from 'lib/conditionals/character/1300/RuanMei'
 import { SparkleB1 } from 'lib/conditionals/character/1300/SparkleB1'
+import { ashblazingMulti, single } from 'lib/conditionals/ashblazingCompute'
 import {
   AbilityEidolon,
   type Conditionals,
   type ContentDefinition,
   createEnum,
 } from 'lib/conditionals/conditionalUtils'
+import {
+  boostUltAshblazingAtk,
+  gpuBoostUltAshblazingAtk,
+} from 'lib/conditionals/conditionalFinalizers'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
 import { ButTheBattleIsntOver } from 'lib/conditionals/lightcone/5star/ButTheBattleIsntOver'
 import { NightOfFright } from 'lib/conditionals/lightcone/5star/NightOfFright'
@@ -83,6 +88,8 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   const skillScaling = skill(e, 2.00, 2.20)
   let ultStackScaling = ult(e, 0.60, 0.65)
   ultStackScaling += e >= 4 ? 0.06 : 0
+
+  const ultHitMulti = ashblazingMulti(Array(10).fill(single(1.00)))
 
   const defaults = {
     ultHitsOnTarget: 10,
@@ -216,10 +223,10 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
+      boostUltAshblazingAtk(x, action, ultHitMulti(context))
     },
-
     newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
-      return ''
+      return gpuBoostUltAshblazingAtk(action, ultHitMulti(context))
     },
   }
 }

--- a/src/lib/conditionals/character/1300/Misha.ts
+++ b/src/lib/conditionals/character/1300/Misha.ts
@@ -330,6 +330,7 @@ const scoring = (): ScoringMetadata => ({
   },
   presets: [
     PresetEffects.fnPioneerSet(4),
+    PresetEffects.fnMortenaxAshblazingSet(8),
   ],
   sortOption: SortOption.ULT,
   hiddenColumns: [

--- a/src/lib/conditionals/character/1300/TheDahlia.ts
+++ b/src/lib/conditionals/character/1300/TheDahlia.ts
@@ -8,6 +8,7 @@ import { Anaxa } from 'lib/conditionals/character/1400/Anaxa'
 import { Phainon } from 'lib/conditionals/character/1400/Phainon'
 import {
   ASHBLAZING_ATK_STACK,
+  ULT_ASHBLAZING_1_AOE,
 } from 'lib/conditionals/conditionalConstants'
 import {
   boostAshblazingAtkContainer,
@@ -239,6 +240,13 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
       5: ASHBLAZING_ATK_STACK * (3 * 1.00),
     }
 
+  function getHitMulti(action: OptimizerAction, context: OptimizerContext) {
+    if (action.actionType === AbilityKind.ULT) {
+      return ULT_ASHBLAZING_1_AOE[context.enemyCount]
+    }
+    return hitMultiByTargets[context.enemyCount]
+  }
+
   return {
     content: () => Object.values(content),
     teammateContent: () => Object.values(teammateContent),
@@ -420,10 +428,10 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
-      boostAshblazingAtkContainer(x, action, hitMultiByTargets[context.enemyCount])
+      boostAshblazingAtkContainer(x, action, getHitMulti(action, context))
     },
     newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
-      return gpuBoostAshblazingAtkContainer(hitMultiByTargets[context.enemyCount], action)
+      return gpuBoostAshblazingAtkContainer(getHitMulti(action, context), action)
     },
   }
 }

--- a/src/lib/conditionals/character/1300/TheDahlia.ts
+++ b/src/lib/conditionals/character/1300/TheDahlia.ts
@@ -6,10 +6,8 @@ import { Firefly } from 'lib/conditionals/character/1300/Firefly'
 import { FireflyB1 } from 'lib/conditionals/character/1300/FireflyB1'
 import { Anaxa } from 'lib/conditionals/character/1400/Anaxa'
 import { Phainon } from 'lib/conditionals/character/1400/Phainon'
-import {
-  ASHBLAZING_ATK_STACK,
-  ULT_ASHBLAZING_1_AOE,
-} from 'lib/conditionals/conditionalConstants'
+import { aoe, ashblazingMulti } from 'lib/conditionals/ashblazingCompute'
+import { ASHBLAZING_ATK_STACK } from 'lib/conditionals/conditionalConstants'
 import {
   boostAshblazingAtkContainer,
   gpuBoostAshblazingAtkContainer,
@@ -228,6 +226,8 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 
   const fuaHits = (e >= 4) ? 10 : 5
 
+  const ultHitMulti = ashblazingMulti([aoe(1.00)])
+
   const hitMultiByTargets: NumberToNumberMap = (e >= 4)
     ? {
       1: ASHBLAZING_ATK_STACK * (1 * 0.10 + 2 * 0.10 + 3 * 0.10 + 4 * 0.10 + 5 * 0.10 + 6 * 0.10 + 7 * 0.10 + 8 * 0.10 + 9 * 0.10 + 10 * 0.10),
@@ -242,7 +242,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 
   function getHitMulti(action: OptimizerAction, context: OptimizerContext) {
     if (action.actionType === AbilityKind.ULT) {
-      return ULT_ASHBLAZING_1_AOE[context.enemyCount]
+      return ultHitMulti(context)
     }
     return hitMultiByTargets[context.enemyCount]
   }

--- a/src/lib/conditionals/character/1400/Anaxa.ts
+++ b/src/lib/conditionals/character/1400/Anaxa.ts
@@ -5,7 +5,7 @@ import {
   cyreneSpecialEffectEidolonUpgraded,
 } from 'lib/conditionals/character/1400/Cyrene'
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
-import { ULT_ASHBLAZING_1_AOE } from 'lib/conditionals/conditionalConstants'
+import { aoe, ashblazingMulti } from 'lib/conditionals/ashblazingCompute'
 import {
   boostUltAshblazingAtk,
   gpuBoostUltAshblazingAtk,
@@ -88,6 +88,8 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     SOURCE_E4,
     SOURCE_E6,
   } = Source.character('1405')
+
+  const ultHitMulti = ashblazingMulti([aoe(1.00)])
 
   const basicScaling = basic(e, 1.00, 1.10)
   const skillScaling = skill(e, 0.70, 0.77)
@@ -324,10 +326,10 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
-      boostUltAshblazingAtk(x, action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
+      boostUltAshblazingAtk(x, action, ultHitMulti(context))
     },
     newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
-      return gpuBoostUltAshblazingAtk(action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
+      return gpuBoostUltAshblazingAtk(action, ultHitMulti(context))
     },
   }
 }

--- a/src/lib/conditionals/character/1400/Anaxa.ts
+++ b/src/lib/conditionals/character/1400/Anaxa.ts
@@ -444,6 +444,7 @@ const scoring = (): ScoringMetadata => ({
   presets: [
     PresetEffects.fnPioneerSet(4),
     PresetEffects.GENIUS_SET,
+    PresetEffects.fnMortenaxAshblazingSet(5),
   ],
   sortOption: SortOption.SKILL,
   hiddenColumns: [SortOption.FUA, SortOption.DOT],

--- a/src/lib/conditionals/character/1400/Anaxa.ts
+++ b/src/lib/conditionals/character/1400/Anaxa.ts
@@ -5,6 +5,11 @@ import {
   cyreneSpecialEffectEidolonUpgraded,
 } from 'lib/conditionals/character/1400/Cyrene'
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
+import { ULT_ASHBLAZING_1_AOE } from 'lib/conditionals/conditionalConstants'
+import {
+  boostUltAshblazingAtk,
+  gpuBoostUltAshblazingAtk,
+} from 'lib/conditionals/conditionalFinalizers'
 import {
   AbilityEidolon,
   type Conditionals,
@@ -319,8 +324,11 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
+      boostUltAshblazingAtk(x, action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
     },
-    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => '',
+    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
+      return gpuBoostUltAshblazingAtk(action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
+    },
   }
 }
 

--- a/src/lib/conditionals/character/1400/Cerydra.ts
+++ b/src/lib/conditionals/character/1400/Cerydra.ts
@@ -5,7 +5,7 @@ import {
 } from 'lib/conditionals/character/1400/Cyrene'
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
 import { Phainon } from 'lib/conditionals/character/1400/Phainon'
-import { ULT_ASHBLAZING_1_AOE } from 'lib/conditionals/conditionalConstants'
+import { aoe, ashblazingMulti } from 'lib/conditionals/ashblazingCompute'
 import {
   boostUltAshblazingAtk,
   gpuBoostUltAshblazingAtk,
@@ -91,6 +91,8 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     SOURCE_E6,
     SOURCE_MEMO,
   } = Source.character(Cerydra.id)
+
+  const ultHitMulti = ashblazingMulti([aoe(1.00)])
 
   const basicScaling = basic(e, 1.00, 1.10)
   const skillCdScaling = skill(e, 0.72, 0.792)
@@ -332,10 +334,10 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
-      boostUltAshblazingAtk(x, action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
+      boostUltAshblazingAtk(x, action, ultHitMulti(context))
     },
     newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
-      return gpuBoostUltAshblazingAtk(action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
+      return gpuBoostUltAshblazingAtk(action, ultHitMulti(context))
     },
 
     dynamicConditionals: [

--- a/src/lib/conditionals/character/1400/Cerydra.ts
+++ b/src/lib/conditionals/character/1400/Cerydra.ts
@@ -5,6 +5,11 @@ import {
 } from 'lib/conditionals/character/1400/Cyrene'
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
 import { Phainon } from 'lib/conditionals/character/1400/Phainon'
+import { ULT_ASHBLAZING_1_AOE } from 'lib/conditionals/conditionalConstants'
+import {
+  boostUltAshblazingAtk,
+  gpuBoostUltAshblazingAtk,
+} from 'lib/conditionals/conditionalFinalizers'
 import {
   AbilityEidolon,
   type Conditionals,
@@ -327,8 +332,11 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
+      boostUltAshblazingAtk(x, action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
     },
-    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => '',
+    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
+      return gpuBoostUltAshblazingAtk(action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
+    },
 
     dynamicConditionals: [
       {

--- a/src/lib/conditionals/character/1400/Cerydra.ts
+++ b/src/lib/conditionals/character/1400/Cerydra.ts
@@ -51,6 +51,7 @@ import {
   SPREAD_ORNAMENTS_2P_SUPPORT,
   SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
 } from 'lib/scoring/scoringConstants'
+import { PresetEffects } from 'lib/scoring/presetEffects'
 import { wrappedFixedT } from 'lib/utils/i18nUtils'
 import {
   floorSafe,
@@ -465,7 +466,9 @@ const scoring = (): ScoringMetadata => ({
       Stats.ERR,
     ],
   },
-  presets: [],
+  presets: [
+    PresetEffects.fnMortenaxAshblazingSet(5),
+  ],
   sortOption: SortOption.ULT,
   hiddenColumns: [SortOption.DOT],
   supportSimulation: supportSimulation(),

--- a/src/lib/conditionals/character/1400/Cipher.ts
+++ b/src/lib/conditionals/character/1400/Cipher.ts
@@ -5,6 +5,7 @@ import {
   cyreneSpecialEffectEidolonUpgraded,
 } from 'lib/conditionals/character/1400/Cyrene'
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
+import { ashblazingMulti, blast, single } from 'lib/conditionals/ashblazingCompute'
 import {
   ASHBLAZING_ATK_STACK,
 } from 'lib/conditionals/conditionalConstants'
@@ -195,6 +196,15 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   const hitMulti = ASHBLAZING_ATK_STACK
     * (1 * 0.20 + 2 * 0.10 + 3 * 0.10 + 4 * 0.60)
 
+  const ultHitMulti = ashblazingMulti([single(ultScaling), blast(ultSecondaryScaling)])
+
+  function getHitMulti(action: OptimizerAction, context: OptimizerContext) {
+    if (action.actionType === AbilityKind.ULT) {
+      return ultHitMulti(context)
+    }
+    return hitMulti
+  }
+
   return {
     content: () => Object.values(content),
     defaults: () => defaults,
@@ -344,10 +354,10 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
-      boostAshblazingAtkContainer(x, action, hitMulti)
+      boostAshblazingAtkContainer(x, action, getHitMulti(action, context))
     },
     newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
-      return gpuBoostAshblazingAtkContainer(hitMulti, action)
+      return gpuBoostAshblazingAtkContainer(getHitMulti(action, context), action)
     },
 
     dynamicConditionals: [

--- a/src/lib/conditionals/character/1400/Cipher.ts
+++ b/src/lib/conditionals/character/1400/Cipher.ts
@@ -1,3 +1,8 @@
+import {
+  ashblazingMulti,
+  blast,
+  single,
+} from 'lib/conditionals/ashblazingCompute'
 import { Feixiao } from 'lib/conditionals/character/1200/Feixiao'
 import { Robin } from 'lib/conditionals/character/1300/Robin'
 import {
@@ -5,7 +10,6 @@ import {
   cyreneSpecialEffectEidolonUpgraded,
 } from 'lib/conditionals/character/1400/Cyrene'
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
-import { ashblazingMulti, blast, single } from 'lib/conditionals/ashblazingCompute'
 import {
   ASHBLAZING_ATK_STACK,
 } from 'lib/conditionals/conditionalConstants'
@@ -196,7 +200,10 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   const hitMulti = ASHBLAZING_ATK_STACK
     * (1 * 0.20 + 2 * 0.10 + 3 * 0.10 + 4 * 0.60)
 
-  const ultHitMulti = ashblazingMulti([single(ultScaling), blast(ultSecondaryScaling)])
+  const ultHitMulti = ashblazingMulti([
+    single(ultScaling),
+    blast(ultSecondaryScaling),
+  ])
 
   function getHitMulti(action: OptimizerAction, context: OptimizerContext) {
     if (action.actionType === AbilityKind.ULT) {

--- a/src/lib/conditionals/character/1400/Hysilens.ts
+++ b/src/lib/conditionals/character/1400/Hysilens.ts
@@ -5,6 +5,11 @@ import {
   cyreneSpecialEffectEidolonUpgraded,
 } from 'lib/conditionals/character/1400/Cyrene'
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
+import { ULT_ASHBLAZING_1_AOE } from 'lib/conditionals/conditionalConstants'
+import {
+  boostUltAshblazingAtk,
+  gpuBoostUltAshblazingAtk,
+} from 'lib/conditionals/conditionalFinalizers'
 import {
   AbilityEidolon,
   type Conditionals,
@@ -363,6 +368,8 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
       const ehrBoost = (r.ehrToDmg) ? Math.max(0, Math.min(0.90, 0.15 * floorSafe((ehrValue - 0.60) / 0.10))) : 0
 
       x.buff(StatKey.BOOST, ehrBoost, x.source(SOURCE_TRACE))
+
+      boostUltAshblazingAtk(x, action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
     },
     newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
       const r = action.characterConditionals as Conditionals<typeof content>
@@ -372,7 +379,7 @@ if (${wgslTrue(r.ehrToDmg)}) {
   let dmgBuff = min(0.90, 0.15 * floorSafe((${containerActionVal(SELF_ENTITY_INDEX, StatKey.EHR, action.config)} - 0.60) / 0.10));
   ${buff.action(AKey.BOOST, 'dmgBuff').wgsl(action)}
 }
-`
+` + gpuBoostUltAshblazingAtk(action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
     },
   }
 }

--- a/src/lib/conditionals/character/1400/Hysilens.ts
+++ b/src/lib/conditionals/character/1400/Hysilens.ts
@@ -5,7 +5,7 @@ import {
   cyreneSpecialEffectEidolonUpgraded,
 } from 'lib/conditionals/character/1400/Cyrene'
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
-import { ULT_ASHBLAZING_1_AOE } from 'lib/conditionals/conditionalConstants'
+import { aoe, ashblazingMulti } from 'lib/conditionals/ashblazingCompute'
 import {
   boostUltAshblazingAtk,
   gpuBoostUltAshblazingAtk,
@@ -93,6 +93,8 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     SOURCE_E4,
     SOURCE_E6,
   } = Source.character(Hysilens.id)
+
+  const ultHitMulti = ashblazingMulti([aoe(1.00)])
 
   const basicScaling = basic(e, 1.00, 1.10)
 
@@ -369,7 +371,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 
       x.buff(StatKey.BOOST, ehrBoost, x.source(SOURCE_TRACE))
 
-      boostUltAshblazingAtk(x, action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
+      boostUltAshblazingAtk(x, action, ultHitMulti(context))
     },
     newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
       const r = action.characterConditionals as Conditionals<typeof content>
@@ -379,7 +381,7 @@ if (${wgslTrue(r.ehrToDmg)}) {
   let dmgBuff = min(0.90, 0.15 * floorSafe((${containerActionVal(SELF_ENTITY_INDEX, StatKey.EHR, action.config)} - 0.60) / 0.10));
   ${buff.action(AKey.BOOST, 'dmgBuff').wgsl(action)}
 }
-` + gpuBoostUltAshblazingAtk(action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
+` + gpuBoostUltAshblazingAtk(action, ultHitMulti(context))
     },
   }
 }

--- a/src/lib/conditionals/character/1400/Hysilens.ts
+++ b/src/lib/conditionals/character/1400/Hysilens.ts
@@ -492,6 +492,7 @@ const scoring = (): ScoringMetadata => ({
   presets: [
     PresetEffects.PRISONER_SET,
     PresetEffects.fnPioneerSet(4),
+    PresetEffects.fnMortenaxAshblazingSet(5),
   ],
   sortOption: SortOption.DOT,
   hiddenColumns: [SortOption.FUA],

--- a/src/lib/conditionals/character/1400/Mydei.ts
+++ b/src/lib/conditionals/character/1400/Mydei.ts
@@ -5,6 +5,11 @@ import {
 } from 'lib/conditionals/character/1400/Cyrene'
 import { Hyacine } from 'lib/conditionals/character/1400/Hyacine'
 import { Tribbie } from 'lib/conditionals/character/1400/Tribbie'
+import { ULT_ASHBLAZING_1_BLAST } from 'lib/conditionals/conditionalConstants'
+import {
+  boostUltAshblazingAtk,
+  gpuBoostUltAshblazingAtk,
+} from 'lib/conditionals/conditionalFinalizers'
 import {
   AbilityEidolon,
   type Conditionals,
@@ -278,6 +283,8 @@ if (${wgslTrue(r.hpToCrConversion)}) {
       if (r.vendettaState) {
         x.set(StatKey.DEF, 0, x.source(SOURCE_TALENT))
       }
+
+      boostUltAshblazingAtk(x, action, ULT_ASHBLAZING_1_BLAST[context.enemyCount])
     },
     newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
       const r = action.characterConditionals as Conditionals<typeof content>
@@ -286,7 +293,7 @@ if (${wgslTrue(r.hpToCrConversion)}) {
 if (${wgslTrue(r.vendettaState)}) {
   ${buff.actionSet(AKey.DEF, '0.0').wgsl(action)}
 }
-`
+` + gpuBoostUltAshblazingAtk(action, ULT_ASHBLAZING_1_BLAST[context.enemyCount])
     },
 
     dynamicConditionals: [

--- a/src/lib/conditionals/character/1400/Mydei.ts
+++ b/src/lib/conditionals/character/1400/Mydei.ts
@@ -5,7 +5,7 @@ import {
 } from 'lib/conditionals/character/1400/Cyrene'
 import { Hyacine } from 'lib/conditionals/character/1400/Hyacine'
 import { Tribbie } from 'lib/conditionals/character/1400/Tribbie'
-import { ULT_ASHBLAZING_1_BLAST } from 'lib/conditionals/conditionalConstants'
+import { ashblazingMulti, blast } from 'lib/conditionals/ashblazingCompute'
 import {
   boostUltAshblazingAtk,
   gpuBoostUltAshblazingAtk,
@@ -94,6 +94,8 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     SOURCE_E2,
     SOURCE_E4,
   } = Source.character('1404')
+
+  const ultHitMulti = ashblazingMulti([blast(1.00)])
 
   const basicScaling = basic(e, 0.50, 0.55)
 
@@ -284,7 +286,7 @@ if (${wgslTrue(r.hpToCrConversion)}) {
         x.set(StatKey.DEF, 0, x.source(SOURCE_TALENT))
       }
 
-      boostUltAshblazingAtk(x, action, ULT_ASHBLAZING_1_BLAST[context.enemyCount])
+      boostUltAshblazingAtk(x, action, ultHitMulti(context))
     },
     newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
       const r = action.characterConditionals as Conditionals<typeof content>
@@ -293,7 +295,7 @@ if (${wgslTrue(r.hpToCrConversion)}) {
 if (${wgslTrue(r.vendettaState)}) {
   ${buff.actionSet(AKey.DEF, '0.0').wgsl(action)}
 }
-` + gpuBoostUltAshblazingAtk(action, ULT_ASHBLAZING_1_BLAST[context.enemyCount])
+` + gpuBoostUltAshblazingAtk(action, ultHitMulti(context))
     },
 
     dynamicConditionals: [

--- a/src/lib/conditionals/character/1400/Mydei.ts
+++ b/src/lib/conditionals/character/1400/Mydei.ts
@@ -5,11 +5,6 @@ import {
 } from 'lib/conditionals/character/1400/Cyrene'
 import { Hyacine } from 'lib/conditionals/character/1400/Hyacine'
 import { Tribbie } from 'lib/conditionals/character/1400/Tribbie'
-import { ashblazingMulti, blast } from 'lib/conditionals/ashblazingCompute'
-import {
-  boostUltAshblazingAtk,
-  gpuBoostUltAshblazingAtk,
-} from 'lib/conditionals/conditionalFinalizers'
 import {
   AbilityEidolon,
   type Conditionals,
@@ -94,8 +89,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     SOURCE_E2,
     SOURCE_E4,
   } = Source.character('1404')
-
-  const ultHitMulti = ashblazingMulti([blast(1.00)])
 
   const basicScaling = basic(e, 0.50, 0.55)
 
@@ -286,7 +279,6 @@ if (${wgslTrue(r.hpToCrConversion)}) {
         x.set(StatKey.DEF, 0, x.source(SOURCE_TALENT))
       }
 
-      boostUltAshblazingAtk(x, action, ultHitMulti(context))
     },
     newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
       const r = action.characterConditionals as Conditionals<typeof content>
@@ -295,7 +287,7 @@ if (${wgslTrue(r.hpToCrConversion)}) {
 if (${wgslTrue(r.vendettaState)}) {
   ${buff.actionSet(AKey.DEF, '0.0').wgsl(action)}
 }
-` + gpuBoostUltAshblazingAtk(action, ultHitMulti(context))
+`
     },
 
     dynamicConditionals: [

--- a/src/lib/conditionals/character/1400/PermansorTerrae.ts
+++ b/src/lib/conditionals/character/1400/PermansorTerrae.ts
@@ -5,6 +5,7 @@ import {
 } from 'lib/conditionals/character/1400/Cyrene'
 import { Phainon } from 'lib/conditionals/character/1400/Phainon'
 import { Tribbie } from 'lib/conditionals/character/1400/Tribbie'
+import { ashblazingMulti, aoe } from 'lib/conditionals/ashblazingCompute'
 import {
   ASHBLAZING_ATK_STACK,
   NONE_TYPE,
@@ -177,6 +178,15 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     5: ASHBLAZING_ATK_STACK * (3 * 0.25 + 8 * 0.25 + 8 * 0.25 + 8 * 0.25),
   }
 
+  const ultHitMulti = ashblazingMulti([aoe(1.00)])
+
+  function getHitMulti(action: OptimizerAction, context: OptimizerContext) {
+    if (action.actionType === AbilityKind.ULT) {
+      return ultHitMulti(context)
+    }
+    return hitMultiByTargets[context.enemyCount]
+  }
+
   return {
     content: () => Object.values(content),
     teammateContent: () => Object.values(teammateContent),
@@ -315,10 +325,10 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
-      boostAshblazingAtkContainer(x, action, hitMultiByTargets[context.enemyCount])
+      boostAshblazingAtkContainer(x, action, getHitMulti(action, context))
     },
     newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
-      return gpuBoostAshblazingAtkContainer(hitMultiByTargets[context.enemyCount], action)
+      return gpuBoostAshblazingAtkContainer(getHitMulti(action, context), action)
     },
   }
 }

--- a/src/lib/conditionals/character/1400/TheHerta.ts
+++ b/src/lib/conditionals/character/1400/TheHerta.ts
@@ -1,7 +1,7 @@
 import { Jade } from 'lib/conditionals/character/1300/Jade'
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
 import { Tribbie } from 'lib/conditionals/character/1400/Tribbie'
-import { ULT_ASHBLAZING_1_AOE } from 'lib/conditionals/conditionalConstants'
+import { aoe, ashblazingMulti } from 'lib/conditionals/ashblazingCompute'
 import {
   boostUltAshblazingAtk,
   gpuBoostUltAshblazingAtk,
@@ -82,6 +82,8 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     SOURCE_E4,
     SOURCE_E6,
   } = Source.character('1401')
+
+  const ultHitMulti = ashblazingMulti([aoe(1.00)])
 
   const basicScaling = basic(e, 1.00, 1.10)
   const skillScaling = skill(e, 0.70, 0.77)
@@ -245,10 +247,10 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     defaults: () => defaults,
     teammateDefaults: () => teammateDefaults,
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
-      boostUltAshblazingAtk(x, action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
+      boostUltAshblazingAtk(x, action, ultHitMulti(context))
     },
     newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
-      return gpuBoostUltAshblazingAtk(action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
+      return gpuBoostUltAshblazingAtk(action, ultHitMulti(context))
     },
 
     // New container methods

--- a/src/lib/conditionals/character/1400/TheHerta.ts
+++ b/src/lib/conditionals/character/1400/TheHerta.ts
@@ -44,6 +44,7 @@ import {
   SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
   SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
 } from 'lib/scoring/scoringConstants'
+import { PresetEffects } from 'lib/scoring/presetEffects'
 import { wrappedFixedT } from 'lib/utils/i18nUtils'
 import { precisionRound } from 'lib/utils/mathUtils'
 import { type Eidolon } from 'types/character'
@@ -383,7 +384,9 @@ const scoring = (): ScoringMetadata => ({
       Stats.ERR,
     ],
   },
-  presets: [],
+  presets: [
+    PresetEffects.fnMortenaxAshblazingSet(5),
+  ],
   sortOption: SortOption.SKILL,
   hiddenColumns: [
     SortOption.FUA,

--- a/src/lib/conditionals/character/1400/TheHerta.ts
+++ b/src/lib/conditionals/character/1400/TheHerta.ts
@@ -1,6 +1,11 @@
 import { Jade } from 'lib/conditionals/character/1300/Jade'
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
 import { Tribbie } from 'lib/conditionals/character/1400/Tribbie'
+import { ULT_ASHBLAZING_1_AOE } from 'lib/conditionals/conditionalConstants'
+import {
+  boostUltAshblazingAtk,
+  gpuBoostUltAshblazingAtk,
+} from 'lib/conditionals/conditionalFinalizers'
 import {
   AbilityEidolon,
   type Conditionals,
@@ -240,8 +245,11 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     defaults: () => defaults,
     teammateDefaults: () => teammateDefaults,
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
+      boostUltAshblazingAtk(x, action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
     },
-    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => '',
+    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
+      return gpuBoostUltAshblazingAtk(action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
+    },
 
     // New container methods
     precomputeEffectsContainer: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {

--- a/src/lib/conditionals/character/1400/Tribbie.ts
+++ b/src/lib/conditionals/character/1400/Tribbie.ts
@@ -5,6 +5,11 @@ import {
 } from 'lib/conditionals/character/1400/Cyrene'
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
 import { TheHerta } from 'lib/conditionals/character/1400/TheHerta'
+import { ULT_ASHBLAZING_1_AOE } from 'lib/conditionals/conditionalConstants'
+import {
+  boostUltAshblazingAtk,
+  gpuBoostUltAshblazingAtk,
+} from 'lib/conditionals/conditionalFinalizers'
 import {
   AbilityEidolon,
   type Conditionals,
@@ -331,8 +336,11 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
+      boostUltAshblazingAtk(x, action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
     },
-    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => '',
+    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
+      return gpuBoostUltAshblazingAtk(action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
+    },
   }
 }
 

--- a/src/lib/conditionals/character/1400/Tribbie.ts
+++ b/src/lib/conditionals/character/1400/Tribbie.ts
@@ -5,11 +5,6 @@ import {
 } from 'lib/conditionals/character/1400/Cyrene'
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
 import { TheHerta } from 'lib/conditionals/character/1400/TheHerta'
-import { aoe, ashblazingMulti } from 'lib/conditionals/ashblazingCompute'
-import {
-  boostUltAshblazingAtk,
-  gpuBoostUltAshblazingAtk,
-} from 'lib/conditionals/conditionalFinalizers'
 import {
   AbilityEidolon,
   type Conditionals,
@@ -90,8 +85,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     SOURCE_E4,
     SOURCE_E6,
   } = Source.character('1403')
-
-  const ultHitMulti = ashblazingMulti([aoe(1.00)])
 
   const basicScaling = basic(e, 0.30, 0.33)
 
@@ -338,10 +331,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
-      boostUltAshblazingAtk(x, action, ultHitMulti(context))
-    },
-    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
-      return gpuBoostUltAshblazingAtk(action, ultHitMulti(context))
     },
   }
 }

--- a/src/lib/conditionals/character/1400/Tribbie.ts
+++ b/src/lib/conditionals/character/1400/Tribbie.ts
@@ -5,7 +5,7 @@ import {
 } from 'lib/conditionals/character/1400/Cyrene'
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
 import { TheHerta } from 'lib/conditionals/character/1400/TheHerta'
-import { ULT_ASHBLAZING_1_AOE } from 'lib/conditionals/conditionalConstants'
+import { aoe, ashblazingMulti } from 'lib/conditionals/ashblazingCompute'
 import {
   boostUltAshblazingAtk,
   gpuBoostUltAshblazingAtk,
@@ -90,6 +90,8 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     SOURCE_E4,
     SOURCE_E6,
   } = Source.character('1403')
+
+  const ultHitMulti = ashblazingMulti([aoe(1.00)])
 
   const basicScaling = basic(e, 0.30, 0.33)
 
@@ -336,10 +338,10 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
-      boostUltAshblazingAtk(x, action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
+      boostUltAshblazingAtk(x, action, ultHitMulti(context))
     },
     newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
-      return gpuBoostUltAshblazingAtk(action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
+      return gpuBoostUltAshblazingAtk(action, ultHitMulti(context))
     },
   }
 }

--- a/src/lib/conditionals/character/1500/Ashveil.ts
+++ b/src/lib/conditionals/character/1500/Ashveil.ts
@@ -1,9 +1,8 @@
 import { SparkleB1 } from 'lib/conditionals/character/1300/SparkleB1'
 import { Sunday } from 'lib/conditionals/character/1300/Sunday'
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
-import {
-  ASHBLAZING_ATK_STACK,
-} from 'lib/conditionals/conditionalConstants'
+import { ashblazingMulti, single } from 'lib/conditionals/ashblazingCompute'
+import { ASHBLAZING_ATK_STACK } from 'lib/conditionals/conditionalConstants'
 import {
   boostAshblazingAtkContainer,
   gpuBoostAshblazingAtkContainer,
@@ -103,11 +102,11 @@ const conditionals: CharacterConditionalFunction = (e, withContent) => {
   const fuaHitCountMulti = ASHBLAZING_ATK_STACK
     * (1 * 1 / 10 + 2 * 1 / 10 + 3 * 1 / 10 + 4 * 1 / 10 + 5 * 1 / 10 + 6 * 1 / 10 + 7 * 1 / 10 + 8 * 1 / 10 + 8 * 1 / 10 + 8 * 1 / 10)
 
-  const ultHitMulti = ASHBLAZING_ATK_STACK * (1 * 0.05 + 2 * 0.05 + 3 * 0.05 + 4 * 0.05 + 5 * 0.05 + 6 * 0.05 + 7 * 0.05 + 8 * 0.05 * 13)
+  const ultHitMulti = ashblazingMulti(Array(20).fill(single(0.05)))
 
   function getHitMulti(action: OptimizerAction, context: OptimizerContext) {
     if (action.actionType === AbilityKind.ULT) {
-      return ultHitMulti
+      return ultHitMulti(context)
     }
     return fuaHitCountMulti
   }

--- a/src/lib/conditionals/character/1500/Ashveil.ts
+++ b/src/lib/conditionals/character/1500/Ashveil.ts
@@ -1,7 +1,9 @@
 import { SparkleB1 } from 'lib/conditionals/character/1300/SparkleB1'
 import { Sunday } from 'lib/conditionals/character/1300/Sunday'
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
-import { ASHBLAZING_ATK_STACK } from 'lib/conditionals/conditionalConstants'
+import {
+  ASHBLAZING_ATK_STACK,
+} from 'lib/conditionals/conditionalConstants'
 import {
   boostAshblazingAtkContainer,
   gpuBoostAshblazingAtkContainer,
@@ -100,6 +102,15 @@ const conditionals: CharacterConditionalFunction = (e, withContent) => {
 
   const fuaHitCountMulti = ASHBLAZING_ATK_STACK
     * (1 * 1 / 10 + 2 * 1 / 10 + 3 * 1 / 10 + 4 * 1 / 10 + 5 * 1 / 10 + 6 * 1 / 10 + 7 * 1 / 10 + 8 * 1 / 10 + 8 * 1 / 10 + 8 * 1 / 10)
+
+  const ultHitMulti = ASHBLAZING_ATK_STACK * (1 * 0.05 + 2 * 0.05 + 3 * 0.05 + 4 * 0.05 + 5 * 0.05 + 6 * 0.05 + 7 * 0.05 + 8 * 0.05 * 13)
+
+  function getHitMulti(action: OptimizerAction, context: OptimizerContext) {
+    if (action.actionType === AbilityKind.ULT) {
+      return ultHitMulti
+    }
+    return fuaHitCountMulti
+  }
 
   const maxGluttonyStacks = (e >= 2) ? 18 : 12
 
@@ -296,10 +307,10 @@ const conditionals: CharacterConditionalFunction = (e, withContent) => {
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
-      boostAshblazingAtkContainer(x, action, fuaHitCountMulti)
+      boostAshblazingAtkContainer(x, action, getHitMulti(action, context))
     },
     newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
-      return gpuBoostAshblazingAtkContainer(fuaHitCountMulti, action)
+      return gpuBoostAshblazingAtkContainer(getHitMulti(action, context), action)
     },
   }
 }

--- a/src/lib/conditionals/character/1500/Evanescia.ts
+++ b/src/lib/conditionals/character/1500/Evanescia.ts
@@ -1,10 +1,18 @@
+import {
+  aoe,
+  ashblazingMulti,
+  single,
+} from 'lib/conditionals/ashblazingCompute'
 import { HuohuoB1 } from 'lib/conditionals/character/1200/HuohuoB1'
 import {
   getYaoguangAhaPunchlineValue,
   Yaoguang,
 } from 'lib/conditionals/character/1500/Yaoguang'
 import { TrailblazerElationStelle } from 'lib/conditionals/character/8000/TrailblazerElation'
-import { aoe, ashblazingMulti, single } from 'lib/conditionals/ashblazingCompute'
+import {
+  boostUltAshblazingAtk,
+  gpuBoostUltAshblazingAtk,
+} from 'lib/conditionals/conditionalFinalizers'
 import {
   AbilityEidolon,
   type Conditionals,
@@ -15,10 +23,6 @@ import {
   dynamicStatConversionContainer,
   gpuDynamicStatConversion,
 } from 'lib/conditionals/evaluation/statConversion'
-import {
-  boostUltAshblazingAtk,
-  gpuBoostUltAshblazingAtk,
-} from 'lib/conditionals/conditionalFinalizers'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
 import { MushyShroomysAdventures } from 'lib/conditionals/lightcone/4star/MushyShroomysAdventures'
 import { ElationBrimmingWithBlessings } from 'lib/conditionals/lightcone/5star/ElationBrimmingWithBlessings'
@@ -105,7 +109,10 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   const ultAoeScaling = ult(e, 1.60, 1.76)
   const ultBounceScaling = ult(e, 1.20, 1.296)
 
-  const ultHitMulti = ashblazingMulti([aoe(ultAoeScaling), ...Array(5).fill(single(ultBounceScaling))])
+  const ultHitMulti = ashblazingMulti([
+    aoe(ultAoeScaling),
+    ...Array(5).fill(single(ultBounceScaling)),
+  ])
 
   const cdToElationRatio = 0.20
   const talentSkillElationScaling = talent(e, 0.16, 0.176)

--- a/src/lib/conditionals/character/1500/Evanescia.ts
+++ b/src/lib/conditionals/character/1500/Evanescia.ts
@@ -4,6 +4,7 @@ import {
   Yaoguang,
 } from 'lib/conditionals/character/1500/Yaoguang'
 import { TrailblazerElationStelle } from 'lib/conditionals/character/8000/TrailblazerElation'
+import { aoe, ashblazingMulti, single } from 'lib/conditionals/ashblazingCompute'
 import {
   AbilityEidolon,
   type Conditionals,
@@ -14,6 +15,10 @@ import {
   dynamicStatConversionContainer,
   gpuDynamicStatConversion,
 } from 'lib/conditionals/evaluation/statConversion'
+import {
+  boostUltAshblazingAtk,
+  gpuBoostUltAshblazingAtk,
+} from 'lib/conditionals/conditionalFinalizers'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
 import { MushyShroomysAdventures } from 'lib/conditionals/lightcone/4star/MushyShroomysAdventures'
 import { ElationBrimmingWithBlessings } from 'lib/conditionals/lightcone/5star/ElationBrimmingWithBlessings'
@@ -99,6 +104,8 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   const skillMainScaling = skill(e, 3.00, 3.30)
   const ultAoeScaling = ult(e, 1.60, 1.76)
   const ultBounceScaling = ult(e, 1.20, 1.296)
+
+  const ultHitMulti = ashblazingMulti([aoe(ultAoeScaling), ...Array(5).fill(single(ultBounceScaling))])
 
   const cdToElationRatio = 0.20
   const talentSkillElationScaling = talent(e, 0.16, 0.176)
@@ -352,8 +359,11 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
+      boostUltAshblazingAtk(x, action, ultHitMulti(context))
     },
-    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => '',
+    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
+      return gpuBoostUltAshblazingAtk(action, ultHitMulti(context))
+    },
 
     // Talent: CD to Elation conversion
     dynamicConditionals: [{

--- a/src/lib/conditionals/character/1500/Evanescia.ts
+++ b/src/lib/conditionals/character/1500/Evanescia.ts
@@ -515,6 +515,7 @@ const scoring = (): ScoringMetadata => ({
   },
   presets: [
     PresetEffects.fnPioneerSet(4),
+    PresetEffects.fnMortenaxAshblazingSet(8),
   ],
   sortOption: SortOption.ELATION_SKILL,
   hiddenColumns: [SortOption.FUA, SortOption.DOT],

--- a/src/lib/conditionals/character/1500/Sparxie.ts
+++ b/src/lib/conditionals/character/1500/Sparxie.ts
@@ -514,6 +514,7 @@ const scoring = (): ScoringMetadata => ({
   },
   presets: [
     PresetEffects.TENGOKU_SET,
+    PresetEffects.fnMortenaxAshblazingSet(5),
   ],
   sortOption: SortOption.BASIC,
   hiddenColumns: [SortOption.SKILL, SortOption.FUA, SortOption.DOT],

--- a/src/lib/conditionals/character/1500/Sparxie.ts
+++ b/src/lib/conditionals/character/1500/Sparxie.ts
@@ -4,7 +4,7 @@ import {
   getYaoguangAhaPunchlineValue,
   Yaoguang,
 } from 'lib/conditionals/character/1500/Yaoguang'
-import { ULT_ASHBLAZING_1_AOE } from 'lib/conditionals/conditionalConstants'
+import { aoe, ashblazingMulti } from 'lib/conditionals/ashblazingCompute'
 import {
   boostUltAshblazingAtk,
   gpuBoostUltAshblazingAtk,
@@ -97,6 +97,8 @@ const conditionals: CharacterConditionalFunction = (e, withContent) => {
   } = Source.character(Sparxie.id)
 
   const t = wrappedFixedT(withContent).get(null, 'conditionals', 'Characters.Sparxie.Content')
+
+  const ultHitMulti = ashblazingMulti([aoe(1.00)])
 
   const basicScaling = basic(e, 1.00, 1.10)
   const engagementScaling = skill(e, 0.20, 0.22)
@@ -356,10 +358,10 @@ const conditionals: CharacterConditionalFunction = (e, withContent) => {
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
-      boostUltAshblazingAtk(x, action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
+      boostUltAshblazingAtk(x, action, ultHitMulti(context))
     },
     newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
-      return gpuBoostUltAshblazingAtk(action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
+      return gpuBoostUltAshblazingAtk(action, ultHitMulti(context))
     },
     dynamicConditionals: [
       {

--- a/src/lib/conditionals/character/1500/Sparxie.ts
+++ b/src/lib/conditionals/character/1500/Sparxie.ts
@@ -4,6 +4,11 @@ import {
   getYaoguangAhaPunchlineValue,
   Yaoguang,
 } from 'lib/conditionals/character/1500/Yaoguang'
+import { ULT_ASHBLAZING_1_AOE } from 'lib/conditionals/conditionalConstants'
+import {
+  boostUltAshblazingAtk,
+  gpuBoostUltAshblazingAtk,
+} from 'lib/conditionals/conditionalFinalizers'
 import {
   AbilityEidolon,
   type Conditionals,
@@ -350,8 +355,12 @@ const conditionals: CharacterConditionalFunction = (e, withContent) => {
     precomputeTeammateEffectsContainer: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
     },
 
-    finalizeCalculations: () => {},
-    newGpuFinalizeCalculations: () => '',
+    finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
+      boostUltAshblazingAtk(x, action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
+    },
+    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
+      return gpuBoostUltAshblazingAtk(action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
+    },
     dynamicConditionals: [
       {
         id: 'SparxieAtkElationConditional',

--- a/src/lib/conditionals/character/8000/TrailblazerDestruction.ts
+++ b/src/lib/conditionals/character/8000/TrailblazerDestruction.ts
@@ -1,6 +1,11 @@
 import { Bronya } from 'lib/conditionals/character/1100/Bronya'
 import { HuohuoB1 } from 'lib/conditionals/character/1200/HuohuoB1'
 import { RuanMei } from 'lib/conditionals/character/1300/RuanMei'
+import { ULT_ASHBLAZING_1_SINGLE } from 'lib/conditionals/conditionalConstants'
+import {
+  boostUltAshblazingAtk,
+  gpuBoostUltAshblazingAtk,
+} from 'lib/conditionals/conditionalFinalizers'
 import {
   AbilityEidolon,
   type Conditionals,
@@ -161,8 +166,11 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     content: () => Object.values(content),
     defaults: () => defaults,
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
+      boostUltAshblazingAtk(x, action, ULT_ASHBLAZING_1_SINGLE)
     },
-    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => '',
+    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
+      return gpuBoostUltAshblazingAtk(action, ULT_ASHBLAZING_1_SINGLE)
+    },
 
     // New container methods
     precomputeEffectsContainer: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {

--- a/src/lib/conditionals/character/8000/TrailblazerDestruction.ts
+++ b/src/lib/conditionals/character/8000/TrailblazerDestruction.ts
@@ -1,7 +1,7 @@
 import { Bronya } from 'lib/conditionals/character/1100/Bronya'
 import { HuohuoB1 } from 'lib/conditionals/character/1200/HuohuoB1'
 import { RuanMei } from 'lib/conditionals/character/1300/RuanMei'
-import { ULT_ASHBLAZING_1_SINGLE } from 'lib/conditionals/conditionalConstants'
+import { ashblazingMulti, single } from 'lib/conditionals/ashblazingCompute'
 import {
   boostUltAshblazingAtk,
   gpuBoostUltAshblazingAtk,
@@ -79,6 +79,8 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     SOURCE_E4,
     SOURCE_E6,
   } = Source.character(TrailblazerDestructionStelle.id)
+
+  const ultHitMulti = ashblazingMulti([single(1.00)])
 
   const talentAtkScalingValue = talent(e, 0.20, 0.22)
 
@@ -166,10 +168,10 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     content: () => Object.values(content),
     defaults: () => defaults,
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
-      boostUltAshblazingAtk(x, action, ULT_ASHBLAZING_1_SINGLE)
+      boostUltAshblazingAtk(x, action, ultHitMulti(context))
     },
     newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
-      return gpuBoostUltAshblazingAtk(action, ULT_ASHBLAZING_1_SINGLE)
+      return gpuBoostUltAshblazingAtk(action, ultHitMulti(context))
     },
 
     // New container methods

--- a/src/lib/conditionals/character/8000/TrailblazerDestruction.ts
+++ b/src/lib/conditionals/character/8000/TrailblazerDestruction.ts
@@ -40,6 +40,7 @@ import {
   SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
   SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
 } from 'lib/scoring/scoringConstants'
+import { PresetEffects } from 'lib/scoring/presetEffects'
 import { wrappedFixedT } from 'lib/utils/i18nUtils'
 import { type Eidolon } from 'types/character'
 import { type CharacterConfig } from 'types/characterConfig'
@@ -287,7 +288,9 @@ const scoring = (): ScoringMetadata => ({
       Stats.BE,
     ],
   },
-  presets: [],
+  presets: [
+    PresetEffects.fnMortenaxAshblazingSet(3),
+  ],
   sortOption: SortOption.SKILL,
   hiddenColumns: [SortOption.FUA, SortOption.DOT],
   simulation: simulation(),

--- a/src/lib/conditionals/character/8000/TrailblazerPreservation.ts
+++ b/src/lib/conditionals/character/8000/TrailblazerPreservation.ts
@@ -1,7 +1,7 @@
 import { Jiaoqiu } from 'lib/conditionals/character/1200/Jiaoqiu'
 import { Acheron } from 'lib/conditionals/character/1300/Acheron'
 import { Cipher } from 'lib/conditionals/character/1400/Cipher'
-import { ULT_ASHBLAZING_1_AOE } from 'lib/conditionals/conditionalConstants'
+import { aoe, ashblazingMulti } from 'lib/conditionals/ashblazingCompute'
 import {
   boostUltAshblazingAtk,
   gpuBoostUltAshblazingAtk,
@@ -77,6 +77,8 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     SOURCE_E4,
     SOURCE_E6,
   } = Source.character(TrailblazerPreservationStelle.id)
+
+  const ultHitMulti = ashblazingMulti([aoe(1.00)])
 
   const skillDamageReductionValue = skill(e, 0.50, 0.52)
 
@@ -217,10 +219,10 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
-      boostUltAshblazingAtk(x, action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
+      boostUltAshblazingAtk(x, action, ultHitMulti(context))
     },
     newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
-      return gpuBoostUltAshblazingAtk(action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
+      return gpuBoostUltAshblazingAtk(action, ultHitMulti(context))
     },
   }
 }

--- a/src/lib/conditionals/character/8000/TrailblazerPreservation.ts
+++ b/src/lib/conditionals/character/8000/TrailblazerPreservation.ts
@@ -33,6 +33,7 @@ import {
   SPREAD_ORNAMENTS_2P_SUPPORT,
   SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
 } from 'lib/scoring/scoringConstants'
+import { PresetEffects } from 'lib/scoring/presetEffects'
 import { wrappedFixedT } from 'lib/utils/i18nUtils'
 import { type Eidolon } from 'types/character'
 import { type CharacterConfig } from 'types/characterConfig'
@@ -309,7 +310,9 @@ const scoring = (): ScoringMetadata => ({
       Stats.ERR,
     ],
   },
-  presets: [],
+  presets: [
+    PresetEffects.fnMortenaxAshblazingSet(5),
+  ],
   sortOption: SortOption.TALENT_SHIELD,
   addedColumns: [],
   hiddenColumns: [SortOption.SKILL, SortOption.FUA, SortOption.DOT],

--- a/src/lib/conditionals/character/8000/TrailblazerPreservation.ts
+++ b/src/lib/conditionals/character/8000/TrailblazerPreservation.ts
@@ -1,6 +1,11 @@
 import { Jiaoqiu } from 'lib/conditionals/character/1200/Jiaoqiu'
 import { Acheron } from 'lib/conditionals/character/1300/Acheron'
 import { Cipher } from 'lib/conditionals/character/1400/Cipher'
+import { ULT_ASHBLAZING_1_AOE } from 'lib/conditionals/conditionalConstants'
+import {
+  boostUltAshblazingAtk,
+  gpuBoostUltAshblazingAtk,
+} from 'lib/conditionals/conditionalFinalizers'
 import {
   AbilityEidolon,
   type Conditionals,
@@ -212,8 +217,11 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
+      boostUltAshblazingAtk(x, action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
     },
-    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => '',
+    newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
+      return gpuBoostUltAshblazingAtk(action, ULT_ASHBLAZING_1_AOE[context.enemyCount])
+    },
   }
 }
 

--- a/src/lib/conditionals/conditionalConstants.ts
+++ b/src/lib/conditionals/conditionalConstants.ts
@@ -1,25 +1,7 @@
 import type { SetKey } from 'lib/constants/constants'
 import type { ComputedStatsObjectExternal } from 'lib/optimization/engine/container/computedStatsContainer'
-import type { NumberToNumberMap } from 'types/common'
 
 export const ASHBLAZING_ATK_STACK = 0.06
-
-// ULT ashblazing hitMulti: 1 single-target hit, 100% weight — constant across enemy counts
-export const ULT_ASHBLAZING_1_SINGLE = ASHBLAZING_ATK_STACK * (1 * 1.00)
-
-// ULT ashblazing hitMulti: 1 AoE hit, 100% weight — varies by enemy count
-export const ULT_ASHBLAZING_1_AOE: NumberToNumberMap = {
-  1: ASHBLAZING_ATK_STACK * (1 * 1.00),
-  3: ASHBLAZING_ATK_STACK * (2 * 1.00),
-  5: ASHBLAZING_ATK_STACK * (3 * 1.00),
-}
-
-// ULT ashblazing hitMulti: 1 blast hit, 100% weight — blast hits max 3 targets (target + adjacent)
-export const ULT_ASHBLAZING_1_BLAST: NumberToNumberMap = {
-  1: ASHBLAZING_ATK_STACK * (1 * 1.00),
-  3: ASHBLAZING_ATK_STACK * (2 * 1.00),
-  5: ASHBLAZING_ATK_STACK * (2 * 1.00),
-}
 
 // Ability types
 export const NONE_TYPE = 0

--- a/src/lib/conditionals/conditionalConstants.ts
+++ b/src/lib/conditionals/conditionalConstants.ts
@@ -3,6 +3,9 @@ import type { ComputedStatsObjectExternal } from 'lib/optimization/engine/contai
 
 export const ASHBLAZING_ATK_STACK = 0.06
 
+// ULT ashblazing hitMulti: 1 single-target hit, 100% weight — constant across enemy counts
+export const ULT_ASHBLAZING_1_SINGLE = ASHBLAZING_ATK_STACK * (1 * 1.00)
+
 // Ability types
 export const NONE_TYPE = 0
 

--- a/src/lib/conditionals/conditionalConstants.ts
+++ b/src/lib/conditionals/conditionalConstants.ts
@@ -1,10 +1,25 @@
 import type { SetKey } from 'lib/constants/constants'
 import type { ComputedStatsObjectExternal } from 'lib/optimization/engine/container/computedStatsContainer'
+import type { NumberToNumberMap } from 'types/common'
 
 export const ASHBLAZING_ATK_STACK = 0.06
 
 // ULT ashblazing hitMulti: 1 single-target hit, 100% weight — constant across enemy counts
 export const ULT_ASHBLAZING_1_SINGLE = ASHBLAZING_ATK_STACK * (1 * 1.00)
+
+// ULT ashblazing hitMulti: 1 AoE hit, 100% weight — varies by enemy count
+export const ULT_ASHBLAZING_1_AOE: NumberToNumberMap = {
+  1: ASHBLAZING_ATK_STACK * (1 * 1.00),
+  3: ASHBLAZING_ATK_STACK * (2 * 1.00),
+  5: ASHBLAZING_ATK_STACK * (3 * 1.00),
+}
+
+// ULT ashblazing hitMulti: 1 blast hit, 100% weight — blast hits max 3 targets (target + adjacent)
+export const ULT_ASHBLAZING_1_BLAST: NumberToNumberMap = {
+  1: ASHBLAZING_ATK_STACK * (1 * 1.00),
+  3: ASHBLAZING_ATK_STACK * (2 * 1.00),
+  5: ASHBLAZING_ATK_STACK * (2 * 1.00),
+}
 
 // Ability types
 export const NONE_TYPE = 0

--- a/src/lib/conditionals/conditionalFinalizers.ts
+++ b/src/lib/conditionals/conditionalFinalizers.ts
@@ -11,6 +11,7 @@ import {
   relic4p,
   SetKeys,
 } from 'lib/optimization/setMatching'
+import { AbilityKind } from 'lib/optimization/rotation/turnAbilityConfig'
 import type { OptimizerAction } from 'types/optimizer'
 
 export function boostAshblazingAtkContainer(x: ComputedStatsContainer, action: OptimizerAction, hitMulti: number) {
@@ -20,6 +21,19 @@ export function boostAshblazingAtkContainer(x: ComputedStatsContainer, action: O
     const baseATK = x.config.selfEntity.baseAtk
     x.buff(StatKey.ATK, delta * baseATK, x.damageType(DamageTag.FUA).source(Source.TheAshblazingGrandDuke))
   }
+}
+
+export function boostUltAshblazingAtk(x: ComputedStatsContainer, action: OptimizerAction, hitMulti: number) {
+  if (action.actionType === AbilityKind.ULT) {
+    boostAshblazingAtkContainer(x, action, hitMulti)
+  }
+}
+
+export function gpuBoostUltAshblazingAtk(action: OptimizerAction, hitMulti: number): string {
+  if (action.actionType === AbilityKind.ULT) {
+    return gpuBoostAshblazingAtkContainer(hitMulti, action)
+  }
+  return ''
 }
 
 export function gpuBoostAshblazingAtkContainer(hitMulti: number, action: OptimizerAction) {

--- a/src/lib/conditionals/evaluation/applyPresets.test.ts
+++ b/src/lib/conditionals/evaluation/applyPresets.test.ts
@@ -1,0 +1,40 @@
+import {
+  applyScoringMetadataPresets,
+} from 'lib/conditionals/evaluation/applyPresets'
+import { MortenaxBlade } from 'lib/conditionals/character/1500/MortenaxBlade'
+import { Pela } from 'lib/conditionals/character/1100/Pela'
+import { defaultSetConditionals } from 'lib/optimization/defaultForm'
+import { Sets } from 'lib/constants/constants'
+import { Metadata } from 'lib/state/metadataInitializer'
+import { clone } from 'lib/utils/objectUtils'
+import type { Form } from 'types/form'
+import { describe, expect, it } from 'vitest'
+
+Metadata.initialize()
+
+function buildPelaForm() {
+  return {
+    characterId: Pela.id,
+    setConditionals: clone(defaultSetConditionals),
+  } as Form
+}
+
+describe('applyPresets', () => {
+  it('does not apply teammate-gated scoring metadata presets without matching teammates', () => {
+    const form = buildPelaForm()
+
+    applyScoringMetadataPresets(form, [])
+
+    expect(form.setConditionals[Sets.TheAshblazingGrandDuke][1]).toBe(
+      defaultSetConditionals[Sets.TheAshblazingGrandDuke][1],
+    )
+  })
+
+  it('applies teammate-gated scoring metadata presets with matching teammates', () => {
+    const form = buildPelaForm()
+
+    applyScoringMetadataPresets(form, [{ id: MortenaxBlade.id, eidolon: 2 }])
+
+    expect(form.setConditionals[Sets.TheAshblazingGrandDuke][1]).toBe(5)
+  })
+})

--- a/src/lib/conditionals/evaluation/applyPresets.ts
+++ b/src/lib/conditionals/evaluation/applyPresets.ts
@@ -140,14 +140,28 @@ export function applyScoringMetadataPresets(form: Form | BenchmarkForm, teammate
       const match = teammates.some((teammate) =>
         teammate.id === teammateCondition.characterId && teammate.eidolon >= teammateCondition.minEidolon
       )
-      if (!match) {
-        const index = preset.index ?? 1
-        form.setConditionals[preset.set][index] = defaultSetConditionals[preset.set][index]
-        continue
-      }
+      if (!match) continue
     }
 
     applyPreset(form, preset)
+  }
+}
+
+export function applyTeammateConditionalPresets(form: Form | BenchmarkForm, teammates: TeammateInfo[]) {
+  const presets = resolveScoringMetadataPresets(form)
+
+  for (const preset of presets) {
+    const { teammateCondition } = preset
+    if (!teammateCondition) continue
+
+    const index = preset.index ?? 1
+    const match = teammates.some((teammate) =>
+      teammate.id === teammateCondition.characterId && teammate.eidolon >= teammateCondition.minEidolon
+    )
+
+    form.setConditionals[preset.set][index] = match
+      ? preset.value
+      : defaultSetConditionals[preset.set][index]
   }
 }
 
@@ -207,7 +221,7 @@ export function applyTeamAwareSetConditionalPresetsToStore() {
   const form = displayToInternal(state)
   const teammates = resolveTeammateInfo(form.teammate0, form.teammate1, form.teammate2)
   applyTeamAwareSetConditionalPresets(form, teammates)
-  applyScoringMetadataPresets(form, teammates)
+  applyTeammateConditionalPresets(form, teammates)
 
   useOptimizerRequestStore.getState().setSetConditionals(form.setConditionals)
 }

--- a/src/lib/conditionals/evaluation/applyPresets.ts
+++ b/src/lib/conditionals/evaluation/applyPresets.ts
@@ -38,6 +38,12 @@ import type { CharacterId } from 'types/character'
 import type { Form } from 'types/form'
 import type { ScoringMetadata } from 'types/metadata'
 
+export type TeammateInfo = { id: CharacterId | undefined, eidolon: number }
+type TeammateInfoSource = {
+  characterId?: CharacterId | null,
+  characterEidolon?: number | null,
+} | null | undefined
+
 export function applySpdPreset(spd: number, characterId: CharacterId | null | undefined) {
   if (!characterId) return
 
@@ -106,15 +112,37 @@ function applyMetadataPresetToForm(form: Form, scoringMetadata: ScoringMetadata)
   form.weights = { ...form.weights, ...scoringMetadata.stats }
   form.weights.minWeightedRolls = form.weights.minWeightedRolls ?? 0
 
-  applySetConditionalPresets(form)
-  applyScoringMetadataPresets(form)
+  const teammates = resolveTeammateInfo(form.teammate0, form.teammate1, form.teammate2)
+  applySetConditionalPresets(form, teammates)
+  applyScoringMetadataPresets(form, teammates)
 }
 
-export function applyScoringMetadataPresets(form: Form | BenchmarkForm) {
+function resolveScoringMetadataPresets(form: Form | BenchmarkForm) {
   const character = getGameMetadata().characters[form.characterId]
-  const presets = character?.scoringMetadata?.presets ?? []
+  return character?.scoringMetadata?.presets ?? []
+}
+
+export function resolveTeammateInfo(...teammates: TeammateInfoSource[]): TeammateInfo[] {
+  return teammates
+    .filter((teammate) => teammate != null)
+    .map((teammate) => ({
+      id: teammate.characterId ?? undefined,
+      eidolon: teammate.characterEidolon ?? 0,
+    }))
+}
+
+export function applyScoringMetadataPresets(form: Form | BenchmarkForm, teammates: TeammateInfo[]) {
+  const presets = resolveScoringMetadataPresets(form)
 
   for (const preset of presets) {
+    const { teammateCondition } = preset
+    if (teammateCondition) {
+      const match = teammates.some((teammate) =>
+        teammate.id === teammateCondition.characterId && teammate.eidolon >= teammateCondition.minEidolon
+      )
+      if (!match) continue
+    }
+
     applyPreset(form, preset)
   }
 }
@@ -123,7 +151,7 @@ export function applyPreset(form: Form | BenchmarkForm, preset: PresetDefinition
   form.setConditionals[preset.set][preset.index ?? 1] = preset.value
 }
 
-export function applySetConditionalPresets(form: Form | BenchmarkForm) {
+export function applySetConditionalPresets(form: Form | BenchmarkForm, teammates: TeammateInfo[]) {
   const metadataCharacters = getGameMetadata().characters
   const characterMetadata = metadataCharacters[form.characterId]
   mergeUndefinedValues(form.setConditionals, defaultSetConditionals)
@@ -141,25 +169,14 @@ export function applySetConditionalPresets(form: Form | BenchmarkForm) {
   form.setConditionals[Sets.WorldRemakingDeliverer][1] = path == PathNames.Remembrance
   form.setConditionals[Sets.AmphoreusTheEternalLand][1] = path == PathNames.Remembrance
 
-  applyTeamAwareSetConditionalPresets(form)
+  applyTeamAwareSetConditionalPresets(form, teammates)
 }
 
-export function applyTeamAwareSetConditionalPresets(form: Form | BenchmarkForm, teammateIds?: (CharacterId | undefined)[]) {
+export function applyTeamAwareSetConditionalPresets(form: Form | BenchmarkForm, teammates: TeammateInfo[]) {
   if (!form.setConditionals) return
   const metadataCharacters = getGameMetadata().characters
 
-  const allyIds = [
-    form.characterId,
-    ...(
-      teammateIds
-        ? teammateIds
-        : [
-          form.teammate0?.characterId,
-          form.teammate1?.characterId,
-          form.teammate2?.characterId,
-        ]
-    ),
-  ].filter((x) => !!x)
+  const allyIds = [form.characterId, ...teammates.map((t) => t.id)].filter((x) => !!x)
 
   // Arcadia depends on the number of ally targets
   // Demiurge is out-of-bounds and therefore not a target
@@ -184,7 +201,7 @@ export function applyTeamAwareSetConditionalPresets(form: Form | BenchmarkForm, 
 export function applyTeamAwareSetConditionalPresetsToStore() {
   const state = useOptimizerRequestStore.getState()
   const form = displayToInternal(state)
-  applyTeamAwareSetConditionalPresets(form)
+  applyTeamAwareSetConditionalPresets(form, resolveTeammateInfo(form.teammate0, form.teammate1, form.teammate2))
 
   // Update the store with the modified set conditionals
   useOptimizerRequestStore.getState().setSetConditionals(form.setConditionals)

--- a/src/lib/conditionals/evaluation/applyPresets.ts
+++ b/src/lib/conditionals/evaluation/applyPresets.ts
@@ -140,7 +140,11 @@ export function applyScoringMetadataPresets(form: Form | BenchmarkForm, teammate
       const match = teammates.some((teammate) =>
         teammate.id === teammateCondition.characterId && teammate.eidolon >= teammateCondition.minEidolon
       )
-      if (!match) continue
+      if (!match) {
+        const index = preset.index ?? 1
+        form.setConditionals[preset.set][index] = defaultSetConditionals[preset.set][index]
+        continue
+      }
     }
 
     applyPreset(form, preset)
@@ -201,8 +205,9 @@ export function applyTeamAwareSetConditionalPresets(form: Form | BenchmarkForm, 
 export function applyTeamAwareSetConditionalPresetsToStore() {
   const state = useOptimizerRequestStore.getState()
   const form = displayToInternal(state)
-  applyTeamAwareSetConditionalPresets(form, resolveTeammateInfo(form.teammate0, form.teammate1, form.teammate2))
+  const teammates = resolveTeammateInfo(form.teammate0, form.teammate1, form.teammate2)
+  applyTeamAwareSetConditionalPresets(form, teammates)
+  applyScoringMetadataPresets(form, teammates)
 
-  // Update the store with the modified set conditionals
   useOptimizerRequestStore.getState().setSetConditionals(form.setConditionals)
 }

--- a/src/lib/optimization/combo/comboInitializers.ts
+++ b/src/lib/optimization/combo/comboInitializers.ts
@@ -1,4 +1,4 @@
-import { applyPreset } from 'lib/conditionals/evaluation/applyPresets'
+import { applyScoringMetadataPresets, resolveTeammateInfo } from 'lib/conditionals/evaluation/applyPresets'
 import { CharacterConditionalsResolver } from 'lib/conditionals/resolver/characterConditionalsResolver'
 import { LightConeConditionalsResolver } from 'lib/conditionals/resolver/lightConeConditionalsResolver'
 import {
@@ -147,10 +147,8 @@ function shiftDefaultConditionalToFirst(comboConditionals?: ComboConditionals) {
 
 function displayModifiedSets(request: Form, comboState: ComboState) {
   const defaultForm = getDefaultForm({ id: request.characterId })
-  const presets = getGameMetadata().characters[request.characterId].scoringMetadata.presets || []
-  for (const preset of presets) {
-    applyPreset(defaultForm, preset)
-  }
+  const teammates = resolveTeammateInfo(request.teammate0, request.teammate1, request.teammate2)
+  applyScoringMetadataPresets(defaultForm, teammates)
 
   const modified: string[] = []
 

--- a/src/lib/optimization/defaultForm.ts
+++ b/src/lib/optimization/defaultForm.ts
@@ -104,8 +104,8 @@ export function getDefaultForm(initialCharacter: { id: CharacterId }) {
     ...defaultEnemyOptions(),
   })
 
-  applySetConditionalPresets(defaultForm as Form)
-  applyScoringMetadataPresets(defaultForm as Form)
+  applySetConditionalPresets(defaultForm as Form, [])
+  applyScoringMetadataPresets(defaultForm as Form, [])
 
   if (scoringMetadata?.simulation?.comboTurnAbilities) {
     defaultForm.comboTurnAbilities = [...scoringMetadata.simulation.comboTurnAbilities]

--- a/src/lib/scoring/presetEffects.ts
+++ b/src/lib/scoring/presetEffects.ts
@@ -3,12 +3,18 @@ import type {
   SetsOrnaments,
   SetsRelics,
 } from 'lib/sets/setConfigRegistry'
+import { MortenaxBlade } from 'lib/conditionals/character/1500/MortenaxBlade'
+import type { CharacterId } from 'types/character'
 
 export type PresetDefinition = {
   name: string,
   set: SetsRelics | SetsOrnaments,
   value: number | boolean,
   index?: number,
+  teammateCondition?: {
+    characterId: CharacterId,
+    minEidolon: number,
+  },
 }
 
 export const PresetEffects = {
@@ -35,6 +41,12 @@ export const PresetEffects = {
       set: Sets.SacerdosRelivedOrdeal,
     }
   },
+  fnMortenaxAshblazingSet: (stacks: number): PresetDefinition => ({
+    name: 'fnMortenaxAshblazingSet',
+    value: stacks,
+    set: Sets.TheAshblazingGrandDuke,
+    teammateCondition: { characterId: MortenaxBlade.id, minEidolon: 2 },
+  }),
 
   // Preset values
 

--- a/src/lib/simulations/orchestrator/benchmarkSimulationOrchestrator.ts
+++ b/src/lib/simulations/orchestrator/benchmarkSimulationOrchestrator.ts
@@ -7,7 +7,11 @@ import {
   TrailblazerHarmonyCaelus,
   TrailblazerHarmonyStelle,
 } from 'lib/conditionals/character/8000/TrailblazerHarmony'
-import { applyScoringMetadataPresets, applyTeamAwareSetConditionalPresets } from 'lib/conditionals/evaluation/applyPresets'
+import {
+  applyScoringMetadataPresets,
+  applyTeamAwareSetConditionalPresets,
+  resolveTeammateInfo,
+} from 'lib/conditionals/evaluation/applyPresets'
 import {
   Parts,
   Sets,
@@ -240,7 +244,7 @@ export class BenchmarkSimulationOrchestrator {
       this.form!.comboType = ComboType.ADVANCED
     }
 
-    applyScoringMetadataPresets(this.form!)
+    applyScoringMetadataPresets(this.form!, resolveTeammateInfo(...this.metadata.teammates))
   }
 
   public applyResEqualization() {
@@ -334,7 +338,7 @@ export class BenchmarkSimulationOrchestrator {
 
     simulationForm.deprioritizeBuffs = this.metadata.deprioritizeBuffs
 
-    applyTeamAwareSetConditionalPresets(simulationForm)
+    applyTeamAwareSetConditionalPresets(simulationForm, resolveTeammateInfo(...metadata.teammates))
 
     this.form = simulationForm
   }

--- a/src/lib/simulations/tests/customBenchmark/benchmarkOrchestratorTestUtils.ts
+++ b/src/lib/simulations/tests/customBenchmark/benchmarkOrchestratorTestUtils.ts
@@ -2,6 +2,7 @@ import i18next from 'i18next'
 import {
   applyScoringMetadataPresets,
   applySetConditionalPresets,
+  resolveTeammateInfo,
 } from 'lib/conditionals/evaluation/applyPresets'
 import { Stats } from 'lib/constants/constants'
 import { defaultSetConditionals } from 'lib/optimization/defaultForm'
@@ -46,8 +47,9 @@ export async function expectBenchmarkResultsToMatch(
     setConditionals: clone(defaultSetConditionals),
   }
 
-  applySetConditionalPresets(benchmarkForm)
-  applyScoringMetadataPresets(benchmarkForm)
+  const teammates = resolveTeammateInfo(teammate0, teammate1, teammate2)
+  applySetConditionalPresets(benchmarkForm, teammates)
+  applyScoringMetadataPresets(benchmarkForm, teammates)
 
   const orchestrator = await runCustomBenchmarkOrchestrator(benchmarkForm)
   const benchmarkSimScore = orchestrator.benchmarkSimResult?.simScore

--- a/src/lib/tabs/tabBenchmarks/benchmarksTabController.ts
+++ b/src/lib/tabs/tabBenchmarks/benchmarksTabController.ts
@@ -215,6 +215,7 @@ export function applyTeamAwareSetConditionalPresetsToBenchmarkFormInstance(
   const teammates = resolveTeammateInfo(teammate0, teammate1, teammate2)
 
   applyTeamAwareSetConditionalPresets(form, teammates)
+  applyScoringMetadataPresets(form, teammates)
 
   if (form.setConditionals) {
     useBenchmarksTabStore.getState().setSetConditionals(form.setConditionals)

--- a/src/lib/tabs/tabBenchmarks/benchmarksTabController.ts
+++ b/src/lib/tabs/tabBenchmarks/benchmarksTabController.ts
@@ -4,6 +4,7 @@ import {
   applyScoringMetadataPresets,
   applySetConditionalPresets,
   applyTeamAwareSetConditionalPresets,
+  resolveTeammateInfo,
 } from 'lib/conditionals/evaluation/applyPresets'
 import { Message } from 'lib/interactions/message'
 import { defaultSetConditionals } from 'lib/optimization/defaultForm'
@@ -187,9 +188,10 @@ export function handleCharacterSelectChange(id: CharacterId | null, formInstance
   form.simOrnamentSet = simulationMetadata.ornamentSets[0]
   form.subDps = !!simulationMetadata.deprioritizeBuffs
 
+  const teammates = resolveTeammateInfo(...simulationMetadata.teammates)
   form.setConditionals = clone(defaultSetConditionals)
-  applySetConditionalPresets(form)
-  applyScoringMetadataPresets(form)
+  applySetConditionalPresets(form, teammates)
+  applyScoringMetadataPresets(form, teammates)
 
   const state = useBenchmarksTabStore.getState()
   state.updateTeammate(0, simulationMetadata.teammates[0])
@@ -210,13 +212,9 @@ export function applyTeamAwareSetConditionalPresetsToBenchmarkFormInstance(
   const currentSetConditionals = clone(useBenchmarksTabStore.getState().setConditionals)
   const form = { ...formInstance.getValues(), setConditionals: currentSetConditionals }
 
-  const teammateIds = [
-    teammate0?.characterId,
-    teammate1?.characterId,
-    teammate2?.characterId,
-  ]
+  const teammates = resolveTeammateInfo(teammate0, teammate1, teammate2)
 
-  applyTeamAwareSetConditionalPresets(form, teammateIds)
+  applyTeamAwareSetConditionalPresets(form, teammates)
 
   if (form.setConditionals) {
     useBenchmarksTabStore.getState().setSetConditionals(form.setConditionals)

--- a/src/lib/tabs/tabBenchmarks/benchmarksTabController.ts
+++ b/src/lib/tabs/tabBenchmarks/benchmarksTabController.ts
@@ -4,6 +4,7 @@ import {
   applyScoringMetadataPresets,
   applySetConditionalPresets,
   applyTeamAwareSetConditionalPresets,
+  applyTeammateConditionalPresets,
   resolveTeammateInfo,
 } from 'lib/conditionals/evaluation/applyPresets'
 import { Message } from 'lib/interactions/message'
@@ -215,7 +216,7 @@ export function applyTeamAwareSetConditionalPresetsToBenchmarkFormInstance(
   const teammates = resolveTeammateInfo(teammate0, teammate1, teammate2)
 
   applyTeamAwareSetConditionalPresets(form, teammates)
-  applyScoringMetadataPresets(form, teammates)
+  applyTeammateConditionalPresets(form, teammates)
 
   if (form.setConditionals) {
     useBenchmarksTabStore.getState().setSetConditionals(form.setConditionals)

--- a/src/lib/tabs/tabMetadata/MetadataTab.tsx
+++ b/src/lib/tabs/tabMetadata/MetadataTab.tsx
@@ -250,6 +250,7 @@ const presetToSetMapping: Record<string, string> = {
   fnAshblazingSet: Sets.TheAshblazingGrandDuke,
   fnPioneerSet: Sets.PioneerDiverOfDeadWaters,
   fnSacerdosSet: Sets.SacerdosRelivedOrdeal,
+  fnMortenaxAshblazingSet: Sets.TheAshblazingGrandDuke,
   PRISONER_SET: Sets.PrisonerInDeepConfinement,
   WASTELANDER_SET: Sets.WastelanderOfBanditryDesert,
   VALOROUS_SET: Sets.TheWindSoaringValorous,

--- a/src/lib/tabs/tabMetadata/setAuditor/setAuditorEngine.ts
+++ b/src/lib/tabs/tabMetadata/setAuditor/setAuditorEngine.ts
@@ -1,6 +1,7 @@
 import {
   applyScoringMetadataPresets,
   applySetConditionalPresets,
+  resolveTeammateInfo,
 } from 'lib/conditionals/evaluation/applyPresets'
 import { TwoPieceStatTags } from 'lib/constants/constants'
 import { defaultSetConditionals } from 'lib/optimization/defaultForm'
@@ -175,8 +176,9 @@ function buildBenchmarkForm(
     setConditionals: clone(defaultSetConditionals),
   }
 
-  applySetConditionalPresets(form)
-  applyScoringMetadataPresets(form)
+  const teammates = resolveTeammateInfo(...config.teammates)
+  applySetConditionalPresets(form, teammates)
+  applyScoringMetadataPresets(form, teammates)
 
   return form
 }

--- a/src/lib/tabs/tabOptimizer/optimizerForm/components/CharacterSelectorDisplay.tsx
+++ b/src/lib/tabs/tabOptimizer/optimizerForm/components/CharacterSelectorDisplay.tsx
@@ -245,7 +245,7 @@ export function CharacterSelectorDisplay() {
         }))}
         renderOption={({ option }) => {
           const stat = sortKeyToStat[option.value]
-          const isOptimization = optimizationKeys.has(option.value)
+          const isOptimization = optimizationKeys.has(option.value as SortOptionKey)
           return (
             <Flex align='center' gap={6}>
               {stat && <img src={Assets.getStatIcon(stat)} className={iconClasses.icon20} />}

--- a/src/lib/tabs/tabOptimizer/optimizerForm/components/TeammateCard.tsx
+++ b/src/lib/tabs/tabOptimizer/optimizerForm/components/TeammateCard.tsx
@@ -12,6 +12,7 @@ import {
   useCombobox,
 } from '@mantine/core'
 import { IconRefresh } from '@tabler/icons-react'
+import { applyTeamAwareSetConditionalPresetsToStore } from 'lib/conditionals/evaluation/applyPresets'
 import { Constants } from 'lib/constants/constants'
 import { Message } from 'lib/interactions/message'
 import { Assets } from 'lib/rendering/assets'
@@ -144,7 +145,10 @@ export const TeammateCard = memo(function TeammateCard({ index, dbMetadata }: {
             size='xs'
             data={EIDOLON_DATA}
             value={String(teammateEidolon ?? 0)}
-            onChange={(v) => useOptimizerRequestStore.getState().setTeammateField(index, 'characterEidolon', Number(v))}
+            onChange={(v) => {
+              useOptimizerRequestStore.getState().setTeammateField(index, 'characterEidolon', Number(v))
+              applyTeamAwareSetConditionalPresetsToStore()
+            }}
             fullWidth
             withItemsBorders={false}
             className={classes.segmented}


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

- Add ashblazing ATK stack computation for ULT abilities across ~45 characters (Archer, Arlan, DanHeng, Herta, Himeko, Kafka, March7th, Saber, SilverWolf, Welt, Hook, Luka, Pela, Sampo, Seele, Serval, Feixiao, Fugue, Guinaifen, ImbibitorLunae, Jiaoqiu, JingYuan, Jingliu, Lingsha, Luocha, March7thImaginary, Moze, Qingque, Sushang, Xueyi, Yanqing, Yukong, Acheron, Argenti, BlackSwan, Boothill, DrRatio, Gallagher, Jade, Misha, TheDahlia, Anaxa, Cerydra, Cipher, Hysilens, PermansorTerrae, TheHerta, Ashveil, Evanescia, Sparxie, TrailblazerDestruction, TrailblazerPreservation)
- Add new ashblazingCompute module with typed hit descriptors (single, aoe, blast) and enemy-count-aware stack computation
- Add boostUltAshblazingAtk and gpuBoostUltAshblazingAtk finalizers that only apply to ULT action types
- Add Mortenax/Ashblazing set preset (fnMortenaxAshblazingSet) gated on Mortenax Blade E2 teammate
- Add teammate-conditional preset system so set presets can activate only when a specific teammate is present
- Pass teammate info through preset application pipeline (applySetConditionalPresets, applyScoringMetadataPresets, applyTeamAwareSetConditionalPresets)
- Re-apply team-aware set conditional presets when teammate eidolon changes in optimizer form
- Remove empty newGpuFinalizeCalculations stubs that returned empty strings
- Add unit tests for ashblazingCompute and applyPresets teammate-gated logic

## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [ ] I have added commit messages that are descriptive and meaningful.
- [ ] I have tested the changes locally.
- [ ] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
