### PR TITLE
feat: beta 7 better res matching, ux tewaks

### DIFF
--- a/public/locales/en_US/charactersTab.yaml
+++ b/public/locales/en_US/charactersTab.yaml
@@ -79,7 +79,7 @@ CharacterPreview:
       Standard: Standard
     PaletteLabel: Portrait color palette
     ShowUID: Show UID
-    ShowL2D: Show Live2D
+    ShowL2D: Animations
   ArtBy: 'Art by {{artistName}}'
   EditCharacter: Edit character
   EditPortrait: Edit portrait

--- a/src/lib/characterPreview/customization/ShowcaseCustomizationSidebar.tsx
+++ b/src/lib/characterPreview/customization/ShowcaseCustomizationSidebar.tsx
@@ -455,7 +455,7 @@ const CustomizationPanel = memo(function CustomizationPanel({
 
       <HorizontalDivider />
       <HeaderText className={classes.headerCenteredMb} style={{ marginBottom: 1 }}>
-        {tCustomization('ShowL2D') /* Show Live2D */}
+        {tCustomization('ShowL2D') /* Animations */}
       </HeaderText>
       <SegmentedControl
         data={[

--- a/src/lib/characterPreview/summary/SubstatRollsSummary.module.css
+++ b/src/lib/characterPreview/summary/SubstatRollsSummary.module.css
@@ -34,6 +34,7 @@
 .zebraContainer {
   composes: zebraContainer from './summaryStyles.module.css';
   min-width: 150px;
+  width: 100%;
 }
 
 .zebraContainer > div {

--- a/src/lib/conditionals/character/1400/PermansorTerrae.ts
+++ b/src/lib/conditionals/character/1400/PermansorTerrae.ts
@@ -484,7 +484,7 @@ const display = {
     y: 1042,
     z: 1.1,
   },
-  showcaseColor: '#93ccca',
+  showcaseColor: '#639480',
 }
 
 export const PermansorTerrae: CharacterConfig = {

--- a/src/lib/conditionals/character/1500/Sparxie.ts
+++ b/src/lib/conditionals/character/1500/Sparxie.ts
@@ -527,7 +527,7 @@ const display = {
     y: 1050,
     z: 1.10,
   },
-  showcaseColor: '#b385ea',
+  showcaseColor: '#8e68ba',
   gridPortraitOffset: 20,
 }
 

--- a/src/lib/optimization/engine/container/computedStatsContainer.ts
+++ b/src/lib/optimization/engine/container/computedStatsContainer.ts
@@ -359,6 +359,8 @@ export class ComputedStatsContainer {
     clonedBasic.id = this.c.id
     clonedBasic.relicSetIndex = this.c.relicSetIndex
     clonedBasic.ornamentSetIndex = this.c.ornamentSetIndex
+    clonedBasic.sets = this.c.sets
+    clonedBasic.setsArray = this.c.setsArray
     clonedBasic.weight = this.c.weight
     clone.c = clonedBasic as BasicStatsArray
 

--- a/src/lib/scoring/simScoringUtils.ts
+++ b/src/lib/scoring/simScoringUtils.ts
@@ -16,6 +16,10 @@ import {
   StatKey,
 } from 'lib/optimization/engine/config/keys'
 import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
+import {
+  ornament2p,
+  SetKeys,
+} from 'lib/optimization/setMatching'
 import { StatCalculator } from 'lib/relics/statCalculator'
 import type { SimulationSets } from 'lib/scoring/dpsScore'
 import { SCORING_CONFIG_REGISTRY } from 'lib/scoring/scoringConfig'
@@ -371,6 +375,13 @@ function calculatePenaltyMultiplier(
               / StatCalculator.getMaxedSubstatValue(stat as SubStats, 1.0),
         )
       }
+    }
+  }
+
+  if (user && ornament2p(SetKeys.BrokenKeel, x.c.sets)) {
+    const combatRes = x.getSelfValue(StatKey.RES)
+    if (combatRes < 0.30) {
+      newPenaltyMultiplier *= 0.75
     }
   }
 

--- a/src/lib/simulations/orchestrator/benchmarkSimulationOrchestrator.ts
+++ b/src/lib/simulations/orchestrator/benchmarkSimulationOrchestrator.ts
@@ -252,8 +252,9 @@ export class BenchmarkSimulationOrchestrator {
     if (!entry.applyResEqualization) return
 
     const combatRes = this.originalSimResult!.x.getActionValueByIndex(StatKey.RES, SELF_ENTITY_INDEX)
-    if (combatRes >= 0.50) {
-      this.flags.benchmarkBasicResTarget = combatRes
+    const baselineRes = this.baselineSimResult!.x.getActionValueByIndex(StatKey.RES, SELF_ENTITY_INDEX)
+    if (combatRes - baselineRes >= 0.30) {
+      this.flags.benchmarkBasicResTarget = Math.min(combatRes, 1.00)
     }
   }
 

--- a/src/lib/tabs/tabCalculators/AhaPanelContent.module.css
+++ b/src/lib/tabs/tabCalculators/AhaPanelContent.module.css
@@ -84,7 +84,6 @@
   font-weight: 400;
   font-variant-numeric: tabular-nums;
   line-height: 1.15;
-  text-align: right;
+  text-align: left;
   white-space: nowrap;
 }
-

--- a/src/lib/tabs/tabCalculators/AhaPanelContent.tsx
+++ b/src/lib/tabs/tabCalculators/AhaPanelContent.tsx
@@ -265,11 +265,7 @@ function ReverseSolve(props: AhaPanelContentProps) {
   const allSlotsFilled = speeds.length >= 4
   const targetAlreadyMet = !allSlotsFilled && desiredValue !== undefined && ahaSpeed >= desiredValue
   const displaySpeed = teammateSpeed !== null && Math.abs(teammateSpeed) < 0.0005 ? 0 : teammateSpeed
-  const outputValue = displaySpeed !== null
-    ? targetAlreadyMet
-      ? `Already met (${localeNumber_000(displaySpeed)})`
-      : localeNumber_000(displaySpeed)
-    : ''
+  const outputValue = displaySpeed !== null ? localeNumber_000(displaySpeed) : ''
 
   return (
     <div className={classes.reverse}>
@@ -284,9 +280,13 @@ function ReverseSolve(props: AhaPanelContentProps) {
       </div>
       <div className={classes.reverseOutput} style={{ opacity: !allSlotsFilled && teammateSpeed === null ? 0.3 : undefined }}>
         <HeaderText>
-          {allSlotsFilled ? 'No slots open' : t(`Output.Teammate${speeds.length as 0 | 1 | 2 | 3}`)}
+          {allSlotsFilled
+            ? 'No slots open'
+            : targetAlreadyMet
+              ? 'SPD target already reached'
+              : t(`Output.Teammate${speeds.length as 0 | 1 | 2 | 3}`)}
         </HeaderText>
-        <span className={targetAlreadyMet ? classes.alreadyMetValue : undefined}>{outputValue}</span>
+        <span>{outputValue}</span>
       </div>
     </div>
   )

--- a/src/lib/tabs/tabCalculators/AhaPanelContent.tsx
+++ b/src/lib/tabs/tabCalculators/AhaPanelContent.tsx
@@ -1,4 +1,5 @@
 import {
+  CloseButton,
   Divider,
   NumberInput,
 } from '@mantine/core'
@@ -104,7 +105,7 @@ function IntegratedRows({ form, rows, ahaSpeed }: {
             form={form}
             row={row}
             ahaSpeed={ahaSpeed}
-            label={`Teammate ${visualPos + 1}`}
+            label='Teammate'
             style={{ transform: offset ? `translateY(${offset}px)` : undefined }}
             isNextSlot={isNextSlot}
           />
@@ -168,6 +169,19 @@ function IntegratedRow({ form, row, ahaSpeed, label, style, isNextSlot }: {
         {...form.getInputProps(row.key)}
         {...sharedInputProps}
         className={classes.rowInput}
+        rightSection={
+          row.speed !== '' && (
+            <CloseButton
+              size='xs'
+              variant='transparent'
+              tabIndex={-1}
+              style={{ marginRight: 8 }}
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={() => form.setFieldValue(row.key, '')}
+            />
+          )
+        }
+        rightSectionPointerEvents='all'
       />
       <div className={classes.rowTrack}>
         {hasContribution && (
@@ -240,6 +254,7 @@ function FormulaSummary({ rows, ahaSpeed }: {
 
 function ReverseSolve(props: AhaPanelContentProps) {
   const {
+    ahaSpeed,
     speeds,
     teammateSpeed,
     desiredValue,
@@ -248,7 +263,13 @@ function ReverseSolve(props: AhaPanelContentProps) {
     t,
   } = props
   const allSlotsFilled = speeds.length >= 4
+  const targetAlreadyMet = !allSlotsFilled && desiredValue !== undefined && ahaSpeed >= desiredValue
   const displaySpeed = teammateSpeed !== null && Math.abs(teammateSpeed) < 0.0005 ? 0 : teammateSpeed
+  const outputValue = displaySpeed !== null
+    ? targetAlreadyMet
+      ? `Already met (${localeNumber_000(displaySpeed)})`
+      : localeNumber_000(displaySpeed)
+    : ''
 
   return (
     <div className={classes.reverse}>
@@ -265,9 +286,7 @@ function ReverseSolve(props: AhaPanelContentProps) {
         <HeaderText>
           {allSlotsFilled ? 'No slots open' : t(`Output.Teammate${speeds.length as 0 | 1 | 2 | 3}`)}
         </HeaderText>
-        <span>
-          {displaySpeed !== null ? localeNumber_000(displaySpeed) : ''}
-        </span>
+        <span className={targetAlreadyMet ? classes.alreadyMetValue : undefined}>{outputValue}</span>
       </div>
     </div>
   )

--- a/src/lib/tabs/tabCalculators/CalculatorPanel.module.css
+++ b/src/lib/tabs/tabCalculators/CalculatorPanel.module.css
@@ -48,9 +48,3 @@
   font-variant-numeric: tabular-nums;
   text-align: center;
 }
-
-.reverseOutput span.alreadyMetValue {
-  font-size: 13px;
-  line-height: 1.2;
-  white-space: nowrap;
-}

--- a/src/lib/tabs/tabCalculators/CalculatorPanel.module.css
+++ b/src/lib/tabs/tabCalculators/CalculatorPanel.module.css
@@ -48,3 +48,9 @@
   font-variant-numeric: tabular-nums;
   text-align: center;
 }
+
+.reverseOutput span.alreadyMetValue {
+  font-size: 13px;
+  line-height: 1.2;
+  white-space: nowrap;
+}


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

- Rename "Show Live2D" label to "Animations"
- Update showcase colors for Permansor Terrae and Sparxie
- Add Broken Keel RES penalty when combat RES is below 30%
- Fix RES equalization to compare against baseline and cap at 100%
- Copy set data (sets, setsArray) when cloning computed stats container
- Make substat rolls summary container full width
- Add clear buttons to Aha speed calculator inputs
- Simplify Aha teammate labels and left-align contribution numbers
- Show "SPD target already reached" in Aha solver when current speed meets target
- Update scoring version to BETA 7

## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [ ] I have added commit messages that are descriptive and meaningful.
- [ ] I have tested the changes locally.
- [ ] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
