### PR TITLE
feat: set matching updates

### DIFF
--- a/src/lib/characterPreview/scoring/CharacterCardCombatStats.tsx
+++ b/src/lib/characterPreview/scoring/CharacterCardCombatStats.tsx
@@ -49,7 +49,7 @@ import { useTranslation } from 'react-i18next'
 import iconClasses from 'style/icons.module.css'
 import {
   type DBMetadataCharacter,
-  type ScoringConfigType,
+  ScoringConfigType,
   type SimulationMetadata,
 } from 'types/metadata'
 
@@ -70,7 +70,7 @@ export const CharacterCardCombatStats = memo(
     const primaryActionStats = originalSimResult.primaryActionStats
 
     const simMetadata = simulationMetadata ?? characterMetadata.scoringMetadata.simulation!
-    const upgradeStats: StatsValues[] = pickCombatStats(characterMetadata, simMetadata)
+    const upgradeStats: StatsValues[] = pickCombatStats(characterMetadata, simMetadata, configType)
     const upgradeDisplayWrappers = aggregateCombatStats(x, upgradeStats, preciseSpd, element, primaryActionStats)
 
     const rows: ReactElement[] = []
@@ -161,7 +161,7 @@ function aggregateCombatStats(
   return displayWrappers
 }
 
-function pickCombatStats(characterMetadata: DBMetadataCharacter, simulationMetadata: SimulationMetadata) {
+function pickCombatStats(characterMetadata: DBMetadataCharacter, simulationMetadata: SimulationMetadata, configType: ScoringConfigType) {
   const elementalDmgValue = ElementToDamage[characterMetadata.element]
 
   let substats: StatsValues[] = [...simulationMetadata.substats as SubStats[]]
@@ -172,7 +172,7 @@ function pickCombatStats(characterMetadata: DBMetadataCharacter, simulationMetad
   substats = filterUnique(substats).filter((x) => !percentFlatStats[x])
   substats.sort((a, b) => getIndexOf(SubStats, a) - getIndexOf(SubStats, b))
 
-  let includeElementalDmg = true
+  let includeElementalDmg = configType === ScoringConfigType.DPS
   const config = simulationMetadata.combatStatsConfig
   if (config) {
     for (const entry of config) {

--- a/src/lib/conditionals/character/1000/March7th.ts
+++ b/src/lib/conditionals/character/1000/March7th.ts
@@ -35,7 +35,7 @@ import { SortOption } from 'lib/optimization/sortOptions'
 import { PresetEffects } from 'lib/scoring/presetEffects'
 import {
   SPREAD_ORNAMENTS_2P_SUPPORT,
-  SPREAD_RELICS_4P_SUPPORT,
+  SPREAD_RELICS_4P_SHIELD,
 } from 'lib/scoring/scoringConstants'
 import { type Eidolon } from 'types/character'
 import { type CharacterConfig } from 'types/characterConfig'
@@ -193,7 +193,7 @@ const shieldSimulation = (): SimulationMetadata => ({
   ],
   relicSets: [
     [Sets.SelfEnshroudedRecluse, Sets.SelfEnshroudedRecluse],
-    ...SPREAD_RELICS_4P_SUPPORT,
+    ...SPREAD_RELICS_4P_SHIELD,
   ],
   ornamentSets: [
     Sets.LushakaTheSunkenSeas,

--- a/src/lib/conditionals/character/1100/Gepard.ts
+++ b/src/lib/conditionals/character/1100/Gepard.ts
@@ -37,7 +37,7 @@ import {
 import { SortOption } from 'lib/optimization/sortOptions'
 import {
   SPREAD_ORNAMENTS_2P_SUPPORT,
-  SPREAD_RELICS_4P_SUPPORT,
+  SPREAD_RELICS_4P_SHIELD,
 } from 'lib/scoring/scoringConstants'
 import { wrappedFixedT } from 'lib/utils/i18nUtils'
 import { type Eidolon } from 'types/character'
@@ -211,7 +211,7 @@ const shieldSimulation = (): SimulationMetadata => ({
   ],
   relicSets: [
     [Sets.SelfEnshroudedRecluse, Sets.SelfEnshroudedRecluse],
-    ...SPREAD_RELICS_4P_SUPPORT,
+    ...SPREAD_RELICS_4P_SHIELD,
   ],
   ornamentSets: [
     Sets.LushakaTheSunkenSeas,

--- a/src/lib/conditionals/character/1100/Lynx.ts
+++ b/src/lib/conditionals/character/1100/Lynx.ts
@@ -45,8 +45,8 @@ import {
 import { SortOption } from 'lib/optimization/sortOptions'
 import { PresetEffects } from 'lib/scoring/presetEffects'
 import {
-  SPREAD_ORNAMENTS_2P_SUPPORT,
-  SPREAD_RELICS_4P_SUPPORT,
+  SPREAD_ORNAMENTS_2P_HEAL,
+  SPREAD_RELICS_4P_HEAL,
 } from 'lib/scoring/scoringConstants'
 import { wrappedFixedT } from 'lib/utils/i18nUtils'
 import { type Eidolon } from 'types/character'
@@ -316,11 +316,11 @@ const healSimulation = (): SimulationMetadata => ({
   ],
   relicSets: [
     [Sets.WarriorGoddessOfSunAndThunder, Sets.WarriorGoddessOfSunAndThunder],
-    ...SPREAD_RELICS_4P_SUPPORT,
+    ...SPREAD_RELICS_4P_HEAL,
   ],
   ornamentSets: [
     Sets.LushakaTheSunkenSeas,
-    ...SPREAD_ORNAMENTS_2P_SUPPORT,
+    ...SPREAD_ORNAMENTS_2P_HEAL,
   ],
   teammates: [
     {

--- a/src/lib/conditionals/character/1100/Natasha.ts
+++ b/src/lib/conditionals/character/1100/Natasha.ts
@@ -28,8 +28,8 @@ import {
 import { SortOption } from 'lib/optimization/sortOptions'
 import { PresetEffects } from 'lib/scoring/presetEffects'
 import {
-  SPREAD_ORNAMENTS_2P_SUPPORT,
-  SPREAD_RELICS_4P_SUPPORT,
+  SPREAD_ORNAMENTS_2P_HEAL,
+  SPREAD_RELICS_4P_HEAL,
 } from 'lib/scoring/scoringConstants'
 import { wrappedFixedT } from 'lib/utils/i18nUtils'
 import { type Eidolon } from 'types/character'
@@ -158,11 +158,11 @@ const healSimulation = (): SimulationMetadata => ({
   ],
   relicSets: [
     [Sets.WarriorGoddessOfSunAndThunder, Sets.WarriorGoddessOfSunAndThunder],
-    ...SPREAD_RELICS_4P_SUPPORT,
+    ...SPREAD_RELICS_4P_HEAL,
   ],
   ornamentSets: [
     Sets.LushakaTheSunkenSeas,
-    ...SPREAD_ORNAMENTS_2P_SUPPORT,
+    ...SPREAD_ORNAMENTS_2P_HEAL,
   ],
   teammates: [
     {

--- a/src/lib/conditionals/character/1200/Bailu.ts
+++ b/src/lib/conditionals/character/1200/Bailu.ts
@@ -26,8 +26,8 @@ import { type ComputedStatsContainer } from 'lib/optimization/engine/container/c
 import { SortOption } from 'lib/optimization/sortOptions'
 import { PresetEffects } from 'lib/scoring/presetEffects'
 import {
-  SPREAD_ORNAMENTS_2P_SUPPORT,
-  SPREAD_RELICS_4P_SUPPORT,
+  SPREAD_ORNAMENTS_2P_HEAL,
+  SPREAD_RELICS_4P_HEAL,
 } from 'lib/scoring/scoringConstants'
 import { wrappedFixedT } from 'lib/utils/i18nUtils'
 
@@ -243,11 +243,11 @@ const healSimulation = (): SimulationMetadata => ({
   ],
   relicSets: [
     [Sets.WarriorGoddessOfSunAndThunder, Sets.WarriorGoddessOfSunAndThunder],
-    ...SPREAD_RELICS_4P_SUPPORT,
+    ...SPREAD_RELICS_4P_HEAL,
   ],
   ornamentSets: [
     Sets.LushakaTheSunkenSeas,
-    ...SPREAD_ORNAMENTS_2P_SUPPORT,
+    ...SPREAD_ORNAMENTS_2P_HEAL,
   ],
   teammates: [
     {

--- a/src/lib/conditionals/character/1200/FuXuan.ts
+++ b/src/lib/conditionals/character/1200/FuXuan.ts
@@ -34,7 +34,7 @@ import { SortOption } from 'lib/optimization/sortOptions'
 import { PresetEffects } from 'lib/scoring/presetEffects'
 import {
   SPREAD_ORNAMENTS_2P_SUPPORT,
-  SPREAD_RELICS_4P_SUPPORT,
+  SPREAD_RELICS_4P_SHIELD,
 } from 'lib/scoring/scoringConstants'
 import { wrappedFixedT } from 'lib/utils/i18nUtils'
 
@@ -299,7 +299,7 @@ const healSimulation = (): SimulationMetadata => ({
   ],
   relicSets: [
     [Sets.WarriorGoddessOfSunAndThunder, Sets.WarriorGoddessOfSunAndThunder],
-    ...SPREAD_RELICS_4P_SUPPORT,
+    ...SPREAD_RELICS_4P_SHIELD,
   ],
   ornamentSets: [
     Sets.LushakaTheSunkenSeas,

--- a/src/lib/conditionals/character/1200/HuohuoB1.ts
+++ b/src/lib/conditionals/character/1200/HuohuoB1.ts
@@ -35,8 +35,8 @@ import {
 import { SortOption } from 'lib/optimization/sortOptions'
 import { PresetEffects } from 'lib/scoring/presetEffects'
 import {
-  SPREAD_ORNAMENTS_2P_SUPPORT,
-  SPREAD_RELICS_4P_SUPPORT,
+  SPREAD_ORNAMENTS_2P_HEAL,
+  SPREAD_RELICS_4P_HEAL,
 } from 'lib/scoring/scoringConstants'
 import { wrappedFixedT } from 'lib/utils/i18nUtils'
 import { precisionRound } from 'lib/utils/mathUtils'
@@ -224,11 +224,11 @@ const healSimulation = (): SimulationMetadata => ({
   ],
   relicSets: [
     [Sets.WarriorGoddessOfSunAndThunder, Sets.WarriorGoddessOfSunAndThunder],
-    ...SPREAD_RELICS_4P_SUPPORT,
+    ...SPREAD_RELICS_4P_HEAL,
   ],
   ornamentSets: [
     Sets.LushakaTheSunkenSeas,
-    ...SPREAD_ORNAMENTS_2P_SUPPORT,
+    ...SPREAD_ORNAMENTS_2P_HEAL,
   ],
   teammates: [
     {

--- a/src/lib/conditionals/character/1200/Lingsha.ts
+++ b/src/lib/conditionals/character/1200/Lingsha.ts
@@ -40,8 +40,8 @@ import { type ComputedStatsContainer } from 'lib/optimization/engine/container/c
 import { SortOption } from 'lib/optimization/sortOptions'
 import { PresetEffects } from 'lib/scoring/presetEffects'
 import {
-  SPREAD_ORNAMENTS_2P_SUPPORT,
-  SPREAD_RELICS_4P_SUPPORT,
+  SPREAD_ORNAMENTS_2P_HEAL,
+  SPREAD_RELICS_4P_HEAL,
 } from 'lib/scoring/scoringConstants'
 import { wrappedFixedT } from 'lib/utils/i18nUtils'
 
@@ -409,11 +409,11 @@ const healSimulation = (): SimulationMetadata => ({
   ],
   relicSets: [
     [Sets.IronCavalryAgainstTheScourge, Sets.IronCavalryAgainstTheScourge],
-    ...SPREAD_RELICS_4P_SUPPORT,
+    ...SPREAD_RELICS_4P_HEAL,
   ],
   ornamentSets: [
     Sets.ForgeOfTheKalpagniLantern,
-    ...SPREAD_ORNAMENTS_2P_SUPPORT,
+    ...SPREAD_ORNAMENTS_2P_HEAL,
   ],
   teammates: [
     {

--- a/src/lib/conditionals/character/1200/Luocha.ts
+++ b/src/lib/conditionals/character/1200/Luocha.ts
@@ -31,8 +31,8 @@ import { type ComputedStatsContainer } from 'lib/optimization/engine/container/c
 import { SortOption } from 'lib/optimization/sortOptions'
 import { PresetEffects } from 'lib/scoring/presetEffects'
 import {
-  SPREAD_ORNAMENTS_2P_SUPPORT,
-  SPREAD_RELICS_4P_SUPPORT,
+  SPREAD_ORNAMENTS_2P_HEAL,
+  SPREAD_RELICS_4P_HEAL,
 } from 'lib/scoring/scoringConstants'
 import { wrappedFixedT } from 'lib/utils/i18nUtils'
 import { type Eidolon } from 'types/character'
@@ -224,11 +224,11 @@ const healSimulation = (): SimulationMetadata => ({
   ],
   relicSets: [
     [Sets.WarriorGoddessOfSunAndThunder, Sets.WarriorGoddessOfSunAndThunder],
-    ...SPREAD_RELICS_4P_SUPPORT,
+    ...SPREAD_RELICS_4P_HEAL,
   ],
   ornamentSets: [
     Sets.LushakaTheSunkenSeas,
-    ...SPREAD_ORNAMENTS_2P_SUPPORT,
+    ...SPREAD_ORNAMENTS_2P_HEAL,
   ],
   teammates: [
     {

--- a/src/lib/conditionals/character/1300/Aventurine.ts
+++ b/src/lib/conditionals/character/1300/Aventurine.ts
@@ -50,7 +50,7 @@ import {
   SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
   SPREAD_ORNAMENTS_2P_SUPPORT,
   SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
-  SPREAD_RELICS_4P_SUPPORT,
+  SPREAD_RELICS_4P_SHIELD,
 } from 'lib/scoring/scoringConstants'
 import { wrappedFixedT } from 'lib/utils/i18nUtils'
 import { floorSafe } from 'lib/utils/mathUtils'
@@ -409,7 +409,7 @@ const shieldSimulation = (): SimulationMetadata => ({
   ],
   relicSets: [
     [Sets.SelfEnshroudedRecluse, Sets.SelfEnshroudedRecluse],
-    ...SPREAD_RELICS_4P_SUPPORT,
+    ...SPREAD_RELICS_4P_SHIELD,
   ],
   ornamentSets: [
     Sets.LushakaTheSunkenSeas,

--- a/src/lib/conditionals/character/1300/TheDahlia.ts
+++ b/src/lib/conditionals/character/1300/TheDahlia.ts
@@ -2,7 +2,6 @@ import { SilverWolf } from 'lib/conditionals/character/1000/SilverWolf'
 import { Fugue } from 'lib/conditionals/character/1200/Fugue'
 import { Lingsha } from 'lib/conditionals/character/1200/Lingsha'
 import { Boothill } from 'lib/conditionals/character/1300/Boothill'
-import { Firefly } from 'lib/conditionals/character/1300/Firefly'
 import { FireflyB1 } from 'lib/conditionals/character/1300/FireflyB1'
 import { Anaxa } from 'lib/conditionals/character/1400/Anaxa'
 import { Phainon } from 'lib/conditionals/character/1400/Phainon'
@@ -51,7 +50,6 @@ import {
   SPREAD_ORNAMENTS_2P_ENERGY_REGEN,
   SPREAD_ORNAMENTS_2P_SUPPORT,
   SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
-  SPREAD_RELICS_4P_SUPPORT,
 } from 'lib/scoring/scoringConstants'
 import { relics2pByStats } from 'lib/sets/setConfigRegistry'
 import { wrappedFixedT } from 'lib/utils/i18nUtils'
@@ -510,56 +508,6 @@ const simulation = (): SimulationMetadata => ({
   ],
 })
 
-const supportSimulation = (): SimulationMetadata => ({
-  parts: {
-    [Parts.Body]: [Stats.HP_P, Stats.DEF_P],
-    [Parts.Feet]: [Stats.SPD],
-    [Parts.PlanarSphere]: [Stats.HP_P, Stats.DEF_P],
-    [Parts.LinkRope]: [Stats.ERR, Stats.BE],
-  },
-  substats: [
-    Stats.BE,
-    Stats.SPD,
-    Stats.RES,
-    Stats.HP_P,
-    Stats.DEF_P,
-  ],
-  buffStat: StatKey.BE,
-  errRopeEidolon: 0,
-  comboTurnAbilities: [
-    NULL_TURN_ABILITY_NAME,
-  ],
-  relicSets: [
-    [Sets.IronCavalryAgainstTheScourge, Sets.IronCavalryAgainstTheScourge],
-    ...SPREAD_RELICS_4P_SUPPORT,
-  ],
-  ornamentSets: [
-    Sets.ForgeOfTheKalpagniLantern,
-    ...SPREAD_ORNAMENTS_2P_SUPPORT,
-  ],
-  teammates: [
-    {
-      characterId: Firefly.id,
-      lightCone: WhereaboutsShouldDreamsRest.id,
-      characterEidolon: 0,
-      lightConeSuperimposition: 1,
-    },
-    {
-      characterId: Fugue.id,
-      lightCone: LongRoadLeadsHome.id,
-      characterEidolon: 0,
-      lightConeSuperimposition: 1,
-    },
-    {
-      characterId: Lingsha.id,
-      lightCone: ScentAloneStaysTrue.id,
-      characterEidolon: 0,
-      lightConeSuperimposition: 1,
-    },
-  ],
-  deprioritizeBuffs: true,
-})
-
 const scoring = (): ScoringMetadata => ({
   stats: {
     [Stats.ATK]: 0,
@@ -594,7 +542,6 @@ const scoring = (): ScoringMetadata => ({
     SortOption.DOT,
   ],
   simulation: simulation(),
-  supportSimulation: supportSimulation(),
 })
 
 const display = {

--- a/src/lib/conditionals/character/1400/Cerydra.ts
+++ b/src/lib/conditionals/character/1400/Cerydra.ts
@@ -48,8 +48,8 @@ import {
 } from 'lib/optimization/rotation/turnAbilityConfig'
 import { SortOption } from 'lib/optimization/sortOptions'
 import {
-  SPREAD_ORNAMENTS_2P_SUPPORT,
-  SPREAD_RELICS_4P_SUPPORT,
+  SPREAD_ORNAMENTS_2P_HEAL,
+  SPREAD_RELICS_4P_HEAL,
 } from 'lib/scoring/scoringConstants'
 import { PresetEffects } from 'lib/scoring/presetEffects'
 import { wrappedFixedT } from 'lib/utils/i18nUtils'
@@ -405,11 +405,11 @@ const supportSimulation = (): SimulationMetadata => ({
   ],
   relicSets: [
     [Sets.SacerdosRelivedOrdeal, Sets.SacerdosRelivedOrdeal],
-    ...SPREAD_RELICS_4P_SUPPORT,
+    ...SPREAD_RELICS_4P_HEAL,
   ],
   ornamentSets: [
     Sets.LushakaTheSunkenSeas,
-    ...SPREAD_ORNAMENTS_2P_SUPPORT,
+    ...SPREAD_ORNAMENTS_2P_HEAL,
   ],
   teammates: [
     {

--- a/src/lib/conditionals/character/1400/Hyacine.ts
+++ b/src/lib/conditionals/character/1400/Hyacine.ts
@@ -59,8 +59,8 @@ import {
 import { SortOption } from 'lib/optimization/sortOptions'
 import { PresetEffects } from 'lib/scoring/presetEffects'
 import {
-  SPREAD_ORNAMENTS_2P_SUPPORT,
-  SPREAD_RELICS_4P_SUPPORT,
+  SPREAD_ORNAMENTS_2P_HEAL,
+  SPREAD_RELICS_4P_HEAL,
 } from 'lib/scoring/scoringConstants'
 import { relics2pByStats } from 'lib/sets/setConfigRegistry'
 import { wrappedFixedT } from 'lib/utils/i18nUtils'
@@ -573,7 +573,7 @@ const simulation = (): SimulationMetadata => ({
     Sets.GiantTreeOfRaptBrooding,
     Sets.BoneCollectionsSereneDemesne,
     Sets.ArcadiaOfWovenDreams,
-    ...SPREAD_ORNAMENTS_2P_SUPPORT,
+    ...SPREAD_ORNAMENTS_2P_HEAL,
   ],
   teammates: [
     {
@@ -620,11 +620,11 @@ const healSimulation = (): SimulationMetadata => ({
   ],
   relicSets: [
     [Sets.WarriorGoddessOfSunAndThunder, Sets.WarriorGoddessOfSunAndThunder],
-    ...SPREAD_RELICS_4P_SUPPORT,
+    ...SPREAD_RELICS_4P_HEAL,
   ],
   ornamentSets: [
     Sets.GiantTreeOfRaptBrooding,
-    ...SPREAD_ORNAMENTS_2P_SUPPORT,
+    ...SPREAD_ORNAMENTS_2P_HEAL,
   ],
   teammates: [
     {

--- a/src/lib/conditionals/character/1400/PermansorTerrae.ts
+++ b/src/lib/conditionals/character/1400/PermansorTerrae.ts
@@ -47,7 +47,7 @@ import { SortOption } from 'lib/optimization/sortOptions'
 import { PresetEffects } from 'lib/scoring/presetEffects'
 import {
   SPREAD_ORNAMENTS_2P_SUPPORT,
-  SPREAD_RELICS_4P_SUPPORT,
+  SPREAD_RELICS_4P_SHIELD,
 } from 'lib/scoring/scoringConstants'
 import { wrappedFixedT } from 'lib/utils/i18nUtils'
 import { type Eidolon } from 'types/character'
@@ -354,7 +354,7 @@ const shieldSimulation = (): SimulationMetadata => ({
   ],
   relicSets: [
     [Sets.SelfEnshroudedRecluse, Sets.SelfEnshroudedRecluse],
-    ...SPREAD_RELICS_4P_SUPPORT,
+    ...SPREAD_RELICS_4P_SHIELD,
   ],
   ornamentSets: [
     Sets.LushakaTheSunkenSeas,
@@ -404,7 +404,7 @@ const supportSimulation = (): SimulationMetadata => ({
   ],
   relicSets: [
     [Sets.SelfEnshroudedRecluse, Sets.SelfEnshroudedRecluse],
-    ...SPREAD_RELICS_4P_SUPPORT,
+    ...SPREAD_RELICS_4P_SHIELD,
   ],
   ornamentSets: [
     Sets.LushakaTheSunkenSeas,

--- a/src/lib/conditionals/character/1400/PermansorTerrae.ts
+++ b/src/lib/conditionals/character/1400/PermansorTerrae.ts
@@ -40,7 +40,6 @@ import {
 import { type ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
 import {
   AbilityKind,
-  DEFAULT_SKILL_SHIELD,
   NULL_TURN_ABILITY_NAME,
 } from 'lib/optimization/rotation/turnAbilityConfig'
 import { SortOption } from 'lib/optimization/sortOptions'
@@ -332,57 +331,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   }
 }
 
-const shieldSimulation = (): SimulationMetadata => ({
-  parts: {
-    [Parts.Body]: [Stats.ATK_P],
-    [Parts.Feet]: [Stats.SPD, Stats.ATK_P],
-    [Parts.PlanarSphere]: [Stats.ATK_P],
-    [Parts.LinkRope]: [Stats.ERR, Stats.ATK_P],
-  },
-  substats: [
-    Stats.ATK_P,
-    Stats.ATK,
-    Stats.SPD,
-    Stats.RES,
-    Stats.HP_P,
-  ],
-  errRopeEidolon: 0,
-  comboTurnAbilities: [
-    NULL_TURN_ABILITY_NAME,
-    DEFAULT_SKILL_SHIELD,
-    DEFAULT_SKILL_SHIELD,
-  ],
-  relicSets: [
-    [Sets.SelfEnshroudedRecluse, Sets.SelfEnshroudedRecluse],
-    ...SPREAD_RELICS_4P_SHIELD,
-  ],
-  ornamentSets: [
-    Sets.LushakaTheSunkenSeas,
-    ...SPREAD_ORNAMENTS_2P_SUPPORT,
-  ],
-  teammates: [
-    {
-      characterId: Phainon.id,
-      lightCone: ThusBurnsTheDawn.id,
-      characterEidolon: 0,
-      lightConeSuperimposition: 1,
-    },
-    {
-      characterId: Sunday.id,
-      lightCone: AGroundedAscent.id,
-      characterEidolon: 0,
-      lightConeSuperimposition: 1,
-    },
-    {
-      characterId: Tribbie.id,
-      lightCone: IfTimeWereAFlower.id,
-      characterEidolon: 0,
-      lightConeSuperimposition: 1,
-    },
-  ],
-  deprioritizeBuffs: true,
-})
-
 const supportSimulation = (): SimulationMetadata => ({
   parts: {
     [Parts.Body]: [Stats.ATK_P],
@@ -474,7 +422,6 @@ const scoring = (): ScoringMetadata => ({
   addedColumns: [],
   hiddenColumns: [SortOption.DOT, SortOption.SKILL],
   supportSimulation: supportSimulation(),
-  shieldSimulation: shieldSimulation(),
 })
 
 const display = {

--- a/src/lib/conditionals/character/8000/TrailblazerPreservation.ts
+++ b/src/lib/conditionals/character/8000/TrailblazerPreservation.ts
@@ -31,7 +31,7 @@ import { type ComputedStatsContainer } from 'lib/optimization/engine/container/c
 import { SortOption } from 'lib/optimization/sortOptions'
 import {
   SPREAD_ORNAMENTS_2P_SUPPORT,
-  SPREAD_RELICS_4P_SUPPORT,
+  SPREAD_RELICS_4P_SHIELD,
 } from 'lib/scoring/scoringConstants'
 import { PresetEffects } from 'lib/scoring/presetEffects'
 import { wrappedFixedT } from 'lib/utils/i18nUtils'
@@ -250,7 +250,7 @@ const shieldSimulation = (): SimulationMetadata => ({
   ],
   relicSets: [
     [Sets.SelfEnshroudedRecluse, Sets.SelfEnshroudedRecluse],
-    ...SPREAD_RELICS_4P_SUPPORT,
+    ...SPREAD_RELICS_4P_SHIELD,
   ],
   ornamentSets: [
     Sets.LushakaTheSunkenSeas,

--- a/src/lib/scoring/scoringConstants.ts
+++ b/src/lib/scoring/scoringConstants.ts
@@ -1,5 +1,8 @@
 import { Sets } from 'lib/constants/constants'
 
+// Set matching allows the scoring benchmark to recognize a user's equipped sets as valid alternatives,
+// even when their value (action advance, team buffs, SP generation) isn't fully reflected in sim output.
+
 export const SPREAD_RELICS_4P_GENERAL_CONDITIONALS = [
   [Sets.EagleOfTwilightLine, Sets.EagleOfTwilightLine],
 ]
@@ -8,6 +11,18 @@ export const SPREAD_RELICS_4P_SUPPORT = [
   [Sets.SacerdosRelivedOrdeal, Sets.SacerdosRelivedOrdeal],
   [Sets.EagleOfTwilightLine, Sets.EagleOfTwilightLine],
   [Sets.MessengerTraversingHackerspace, Sets.MessengerTraversingHackerspace],
+]
+
+export const SPREAD_RELICS_4P_HEAL = [
+  ...SPREAD_RELICS_4P_SUPPORT,
+  [Sets.WarriorGoddessOfSunAndThunder, Sets.WarriorGoddessOfSunAndThunder],
+  [Sets.PasserbyOfWanderingCloud, Sets.PasserbyOfWanderingCloud],
+]
+
+export const SPREAD_RELICS_4P_SHIELD = [
+  ...SPREAD_RELICS_4P_SUPPORT,
+  [Sets.SelfEnshroudedRecluse, Sets.SelfEnshroudedRecluse],
+  [Sets.KnightOfPurityPalace, Sets.KnightOfPurityPalace],
 ]
 
 export const SPREAD_ORNAMENTS_2P_FUA = [
@@ -33,7 +48,10 @@ export const SPREAD_ORNAMENTS_2P_SUPPORT = [
   Sets.PenaconyLandOfTheDreams,
   Sets.FleetOfTheAgeless,
   Sets.LushakaTheSunkenSeas,
-  Sets.ForgeOfTheKalpagniLantern,
-  Sets.GiantTreeOfRaptBrooding,
   Sets.CityOfConvergingStars,
+]
+
+export const SPREAD_ORNAMENTS_2P_HEAL = [
+  ...SPREAD_ORNAMENTS_2P_SUPPORT,
+  Sets.GiantTreeOfRaptBrooding,
 ]


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

- Add archetype-specific set matching spreads for healers (HEAL) and shielders (SHIELD), extending the base support spread
- Add Warrior Goddess and Passerby to healer relic matching, Self-Enshrouded Recluse and Knight of Purity Palace to shielder matching
- Add healer-specific ornament spread with Giant Tree of Rapt Brooding
- Remove Forge of Kalpagni Lantern and Giant Tree from universal support ornament spread (now case-by-case / healer-only)
- Migrate all healer characters to HEAL spreads and all shielder characters to SHIELD spreads
- Remove shield simulation from PermansorTerrae
- Remove support simulation from TheDahlia
- Remove elemental DMG% from combat stats display for non-DPS scoring configs

## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [ ] I have added commit messages that are descriptive and meaningful.
- [ ] I have tested the changes locally.
- [ ] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
