### PR TITLE
fix: robin err / atk rope handling

### DIFF
--- a/src/lib/conditionals/character/1000/March7th.ts
+++ b/src/lib/conditionals/character/1000/March7th.ts
@@ -176,7 +176,7 @@ const shieldSimulation = (): SimulationMetadata => ({
     [Parts.Body]: [Stats.DEF_P],
     [Parts.Feet]: [Stats.DEF_P, Stats.SPD],
     [Parts.PlanarSphere]: [Stats.DEF_P],
-    [Parts.LinkRope]: [Stats.DEF_P, Stats.ERR],
+    [Parts.LinkRope]: [Stats.DEF_P],
   },
   substats: [
     Stats.DEF_P,

--- a/src/lib/conditionals/character/1100/Gepard.ts
+++ b/src/lib/conditionals/character/1100/Gepard.ts
@@ -195,7 +195,7 @@ const shieldSimulation = (): SimulationMetadata => ({
     [Parts.Body]: [Stats.DEF_P],
     [Parts.Feet]: [Stats.DEF_P, Stats.SPD],
     [Parts.PlanarSphere]: [Stats.DEF_P],
-    [Parts.LinkRope]: [Stats.DEF_P, Stats.ERR],
+    [Parts.LinkRope]: [Stats.DEF_P],
   },
   substats: [
     Stats.DEF_P,

--- a/src/lib/conditionals/character/1300/Aventurine.ts
+++ b/src/lib/conditionals/character/1300/Aventurine.ts
@@ -392,7 +392,7 @@ const shieldSimulation = (): SimulationMetadata => ({
     [Parts.Body]: [Stats.DEF_P],
     [Parts.Feet]: [Stats.DEF_P, Stats.SPD],
     [Parts.PlanarSphere]: [Stats.DEF_P],
-    [Parts.LinkRope]: [Stats.DEF_P, Stats.ERR],
+    [Parts.LinkRope]: [Stats.DEF_P],
   },
   substats: [
     Stats.DEF_P,

--- a/src/lib/conditionals/character/1300/Robin.ts
+++ b/src/lib/conditionals/character/1300/Robin.ts
@@ -340,7 +340,7 @@ const supportSimulation = (): SimulationMetadata => ({
     [Parts.Body]: [Stats.ATK_P],
     [Parts.Feet]: [Stats.ATK_P, Stats.SPD],
     [Parts.PlanarSphere]: [Stats.ATK_P],
-    [Parts.LinkRope]: [Stats.ERR],
+    [Parts.LinkRope]: [Stats.ATK_P],
   },
   substats: [
     Stats.ATK_P,
@@ -414,6 +414,7 @@ const scoring = (): ScoringMetadata => ({
       Stats.Physical_DMG,
     ],
     [Parts.LinkRope]: [
+      Stats.ATK_P,
       Stats.ERR,
     ],
   },

--- a/src/lib/conditionals/character/1400/Cerydra.ts
+++ b/src/lib/conditionals/character/1400/Cerydra.ts
@@ -389,7 +389,7 @@ const supportSimulation = (): SimulationMetadata => ({
     [Parts.Body]: [Stats.ATK_P],
     [Parts.Feet]: [Stats.ATK_P, Stats.SPD],
     [Parts.PlanarSphere]: [Stats.ATK_P],
-    [Parts.LinkRope]: [Stats.ATK_P, Stats.ERR],
+    [Parts.LinkRope]: [Stats.ATK_P],
   },
   substats: [
     Stats.ATK_P,

--- a/src/lib/conditionals/character/1400/PermansorTerrae.ts
+++ b/src/lib/conditionals/character/1400/PermansorTerrae.ts
@@ -336,7 +336,7 @@ const supportSimulation = (): SimulationMetadata => ({
     [Parts.Body]: [Stats.ATK_P],
     [Parts.Feet]: [Stats.SPD, Stats.ATK_P],
     [Parts.PlanarSphere]: [Stats.ATK_P],
-    [Parts.LinkRope]: [Stats.ERR, Stats.ATK_P],
+    [Parts.LinkRope]: [Stats.ATK_P],
   },
   substats: [
     Stats.ATK_P,

--- a/src/lib/conditionals/character/8000/TrailblazerHarmony.ts
+++ b/src/lib/conditionals/character/8000/TrailblazerHarmony.ts
@@ -255,7 +255,7 @@ const supportSimulation = (): SimulationMetadata => ({
     [Parts.Body]: [Stats.HP_P, Stats.DEF_P],
     [Parts.Feet]: [Stats.SPD],
     [Parts.PlanarSphere]: [Stats.HP_P, Stats.DEF_P],
-    [Parts.LinkRope]: [Stats.ERR, Stats.BE],
+    [Parts.LinkRope]: [Stats.BE],
   },
   substats: [
     Stats.BE,

--- a/src/lib/conditionals/character/8000/TrailblazerPreservation.ts
+++ b/src/lib/conditionals/character/8000/TrailblazerPreservation.ts
@@ -233,7 +233,7 @@ const shieldSimulation = (): SimulationMetadata => ({
     [Parts.Body]: [Stats.DEF_P],
     [Parts.Feet]: [Stats.DEF_P, Stats.SPD],
     [Parts.PlanarSphere]: [Stats.DEF_P],
-    [Parts.LinkRope]: [Stats.DEF_P, Stats.ERR],
+    [Parts.LinkRope]: [Stats.DEF_P],
   },
   substats: [
     Stats.DEF_P,

--- a/src/lib/simulations/tests/supportScore/supportScoreTest.test.ts
+++ b/src/lib/simulations/tests/supportScore/supportScoreTest.test.ts
@@ -199,9 +199,8 @@ test('Robin support score prepare', () => {
   globalThis.SEQUENTIAL_BENCHMARKS = true
   const character = { form: { characterId: '1309', characterEidolon: 6, lightCone: '23026', lightConeSuperimposition: 5 } } as Character
   const robinSimulation: SimulationMetadata = {
-    parts: { [Parts.Body]: [Stats.ATK_P], [Parts.Feet]: [Stats.ATK_P, Stats.SPD], [Parts.PlanarSphere]: [Stats.ATK_P], [Parts.LinkRope]: [Stats.ERR] },
+    parts: { [Parts.Body]: [Stats.ATK_P], [Parts.Feet]: [Stats.ATK_P, Stats.SPD], [Parts.PlanarSphere]: [Stats.ATK_P], [Parts.LinkRope]: [Stats.ATK_P] },
     substats: [Stats.ATK_P, Stats.ATK, Stats.SPD, Stats.RES, Stats.HP_P],
-    errRopeEidolon: 0,
     comboTurnAbilities: [NULL_TURN_ABILITY_NAME],
     relicSets: [[Sets.MessengerTraversingHackerspace, Sets.MessengerTraversingHackerspace]],
     ornamentSets: [Sets.FleetOfTheAgeless, Sets.BrokenKeel, Sets.PenaconyLandOfTheDreams, Sets.LushakaTheSunkenSeas],
@@ -214,7 +213,7 @@ test('Robin support score prepare', () => {
   }
   const singleRelicByPart = generateTestSingleRelicsByPart(
     testSets(Sets.MessengerTraversingHackerspace, Sets.MessengerTraversingHackerspace, Sets.FleetOfTheAgeless),
-    testMains(Stats.ATK_P, Stats.ATK_P, Stats.ATK_P, Stats.ERR),
+    testMains(Stats.ATK_P, Stats.ATK_P, Stats.ATK_P, Stats.ATK_P),
     testStatSpread(),
   )
   const orchestrator = prepareOrchestrator(character, bufferConfig(clone(robinSimulation)), singleRelicByPart, {})


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

- Remove ERR rope from support/shield benchmark simulation pools so ERR is matched via errRopeEidolon instead of being a default candidate
- Fix Robin support benchmark to use ATK% rope instead of ERR, and add ATK% as primary rope in scoring metadata

## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [ ] I have added commit messages that are descriptive and meaningful.
- [ ] I have tested the changes locally.
- [ ] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
