### PR TITLE
feat: tribbie additional dmg tick

### DIFF
--- a/public/locales/en_US/conditionals.yaml
+++ b/public/locales/en_US/conditionals.yaml
@@ -24,6 +24,9 @@ Common:
   DotTickCoefficient:
     Text: 'DOT tick coefficient'
     Content: 'DOT damage percentage per rotation action, accounting for total ticks from enemy turns, detonations, and other sources. 100% = 1 tick of DOT damage.'
+  AdditionalTickCoefficient:
+    Text: 'Additional DMG tick coefficient'
+    Content: 'Multiplier for sources of Additional DMG outside the combo. 100% = 1 instance of Additional DMG.'
 Lightcones:
   AGroundedAscent:
     Content:

--- a/src/lib/conditionals/character/1000/Kafka.ts
+++ b/src/lib/conditionals/character/1000/Kafka.ts
@@ -88,7 +88,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   }
 
   const defaults = {
-    dotTickCoefficient: 4,
+    tickCoefficient: 4,
     e1DotDmgReceivedDebuff: true,
     e2TeamDotBoost: true,
   }
@@ -99,8 +99,8 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   }
 
   const content: ContentDefinition<typeof defaults> = {
-    dotTickCoefficient: {
-      id: 'dotTickCoefficient',
+    tickCoefficient: {
+      id: 'tickCoefficient',
       formItem: 'slider',
       text: tDot('Text'),
       content: tDot('Content'),
@@ -191,7 +191,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
               .dotBaseChance(1.30)
               .damageElement(ElementTag.Lightning)
               .atkScaling(dotScaling + (e >= 6 ? e6DotScaling : 0))
-              .dotTickCoefficient(r.dotTickCoefficient)
+              .tickCoefficient(r.tickCoefficient)
               .build(),
           ],
         },

--- a/src/lib/conditionals/character/1000/KafkaB1.ts
+++ b/src/lib/conditionals/character/1000/KafkaB1.ts
@@ -122,7 +122,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   }
 
   const defaults = {
-    dotTickCoefficient: 4,
+    tickCoefficient: 4,
     ehrBasedBuff: true,
     e1DotDmgReceivedDebuff: true,
     e2TeamDotDmg: true,
@@ -141,8 +141,8 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
       text: t('ehrBasedBuff.text'),
       content: t('ehrBasedBuff.content'),
     },
-    dotTickCoefficient: {
-      id: 'dotTickCoefficient',
+    tickCoefficient: {
+      id: 'tickCoefficient',
       formItem: 'slider',
       text: tDot('Text'),
       content: tDot('Content'),
@@ -237,7 +237,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
               .damageElement(ElementTag.Lightning)
               .dotBaseChance(1.00)
               .atkScaling(dotTotalScaling)
-              .dotTickCoefficient(r.dotTickCoefficient)
+              .tickCoefficient(r.tickCoefficient)
               .build(),
           ],
         },

--- a/src/lib/conditionals/character/1100/Luka.ts
+++ b/src/lib/conditionals/character/1100/Luka.ts
@@ -97,7 +97,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   const dotScaling = skill(e, 3.38, 3.718)
 
   const defaults = {
-    dotTickCoefficient: 1,
+    tickCoefficient: 1,
     basicEnhanced: true,
     targetUltDebuffed: true,
     e1TargetBleeding: true,
@@ -130,8 +130,8 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
       min: 0,
       max: 3,
     },
-    dotTickCoefficient: {
-      id: 'dotTickCoefficient',
+    tickCoefficient: {
+      id: 'tickCoefficient',
       formItem: 'slider',
       text: tDot('Text'),
       content: tDot('Content'),
@@ -218,7 +218,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
               .damageElement(ElementTag.Physical)
               .atkScaling(dotScaling)
               .dotBaseChance(1.00)
-              .dotTickCoefficient(r.dotTickCoefficient)
+              .tickCoefficient(r.tickCoefficient)
               .build(),
           ],
         },

--- a/src/lib/conditionals/character/1100/Sampo.ts
+++ b/src/lib/conditionals/character/1100/Sampo.ts
@@ -95,7 +95,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 
   const maxExtraHits = e < 1 ? 4 : 5
   const defaults = {
-    dotTickCoefficient: 20,
+    tickCoefficient: 20,
     targetDotTakenDebuff: true,
     skillExtraHits: maxExtraHits,
     targetWindShear: true,
@@ -126,8 +126,8 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
       text: t('Content.targetWindShear.text'),
       content: t('Content.targetWindShear.content'),
     },
-    dotTickCoefficient: {
-      id: 'dotTickCoefficient',
+    tickCoefficient: {
+      id: 'tickCoefficient',
       formItem: 'slider',
       text: tDot('Text'),
       content: tDot('Content'),
@@ -201,7 +201,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
               .damageElement(ElementTag.Wind)
               .atkScaling(totalDotScaling)
               .dotBaseChance(0.65)
-              .dotTickCoefficient(r.dotTickCoefficient)
+              .tickCoefficient(r.tickCoefficient)
               .build(),
           ],
         },

--- a/src/lib/conditionals/character/1300/BlackSwan.ts
+++ b/src/lib/conditionals/character/1300/BlackSwan.ts
@@ -88,7 +88,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   const dotChance = talent(e, 0.65, 0.68)
 
   const defaults = {
-    dotTickCoefficient: 2,
+    tickCoefficient: 2,
     ehrToDmgBoost: true,
     epiphanyDebuff: true,
     defDecreaseDebuff: true,
@@ -133,8 +133,8 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
       min: 1,
       max: 50,
     },
-    dotTickCoefficient: {
-      id: 'dotTickCoefficient',
+    tickCoefficient: {
+      id: 'tickCoefficient',
       formItem: 'slider',
       text: tDot('Text'),
       content: tDot('Content'),
@@ -221,7 +221,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
               .damageElement(ElementTag.Wind)
               .damageType(DamageTag.DOT)
               .atkScaling(dotScaling + arcanaStackMultiplier * r.arcanaStacks)
-              .dotTickCoefficient(r.dotTickCoefficient)
+              .tickCoefficient(r.tickCoefficient)
               .build(),
           ],
         },

--- a/src/lib/conditionals/character/1300/BlackSwanB1.ts
+++ b/src/lib/conditionals/character/1300/BlackSwanB1.ts
@@ -104,7 +104,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   const arcanaStackLimit = e >= 6 ? 80 : 50
 
   const defaults = {
-    dotTickCoefficient: 2,
+    tickCoefficient: 2,
     skillDefShred: true,
     epiphanyDebuff: true,
     arcanaStacks: arcanaStackLimit,
@@ -152,8 +152,8 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
       text: t('Content.ehrToDmgBoost.text'),
       content: t('Content.ehrToDmgBoost.content', {}),
     },
-    dotTickCoefficient: {
-      id: 'dotTickCoefficient',
+    tickCoefficient: {
+      id: 'tickCoefficient',
       formItem: 'slider',
       text: tDot('Text'),
       content: tDot('Content'),
@@ -250,7 +250,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
               .damageElement(ElementTag.Wind)
               .damageType(DamageTag.DOT)
               .atkScaling(dotScaling + arcanaStackMultiplier * r.arcanaStacks)
-              .dotTickCoefficient(r.dotTickCoefficient)
+              .tickCoefficient(r.tickCoefficient)
               .build(),
           ],
         },

--- a/src/lib/conditionals/character/1400/Hysilens.ts
+++ b/src/lib/conditionals/character/1400/Hysilens.ts
@@ -111,7 +111,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   const maxUltDotInstances = e >= 6 ? 12 : 8
 
   const defaults = {
-    dotTickCoefficient: 1.25,
+    tickCoefficient: 1.25,
     skillVulnerability: true,
     ultZone: true,
     ultDotStacks: maxUltDotInstances,
@@ -171,8 +171,8 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
       text: t('Content.cyreneSpecialEffect.text'),
       content: t('Content.cyreneSpecialEffect.content'),
     },
-    dotTickCoefficient: {
-      id: 'dotTickCoefficient',
+    tickCoefficient: {
+      id: 'tickCoefficient',
       formItem: 'slider',
       text: tDot('Text'),
       content: tDot('Content'),
@@ -293,31 +293,31 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
               .dotBaseChance(1.0)
               .damageElement(ElementTag.Fire)
               .atkScaling(actualTalentDot)
-              .dotTickCoefficient(r.dotTickCoefficient)
+              .tickCoefficient(r.tickCoefficient)
               .build(),
             HitDefinitionBuilder.standardDot()
               .dotBaseChance(1.0)
               .damageElement(ElementTag.Wind)
               .atkScaling(actualTalentDot)
-              .dotTickCoefficient(r.dotTickCoefficient)
+              .tickCoefficient(r.tickCoefficient)
               .build(),
             HitDefinitionBuilder.standardDot()
               .dotBaseChance(1.0)
               .damageElement(ElementTag.Lightning)
               .atkScaling(actualTalentDot)
-              .dotTickCoefficient(r.dotTickCoefficient)
+              .tickCoefficient(r.tickCoefficient)
               .build(),
             HitDefinitionBuilder.standardDot()
               .dotBaseChance(1.0)
               .damageElement(ElementTag.Physical)
               .atkScaling(actualTalentDot)
-              .dotTickCoefficient(r.dotTickCoefficient)
+              .tickCoefficient(r.tickCoefficient)
               .build(),
             HitDefinitionBuilder.standardDot()
               .dotBaseChance(1.0)
               .damageElement(ElementTag.Physical)
               .atkScaling(actualUltDot)
-              .dotTickCoefficient(r.dotTickCoefficient)
+              .tickCoefficient(r.tickCoefficient)
               .build(),
           ],
         },

--- a/src/lib/conditionals/character/1400/Tribbie.ts
+++ b/src/lib/conditionals/character/1400/Tribbie.ts
@@ -33,7 +33,8 @@ import {
   AbilityKind,
   DEFAULT_FUA,
   DEFAULT_ULT,
-  END_ULT,
+  DEFAULT_UNIQUE,
+  END_FUA,
   NULL_TURN_ABILITY_NAME,
   START_SKILL,
   WHOLE_BASIC,
@@ -64,13 +65,16 @@ import {
 export const TribbieEntities = createEnum('Tribbie')
 export const TribbieAbilities: AbilityKind[] = [
   AbilityKind.BASIC,
+  AbilityKind.SKILL,
   AbilityKind.ULT,
   AbilityKind.FUA,
+  AbilityKind.UNIQUE,
   AbilityKind.BREAK,
 ]
 
 const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsController => {
   const t = wrappedFixedT(withContent).get(null, 'conditionals', 'Characters.Tribbie.Content')
+  const tUnique = wrappedFixedT(withContent).get(null, 'conditionals', 'Common.AdditionalTickCoefficient')
   const { basic, skill, ult, talent } = AbilityEidolon.ULT_BASIC_3_SKILL_TALENT_5
   const {
     SOURCE_BASIC,
@@ -101,6 +105,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     ultZone: true,
     alliesMaxHp: 25000,
     talentFuaStacks: 3,
+    uniqueTickCoefficient: 8,
     cyreneSpecialEffect: true,
     e1TrueDmg: true,
     e2AdditionalDmg: true,
@@ -147,6 +152,15 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
       content: t('talentFuaStacks.content'),
       min: 0,
       max: 3,
+    },
+    uniqueTickCoefficient: {
+      id: 'uniqueTickCoefficient',
+      formItem: 'slider',
+      text: tUnique('Text'),
+      content: tUnique('Content'),
+      min: 0,
+      max: 30,
+      percent: true,
     },
     cyreneSpecialEffect: {
       id: 'cyreneSpecialEffect',
@@ -229,7 +243,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
               .hpScaling(basicScaling)
               .toughnessDmg(10)
               .build(),
-            // Additional damage from ultZone (HP-based)
             ...(
               (totalAdditionalScaling > 0)
                 ? [
@@ -242,6 +255,9 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
             ),
           ],
         },
+        [AbilityKind.SKILL]: {
+          hits: [],
+        },
         [AbilityKind.ULT]: {
           hits: [
             HitDefinitionBuilder.standardUlt()
@@ -249,7 +265,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
               .hpScaling(ultScaling)
               .toughnessDmg(20)
               .build(),
-            // Additional damage from ultZone (HP-based)
             ...(
               (totalAdditionalScaling > 0)
                 ? [
@@ -269,13 +284,27 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
               .hpScaling(talentScaling)
               .toughnessDmg(5)
               .build(),
-            // Additional damage from ultZone (HP-based)
             ...(
               (totalAdditionalScaling > 0)
                 ? [
                   HitDefinitionBuilder.standardAdditional()
                     .damageElement(ElementTag.Quantum)
                     .hpScaling(totalAdditionalScaling)
+                    .build(),
+                ]
+                : []
+            ),
+          ],
+        },
+        [AbilityKind.UNIQUE]: {
+          hits: [
+            ...(
+              (totalAdditionalScaling > 0)
+                ? [
+                  HitDefinitionBuilder.standardAdditional()
+                    .damageElement(ElementTag.Quantum)
+                    .hpScaling(totalAdditionalScaling)
+                    .tickCoefficient(r.uniqueTickCoefficient)
                     .build(),
                 ]
                 : []
@@ -362,16 +391,13 @@ const simulation = (): SimulationMetadata => ({
   ],
   comboTurnAbilities: [
     NULL_TURN_ABILITY_NAME,
+    START_SKILL,
     DEFAULT_ULT,
-    DEFAULT_FUA,
-    DEFAULT_FUA,
-    WHOLE_BASIC,
-    DEFAULT_FUA,
-    DEFAULT_ULT,
-    DEFAULT_FUA,
+    END_FUA,
     WHOLE_BASIC,
     DEFAULT_FUA,
     DEFAULT_FUA,
+    DEFAULT_UNIQUE,
   ],
   errRopeEidolon: 0,
   deprioritizeBuffs: true,

--- a/src/lib/optimization/engine/damage/damageCalculator.ts
+++ b/src/lib/optimization/engine/damage/damageCalculator.ts
@@ -218,7 +218,7 @@ export const DotDamageFunction: DamageFunction = {
     const ehrMulti = calculateEhrMultiFromHit(x, hit, hitIndex, context)
     const trueDmgMulti = 1 + x.getValue(StatKey.TRUE_DMG_MODIFIER, hitIndex) + (hit.trueDmgModifier ?? 0)
 
-    const dotTickCoefficientMulti = hit.dotTickCoefficient ?? 1
+    const tickCoefficientMulti = hit.tickCoefficient ?? 1
 
     const dmg = m.baseUniversalMulti
       * m.defMulti
@@ -229,7 +229,7 @@ export const DotDamageFunction: DamageFunction = {
       * abilityMulti
       * ehrMulti
       * trueDmgMulti
-      * dotTickCoefficientMulti
+      * tickCoefficientMulti
 
     return dmg
   },
@@ -258,7 +258,7 @@ export const DotDamageFunction: DamageFunction = {
     const dotBaseChance = hit.dotBaseChance
     const dotSplit = hit.dotSplit ?? 0
     const dotStacks = hit.dotStacks ?? 1
-    const dotTickCoefficientMulti = hit.dotTickCoefficient ?? 1
+    const tickCoefficientMulti = hit.tickCoefficient ?? 1
     const shouldRecord = hit.recorded !== false
 
     const enemyEffectRes = context.enemyEffectResistance
@@ -307,7 +307,7 @@ export const DotDamageFunction: DamageFunction = {
     * abilityMulti
     * ehrMulti
     * trueDmgMulti
-    * ${dotTickCoefficientMulti};
+    * ${tickCoefficientMulti};
 
   ${shouldRecord ? 'comboDmg += damage;' : ''}
 
@@ -501,6 +501,7 @@ export const AdditionalDamageFunction: DamageFunction = {
     const abilityMulti = calculateInitialDamage(x, hit, hitIndex, context)
     const critMulti = getAdditionalCritMultiplier(x, hit, hitIndex)
     const trueDmgMulti = 1 + x.getValue(StatKey.TRUE_DMG_MODIFIER, hitIndex) + (hit.trueDmgModifier ?? 0)
+    const tickCoefficientMulti = hit.tickCoefficient ?? 1
 
     const dmg = m.baseUniversalMulti
       * m.defMulti
@@ -511,6 +512,7 @@ export const AdditionalDamageFunction: DamageFunction = {
       * abilityMulti
       * critMulti
       * trueDmgMulti
+      * tickCoefficientMulti
 
     return dmg
   },
@@ -542,6 +544,7 @@ export const AdditionalDamageFunction: DamageFunction = {
     const cdExpr = hit.cdOverride != null
       ? `${hit.cdOverride}`
       : `${getValue(StatKey.CD)} + ${getValue(StatKey.CD_BOOST)}`
+    const tickCoefficientMulti = hit.tickCoefficient ?? 1
     const shouldRecord = hit.recorded !== false
 
     return wgsl`
@@ -581,7 +584,8 @@ export const AdditionalDamageFunction: DamageFunction = {
     * dmgBoostMulti
     * abilityMulti
     * critMulti
-    * trueDmgMulti;
+    * trueDmgMulti
+    * ${tickCoefficientMulti};
 
   ${shouldRecord ? 'comboDmg += damage;' : ''}
   ${wgslDebugHitRegister(hit, context)}

--- a/src/lib/simulations/tests/dpsScore/dpsScoreOrchestrator.test.ts
+++ b/src/lib/simulations/tests/dpsScore/dpsScoreOrchestrator.test.ts
@@ -235,7 +235,7 @@ test('Tribbie benchmark poet 88.3', async () => {
       mains: testMains(Stats.CD, Stats.HP_P, Stats.Quantum_DMG, Stats.HP_P),
       stats: testStatSpreadSpd(0),
     }),
-    0.8821384217458543,
+    0.9009106288793595,
   )
 }, TIMEOUT)
 
@@ -250,7 +250,7 @@ test('Tribbie benchmark poet 101.3', async () => {
       mains: testMains(Stats.CD, Stats.HP_P, Stats.Quantum_DMG, Stats.HP_P),
       stats: testStatSpreadSpd(5),
     }),
-    0.7116109697654351,
+    0.7286561551228741,
   )
 }, TIMEOUT)
 
@@ -265,7 +265,7 @@ test('Tribbie benchmark poet 114.3', async () => {
       mains: testMains(Stats.CD, Stats.HP_P, Stats.Quantum_DMG, Stats.HP_P),
       stats: testStatSpreadSpd(10),
     }),
-    0.38504548492980584,
+    0.39831101296360977,
   )
 }, TIMEOUT)
 
@@ -282,7 +282,7 @@ test('Tribbie benchmark poet 88.3 @ 88.3', async () => {
       mains: testMains(Stats.CD, Stats.HP_P, Stats.Quantum_DMG, Stats.HP_P),
       stats: testStatSpreadSpd(0),
     }),
-    0.8821384217458543,
+    0.9009106288793595,
     88.3,
   )
 }, TIMEOUT)
@@ -298,7 +298,7 @@ test('Tribbie benchmark poet 101.3 @ 88.3', async () => {
       mains: testMains(Stats.CD, Stats.HP_P, Stats.Quantum_DMG, Stats.HP_P),
       stats: testStatSpreadSpd(5),
     }),
-    0.6916855241765822,
+    0.7082534362374845,
     88.3,
   )
 }, TIMEOUT)
@@ -314,7 +314,7 @@ test('Tribbie benchmark poet 114.3 @ 88.3', async () => {
       mains: testMains(Stats.CD, Stats.HP_P, Stats.Quantum_DMG, Stats.HP_P),
       stats: testStatSpreadSpd(10),
     }),
-    0.37426402822779453,
+    0.3871581151676927,
     88.3,
   )
 }, TIMEOUT)

--- a/src/lib/tabs/tabOptimizer/analysis/DamageSplitsChart.tsx
+++ b/src/lib/tabs/tabOptimizer/analysis/DamageSplitsChart.tsx
@@ -272,7 +272,7 @@ export function DamageSplitsChart({ data }: { data: DamageSplitEntry[] }) {
           type='number'
           domain={[0, maxTotal]}
           tick={{ fill: chartColor, textRendering: 'geometricPrecision', fontWeight: 300, fontSize: 13 }}
-          tickFormatter={renderThousandsK}
+          tickFormatter={(v: number) => renderThousandsK(v)}
           width={100}
         />
         <YAxis

--- a/src/types/hitConditionalTypes.ts
+++ b/src/types/hitConditionalTypes.ts
@@ -48,6 +48,7 @@ interface BaseHitDefinition {
   defScaling?: number
   // Hit-specific modifiers
   trueDmgModifier?: number
+  tickCoefficient?: number
 }
 
 // Crit hits (default for most abilities)
@@ -64,7 +65,6 @@ export interface DotHitDefinition extends BaseHitDefinition {
   dotBaseChance: number
   dotSplit?: number
   dotStacks?: number
-  dotTickCoefficient?: number
 }
 
 export interface BreakHitDefinition extends BaseHitDefinition {

--- a/src/types/resources.d.ts
+++ b/src/types/resources.d.ts
@@ -3265,6 +3265,10 @@ export default interface Resources {
       }
     },
     "Common": {
+      "AdditionalTickCoefficient": {
+        "Content": "Multiplier for sources of Additional DMG outside the combo. 100% = 1 instance of Additional DMG.",
+        "Text": "Additional DMG tick coefficient"
+      },
       "BuffPriority": {
         "Content": "Select the preferred recipient for single target buffs",
         "Memo": "Buff priority: Memo",


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

- Rename dotTickCoefficient to tickCoefficient and move it from DOT-specific to base hit definition, enabling tick coefficient support for Additional DMG hits
- Add Additional DMG tick coefficient slider for Tribbie to account for extra instances of Additional DMG outside the combo
- Add SKILL and UNIQUE ability kinds to Tribbie with a dedicated Additional DMG hit using the new tick coefficient
- Update Tribbie's combo rotation to include skill and unique ability turns
- Apply tick coefficient multiplier in the Additional DMG damage calculator (both CPU and GPU paths)

## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [ ] I have added commit messages that are descriptive and meaningful.
- [ ] I have tested the changes locally.
- [ ] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
