### PR TITLE
fix: conditional audits

### DIFF
--- a/public/locales/en_US/conditionals.yaml
+++ b/public/locales/en_US/conditionals.yaml
@@ -1024,9 +1024,6 @@ Characters:
         content: While "Bait" exists on the field, reduces all enemies' All-Type RES by 20%. For each stack of "Gluttony" Ashveil has gained, his DMG dealt increases by 4.0%.
   Asta:
     Content:
-      skillExtraDmgHits:
-        text: Skill extra hits
-        content: "Deals Fire DMG equal to {{skillScaling}}% of Asta's ATK to a single enemy and further deals DMG for {{skillExtraDmgHitsMax}} extra times, with each time dealing Fire DMG equal to {{skillScaling}}% of Asta's ATK to a random enemy.::BR::E1: When using Skill, deals DMG for 1 extra time to a random enemy."
       talentBuffStacks:
         text: Talent ATK buff stacks
         content: "Increases allies' ATK by {{talentStacksAtkBuff}}% for every stack.::BR::E4: Asta's Energy Regeneration Rate increases by 15% when she has 2 or more Charging stacks."

--- a/src/lib/conditionals/character/1000/Archer.ts
+++ b/src/lib/conditionals/character/1000/Archer.ts
@@ -72,7 +72,7 @@ export const ArcherAbilities: AbilityKind[] = [
 
 const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsController => {
   const t = wrappedFixedT(withContent).get(null, 'conditionals', 'Characters.Archer.Content')
-  const { basic, skill, talent } = AbilityEidolon.SKILL_BASIC_3_ULT_TALENT_5
+  const { basic, skill, talent, ult } = AbilityEidolon.SKILL_BASIC_3_ULT_TALENT_5
   const {
     SOURCE_BASIC,
     SOURCE_SKILL,
@@ -94,7 +94,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   const skillScaling = skill(e, 3.60, 3.96)
   const skillEnhancedExtraScaling = skill(e, 1.00, 1.08)
 
-  const ultScaling = skill(e, 10.00, 10.80)
+  const ultScaling = ult(e, 10.00, 10.80)
 
   const fuaScaling = talent(e, 2.00, 2.20)
 

--- a/src/lib/conditionals/character/1000/Asta.ts
+++ b/src/lib/conditionals/character/1000/Asta.ts
@@ -66,7 +66,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 
   const defaults = {
     talentBuffStacks: 5,
-    skillExtraDmgHits: skillExtraDmgHitsMax,
     ultSpdBuff: true,
     fireDmgBoost: true,
   }
@@ -78,14 +77,6 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   }
 
   const content: ContentDefinition<typeof defaults> = {
-    skillExtraDmgHits: {
-      id: 'skillExtraDmgHits',
-      formItem: 'slider',
-      text: t('Content.skillExtraDmgHits.text'),
-      content: t('Content.skillExtraDmgHits.content', { skillScaling: precisionRound(skillScaling * 100), skillExtraDmgHitsMax }),
-      min: 0,
-      max: skillExtraDmgHitsMax,
-    },
     talentBuffStacks: {
       id: 'talentBuffStacks',
       formItem: 'slider',
@@ -133,8 +124,8 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     actionDefinition: (action: OptimizerAction, context: OptimizerContext) => {
       const r = action.characterConditionals as Conditionals<typeof content>
 
-      const totalSkillScaling = skillScaling + r.skillExtraDmgHits * skillScaling
-      const skillToughness = 10 + 5 * r.skillExtraDmgHits
+      const totalSkillScaling = skillScaling + skillExtraDmgHitsMax * skillScaling / context.enemyCount
+      const skillToughness = 10 + 5 * skillExtraDmgHitsMax / context.enemyCount
 
       return {
         [AbilityKind.BASIC]: {

--- a/src/lib/conditionals/character/1000/Herta.ts
+++ b/src/lib/conditionals/character/1000/Herta.ts
@@ -288,6 +288,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
       x.buff(StatKey.ATK_P, (e >= 6 && r.e6UltAtkBuff) ? 0.25 : 0, x.source(SOURCE_E6))
 
       x.buff(StatKey.BOOST, (r.enemyHpGte50) ? 0.20 : 0, x.damageType(DamageTag.SKILL).source(SOURCE_SKILL))
+      x.buff(StatKey.BOOST, (r.enemyHpGte50) ? 0.25 : 0, x.damageType(DamageTag.SKILL).source(SOURCE_TRACE))
       x.buff(StatKey.BOOST, (r.targetFrozen) ? 0.20 : 0, x.damageType(DamageTag.ULT).source(SOURCE_ULT))
       x.buff(StatKey.BOOST, (e >= 4) ? 0.10 : 0, x.damageType(DamageTag.FUA).source(SOURCE_E4))
     },

--- a/src/lib/conditionals/character/1000/KafkaB1.ts
+++ b/src/lib/conditionals/character/1000/KafkaB1.ts
@@ -107,7 +107,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   const skillScaling = skill(e, 1.60, 1.76)
   const ultScaling = ult(e, 0.80, 0.864)
   const fuaScaling = talent(e, 1.40, 1.596)
-  const dotScaling = ult(e, 2.90, 3.183)
+  const dotScaling = ult(e, 2.90, 3.18275)
 
   const fuaHitMulti = ASHBLAZING_ATK_STACK
     * (1 * 0.15 + 2 * 0.15 + 3 * 0.15 + 4 * 0.15 + 5 * 0.15 + 6 * 0.25)

--- a/src/lib/conditionals/character/1000/Saber.ts
+++ b/src/lib/conditionals/character/1000/Saber.ts
@@ -275,7 +275,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
       x.buff(StatKey.BOOST, r.talentDmgBuff ? talentDmgBuffScaling : 0, x.source(SOURCE_TALENT))
 
       // E1: DMG boost
-      x.buff(StatKey.BOOST, (e >= 1 && r.e1DmgBuff) ? 0.60 : 0, x.source(SOURCE_E1))
+      x.buff(StatKey.BOOST, (e >= 1 && r.e1DmgBuff) ? 0.60 : 0, x.damageType(DamageTag.ULT).source(SOURCE_E1))
 
       // E2: DEF PEN (skill scaling handled in actionDefinition)
       x.buff(StatKey.DEF_PEN, (e >= 2 && r.e2Buffs) ? 0.01 * 15 : 0, x.source(SOURCE_E2))
@@ -284,7 +284,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
       x.buff(StatKey.RES_PEN, (e >= 4 && r.e4ResPen) ? 0.08 + 0.04 * 3 : 0, x.elements(ElementTag.Wind).source(SOURCE_E4))
 
       // E6: ULT RES PEN
-      x.buff(StatKey.RES_PEN, (e >= 6 && r.e6ResPen) ? 0.20 : 0, x.damageType(DamageTag.ULT).source(SOURCE_E6))
+      x.buff(StatKey.RES_PEN, (e >= 6 && r.e6ResPen) ? 0.20 : 0, x.damageType(DamageTag.ULT).elements(ElementTag.Wind).source(SOURCE_E6))
     },
 
     precomputeMutualEffectsContainer: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {

--- a/src/lib/conditionals/character/1100/Lynx.ts
+++ b/src/lib/conditionals/character/1100/Lynx.ts
@@ -91,7 +91,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   } = Source.character(Lynx.id)
 
   const skillHpPercentBuff = skill(e, 0.075, 0.08)
-  const skillHpFlatBuff = skill(e, 200, 223)
+  const skillHpFlatBuff = skill(e, 200, 222.5)
 
   const basicScaling = basic(e, 0.50, 0.55)
 
@@ -227,18 +227,18 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     precomputeMutualEffectsContainer: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
       const m = action.characterConditionals as Conditionals<typeof teammateContent>
 
-      x.buff(StatKey.RES, (e >= 6 && m.skillBuff) ? 0.30 : 0, x.targets(TargetTag.FullTeam).source(SOURCE_E6))
+      x.buff(StatKey.RES, (e >= 6 && m.skillBuff) ? 0.30 : 0, x.targets(TargetTag.SingleTarget).source(SOURCE_E6))
     },
 
     precomputeTeammateEffectsContainer: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
       const t = action.characterConditionals as Conditionals<typeof teammateContent>
 
-      x.buff(StatKey.HP, (t.skillBuff) ? skillHpPercentBuff * t.teammateHPValue : 0, x.targets(TargetTag.FullTeam).source(SOURCE_SKILL))
-      x.buff(StatKey.HP, (t.skillBuff) ? skillHpFlatBuff : 0, x.targets(TargetTag.FullTeam).source(SOURCE_SKILL))
-      x.buff(StatKey.HP, (e >= 6 && t.skillBuff) ? 0.06 * t.teammateHPValue : 0, x.targets(TargetTag.FullTeam).source(SOURCE_E6))
+      x.buff(StatKey.HP, (t.skillBuff) ? skillHpPercentBuff * t.teammateHPValue : 0, x.targets(TargetTag.SingleTarget).source(SOURCE_SKILL))
+      x.buff(StatKey.HP, (t.skillBuff) ? skillHpFlatBuff : 0, x.targets(TargetTag.SingleTarget).source(SOURCE_SKILL))
+      x.buff(StatKey.HP, (e >= 6 && t.skillBuff) ? 0.06 * t.teammateHPValue : 0, x.targets(TargetTag.SingleTarget).source(SOURCE_E6))
 
       const atkBuffValue = (e >= 4 && t.skillBuff) ? 0.03 * t.teammateHPValue : 0
-      x.buff(StatKey.ATK, atkBuffValue, x.targets(TargetTag.FullTeam).source(SOURCE_E4))
+      x.buff(StatKey.ATK, atkBuffValue, x.targets(TargetTag.SingleTarget).source(SOURCE_E4))
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {

--- a/src/lib/conditionals/character/1100/SeeleB1.ts
+++ b/src/lib/conditionals/character/1100/SeeleB1.ts
@@ -191,7 +191,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 
       x.buff(StatKey.BOOST, r.dmgBoostStacks * 0.50, x.source(SOURCE_TRACE))
       x.buff(StatKey.BOOST, (r.buffedState) ? buffedStateDmgBuff : 0, x.source(SOURCE_TALENT))
-      x.buff(StatKey.RES_PEN, (r.buffedState) ? 0.25 : 0, x.source(SOURCE_TRACE))
+      x.buff(StatKey.RES_PEN, (r.buffedState) ? 0.25 : 0, x.elements(ElementTag.Quantum).source(SOURCE_TRACE))
     },
 
     precomputeMutualEffectsContainer: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {

--- a/src/lib/conditionals/character/1100/Topaz.ts
+++ b/src/lib/conditionals/character/1100/Topaz.ts
@@ -226,7 +226,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
       const r = action.characterConditionals as Conditionals<typeof content>
 
       x.buff(StatKey.CD, (r.numbyEnhancedState) ? enhancedStateFuaCdBoost : 0, x.target(TopazEntities.Numby).source(SOURCE_ULT))
-      x.buff(StatKey.RES_PEN, (e >= 6) ? 0.10 : 0, x.target(TopazEntities.Numby).source(SOURCE_E6))
+      x.buff(StatKey.RES_PEN, (e >= 6) ? 0.10 : 0, x.target(TopazEntities.Numby).elements(ElementTag.Fire).source(SOURCE_E6))
 
       x.buff(StatKey.BOOST, (context.enemyElementalWeak) ? 0.15 : 0, x.source(SOURCE_TRACE))
     },


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

- Fix Archer Ultimate scaling to use the correct eidolon helper (ult instead of skill)
- Fix Asta Skill extra hits to scale by enemy count instead of a user-controlled slider
- Fix Herta missing Skill DMG boost trace buff when enemy HP >= 50%
- Fix Kafka DoT scaling value from 3.183 to 3.18275 to match kit
- Fix Saber E1 DMG boost to only apply to Ultimate damage instead of all types
- Fix Saber E6 RES PEN to include Wind element scope
- Fix Lynx Survival Response flat HP buff from 223 to 222.5 to match kit
- Fix Lynx Survival Response teammate buffs to use single-target routing instead of full-team
- Fix Seele Amplification RES PEN to scope to Quantum element
- Fix Topaz E6 RES PEN to scope to Fire element
- Remove Asta Skill extra hits slider and its i18n entry

## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [ ] I have added commit messages that are descriptive and meaningful.
- [ ] I have tested the changes locally.
- [ ] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
