### PR TITLE
feat: support set matching

### DIFF
--- a/src/lib/characterPreview/scoring/ShowcaseSimScore.tsx
+++ b/src/lib/characterPreview/scoring/ShowcaseSimScore.tsx
@@ -248,7 +248,7 @@ export const ShowcaseScoreHeader = memo(function ShowcaseScoreHeader({ relics, t
     <div style={{ display: 'flex', alignItems: 'center', flexDirection: 'column' }} className={styles.scoreHeaderWrapper}>
       {!isDps && (
         <StatText className={styles.scoreHeaderText}>
-          [ BETA 6 ]
+          [ BETA 7 ]
         </StatText>
       )}
       <ShowcaseScoreHeaderReady relics={relics} configType={configType} t={t} />

--- a/src/lib/conditionals/character/1000/March7th.ts
+++ b/src/lib/conditionals/character/1000/March7th.ts
@@ -35,7 +35,7 @@ import { SortOption } from 'lib/optimization/sortOptions'
 import { PresetEffects } from 'lib/scoring/presetEffects'
 import {
   SPREAD_ORNAMENTS_2P_SUPPORT,
-  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+  SPREAD_RELICS_4P_SUPPORT,
 } from 'lib/scoring/scoringConstants'
 import { type Eidolon } from 'types/character'
 import { type CharacterConfig } from 'types/characterConfig'
@@ -193,7 +193,7 @@ const shieldSimulation = (): SimulationMetadata => ({
   ],
   relicSets: [
     [Sets.SelfEnshroudedRecluse, Sets.SelfEnshroudedRecluse],
-    ...SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+    ...SPREAD_RELICS_4P_SUPPORT,
   ],
   ornamentSets: [
     Sets.LushakaTheSunkenSeas,

--- a/src/lib/conditionals/character/1100/Bronya.ts
+++ b/src/lib/conditionals/character/1100/Bronya.ts
@@ -46,7 +46,7 @@ import { SortOption } from 'lib/optimization/sortOptions'
 import { PresetEffects } from 'lib/scoring/presetEffects'
 import {
   SPREAD_ORNAMENTS_2P_SUPPORT,
-  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+  SPREAD_RELICS_4P_SUPPORT,
 } from 'lib/scoring/scoringConstants'
 import { wrappedFixedT } from 'lib/utils/i18nUtils'
 
@@ -320,7 +320,7 @@ const supportSimulation = (): SimulationMetadata => ({
   ],
   relicSets: [
     [Sets.SacerdosRelivedOrdeal, Sets.SacerdosRelivedOrdeal],
-    ...SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+    ...SPREAD_RELICS_4P_SUPPORT,
   ],
   ornamentSets: [
     Sets.BrokenKeel,

--- a/src/lib/conditionals/character/1100/Gepard.ts
+++ b/src/lib/conditionals/character/1100/Gepard.ts
@@ -37,7 +37,7 @@ import {
 import { SortOption } from 'lib/optimization/sortOptions'
 import {
   SPREAD_ORNAMENTS_2P_SUPPORT,
-  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+  SPREAD_RELICS_4P_SUPPORT,
 } from 'lib/scoring/scoringConstants'
 import { wrappedFixedT } from 'lib/utils/i18nUtils'
 import { type Eidolon } from 'types/character'
@@ -211,7 +211,7 @@ const shieldSimulation = (): SimulationMetadata => ({
   ],
   relicSets: [
     [Sets.SelfEnshroudedRecluse, Sets.SelfEnshroudedRecluse],
-    ...SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+    ...SPREAD_RELICS_4P_SUPPORT,
   ],
   ornamentSets: [
     Sets.LushakaTheSunkenSeas,

--- a/src/lib/conditionals/character/1100/Lynx.ts
+++ b/src/lib/conditionals/character/1100/Lynx.ts
@@ -46,7 +46,7 @@ import { SortOption } from 'lib/optimization/sortOptions'
 import { PresetEffects } from 'lib/scoring/presetEffects'
 import {
   SPREAD_ORNAMENTS_2P_SUPPORT,
-  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+  SPREAD_RELICS_4P_SUPPORT,
 } from 'lib/scoring/scoringConstants'
 import { wrappedFixedT } from 'lib/utils/i18nUtils'
 import { type Eidolon } from 'types/character'
@@ -316,7 +316,7 @@ const healSimulation = (): SimulationMetadata => ({
   ],
   relicSets: [
     [Sets.WarriorGoddessOfSunAndThunder, Sets.WarriorGoddessOfSunAndThunder],
-    ...SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+    ...SPREAD_RELICS_4P_SUPPORT,
   ],
   ornamentSets: [
     Sets.LushakaTheSunkenSeas,

--- a/src/lib/conditionals/character/1100/Natasha.ts
+++ b/src/lib/conditionals/character/1100/Natasha.ts
@@ -29,7 +29,7 @@ import { SortOption } from 'lib/optimization/sortOptions'
 import { PresetEffects } from 'lib/scoring/presetEffects'
 import {
   SPREAD_ORNAMENTS_2P_SUPPORT,
-  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+  SPREAD_RELICS_4P_SUPPORT,
 } from 'lib/scoring/scoringConstants'
 import { wrappedFixedT } from 'lib/utils/i18nUtils'
 import { type Eidolon } from 'types/character'
@@ -158,7 +158,7 @@ const healSimulation = (): SimulationMetadata => ({
   ],
   relicSets: [
     [Sets.WarriorGoddessOfSunAndThunder, Sets.WarriorGoddessOfSunAndThunder],
-    ...SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+    ...SPREAD_RELICS_4P_SUPPORT,
   ],
   ornamentSets: [
     Sets.LushakaTheSunkenSeas,

--- a/src/lib/conditionals/character/1200/Bailu.ts
+++ b/src/lib/conditionals/character/1200/Bailu.ts
@@ -27,7 +27,7 @@ import { SortOption } from 'lib/optimization/sortOptions'
 import { PresetEffects } from 'lib/scoring/presetEffects'
 import {
   SPREAD_ORNAMENTS_2P_SUPPORT,
-  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+  SPREAD_RELICS_4P_SUPPORT,
 } from 'lib/scoring/scoringConstants'
 import { wrappedFixedT } from 'lib/utils/i18nUtils'
 
@@ -243,7 +243,7 @@ const healSimulation = (): SimulationMetadata => ({
   ],
   relicSets: [
     [Sets.WarriorGoddessOfSunAndThunder, Sets.WarriorGoddessOfSunAndThunder],
-    ...SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+    ...SPREAD_RELICS_4P_SUPPORT,
   ],
   ornamentSets: [
     Sets.LushakaTheSunkenSeas,

--- a/src/lib/conditionals/character/1200/FuXuan.ts
+++ b/src/lib/conditionals/character/1200/FuXuan.ts
@@ -34,7 +34,7 @@ import { SortOption } from 'lib/optimization/sortOptions'
 import { PresetEffects } from 'lib/scoring/presetEffects'
 import {
   SPREAD_ORNAMENTS_2P_SUPPORT,
-  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+  SPREAD_RELICS_4P_SUPPORT,
 } from 'lib/scoring/scoringConstants'
 import { wrappedFixedT } from 'lib/utils/i18nUtils'
 
@@ -299,7 +299,7 @@ const healSimulation = (): SimulationMetadata => ({
   ],
   relicSets: [
     [Sets.WarriorGoddessOfSunAndThunder, Sets.WarriorGoddessOfSunAndThunder],
-    ...SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+    ...SPREAD_RELICS_4P_SUPPORT,
   ],
   ornamentSets: [
     Sets.LushakaTheSunkenSeas,

--- a/src/lib/conditionals/character/1200/HuohuoB1.ts
+++ b/src/lib/conditionals/character/1200/HuohuoB1.ts
@@ -36,7 +36,7 @@ import { SortOption } from 'lib/optimization/sortOptions'
 import { PresetEffects } from 'lib/scoring/presetEffects'
 import {
   SPREAD_ORNAMENTS_2P_SUPPORT,
-  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+  SPREAD_RELICS_4P_SUPPORT,
 } from 'lib/scoring/scoringConstants'
 import { wrappedFixedT } from 'lib/utils/i18nUtils'
 import { precisionRound } from 'lib/utils/mathUtils'
@@ -224,7 +224,7 @@ const healSimulation = (): SimulationMetadata => ({
   ],
   relicSets: [
     [Sets.WarriorGoddessOfSunAndThunder, Sets.WarriorGoddessOfSunAndThunder],
-    ...SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+    ...SPREAD_RELICS_4P_SUPPORT,
   ],
   ornamentSets: [
     Sets.LushakaTheSunkenSeas,

--- a/src/lib/conditionals/character/1200/Lingsha.ts
+++ b/src/lib/conditionals/character/1200/Lingsha.ts
@@ -41,7 +41,7 @@ import { SortOption } from 'lib/optimization/sortOptions'
 import { PresetEffects } from 'lib/scoring/presetEffects'
 import {
   SPREAD_ORNAMENTS_2P_SUPPORT,
-  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+  SPREAD_RELICS_4P_SUPPORT,
 } from 'lib/scoring/scoringConstants'
 import { wrappedFixedT } from 'lib/utils/i18nUtils'
 
@@ -409,7 +409,7 @@ const healSimulation = (): SimulationMetadata => ({
   ],
   relicSets: [
     [Sets.IronCavalryAgainstTheScourge, Sets.IronCavalryAgainstTheScourge],
-    ...SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+    ...SPREAD_RELICS_4P_SUPPORT,
   ],
   ornamentSets: [
     Sets.ForgeOfTheKalpagniLantern,

--- a/src/lib/conditionals/character/1200/Luocha.ts
+++ b/src/lib/conditionals/character/1200/Luocha.ts
@@ -32,7 +32,7 @@ import { SortOption } from 'lib/optimization/sortOptions'
 import { PresetEffects } from 'lib/scoring/presetEffects'
 import {
   SPREAD_ORNAMENTS_2P_SUPPORT,
-  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+  SPREAD_RELICS_4P_SUPPORT,
 } from 'lib/scoring/scoringConstants'
 import { wrappedFixedT } from 'lib/utils/i18nUtils'
 import { type Eidolon } from 'types/character'
@@ -224,7 +224,7 @@ const healSimulation = (): SimulationMetadata => ({
   ],
   relicSets: [
     [Sets.WarriorGoddessOfSunAndThunder, Sets.WarriorGoddessOfSunAndThunder],
-    ...SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+    ...SPREAD_RELICS_4P_SUPPORT,
   ],
   ornamentSets: [
     Sets.LushakaTheSunkenSeas,

--- a/src/lib/conditionals/character/1300/Aventurine.ts
+++ b/src/lib/conditionals/character/1300/Aventurine.ts
@@ -50,6 +50,7 @@ import {
   SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
   SPREAD_ORNAMENTS_2P_SUPPORT,
   SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+  SPREAD_RELICS_4P_SUPPORT,
 } from 'lib/scoring/scoringConstants'
 import { wrappedFixedT } from 'lib/utils/i18nUtils'
 import { floorSafe } from 'lib/utils/mathUtils'
@@ -408,7 +409,7 @@ const shieldSimulation = (): SimulationMetadata => ({
   ],
   relicSets: [
     [Sets.SelfEnshroudedRecluse, Sets.SelfEnshroudedRecluse],
-    ...SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+    ...SPREAD_RELICS_4P_SUPPORT,
   ],
   ornamentSets: [
     Sets.LushakaTheSunkenSeas,

--- a/src/lib/conditionals/character/1300/Robin.ts
+++ b/src/lib/conditionals/character/1300/Robin.ts
@@ -38,7 +38,7 @@ import {
 import { SortOption } from 'lib/optimization/sortOptions'
 import {
   SPREAD_ORNAMENTS_2P_SUPPORT,
-  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+  SPREAD_RELICS_4P_SUPPORT,
 } from 'lib/scoring/scoringConstants'
 import { wrappedFixedT } from 'lib/utils/i18nUtils'
 
@@ -356,7 +356,7 @@ const supportSimulation = (): SimulationMetadata => ({
   ],
   relicSets: [
     [Sets.PrisonerInDeepConfinement, Sets.TheWindSoaringValorous],
-    ...SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+    ...SPREAD_RELICS_4P_SUPPORT,
   ],
   ornamentSets: [
     Sets.SprightlyVonwacq,

--- a/src/lib/conditionals/character/1300/SparkleB1.ts
+++ b/src/lib/conditionals/character/1300/SparkleB1.ts
@@ -41,7 +41,7 @@ import { SortOption } from 'lib/optimization/sortOptions'
 import { PresetEffects } from 'lib/scoring/presetEffects'
 import {
   SPREAD_ORNAMENTS_2P_SUPPORT,
-  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+  SPREAD_RELICS_4P_SUPPORT,
 } from 'lib/scoring/scoringConstants'
 import { wrappedFixedT } from 'lib/utils/i18nUtils'
 
@@ -336,7 +336,7 @@ const supportSimulation = (): SimulationMetadata => ({
   ],
   relicSets: [
     [Sets.SacerdosRelivedOrdeal, Sets.SacerdosRelivedOrdeal],
-    ...SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+    ...SPREAD_RELICS_4P_SUPPORT,
   ],
   ornamentSets: [
     Sets.BrokenKeel,

--- a/src/lib/conditionals/character/1300/Sunday.ts
+++ b/src/lib/conditionals/character/1300/Sunday.ts
@@ -44,7 +44,7 @@ import { SortOption } from 'lib/optimization/sortOptions'
 import { PresetEffects } from 'lib/scoring/presetEffects'
 import {
   SPREAD_ORNAMENTS_2P_SUPPORT,
-  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+  SPREAD_RELICS_4P_SUPPORT,
 } from 'lib/scoring/scoringConstants'
 import { wrappedFixedT } from 'lib/utils/i18nUtils'
 
@@ -439,7 +439,7 @@ const supportSimulation = (): SimulationMetadata => ({
   ],
   relicSets: [
     [Sets.SacerdosRelivedOrdeal, Sets.SacerdosRelivedOrdeal],
-    ...SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+    ...SPREAD_RELICS_4P_SUPPORT,
   ],
   ornamentSets: [
     Sets.BrokenKeel,

--- a/src/lib/conditionals/character/1300/TheDahlia.ts
+++ b/src/lib/conditionals/character/1300/TheDahlia.ts
@@ -51,6 +51,7 @@ import {
   SPREAD_ORNAMENTS_2P_ENERGY_REGEN,
   SPREAD_ORNAMENTS_2P_SUPPORT,
   SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+  SPREAD_RELICS_4P_SUPPORT,
 } from 'lib/scoring/scoringConstants'
 import { relics2pByStats } from 'lib/sets/setConfigRegistry'
 import { wrappedFixedT } from 'lib/utils/i18nUtils'
@@ -530,7 +531,7 @@ const supportSimulation = (): SimulationMetadata => ({
   ],
   relicSets: [
     [Sets.IronCavalryAgainstTheScourge, Sets.IronCavalryAgainstTheScourge],
-    ...SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+    ...SPREAD_RELICS_4P_SUPPORT,
   ],
   ornamentSets: [
     Sets.ForgeOfTheKalpagniLantern,

--- a/src/lib/conditionals/character/1400/Cerydra.ts
+++ b/src/lib/conditionals/character/1400/Cerydra.ts
@@ -49,7 +49,7 @@ import {
 import { SortOption } from 'lib/optimization/sortOptions'
 import {
   SPREAD_ORNAMENTS_2P_SUPPORT,
-  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+  SPREAD_RELICS_4P_SUPPORT,
 } from 'lib/scoring/scoringConstants'
 import { PresetEffects } from 'lib/scoring/presetEffects'
 import { wrappedFixedT } from 'lib/utils/i18nUtils'
@@ -405,7 +405,7 @@ const supportSimulation = (): SimulationMetadata => ({
   ],
   relicSets: [
     [Sets.SacerdosRelivedOrdeal, Sets.SacerdosRelivedOrdeal],
-    ...SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+    ...SPREAD_RELICS_4P_SUPPORT,
   ],
   ornamentSets: [
     Sets.LushakaTheSunkenSeas,

--- a/src/lib/conditionals/character/1400/Hyacine.ts
+++ b/src/lib/conditionals/character/1400/Hyacine.ts
@@ -60,7 +60,7 @@ import { SortOption } from 'lib/optimization/sortOptions'
 import { PresetEffects } from 'lib/scoring/presetEffects'
 import {
   SPREAD_ORNAMENTS_2P_SUPPORT,
-  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+  SPREAD_RELICS_4P_SUPPORT,
 } from 'lib/scoring/scoringConstants'
 import { relics2pByStats } from 'lib/sets/setConfigRegistry'
 import { wrappedFixedT } from 'lib/utils/i18nUtils'
@@ -620,7 +620,7 @@ const healSimulation = (): SimulationMetadata => ({
   ],
   relicSets: [
     [Sets.WarriorGoddessOfSunAndThunder, Sets.WarriorGoddessOfSunAndThunder],
-    ...SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+    ...SPREAD_RELICS_4P_SUPPORT,
   ],
   ornamentSets: [
     Sets.GiantTreeOfRaptBrooding,

--- a/src/lib/conditionals/character/1400/PermansorTerrae.ts
+++ b/src/lib/conditionals/character/1400/PermansorTerrae.ts
@@ -47,7 +47,6 @@ import { SortOption } from 'lib/optimization/sortOptions'
 import { PresetEffects } from 'lib/scoring/presetEffects'
 import {
   SPREAD_ORNAMENTS_2P_SUPPORT,
-  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
   SPREAD_RELICS_4P_SUPPORT,
 } from 'lib/scoring/scoringConstants'
 import { wrappedFixedT } from 'lib/utils/i18nUtils'
@@ -355,7 +354,7 @@ const shieldSimulation = (): SimulationMetadata => ({
   ],
   relicSets: [
     [Sets.SelfEnshroudedRecluse, Sets.SelfEnshroudedRecluse],
-    ...SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+    ...SPREAD_RELICS_4P_SUPPORT,
   ],
   ornamentSets: [
     Sets.LushakaTheSunkenSeas,
@@ -405,7 +404,7 @@ const supportSimulation = (): SimulationMetadata => ({
   ],
   relicSets: [
     [Sets.SelfEnshroudedRecluse, Sets.SelfEnshroudedRecluse],
-    ...SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+    ...SPREAD_RELICS_4P_SUPPORT,
   ],
   ornamentSets: [
     Sets.LushakaTheSunkenSeas,

--- a/src/lib/conditionals/character/8000/TrailblazerElation.ts
+++ b/src/lib/conditionals/character/8000/TrailblazerElation.ts
@@ -1,6 +1,3 @@
-import { HuohuoB1 } from 'lib/conditionals/character/1200/HuohuoB1'
-import { SilverWolfLv999 } from 'lib/conditionals/character/1500/SilverWolfLv999'
-import { Sparxie } from 'lib/conditionals/character/1500/Sparxie'
 import { getYaoguangAhaPunchlineValue } from 'lib/conditionals/character/1500/Yaoguang'
 import {
   AbilityEidolon,
@@ -13,14 +10,10 @@ import {
   gpuDynamicStatConversion,
 } from 'lib/conditionals/evaluation/statConversion'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
-import { DazzledByAFloweryWorld } from 'lib/conditionals/lightcone/5star/DazzledByAFloweryWorld'
-import { NightOfFright } from 'lib/conditionals/lightcone/5star/NightOfFright'
-import { WelcomeToTheCosmicCity } from 'lib/conditionals/lightcone/5star/WelcomeToTheCosmicCity'
 import {
   ConditionalActivation,
   ConditionalType,
   Parts,
-  Sets,
   Stats,
 } from 'lib/constants/constants'
 import { wgslTrue } from 'lib/gpu/injection/wgslUtils'
@@ -32,21 +25,8 @@ import {
   TargetTag,
 } from 'lib/optimization/engine/config/tag'
 import type { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
-import {
-  AbilityKind,
-  NULL_TURN_ABILITY_NAME,
-  START_ULT,
-  WHOLE_ELATION_SKILL,
-  WHOLE_SKILL,
-} from 'lib/optimization/rotation/turnAbilityConfig'
+import { AbilityKind } from 'lib/optimization/rotation/turnAbilityConfig'
 import { SortOption } from 'lib/optimization/sortOptions'
-import {
-  SPREAD_ORNAMENTS_2P_ENERGY_REGEN,
-  SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
-  SPREAD_ORNAMENTS_2P_SUPPORT,
-  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
-  SPREAD_RELICS_4P_SUPPORT,
-} from 'lib/scoring/scoringConstants'
 import { wrappedFixedT } from 'lib/utils/i18nUtils'
 import {
   floorSafe,
@@ -57,10 +37,7 @@ import type { Eidolon } from 'types/character'
 import type { CharacterConfig } from 'types/characterConfig'
 import type { CharacterConditionalsController } from 'types/conditionals'
 import type { HitDefinition } from 'types/hitConditionalTypes'
-import type {
-  ScoringMetadata,
-  SimulationMetadata,
-} from 'types/metadata'
+import type { ScoringMetadata } from 'types/metadata'
 import type {
   OptimizerAction,
   OptimizerContext,
@@ -323,74 +300,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   }
 }
 
-const simulation = (): SimulationMetadata => ({
-  parts: {
-    [Parts.Body]: [
-      Stats.CR,
-      Stats.CD,
-    ],
-    [Parts.Feet]: [
-      Stats.SPD,
-      Stats.ATK_P,
-    ],
-    [Parts.PlanarSphere]: [
-      Stats.Lightning_DMG,
-      Stats.ATK_P,
-    ],
-    [Parts.LinkRope]: [
-      Stats.ATK_P,
-    ],
-  },
-  substats: [
-    Stats.CD,
-    Stats.CR,
-    Stats.ATK_P,
-    Stats.ATK,
-  ],
-  comboTurnAbilities: [
-    NULL_TURN_ABILITY_NAME,
-    START_ULT,
-    WHOLE_SKILL,
-    WHOLE_SKILL,
-    WHOLE_ELATION_SKILL,
-    WHOLE_ELATION_SKILL,
-  ],
-  comboDot: 0,
-  errRopeEidolon: 0,
-  relicSets: [
-    [Sets.EverGloriousMagicalGirl, Sets.EverGloriousMagicalGirl],
-    [Sets.DivinerOfDistantReach, Sets.DivinerOfDistantReach],
-    ...SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
-    ...SPREAD_RELICS_4P_SUPPORT,
-  ],
-  ornamentSets: [
-    Sets.PunklordeStageZero,
-    ...SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
-    ...SPREAD_ORNAMENTS_2P_ENERGY_REGEN,
-    ...SPREAD_ORNAMENTS_2P_SUPPORT,
-  ],
-  teammates: [
-    {
-      characterId: SilverWolfLv999.id,
-      lightCone: WelcomeToTheCosmicCity.id,
-      characterEidolon: 0,
-      lightConeSuperimposition: 1,
-    },
-    {
-      characterId: Sparxie.id,
-      lightCone: DazzledByAFloweryWorld.id,
-      characterEidolon: 0,
-      lightConeSuperimposition: 1,
-    },
-    {
-      characterId: HuohuoB1.id,
-      lightCone: NightOfFright.id,
-      characterEidolon: 0,
-      lightConeSuperimposition: 1,
-    },
-  ],
-})
-
 const scoring = (): ScoringMetadata => ({
   stats: {
     [Stats.ATK]: 0.75,
@@ -427,7 +336,6 @@ const scoring = (): ScoringMetadata => ({
   presets: [],
   sortOption: SortOption.ELATION_SKILL,
   hiddenColumns: [SortOption.ULT, SortOption.FUA, SortOption.DOT],
-  simulation: simulation(),
 })
 
 const display = {

--- a/src/lib/conditionals/character/8000/TrailblazerHarmony.ts
+++ b/src/lib/conditionals/character/8000/TrailblazerHarmony.ts
@@ -33,7 +33,7 @@ import { SortOption } from 'lib/optimization/sortOptions'
 import { PresetEffects } from 'lib/scoring/presetEffects'
 import {
   SPREAD_ORNAMENTS_2P_SUPPORT,
-  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+  SPREAD_RELICS_4P_SUPPORT,
 } from 'lib/scoring/scoringConstants'
 import { wrappedFixedT } from 'lib/utils/i18nUtils'
 import { type CharacterConfig } from 'types/characterConfig'
@@ -271,7 +271,7 @@ const supportSimulation = (): SimulationMetadata => ({
   ],
   relicSets: [
     [Sets.WatchmakerMasterOfDreamMachinations, Sets.WatchmakerMasterOfDreamMachinations],
-    ...SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+    ...SPREAD_RELICS_4P_SUPPORT,
   ],
   ornamentSets: [
     Sets.ForgeOfTheKalpagniLantern,

--- a/src/lib/conditionals/character/8000/TrailblazerPreservation.ts
+++ b/src/lib/conditionals/character/8000/TrailblazerPreservation.ts
@@ -31,7 +31,7 @@ import { type ComputedStatsContainer } from 'lib/optimization/engine/container/c
 import { SortOption } from 'lib/optimization/sortOptions'
 import {
   SPREAD_ORNAMENTS_2P_SUPPORT,
-  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+  SPREAD_RELICS_4P_SUPPORT,
 } from 'lib/scoring/scoringConstants'
 import { PresetEffects } from 'lib/scoring/presetEffects'
 import { wrappedFixedT } from 'lib/utils/i18nUtils'
@@ -250,7 +250,7 @@ const shieldSimulation = (): SimulationMetadata => ({
   ],
   relicSets: [
     [Sets.SelfEnshroudedRecluse, Sets.SelfEnshroudedRecluse],
-    ...SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+    ...SPREAD_RELICS_4P_SUPPORT,
   ],
   ornamentSets: [
     Sets.LushakaTheSunkenSeas,

--- a/src/lib/conditionals/character/8000/TrailblazerRemembrance.ts
+++ b/src/lib/conditionals/character/8000/TrailblazerRemembrance.ts
@@ -45,7 +45,7 @@ import { SortOption } from 'lib/optimization/sortOptions'
 import { PresetEffects } from 'lib/scoring/presetEffects'
 import {
   SPREAD_ORNAMENTS_2P_SUPPORT,
-  SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+  SPREAD_RELICS_4P_SUPPORT,
 } from 'lib/scoring/scoringConstants'
 import { wrappedFixedT } from 'lib/utils/i18nUtils'
 import { precisionRound } from 'lib/utils/mathUtils'
@@ -469,7 +469,7 @@ const supportSimulation = (): SimulationMetadata => ({
   ],
   relicSets: [
     [Sets.SacerdosRelivedOrdeal, Sets.SacerdosRelivedOrdeal],
-    ...SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+    ...SPREAD_RELICS_4P_SUPPORT,
   ],
   ornamentSets: [
     Sets.BrokenKeel,

--- a/src/lib/scoring/scoringConstants.ts
+++ b/src/lib/scoring/scoringConstants.ts
@@ -7,6 +7,7 @@ export const SPREAD_RELICS_4P_GENERAL_CONDITIONALS = [
 export const SPREAD_RELICS_4P_SUPPORT = [
   [Sets.SacerdosRelivedOrdeal, Sets.SacerdosRelivedOrdeal],
   [Sets.EagleOfTwilightLine, Sets.EagleOfTwilightLine],
+  [Sets.MessengerTraversingHackerspace, Sets.MessengerTraversingHackerspace],
 ]
 
 export const SPREAD_ORNAMENTS_2P_FUA = [

--- a/src/lib/scoring/simScoringUtils.ts
+++ b/src/lib/scoring/simScoringUtils.ts
@@ -344,7 +344,7 @@ export function applyScoringFunction(
 
   const entry = SCORING_CONFIG_REGISTRY[configType]
   const unpenalizedSimScore = result.x.getGlobalRegisterValue(entry.comboRegister)
-  const penaltyMultiplier = calculatePenaltyMultiplier(result, metadata, user)
+  const penaltyMultiplier = calculatePenaltyMultiplier(result, metadata, user, configType)
   result.simScore = unpenalizedSimScore * (penalty ? penaltyMultiplier : 1)
 }
 
@@ -352,6 +352,7 @@ function calculatePenaltyMultiplier(
   simulationResult: RunStatSimulationsResult,
   metadata: SimulationMetadata,
   user = false,
+  configType: ScoringConfigType = ScoringConfigType.DPS,
 ) {
   const x = simulationResult.x
   let newPenaltyMultiplier = 1
@@ -378,7 +379,7 @@ function calculatePenaltyMultiplier(
     }
   }
 
-  if (user && ornament2p(SetKeys.BrokenKeel, x.c.sets)) {
+  if (user && configType !== ScoringConfigType.DPS && ornament2p(SetKeys.BrokenKeel, x.c.sets)) {
     const combatRes = x.getSelfValue(StatKey.RES)
     if (combatRes < 0.30) {
       newPenaltyMultiplier *= 0.75

--- a/src/lib/simulations/orchestrator/benchmarkSimulationOrchestrator.ts
+++ b/src/lib/simulations/orchestrator/benchmarkSimulationOrchestrator.ts
@@ -253,7 +253,7 @@ export class BenchmarkSimulationOrchestrator {
 
     const combatRes = this.originalSimResult!.x.getActionValueByIndex(StatKey.RES, SELF_ENTITY_INDEX)
     const baselineRes = this.baselineSimResult!.x.getActionValueByIndex(StatKey.RES, SELF_ENTITY_INDEX)
-    if (combatRes - baselineRes >= 0.30) {
+    if (combatRes - baselineRes >= 0.30 || combatRes >= 1.00) {
       this.flags.benchmarkBasicResTarget = Math.min(combatRes, 1.00)
     }
   }


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

- Replace SPREAD_RELICS_4P_GENERAL_CONDITIONALS with SPREAD_RELICS_4P_SUPPORT across all support/heal/shield character configs
- Add Messenger set to SPREAD_RELICS_4P_SUPPORT constant
- Remove TrailblazerElation DPS simulation config
- Change RES equalization from absolute threshold to relative (30% above baseline), capped at 100%
- Add secondary RES equalization trigger when combat RES reaches 100% cap
- Add Broken Keel penalty (0.75x) for non-DPS scoring when set is equipped but RES < 30%
- Scope Broken Keel penalty to support scoring only, excluding DPS
- Pass configType through to penalty multiplier calculation
- Fix ComputedStatsContainer.clone() not copying set data, breaking post-clone set detection
- Bump support scoring beta version to 7

## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [ ] I have added commit messages that are descriptive and meaningful.
- [ ] I have tested the changes locally.
- [ ] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
