### PR TITLE
feat: new set presets

### DIFF
--- a/src/lib/conditionals/character/1000/Archer.ts
+++ b/src/lib/conditionals/character/1000/Archer.ts
@@ -352,6 +352,7 @@ const scoring = (): ScoringMetadata => ({
     PresetEffects.fnPioneerSet(4),
     PresetEffects.TENGOKU_SET,
     PresetEffects.fnMortenaxAshblazingSet(8),
+    PresetEffects.fnNavigatorSet(3),
   ],
   sortOption: SortOption.SKILL,
   hiddenColumns: [

--- a/src/lib/conditionals/character/1000/SilverWolfB1.ts
+++ b/src/lib/conditionals/character/1000/SilverWolfB1.ts
@@ -438,6 +438,7 @@ const scoring = (): ScoringMetadata => ({
   presets: [
     PresetEffects.fnPioneerSet(4),
     PresetEffects.fnMortenaxAshblazingSet(1),
+    PresetEffects.MASTER_SMITH_SET,
   ],
   sortOption: SortOption.ULT,
   hiddenColumns: [

--- a/src/lib/conditionals/character/1000/WeltB1.ts
+++ b/src/lib/conditionals/character/1000/WeltB1.ts
@@ -493,6 +493,7 @@ const scoring = (): ScoringMetadata => ({
   presets: [
     PresetEffects.WASTELANDER_SET,
     PresetEffects.fnPioneerSet(4),
+    PresetEffects.MASTER_SMITH_SET,
   ],
   sortOption: SortOption.SKILL,
   hiddenColumns: [

--- a/src/lib/conditionals/character/1100/Pela.ts
+++ b/src/lib/conditionals/character/1100/Pela.ts
@@ -269,6 +269,7 @@ const scoring = (): ScoringMetadata => ({
   presets: [
     PresetEffects.fnPioneerSet(4),
     PresetEffects.fnMortenaxAshblazingSet(5),
+    PresetEffects.MASTER_SMITH_SET,
   ],
   sortOption: SortOption.SPD,
   hiddenColumns: [

--- a/src/lib/conditionals/character/1100/Seele.ts
+++ b/src/lib/conditionals/character/1100/Seele.ts
@@ -241,6 +241,7 @@ const scoring = (): ScoringMetadata => ({
   presets: [
     PresetEffects.TENGOKU_SET,
     PresetEffects.fnMortenaxAshblazingSet(1),
+    PresetEffects.fnNavigatorSet(3),
   ],
   sortOption: SortOption.SKILL,
   hiddenColumns: [

--- a/src/lib/conditionals/character/1200/Fugue.ts
+++ b/src/lib/conditionals/character/1200/Fugue.ts
@@ -388,6 +388,7 @@ const scoring = (): ScoringMetadata => ({
   },
   presets: [
     PresetEffects.fnMortenaxAshblazingSet(8),
+    PresetEffects.MASTER_SMITH_SET,
   ],
   sortOption: SortOption.BASIC,
   hiddenColumns: [

--- a/src/lib/conditionals/character/1300/BlackSwanB1.ts
+++ b/src/lib/conditionals/character/1300/BlackSwanB1.ts
@@ -413,6 +413,7 @@ const scoring = (): ScoringMetadata => ({
   },
   presets: [
     PresetEffects.PRISONER_SET,
+    PresetEffects.MASTER_SMITH_SET,
   ],
   sortOption: SortOption.DOT,
   hiddenColumns: [

--- a/src/lib/conditionals/character/1300/Misha.ts
+++ b/src/lib/conditionals/character/1300/Misha.ts
@@ -331,6 +331,7 @@ const scoring = (): ScoringMetadata => ({
   presets: [
     PresetEffects.fnPioneerSet(4),
     PresetEffects.fnMortenaxAshblazingSet(8),
+    PresetEffects.MASTER_SMITH_SET,
   ],
   sortOption: SortOption.ULT,
   hiddenColumns: [

--- a/src/lib/conditionals/character/1300/TheDahlia.ts
+++ b/src/lib/conditionals/character/1300/TheDahlia.ts
@@ -536,6 +536,7 @@ const scoring = (): ScoringMetadata => ({
   },
   presets: [
     PresetEffects.fnAshblazingSet(5),
+    PresetEffects.MASTER_SMITH_SET,
   ],
   sortOption: SortOption.FUA,
   hiddenColumns: [

--- a/src/lib/conditionals/character/1400/Anaxa.ts
+++ b/src/lib/conditionals/character/1400/Anaxa.ts
@@ -446,7 +446,7 @@ const scoring = (): ScoringMetadata => ({
     PresetEffects.GENIUS_SET,
     PresetEffects.fnMortenaxAshblazingSet(5),
     PresetEffects.MASTER_SMITH_SET,
-    PresetEffects.fnNavigatorSet(3),
+    PresetEffects.fnNavigatorSet(2),
   ],
   sortOption: SortOption.SKILL,
   hiddenColumns: [SortOption.FUA, SortOption.DOT],

--- a/src/lib/conditionals/character/1400/Anaxa.ts
+++ b/src/lib/conditionals/character/1400/Anaxa.ts
@@ -445,6 +445,8 @@ const scoring = (): ScoringMetadata => ({
     PresetEffects.fnPioneerSet(4),
     PresetEffects.GENIUS_SET,
     PresetEffects.fnMortenaxAshblazingSet(5),
+    PresetEffects.MASTER_SMITH_SET,
+    PresetEffects.fnNavigatorSet(3),
   ],
   sortOption: SortOption.SKILL,
   hiddenColumns: [SortOption.FUA, SortOption.DOT],

--- a/src/lib/conditionals/character/1400/Cyrene.ts
+++ b/src/lib/conditionals/character/1400/Cyrene.ts
@@ -544,6 +544,7 @@ const scoring = (): ScoringMetadata => ({
   },
   presets: [
     PresetEffects.BANANA_SET,
+    PresetEffects.MASTER_SMITH_SET,
   ],
   sortOption: SortOption.MEMO_SKILL,
   hiddenColumns: [

--- a/src/lib/conditionals/character/1400/Hysilens.ts
+++ b/src/lib/conditionals/character/1400/Hysilens.ts
@@ -493,6 +493,7 @@ const scoring = (): ScoringMetadata => ({
     PresetEffects.PRISONER_SET,
     PresetEffects.fnPioneerSet(4),
     PresetEffects.fnMortenaxAshblazingSet(5),
+    PresetEffects.MASTER_SMITH_SET,
   ],
   sortOption: SortOption.DOT,
   hiddenColumns: [SortOption.FUA],

--- a/src/lib/conditionals/character/1400/Mydei.ts
+++ b/src/lib/conditionals/character/1400/Mydei.ts
@@ -411,6 +411,7 @@ const scoring = (): ScoringMetadata => ({
   },
   presets: [
     PresetEffects.WASTELANDER_SET,
+    PresetEffects.fnNavigatorSet(3),
   ],
   sortOption: SortOption.SKILL,
   hiddenColumns: [],

--- a/src/lib/conditionals/character/1400/Phainon.ts
+++ b/src/lib/conditionals/character/1400/Phainon.ts
@@ -1,4 +1,5 @@
 import { Sunday } from 'lib/conditionals/character/1300/Sunday'
+import { PresetEffects } from 'lib/scoring/presetEffects'
 import { Cerydra } from 'lib/conditionals/character/1400/Cerydra'
 import {
   Cyrene,
@@ -504,7 +505,9 @@ const scoring = (): ScoringMetadata => ({
       Stats.ATK_P,
     ],
   },
-  presets: [],
+  presets: [
+    PresetEffects.fnNavigatorSet(3),
+  ],
   sortOption: SortOption.SKILL,
   hiddenColumns: [SortOption.DOT],
   simulation: simulation(),

--- a/src/lib/conditionals/character/1500/Ashveil.ts
+++ b/src/lib/conditionals/character/1500/Ashveil.ts
@@ -432,6 +432,7 @@ const scoring = (): ScoringMetadata => ({
     PresetEffects.fnAshblazingSet(8),
     PresetEffects.fnPioneerSet(4),
     PresetEffects.VALOROUS_SET,
+    PresetEffects.MASTER_SMITH_SET,
   ],
   sortOption: SortOption.FUA,
   hiddenColumns: [SortOption.DOT],

--- a/src/lib/conditionals/character/1500/MortenaxBlade.ts
+++ b/src/lib/conditionals/character/1500/MortenaxBlade.ts
@@ -400,7 +400,7 @@ const scoring = (): ScoringMetadata => ({
     PresetEffects.fnPioneerSet(4),
     PresetEffects.VALOROUS_SET,
     PresetEffects.MASTER_SMITH_SET,
-    PresetEffects.fnNavigatorSet(3),
+    PresetEffects.fnNavigatorSet(2),
   ],
   sortOption: SortOption.FUA,
   hiddenColumns: [

--- a/src/lib/conditionals/character/1500/MortenaxBlade.ts
+++ b/src/lib/conditionals/character/1500/MortenaxBlade.ts
@@ -399,6 +399,8 @@ const scoring = (): ScoringMetadata => ({
   presets: [
     PresetEffects.fnPioneerSet(4),
     PresetEffects.VALOROUS_SET,
+    PresetEffects.MASTER_SMITH_SET,
+    PresetEffects.fnNavigatorSet(3),
   ],
   sortOption: SortOption.FUA,
   hiddenColumns: [

--- a/src/lib/conditionals/evaluation/applyPresets.ts
+++ b/src/lib/conditionals/evaluation/applyPresets.ts
@@ -3,6 +3,7 @@ import { Moze } from 'lib/conditionals/character/1200/Moze'
 import { LiesAflutterInTheWind } from 'lib/conditionals/lightcone/5star/LiesAflutterInTheWind'
 import { LifeShouldBeCastToFlames } from 'lib/conditionals/lightcone/5star/LifeShouldBeCastToFlames'
 import { ResolutionShinesAsPearlsOfSweat } from 'lib/conditionals/lightcone/4star/ResolutionShinesAsPearlsOfSweat'
+
 import { TheDahlia } from 'lib/conditionals/character/1300/TheDahlia'
 import { Anaxa } from 'lib/conditionals/character/1400/Anaxa'
 import { Cyrene } from 'lib/conditionals/character/1400/Cyrene'
@@ -39,12 +40,25 @@ import {
 } from 'lib/utils/objectUtils'
 import type { CharacterId } from 'types/character'
 import type { Form } from 'types/form'
+import type { LightConeId } from 'types/lightCone'
 import type { ScoringMetadata } from 'types/metadata'
 
-export type TeammateInfo = { id: CharacterId | undefined, eidolon: number }
+const DEF_REDUCTION_LIGHT_CONES = [
+  LiesAflutterInTheWind.id,
+  LifeShouldBeCastToFlames.id,
+  ResolutionShinesAsPearlsOfSweat.id
+]
+
+export type TeammateInfo = {
+  id: CharacterId | undefined,
+  eidolon: number,
+  lightCone?: LightConeId
+}
+
 type TeammateInfoSource = {
   characterId?: CharacterId | null,
   characterEidolon?: number | null,
+  lightCone?: LightConeId | null,
 } | null | undefined
 
 export function applySpdPreset(spd: number, characterId: CharacterId | null | undefined) {
@@ -131,6 +145,7 @@ export function resolveTeammateInfo(...teammates: TeammateInfoSource[]): Teammat
     .map((teammate) => ({
       id: teammate.characterId ?? undefined,
       eidolon: teammate.characterEidolon ?? 0,
+      lightCone: teammate.lightCone ?? undefined,
     }))
 }
 
@@ -218,7 +233,6 @@ export function applyTeamAwareSetConditionalPresets(form: Form | BenchmarkForm, 
     form.setConditionals[Sets.TheWondrousBananAmusementPark][1] = true
   }
 
-  const DEF_REDUCTION_LIGHT_CONES = [LiesAflutterInTheWind.id, LifeShouldBeCastToFlames.id, ResolutionShinesAsPearlsOfSweat.id]
   const allLightCones = [form.lightCone, ...teammates.map((t) => t.lightCone)].filter((x) => !!x)
   if (allLightCones.some((lc) => DEF_REDUCTION_LIGHT_CONES.includes(lc))) {
     form.setConditionals[Sets.DivineQueryingMasterSmith][1] = 2

--- a/src/lib/conditionals/evaluation/applyPresets.ts
+++ b/src/lib/conditionals/evaluation/applyPresets.ts
@@ -36,12 +36,14 @@ import {
 } from 'lib/utils/objectUtils'
 import type { CharacterId } from 'types/character'
 import type { Form } from 'types/form'
+import type { LightConeId } from 'types/lightCone'
 import type { ScoringMetadata } from 'types/metadata'
 
-export type TeammateInfo = { id: CharacterId | undefined, eidolon: number }
+export type TeammateInfo = { id: CharacterId | undefined, eidolon: number, lightCone?: LightConeId }
 type TeammateInfoSource = {
   characterId?: CharacterId | null,
   characterEidolon?: number | null,
+  lightCone?: LightConeId | null,
 } | null | undefined
 
 export function applySpdPreset(spd: number, characterId: CharacterId | null | undefined) {
@@ -128,6 +130,7 @@ export function resolveTeammateInfo(...teammates: TeammateInfoSource[]): Teammat
     .map((teammate) => ({
       id: teammate.characterId ?? undefined,
       eidolon: teammate.characterEidolon ?? 0,
+      lightCone: teammate.lightCone ?? undefined,
     }))
 }
 
@@ -135,12 +138,16 @@ export function applyScoringMetadataPresets(form: Form | BenchmarkForm, teammate
   const presets = resolveScoringMetadataPresets(form)
 
   for (const preset of presets) {
-    const { teammateCondition } = preset
+    const { teammateCondition, lightConeCondition } = preset
     if (teammateCondition) {
       const match = teammates.some((teammate) =>
         teammate.id === teammateCondition.characterId && teammate.eidolon >= teammateCondition.minEidolon
       )
       if (!match) continue
+    }
+    if (lightConeCondition) {
+      const lcIds = lightConeCondition.lightConeIds
+      if (!lcIds.includes(form.lightCone) && !teammates.some((t) => t.lightCone && lcIds.includes(t.lightCone))) continue
     }
 
     applyPreset(form, preset)
@@ -151,13 +158,21 @@ export function applyTeammateConditionalPresets(form: Form | BenchmarkForm, team
   const presets = resolveScoringMetadataPresets(form)
 
   for (const preset of presets) {
-    const { teammateCondition } = preset
-    if (!teammateCondition) continue
+    const { teammateCondition, lightConeCondition } = preset
+    if (!teammateCondition && !lightConeCondition) continue
 
     const index = preset.index ?? 1
-    const match = teammates.some((teammate) =>
-      teammate.id === teammateCondition.characterId && teammate.eidolon >= teammateCondition.minEidolon
-    )
+    let match = true
+
+    if (teammateCondition) {
+      match = teammates.some((teammate) =>
+        teammate.id === teammateCondition.characterId && teammate.eidolon >= teammateCondition.minEidolon
+      )
+    }
+    if (match && lightConeCondition) {
+      const lcIds = lightConeCondition.lightConeIds
+      match = lcIds.includes(form.lightCone) || teammates.some((t) => t.lightCone && lcIds.includes(t.lightCone))
+    }
 
     form.setConditionals[preset.set][index] = match
       ? preset.value

--- a/src/lib/conditionals/evaluation/applyPresets.ts
+++ b/src/lib/conditionals/evaluation/applyPresets.ts
@@ -1,5 +1,8 @@
 import type { UseFormReturnType } from '@mantine/form'
 import { Moze } from 'lib/conditionals/character/1200/Moze'
+import { LiesAflutterInTheWind } from 'lib/conditionals/lightcone/5star/LiesAflutterInTheWind'
+import { LifeShouldBeCastToFlames } from 'lib/conditionals/lightcone/5star/LifeShouldBeCastToFlames'
+import { ResolutionShinesAsPearlsOfSweat } from 'lib/conditionals/lightcone/4star/ResolutionShinesAsPearlsOfSweat'
 import { TheDahlia } from 'lib/conditionals/character/1300/TheDahlia'
 import { Anaxa } from 'lib/conditionals/character/1400/Anaxa'
 import { Cyrene } from 'lib/conditionals/character/1400/Cyrene'
@@ -36,14 +39,12 @@ import {
 } from 'lib/utils/objectUtils'
 import type { CharacterId } from 'types/character'
 import type { Form } from 'types/form'
-import type { LightConeId } from 'types/lightCone'
 import type { ScoringMetadata } from 'types/metadata'
 
-export type TeammateInfo = { id: CharacterId | undefined, eidolon: number, lightCone?: LightConeId }
+export type TeammateInfo = { id: CharacterId | undefined, eidolon: number }
 type TeammateInfoSource = {
   characterId?: CharacterId | null,
   characterEidolon?: number | null,
-  lightCone?: LightConeId | null,
 } | null | undefined
 
 export function applySpdPreset(spd: number, characterId: CharacterId | null | undefined) {
@@ -130,7 +131,6 @@ export function resolveTeammateInfo(...teammates: TeammateInfoSource[]): Teammat
     .map((teammate) => ({
       id: teammate.characterId ?? undefined,
       eidolon: teammate.characterEidolon ?? 0,
-      lightCone: teammate.lightCone ?? undefined,
     }))
 }
 
@@ -138,16 +138,12 @@ export function applyScoringMetadataPresets(form: Form | BenchmarkForm, teammate
   const presets = resolveScoringMetadataPresets(form)
 
   for (const preset of presets) {
-    const { teammateCondition, lightConeCondition } = preset
+    const { teammateCondition } = preset
     if (teammateCondition) {
       const match = teammates.some((teammate) =>
         teammate.id === teammateCondition.characterId && teammate.eidolon >= teammateCondition.minEidolon
       )
       if (!match) continue
-    }
-    if (lightConeCondition) {
-      const lcIds = lightConeCondition.lightConeIds
-      if (!lcIds.includes(form.lightCone) && !teammates.some((t) => t.lightCone && lcIds.includes(t.lightCone))) continue
     }
 
     applyPreset(form, preset)
@@ -158,21 +154,13 @@ export function applyTeammateConditionalPresets(form: Form | BenchmarkForm, team
   const presets = resolveScoringMetadataPresets(form)
 
   for (const preset of presets) {
-    const { teammateCondition, lightConeCondition } = preset
-    if (!teammateCondition && !lightConeCondition) continue
+    const { teammateCondition } = preset
+    if (!teammateCondition) continue
 
     const index = preset.index ?? 1
-    let match = true
-
-    if (teammateCondition) {
-      match = teammates.some((teammate) =>
-        teammate.id === teammateCondition.characterId && teammate.eidolon >= teammateCondition.minEidolon
-      )
-    }
-    if (match && lightConeCondition) {
-      const lcIds = lightConeCondition.lightConeIds
-      match = lcIds.includes(form.lightCone) || teammates.some((t) => t.lightCone && lcIds.includes(t.lightCone))
-    }
+    const match = teammates.some((teammate) =>
+      teammate.id === teammateCondition.characterId && teammate.eidolon >= teammateCondition.minEidolon
+    )
 
     form.setConditionals[preset.set][index] = match
       ? preset.value
@@ -228,6 +216,12 @@ export function applyTeamAwareSetConditionalPresets(form: Form | BenchmarkForm, 
   // DHPT gives a summon to the primary character, enabling banana set conditional
   if (allyIds.includes(PermansorTerrae.id)) {
     form.setConditionals[Sets.TheWondrousBananAmusementPark][1] = true
+  }
+
+  const DEF_REDUCTION_LIGHT_CONES = [LiesAflutterInTheWind.id, LifeShouldBeCastToFlames.id, ResolutionShinesAsPearlsOfSweat.id]
+  const allLightCones = [form.lightCone, ...teammates.map((t) => t.lightCone)].filter((x) => !!x)
+  if (allLightCones.some((lc) => DEF_REDUCTION_LIGHT_CONES.includes(lc))) {
+    form.setConditionals[Sets.DivineQueryingMasterSmith][1] = 2
   }
 }
 

--- a/src/lib/conditionals/evaluation/applyPresets.ts
+++ b/src/lib/conditionals/evaluation/applyPresets.ts
@@ -1,10 +1,10 @@
 import type { UseFormReturnType } from '@mantine/form'
 import { Moze } from 'lib/conditionals/character/1200/Moze'
-import { SilverWolf } from 'lib/conditionals/character/1000/SilverWolf'
-import { Welt } from 'lib/conditionals/character/1000/Welt'
+import { SilverWolfB1 } from 'lib/conditionals/character/1000/SilverWolfB1'
+import { WeltB1 } from 'lib/conditionals/character/1000/WeltB1'
 import { Pela } from 'lib/conditionals/character/1100/Pela'
 import { Fugue } from 'lib/conditionals/character/1200/Fugue'
-import { BlackSwan } from 'lib/conditionals/character/1300/BlackSwan'
+import { BlackSwanB1 } from 'lib/conditionals/character/1300/BlackSwanB1'
 import { Misha } from 'lib/conditionals/character/1300/Misha'
 import { TheDahlia } from 'lib/conditionals/character/1300/TheDahlia'
 import { Anaxa } from 'lib/conditionals/character/1400/Anaxa'
@@ -59,14 +59,14 @@ const DEF_REDUCTION_LIGHT_CONES = [
 
 const DEF_REDUCTION_CHARACTERS = [
   MortenaxBlade.id,
-  SilverWolf.id,
-  BlackSwan.id,
+  SilverWolfB1.id,
+  BlackSwanB1.id,
   Ashveil.id,
   Hysilens.id,
   Cyrene.id,
   Fugue.id,
   Pela.id,
-  Welt.id,
+  WeltB1.id,
   TheDahlia.id,
   Anaxa.id,
   Misha.id,

--- a/src/lib/conditionals/evaluation/applyPresets.ts
+++ b/src/lib/conditionals/evaluation/applyPresets.ts
@@ -1,14 +1,22 @@
 import type { UseFormReturnType } from '@mantine/form'
 import { Moze } from 'lib/conditionals/character/1200/Moze'
-import { LiesAflutterInTheWind } from 'lib/conditionals/lightcone/5star/LiesAflutterInTheWind'
-import { LifeShouldBeCastToFlames } from 'lib/conditionals/lightcone/5star/LifeShouldBeCastToFlames'
-import { ResolutionShinesAsPearlsOfSweat } from 'lib/conditionals/lightcone/4star/ResolutionShinesAsPearlsOfSweat'
-
+import { SilverWolf } from 'lib/conditionals/character/1000/SilverWolf'
+import { Welt } from 'lib/conditionals/character/1000/Welt'
+import { Pela } from 'lib/conditionals/character/1100/Pela'
+import { Fugue } from 'lib/conditionals/character/1200/Fugue'
+import { BlackSwan } from 'lib/conditionals/character/1300/BlackSwan'
+import { Misha } from 'lib/conditionals/character/1300/Misha'
 import { TheDahlia } from 'lib/conditionals/character/1300/TheDahlia'
 import { Anaxa } from 'lib/conditionals/character/1400/Anaxa'
 import { Cyrene } from 'lib/conditionals/character/1400/Cyrene'
+import { Hysilens } from 'lib/conditionals/character/1400/Hysilens'
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
 import { Phainon } from 'lib/conditionals/character/1400/Phainon'
+import { Ashveil } from 'lib/conditionals/character/1500/Ashveil'
+import { MortenaxBlade } from 'lib/conditionals/character/1500/MortenaxBlade'
+import { LiesAflutterInTheWind } from 'lib/conditionals/lightcone/5star/LiesAflutterInTheWind'
+import { LifeShouldBeCastToFlames } from 'lib/conditionals/lightcone/5star/LifeShouldBeCastToFlames'
+import { ResolutionShinesAsPearlsOfSweat } from 'lib/conditionals/lightcone/4star/ResolutionShinesAsPearlsOfSweat'
 import { CharacterConditionalsResolver } from 'lib/conditionals/resolver/characterConditionalsResolver'
 import {
   Constants,
@@ -46,7 +54,22 @@ import type { ScoringMetadata } from 'types/metadata'
 const DEF_REDUCTION_LIGHT_CONES = [
   LiesAflutterInTheWind.id,
   LifeShouldBeCastToFlames.id,
-  ResolutionShinesAsPearlsOfSweat.id
+  ResolutionShinesAsPearlsOfSweat.id,
+]
+
+const DEF_REDUCTION_CHARACTERS = [
+  MortenaxBlade.id,
+  SilverWolf.id,
+  BlackSwan.id,
+  Ashveil.id,
+  Hysilens.id,
+  Cyrene.id,
+  Fugue.id,
+  Pela.id,
+  Welt.id,
+  TheDahlia.id,
+  Anaxa.id,
+  Misha.id,
 ]
 
 export type TeammateInfo = {
@@ -233,9 +256,17 @@ export function applyTeamAwareSetConditionalPresets(form: Form | BenchmarkForm, 
     form.setConditionals[Sets.TheWondrousBananAmusementPark][1] = true
   }
 
-  const allLightCones = [form.lightCone, ...teammates.map((t) => t.lightCone)].filter((x) => !!x)
-  if (allLightCones.some((lc) => DEF_REDUCTION_LIGHT_CONES.includes(lc))) {
+  const wearerHasDefReductionLc = DEF_REDUCTION_LIGHT_CONES.includes(form.lightCone)
+  const wearerIsDefReducer = DEF_REDUCTION_CHARACTERS.includes(form.characterId)
+
+  if (wearerHasDefReductionLc || wearerIsDefReducer) {
     form.setConditionals[Sets.DivineQueryingMasterSmith][1] = 2
+  } else {
+    const teammateHasDefReductionLc = teammates.some((t) => t.lightCone && DEF_REDUCTION_LIGHT_CONES.includes(t.lightCone))
+    const teammateIsDefReducer = teammates.some((t) => t.id && DEF_REDUCTION_CHARACTERS.includes(t.id))
+    if (teammateHasDefReductionLc || teammateIsDefReducer) {
+      form.setConditionals[Sets.DivineQueryingMasterSmith][1] = 1
+    }
   }
 }
 

--- a/src/lib/scoring/presetEffects.ts
+++ b/src/lib/scoring/presetEffects.ts
@@ -48,8 +48,19 @@ export const PresetEffects = {
     teammateCondition: { characterId: MortenaxBlade.id, minEidolon: 2 },
   }),
 
+  fnNavigatorSet: (stacks: number): PresetDefinition => ({
+    name: 'fnNavigatorSet',
+    value: stacks,
+    set: Sets.AsNavigatorIseeSeesIt,
+  }),
+
   // Preset values
 
+  MASTER_SMITH_SET: {
+    name: 'MASTER_SMITH_SET',
+    value: 2,
+    set: Sets.DivineQueryingMasterSmith,
+  } as PresetDefinition,
   PRISONER_SET: {
     name: 'PRISONER_SET',
     value: 3,

--- a/src/lib/scoring/presetEffects.ts
+++ b/src/lib/scoring/presetEffects.ts
@@ -3,12 +3,8 @@ import type {
   SetsOrnaments,
   SetsRelics,
 } from 'lib/sets/setConfigRegistry'
-import { LiesAflutterInTheWind } from 'lib/conditionals/lightcone/5star/LiesAflutterInTheWind'
-import { LifeShouldBeCastToFlames } from 'lib/conditionals/lightcone/5star/LifeShouldBeCastToFlames'
-import { ResolutionShinesAsPearlsOfSweat } from 'lib/conditionals/lightcone/4star/ResolutionShinesAsPearlsOfSweat'
 import { MortenaxBlade } from 'lib/conditionals/character/1500/MortenaxBlade'
 import type { CharacterId } from 'types/character'
-import type { LightConeId } from 'types/lightCone'
 
 export type PresetDefinition = {
   name: string,
@@ -18,9 +14,6 @@ export type PresetDefinition = {
   teammateCondition?: {
     characterId: CharacterId,
     minEidolon: number,
-  },
-  lightConeCondition?: {
-    lightConeIds: LightConeId[],
   },
 }
 
@@ -67,14 +60,6 @@ export const PresetEffects = {
     name: 'MASTER_SMITH_SET',
     value: 2,
     set: Sets.DivineQueryingMasterSmith,
-  } as PresetDefinition,
-  MASTER_SMITH_LC_SET: {
-    name: 'MASTER_SMITH_LC_SET',
-    value: 2,
-    set: Sets.DivineQueryingMasterSmith,
-    lightConeCondition: {
-      lightConeIds: [LiesAflutterInTheWind.id, LifeShouldBeCastToFlames.id, ResolutionShinesAsPearlsOfSweat.id],
-    },
   } as PresetDefinition,
   PRISONER_SET: {
     name: 'PRISONER_SET',

--- a/src/lib/scoring/presetEffects.ts
+++ b/src/lib/scoring/presetEffects.ts
@@ -3,8 +3,12 @@ import type {
   SetsOrnaments,
   SetsRelics,
 } from 'lib/sets/setConfigRegistry'
+import { LiesAflutterInTheWind } from 'lib/conditionals/lightcone/5star/LiesAflutterInTheWind'
+import { LifeShouldBeCastToFlames } from 'lib/conditionals/lightcone/5star/LifeShouldBeCastToFlames'
+import { ResolutionShinesAsPearlsOfSweat } from 'lib/conditionals/lightcone/4star/ResolutionShinesAsPearlsOfSweat'
 import { MortenaxBlade } from 'lib/conditionals/character/1500/MortenaxBlade'
 import type { CharacterId } from 'types/character'
+import type { LightConeId } from 'types/lightCone'
 
 export type PresetDefinition = {
   name: string,
@@ -14,6 +18,9 @@ export type PresetDefinition = {
   teammateCondition?: {
     characterId: CharacterId,
     minEidolon: number,
+  },
+  lightConeCondition?: {
+    lightConeIds: LightConeId[],
   },
 }
 
@@ -60,6 +67,14 @@ export const PresetEffects = {
     name: 'MASTER_SMITH_SET',
     value: 2,
     set: Sets.DivineQueryingMasterSmith,
+  } as PresetDefinition,
+  MASTER_SMITH_LC_SET: {
+    name: 'MASTER_SMITH_LC_SET',
+    value: 2,
+    set: Sets.DivineQueryingMasterSmith,
+    lightConeCondition: {
+      lightConeIds: [LiesAflutterInTheWind.id, LifeShouldBeCastToFlames.id, ResolutionShinesAsPearlsOfSweat.id],
+    },
   } as PresetDefinition,
   PRISONER_SET: {
     name: 'PRISONER_SET',

--- a/src/lib/sets/relics/AsNavigatorIseeSeesIt.ts
+++ b/src/lib/sets/relics/AsNavigatorIseeSeesIt.ts
@@ -41,7 +41,7 @@ const display = {
   conditionalType: ConditionalDataType.SELECT,
   selectionOptions: selectionOptions,
   modifiable: true,
-  defaultValue: 3,
+  defaultValue: 1,
 } as const satisfies SetDisplay
 
 const conditionals: SetConditionals = {

--- a/src/lib/sets/relics/DivineQueryingMasterSmith.ts
+++ b/src/lib/sets/relics/DivineQueryingMasterSmith.ts
@@ -41,7 +41,7 @@ const display = {
   conditionalType: ConditionalDataType.SELECT,
   selectionOptions: selectionOptions,
   modifiable: true,
-  defaultValue: 1,
+  defaultValue: 0,
 } as const satisfies SetDisplay
 
 const conditionals: SetConditionals = {

--- a/src/lib/sets/relics/DivineQueryingMasterSmith.ts
+++ b/src/lib/sets/relics/DivineQueryingMasterSmith.ts
@@ -41,7 +41,7 @@ const display = {
   conditionalType: ConditionalDataType.SELECT,
   selectionOptions: selectionOptions,
   modifiable: true,
-  defaultValue: 2,
+  defaultValue: 1,
 } as const satisfies SetDisplay
 
 const conditionals: SetConditionals = {

--- a/src/lib/sets/relics/DivineQueryingMasterSmith.ts
+++ b/src/lib/sets/relics/DivineQueryingMasterSmith.ts
@@ -84,8 +84,8 @@ const conditionals: SetConditionals = {
 function selectionOptions(): SelectOptionContent[] {
   return [
     { display: 'Off', value: 0, label: 'Off' },
-    { display: '1x', value: 1, label: 'DEF reduced: CD +28%' },
-    { display: '2x', value: 2, label: 'DEF reduced: CD +28% + Comburent DMG +15%' },
+    { display: 'CD', value: 1, label: 'DEF reduced: CD +28%' },
+    { display: 'CD + DMG', value: 2, label: 'DEF reduced: CD +28% + Comburent DMG +15%' },
   ]
 }
 

--- a/src/types/resources.d.ts
+++ b/src/types/resources.d.ts
@@ -1,4 +1,4 @@
-export default interface Resources {
+interface Resources {
   "benchmarksTab": {
     "LeftPanel": {
       "Header": "Benchmark"
@@ -7901,3 +7901,5 @@ export default interface Resources {
     "TotalAvailable": "Total warps available:"
   }
 }
+
+export default Resources;


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->


- Add Navigator set preset (fnNavigatorSet) and lower default from 3 to 1 stack
- Add Master Smith set preset (MASTER_SMITH_SET) and lower default from 2 to 0
- Update Master Smith display labels to Off / CD / CD + DMG
- Add 3x Navigator presets to:
  - Archer
  - Seele
  - Mydei
  - Phainon
- 2x
  - Anaxa
  - Mortenax Blade
- Add Master Smith presets to:
  - Mortenax Blade
  - Silver Wolf B1
  - Black Swan B1
  - Ashveil
  - Hysilens
  - Cyrene
  - Fugue
  - Pela
  - Welt B1
  - The Dahlia
  - Anaxa
  - Misha
- Auto-enable Master Smith based on team DEF reduction sources: value 2 if the wearer reduces DEF, value 1 if a teammate does
- Add team-aware DEF reduction detection for light cones:
  - Lies Dance on the Breeze
  - Life Should Be Cast to Flames
  - Resolution Shines As Pearls of Sweat
  - 
## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [ ] I have added commit messages that are descriptive and meaningful.
- [ ] I have tested the changes locally.
- [ ] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
