### PR TITLE
fix: various fixes

### DIFF
--- a/src/lib/characterPreview/CharacterPreview.tsx
+++ b/src/lib/characterPreview/CharacterPreview.tsx
@@ -72,9 +72,10 @@ import {
 import { CharacterAnnouncement } from 'lib/interactions/CharacterAnnouncement'
 import type { RelicScoringResult } from 'lib/relics/scoring/types'
 import { Assets } from 'lib/rendering/assets'
-import { CONFIG_FIELD_MAP } from 'lib/scoring/scoringConfig'
 import {
+  CONFIG_FIELD_MAP,
   isSimScoreMode,
+  SCORING_CONFIG_REGISTRY,
   ScoringType,
 } from 'lib/scoring/scoringConfig'
 import { injectBenchmarkDebuggers } from 'lib/simulations/tests/simDebuggers'
@@ -379,9 +380,12 @@ const CharacterPreviewInner = memo(function CharacterPreviewInner({
 
   // Layout: forceDebug disables L2D, forces SUBSTAT_SCORE, hides analysis footer
   // editorOverrides.forceSimScoreLayout overrides to DPS_SCORE layout for preview
+  const buildScoringType = savedBuildOverride?.scoringConfigType != null
+    ? SCORING_CONFIG_REGISTRY[savedBuildOverride.scoringConfigType].scoringType
+    : undefined
   const effectiveScoringType = editorOverrides?.forceSimScoreLayout
     ? ScoringType.DPS_SCORE
-    : (forceDebug ? ScoringType.SUBSTAT_SCORE : state.storedScoringType)
+    : (forceDebug ? ScoringType.SUBSTAT_SCORE : (buildScoringType ?? state.storedScoringType))
   // Cache-buster: state.scoringMetadata invalidates when scoring overrides change (SPD weight, buff priority)
   const _scoringMetadataCacheBuster = state.scoringMetadata
   // Cache-buster: portrait edits on the showcase tab wouldn't re-run the layout memo otherwise

--- a/src/lib/characterPreview/scoring/CharacterCardCombatStats.tsx
+++ b/src/lib/characterPreview/scoring/CharacterCardCombatStats.tsx
@@ -167,6 +167,9 @@ function pickCombatStats(characterMetadata: DBMetadataCharacter, simulationMetad
   let substats: StatsValues[] = [...simulationMetadata.substats as SubStats[]]
 
   substats.push(Stats.SPD)
+  if (configType !== ScoringConfigType.DPS) {
+    substats.push(Stats.RES)
+  }
 
   // Dedupe, remove flats, standardize order
   substats = filterUnique(substats).filter((x) => !percentFlatStats[x])

--- a/src/lib/overlays/modals/BuildsModal.tsx
+++ b/src/lib/overlays/modals/BuildsModal.tsx
@@ -33,7 +33,6 @@ import { useScoringStore } from 'lib/stores/scoring/scoringStore'
 import { useCharacterTabStore } from 'lib/tabs/tabCharacters/useCharacterTabStore'
 import { useShowcaseTabStore } from 'lib/tabs/tabShowcase/useShowcaseTabStore'
 import { HeaderText } from 'lib/ui/HeaderText'
-import { getBuildCardStyle } from './buildsModalStyles'
 import {
   type CSSProperties,
   memo,
@@ -328,7 +327,7 @@ const BuildCard = memo(function BuildCard(props: BuildCardProps) {
   return (
     <div
       className={styles.buildCard}
-      style={getBuildCardStyle(selected)}
+      style={{ backgroundColor: selected ? 'var(--layer-3)' : undefined }}
       onClick={(e) => {
         setSelectedBuild(build.name)
         e.stopPropagation()

--- a/src/lib/overlays/modals/BuildsModal.tsx
+++ b/src/lib/overlays/modals/BuildsModal.tsx
@@ -33,6 +33,7 @@ import { useScoringStore } from 'lib/stores/scoring/scoringStore'
 import { useCharacterTabStore } from 'lib/tabs/tabCharacters/useCharacterTabStore'
 import { useShowcaseTabStore } from 'lib/tabs/tabShowcase/useShowcaseTabStore'
 import { HeaderText } from 'lib/ui/HeaderText'
+import { getBuildCardStyle } from './buildsModalStyles'
 import {
   type CSSProperties,
   memo,
@@ -327,9 +328,7 @@ const BuildCard = memo(function BuildCard(props: BuildCardProps) {
   return (
     <div
       className={styles.buildCard}
-      style={{
-        backgroundColor: selected ? 'var(--layer-3)' : 'var(--layer-1)',
-      }}
+      style={getBuildCardStyle(selected)}
       onClick={(e) => {
         setSelectedBuild(build.name)
         e.stopPropagation()

--- a/src/lib/scoring/benchmarkPoolState.ts
+++ b/src/lib/scoring/benchmarkPoolState.ts
@@ -152,7 +152,8 @@ export function resolveComboSpdTarget(
 
   // Zero-mains sim to determine the natural basic SPD for Poet breakpoint detection.
   // Sets like Poet give negative SPD, so each combo needs its own check.
-  const zeroSpdFlags: SimulationFlags = { ...setCombinationFlags, benchmarkBasicSpdTarget: 0 }
+  // Zero both targets so the probe measures natural SPD in isolation.
+  const zeroSpdFlags: SimulationFlags = { ...setCombinationFlags, benchmarkBasicSpdTarget: 0, benchmarkBasicResTarget: 0 }
   const zeroSpdResult = runStatSimulations([baselineSim], form, context, {
     ...baselineScoringParams,
     mainStatMultiplier: 0,

--- a/src/lib/scoring/rollCounter.ts
+++ b/src/lib/scoring/rollCounter.ts
@@ -168,8 +168,12 @@ export function calculateMaxSubstatRollCounts(
       )
   }
 
-  // Forced speed/RES rolls will take up slots from the 36 potential max rolls of other stats
-  const totalDeductions = Math.ceil(partialSimulationWrapper.speedRollsDeduction) + Math.ceil(partialSimulationWrapper.resRollsDeduction) - 6
+  // Approximate: a stat present on all 6 relics gets up to 6 base rolls (1 per piece) that don't
+  // consume upgrade slots. Only forced rolls beyond that are upgrades that displace other stats.
+  const BASE_ROLLS_PER_STAT = 6
+  const spdUpgrades = Math.max(0, Math.ceil(partialSimulationWrapper.speedRollsDeduction) - BASE_ROLLS_PER_STAT)
+  const resUpgrades = Math.max(0, Math.ceil(partialSimulationWrapper.resRollsDeduction) - BASE_ROLLS_PER_STAT)
+  const totalDeductions = spdUpgrades + resUpgrades
   for (const stat of SubStats) {
     if (stat == Stats.SPD) continue
     if (stat == Stats.RES && partialSimulationWrapper.resRollsDeduction > 0) continue

--- a/src/lib/services/buildConverter.test.ts
+++ b/src/lib/services/buildConverter.test.ts
@@ -1,7 +1,6 @@
 // @vitest-environment jsdom
 import { Kafka } from 'lib/conditionals/character/1000/Kafka'
 import { Jingliu } from 'lib/conditionals/character/1200/Jingliu'
-import { DEFAULT_TEAM } from 'lib/constants/constants'
 import { ComboType } from 'lib/optimization/rotation/comboType'
 import { Metadata } from 'lib/state/metadataInitializer'
 import {
@@ -174,31 +173,26 @@ function makeSimTeammate(overrides: Partial<Teammate> = {}): Teammate {
 
 describe('serializeFromCharacterTab', () => {
   it('source is BuildSource.Character', () => {
-    const result = serializeFromCharacterTab('Test', makeCharacter(), undefined, undefined)
+    const result = serializeFromCharacterTab('Test', makeCharacter(), undefined)
     expect(result.source).toBe(BuildSource.Character)
   })
 
   it('has no conditionals, rotation, or deprioritizeBuffs on output', () => {
-    const result = serializeFromCharacterTab('Test', makeCharacter(), undefined, undefined)
+    const result = serializeFromCharacterTab('Test', makeCharacter(), undefined)
     expect('characterConditionals' in result).toBe(false)
     expect('lightConeConditionals' in result).toBe(false)
     expect('comboType' in result).toBe(false)
     expect('deprioritizeBuffs' in result).toBe(false)
   })
 
-  it('default team stores [null, null, null]', () => {
-    const result = serializeFromCharacterTab('Test', makeCharacter(), undefined, undefined)
+  it('no teammates stores [null, null, null]', () => {
+    const result = serializeFromCharacterTab('Test', makeCharacter(), undefined)
     expect(result.team).toEqual([null, null, null])
   })
 
-  it('default team selection string stores [null, null, null]', () => {
-    const result = serializeFromCharacterTab('Test', makeCharacter(), [makeSimTeammate()], DEFAULT_TEAM)
-    expect(result.team).toEqual([null, null, null])
-  })
-
-  it('custom team stores teammate identity + sets, no conditionals', () => {
+  it('stores teammate identity + sets, no conditionals', () => {
     const teammates = [makeSimTeammate(), makeSimTeammate({ characterId: Kafka.id })]
-    const result = serializeFromCharacterTab('Test', makeCharacter(), teammates, 'CustomTeam')
+    const result = serializeFromCharacterTab('Test', makeCharacter(), teammates)
     expect(result.team[0]).not.toBeNull()
     expect(result.team[0]!.characterId).toBe(Jingliu.id)
     expect(result.team[0]!.teamRelicSet).toBe('SetA')
@@ -208,14 +202,14 @@ describe('serializeFromCharacterTab', () => {
   })
 
   it('captures characterEidolon, lightCone, lightConeSuperimposition from form', () => {
-    const result = serializeFromCharacterTab('Test', makeCharacter(), undefined, undefined)
+    const result = serializeFromCharacterTab('Test', makeCharacter(), undefined)
     expect(result.characterEidolon).toBe(2)
     expect(result.lightCone).toBe('21001')
     expect(result.lightConeSuperimposition).toBe(3)
   })
 
   it('captures equipped from character', () => {
-    const result = serializeFromCharacterTab('Test', makeCharacter(), undefined, undefined)
+    const result = serializeFromCharacterTab('Test', makeCharacter(), undefined)
     expect(result.equipped).toEqual({ Head: 'r1', Body: 'r2' })
   })
 })
@@ -400,7 +394,7 @@ describe('deserializeBuild', () => {
 
     it('character tab: serialize then deserialize returns only LC + eidolon overrides', () => {
       const character = makeCharacter()
-      const serialized = serializeFromCharacterTab('Test', character, undefined, undefined)
+      const serialized = serializeFromCharacterTab('Test', character, undefined)
       const patch = deserializeBuild(
         serialized,
         makeForm({

--- a/src/lib/services/buildConverter.ts
+++ b/src/lib/services/buildConverter.ts
@@ -1,4 +1,3 @@
-import { DEFAULT_TEAM } from 'lib/constants/constants'
 import type { SetConditionals } from 'lib/optimization/combo/comboTypes'
 import { createDefaultTeammate } from 'lib/stores/optimizerForm/optimizerFormDefaults'
 import type {
@@ -14,6 +13,7 @@ import type {
   Teammate,
 } from 'types/form'
 import type { LightConeId } from 'types/lightCone'
+import type { ScoringConfigType } from 'types/metadata'
 import {
   type Build,
   BuildSource,
@@ -94,10 +94,9 @@ export function serializeFromCharacterTab(
   name: string,
   character: Character,
   teammates: Teammate[] | undefined,
-  teamSelection: string | undefined,
+  scoringConfigType?: ScoringConfigType,
 ): CharacterSavedBuild {
-  const isCustom = teamSelection != null && teamSelection !== DEFAULT_TEAM
-  const team: TeamTuple<SavedTeammate> = isCustom && teammates
+  const team: TeamTuple<SavedTeammate> = teammates
     ? teammatesFromSimulation(teammates)
     : [null, null, null]
 
@@ -110,6 +109,7 @@ export function serializeFromCharacterTab(
     lightCone: character.form.lightCone,
     lightConeSuperimposition: character.form.lightConeSuperimposition,
     team,
+    ...(scoringConfigType != null && { scoringConfigType }),
   }
 }
 

--- a/src/lib/services/buildService.ts
+++ b/src/lib/services/buildService.ts
@@ -1,9 +1,16 @@
 import i18next from 'i18next'
-import { handleTeamSelection } from 'lib/characterPreview/characterPreviewController'
+import {
+  handleTeamSelection,
+  resolveScoringType,
+} from 'lib/characterPreview/characterPreviewController'
 import { AppPages } from 'lib/constants/appPages'
 import { DEFAULT_TEAM } from 'lib/constants/constants'
 import { SavedSessionKeys } from 'lib/constants/constantsSession'
 import { getDefaultForm } from 'lib/optimization/defaultForm'
+import {
+  CONFIG_FIELD_MAP,
+  configTypeForScoringType,
+} from 'lib/scoring/scoringConfig'
 import {
   deserializeBuild,
   serializeFromCharacterTab,
@@ -49,12 +56,17 @@ export function saveBuild(
     const equipped = useOptimizerDisplayStore.getState().optimizerBuild ?? {}
     build = serializeFromOptimizer(name, characterId, state as typeof state & { lightCone: LightConeId }, equipped)
   } else {
-    const rawTeamSelection = useShowcaseTabStore.getState().showcaseTeamPreferenceByConfig[characterId]?.[ScoringConfigType.DPS]
-    const teamSelection = handleTeamSelection(character, rawTeamSelection)
-    const simulation = getScoringMetadata(character.id)?.simulation
+    const scoringMetadata = getScoringMetadata(character.id)
+    const storedScoringType = useGlobalStore.getState().savedSession.scoringType
+    const effectiveScoringType = resolveScoringType(storedScoringType, scoringMetadata)
+    const configType = configTypeForScoringType(effectiveScoringType) ?? ScoringConfigType.DPS
+    const metadataField = CONFIG_FIELD_MAP[configType]
+    const rawTeamSelection = useShowcaseTabStore.getState().showcaseTeamPreferenceByConfig[characterId]?.[configType]
+    const teamSelection = handleTeamSelection(character, rawTeamSelection, metadataField)
+    const simulation = scoringMetadata[metadataField]
     const useCustom = simulation && teamSelection !== DEFAULT_TEAM
-    const teammates = useCustom ? simulation.teammates : getGameMetadata().characters[characterId]?.scoringMetadata?.simulation?.teammates
-    build = serializeFromCharacterTab(name, character, teammates, teamSelection)
+    const teammates = useCustom ? simulation.teammates : getGameMetadata().characters[characterId]?.scoringMetadata?.[metadataField]?.teammates
+    build = serializeFromCharacterTab(name, character, teammates, configType)
   }
 
   const builds = [...(character.builds ?? [])]

--- a/src/lib/simulations/orchestrator/runDpsScoreBenchmarkOrchestrator.ts
+++ b/src/lib/simulations/orchestrator/runDpsScoreBenchmarkOrchestrator.ts
@@ -145,7 +145,7 @@ export function resolveSimulationMetadata(
   const simulation = { ...defaultSimulation }
   simulation.teammates = getTeammates(teamSelection, customSimulation, defaultSimulation, buildOverride)
 
-  // deprioritizeBuffs is DPS-only — always false for non-DPS
+  // Non-DPS scoring always deprioritizes teammate buffs to isolate the support's own contribution
   if (SCORING_CONFIG_REGISTRY[configType].supportsDeprioritizeBuffs) {
     simulation.deprioritizeBuffs = buildOverride?.source === BuildSource.Optimizer
       ? buildOverride.deprioritizeBuffs

--- a/src/lib/spine/SpinePortrait.tsx
+++ b/src/lib/spine/SpinePortrait.tsx
@@ -83,7 +83,10 @@ export function SpinePortrait({
       const files = getSkeletonFiles(characterId, count)
       const baseUrl = getSpineAssetBaseUrl(characterId)
 
-      createSpineInstance(canvas, baseUrl, files, abortController.signal)
+      const handleRenderError = () => {
+        if (!disposed) onUnsupportedRef.current?.()
+      }
+      createSpineInstance(canvas, baseUrl, files, abortController.signal, handleRenderError)
         .then((instance) => {
           if (disposed) {
             instance.dispose()

--- a/src/lib/spine/spineEngine.ts
+++ b/src/lib/spine/spineEngine.ts
@@ -67,6 +67,7 @@ export async function createSpineInstance(
   baseUrl: string,
   files: { skelFile: string, atlasFile: string }[],
   signal?: AbortSignal,
+  onError?: () => void,
 ): Promise<SpineInstance> {
   // Fast-path if already aborted before we did any work.
   if (signal?.aborted) {
@@ -212,42 +213,75 @@ export async function createSpineInstance(
   renderer.camera.setViewport(canvasSize, canvasSize)
   renderer.camera.update()
 
-  // Lifecycle invariant: `rafId != null` iff the loop is scheduled.
-  // `rafId == null && !disposed` means paused. `disposed` is terminal.
   let rafId: number | null = null
   let lastTime = performance.now()
   let disposed = false
+  let firstFrame = true
+
+  function dispose() {
+    if (disposed) return
+    disposed = true
+    if (rafId != null) {
+      cancelAnimationFrame(rafId)
+      rafId = null
+    }
+    canvas.removeEventListener('webglcontextlost', handleContextLost)
+    renderer.dispose()
+    assetManager.dispose()
+  }
+
+  function handleContextLost() {
+    dispose()
+    onError?.()
+  }
+
+  canvas.addEventListener('webglcontextlost', handleContextLost)
 
   const FRAME_INTERVAL = 1000 / 60
 
   function loop(now: number) {
+    if (disposed) return
     rafId = requestAnimationFrame(loop)
 
     if (now - lastTime < FRAME_INTERVAL) return
 
-    const delta = Math.min((now - lastTime) / 1000, 0.1)
-    lastTime = now
+    try {
+      const delta = Math.min((now - lastTime) / 1000, 0.1)
+      lastTime = now
 
-    for (const entry of entries) {
-      entry.animState.update(delta)
-      entry.animState.apply(entry.skeleton)
-      entry.skeleton.updateWorldTransform()
+      for (const entry of entries) {
+        entry.animState.update(delta)
+        entry.animState.apply(entry.skeleton)
+        entry.skeleton.updateWorldTransform()
+      }
+
+      gl.viewport(0, 0, canvasSize, canvasSize)
+      gl.clearColor(0, 0, 0, 0)
+      gl.clear(gl.COLOR_BUFFER_BIT)
+
+      renderer.begin()
+      for (const entry of entries) {
+        renderer.drawSkeleton(entry.skeleton, false)
+      }
+      renderer.end()
+
+      if (firstFrame) {
+        firstFrame = false
+        const glError = gl.getError()
+        if (glError !== gl.NO_ERROR) {
+          throw new Error(`WebGL error after first frame: 0x${glError.toString(16)}`)
+        }
+      }
+    } catch (err) {
+      console.error('SpinePortrait: render error', err)
+      dispose()
+      onError?.()
+      return
     }
-
-    gl.viewport(0, 0, canvasSize, canvasSize)
-    gl.clearColor(0, 0, 0, 0)
-    gl.clear(gl.COLOR_BUFFER_BIT)
-
-    renderer.begin()
-    for (const entry of entries) {
-      renderer.drawSkeleton(entry.skeleton, false)
-    }
-    renderer.end()
   }
 
   if (signal?.aborted) {
-    renderer.dispose()
-    assetManager.dispose()
+    dispose()
     throw new DOMException('Spine load aborted', 'AbortError')
   }
 
@@ -263,18 +297,11 @@ export async function createSpineInstance(
     },
     resume() {
       if (disposed || rafId != null) return
-      lastTime = performance.now() // avoid a large delta on the resumed frame
+      lastTime = performance.now()
       rafId = requestAnimationFrame(loop)
     },
     dispose() {
-      if (disposed) return
-      disposed = true
-      if (rafId != null) {
-        cancelAnimationFrame(rafId)
-        rafId = null
-      }
-      renderer.dispose()
-      assetManager.dispose()
+      dispose()
     },
   }
 }

--- a/src/lib/tabs/tabOptimizer/optimizerForm/components/CharacterSelectorDisplay.tsx
+++ b/src/lib/tabs/tabOptimizer/optimizerForm/components/CharacterSelectorDisplay.tsx
@@ -47,6 +47,11 @@ const sortKeyToStat: Record<string, string> = {
   ERR: Stats.ERR,
 }
 
+export function handleResultSortSelectChange(val: SortOptionKey | null) {
+  if (val == null) return
+  useOptimizerRequestStore.getState().setResultSort(val)
+}
+
 export function CharacterSelectorDisplay() {
   const { t } = useTranslation(['optimizerTab', 'common'])
   const optimizerTabFocusCharacter = useOptimizerDisplayStore((s) => s.focusCharacterId)
@@ -255,7 +260,8 @@ export function CharacterSelectorDisplay() {
           )
         }}
         value={resultSort}
-        onChange={(val) => useOptimizerRequestStore.getState().setResultSort((val ?? undefined) as keyof typeof SortOption | undefined)}
+        onChange={(val) => handleResultSortSelectChange(val as SortOptionKey | null)}
+        allowDeselect={false}
         maxDropdownHeight={900}
         classNames={{ dropdown: classes.sortTargetDropdown }}
         comboboxProps={{

--- a/src/types/resources.d.ts
+++ b/src/types/resources.d.ts
@@ -153,7 +153,7 @@ export default interface Resources {
           "Standard": "Standard"
         },
         "PaletteLabel": "Portrait color palette",
-        "ShowL2D": "Show Live2D",
+        "ShowL2D": "Animations",
         "ShowUID": "Show UID"
       },
       "DMGUpgrades": "Damage Upgrades",

--- a/src/types/savedBuild.ts
+++ b/src/types/savedBuild.ts
@@ -5,6 +5,7 @@ import type { TurnAbilityName } from 'lib/optimization/rotation/turnAbilityConfi
 import type { CharacterId } from 'types/character'
 import type { ConditionalValueMap } from 'types/conditionals'
 import type { LightConeId } from 'types/lightCone'
+import type { ScoringConfigType } from 'types/metadata'
 import type { Relic } from 'types/relic'
 
 export type Build = Partial<Record<Parts, Relic['id']>>
@@ -38,6 +39,7 @@ type SavedBuildBase = {
   characterEidolon: number,
   lightCone: LightConeId,
   lightConeSuperimposition: number,
+  scoringConfigType?: ScoringConfigType,
 }
 
 export type CharacterSavedBuild = SavedBuildBase & {


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

- Add runtime failure handling for Spine WebGL portraits -> fall back to static image on context loss, render errors, or GL errors after first frame
- Save build scoring config type so saved builds restore the correct scoring mode
- Fix RES stat appearing in combat stats panel for non-DPS scoring configs
- Fix roll counter deduction math -> account for base rolls per stat before deducting from max
- Zero RES target alongside SPD target in benchmark SPD probe to isolate natural SPD
- Save teammates from character tab unconditionally instead of requiring custom team selection
- Prevent result sort deselection on optimizer tab
- Rename "Show Live2D" label to "Animations"
- Remove selected build card background color when not selected

## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [ ] I have added commit messages that are descriptive and meaningful.
- [ ] I have tested the changes locally.
- [ ] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
