### PR TITLE
feat: breakpoint red colors, spd asterisk

### DIFF
--- a/docs/guides/en/benchmarks.md
+++ b/docs/guides/en/benchmarks.md
@@ -144,7 +144,9 @@ Certain characters will have breakpoints that are forced. For example, 120% comb
 passive EHR to DMG conversion, and to land Arcana stacks. Failing to reach the breakpoint will penalize the score for
 the missing percentage. This penalty applies to all simulations.
 
-Missing a SPD breakpoint (e.g. Cyrene's 180 SPD) will penalize by -25%.
+Missing a SPD breakpoint (e.g. Cyrene's 180 SPD) will fully penalize the score to 0%.
+
+Stats that are below their breakpoint threshold are highlighted in red in the Combat Stats panel.
 
 ### RES equalization
 
@@ -155,7 +157,7 @@ RES investment.
 
 Additionally, when a character equips Broken Keel and has at least 30% Effect RES, the benchmark will allocate RES rolls
 to reach the 30% activation threshold when evaluating Broken Keel set combinations. If a character equips Broken Keel but
-does not have enough RES to activate it, a -25% penalty is applied to the score for failing to activate the set bonus.
+does not have enough RES to activate it, the score is fully penalized to 0% for failing to activate the set bonus.
 
 RES equalization does not apply to DPS benchmarks.
 

--- a/src/lib/characterPreview/scoring/CharacterCardCombatStats.tsx
+++ b/src/lib/characterPreview/scoring/CharacterCardCombatStats.tsx
@@ -19,6 +19,7 @@ import { Assets } from 'lib/rendering/assets'
 import { SCORING_CONFIG_REGISTRY } from 'lib/scoring/scoringConfig'
 import {
   getElementalDmgFromContainer,
+  getPenalizedStats,
   StatsToStatKey,
 } from 'lib/scoring/simScoringUtils'
 import {
@@ -53,6 +54,27 @@ import {
   type SimulationMetadata,
 } from 'types/metadata'
 
+function StatIcon({ stat, color }: { stat: StatsValues; color?: string }) {
+  const src = Assets.getStatIcon(stat)
+  if (color) {
+    return (
+      <div
+        className={iconClasses.statIconSpaced}
+        style={{
+          backgroundColor: color,
+          WebkitMaskImage: `url(${src})`,
+          maskImage: `url(${src})`,
+          WebkitMaskSize: 'contain',
+          maskSize: 'contain',
+          WebkitMaskRepeat: 'no-repeat',
+          maskRepeat: 'no-repeat',
+        }}
+      />
+    )
+  }
+  return <img src={src} className={iconClasses.statIconSpaced} />
+}
+
 export const CharacterCardCombatStats = memo(
   function CharacterCardCombatStats({ characterMetadata, originalSimResult, deprioritizeBuffs, simulationMetadata, configType }: {
     characterMetadata: DBMetadataCharacter,
@@ -71,21 +93,24 @@ export const CharacterCardCombatStats = memo(
 
     const simMetadata = simulationMetadata ?? characterMetadata.scoringMetadata.simulation!
     const upgradeStats: StatsValues[] = pickCombatStats(characterMetadata, simMetadata, configType)
-    const upgradeDisplayWrappers = aggregateCombatStats(x, upgradeStats, preciseSpd, element, primaryActionStats)
+    const penalizedStats = getPenalizedStats(x, simMetadata, configType)
+    const upgradeDisplayWrappers = aggregateCombatStats(x, upgradeStats, preciseSpd, element, primaryActionStats, penalizedStats)
 
     const rows: ReactElement[] = []
 
     for (const wrapper of upgradeDisplayWrappers) {
-      const { stat, display, flat, upgraded } = wrapper
+      const { stat, display, flat, upgraded, penalized } = wrapper
 
       const isElationDmg = stat === Stats.Elation
       const isElementalDmg = !isElationDmg && damageStats[stat] != null
       const statName = isElementalDmg ? t('DamagePercent') : t(`ReadableStats.${stat}`)
 
       // Best arrows 🠙 🠡 🡑 🠙 ↑ ↑ ⬆
+      const penaltyColor = penalized ? '#ff9a9a' : undefined
+
       rows.push(
-        <div key={stat} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', width: '100%' }}>
-          <img src={Assets.getStatIcon(stat)} className={iconClasses.statIconSpaced} />
+        <div key={stat} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', width: '100%', color: penaltyColor }}>
+          <StatIcon stat={stat} color={penaltyColor} />
           <div style={{ display: 'flex', gap: 1, alignItems: 'center' }}>
             <StatTextSm>
               {statName}
@@ -122,6 +147,7 @@ type StatDisplayWrapper = {
   display: string,
   flat: boolean,
   upgraded: boolean,
+  penalized: boolean,
 }
 
 function aggregateCombatStats(
@@ -129,7 +155,8 @@ function aggregateCombatStats(
   upgradeStats: StatsValues[],
   preciseSpd: boolean,
   element: ElementName,
-  primaryActionStats?: PrimaryActionStats,
+  primaryActionStats: PrimaryActionStats | undefined,
+  penalizedStats: Set<StatsValues>,
 ) {
   const displayWrappers: StatDisplayWrapper[] = []
 
@@ -155,6 +182,7 @@ function aggregateCombatStats(
       upgraded,
       display,
       flat,
+      penalized: penalizedStats.has(stat),
     })
   }
 

--- a/src/lib/scoring/simScoringUtils.ts
+++ b/src/lib/scoring/simScoringUtils.ts
@@ -31,6 +31,7 @@ import type {
 } from 'lib/simulations/statSimulationTypes'
 import type { TeammateSetUpgrade } from 'lib/simulations/teammateUpgradeGrouping'
 import { renderThousandsK } from 'lib/utils/i18nUtils'
+import { precisionRound } from 'lib/utils/mathUtils'
 import { isFlat } from 'lib/utils/statUtils'
 import type { Form } from 'types/form'
 import type {
@@ -370,7 +371,7 @@ function collectPenaltyRecords(
         }
       } else if (isFlat(stat)) {
         const multiplier = (Math.min(1, statValue / metadata.breakpoints[stat]) + 1) / 2
-        if (multiplier < 1) {
+        if (precisionRound(multiplier) < 1) {
           records.push({ stat: stat as StatsValues, multiplier })
         }
       } else {
@@ -380,7 +381,7 @@ function collectPenaltyRecords(
             - (metadata.breakpoints[stat] - statValue)
               / StatCalculator.getMaxedSubstatValue(stat as SubStats, 1.0),
         )
-        if (multiplier < 1) {
+        if (precisionRound(multiplier) < 1) {
           records.push({ stat: stat as StatsValues, multiplier })
         }
       }

--- a/src/lib/scoring/simScoringUtils.ts
+++ b/src/lib/scoring/simScoringUtils.ts
@@ -366,7 +366,7 @@ function collectPenaltyRecords(
       const statValue = x.getSelfValue(StatsToStatKey[stat as StatsValues])
       if (stat == Stats.SPD && statValue < metadata.breakpoints[stat]) {
         if (user) {
-          records.push({ stat: stat as StatsValues, multiplier: 0.75 })
+          records.push({ stat: stat as StatsValues, multiplier: 0 })
         }
       } else if (isFlat(stat)) {
         const multiplier = (Math.min(1, statValue / metadata.breakpoints[stat]) + 1) / 2
@@ -389,7 +389,7 @@ function collectPenaltyRecords(
 
   if (user && configType !== ScoringConfigType.DPS && ornament2p(SetKeys.BrokenKeel, x.c.sets)) {
     if (x.getSelfValue(StatKey.RES) < 0.30) {
-      records.push({ stat: Stats.RES, multiplier: 0.75 })
+      records.push({ stat: Stats.RES, multiplier: 0 })
     }
   }
 

--- a/src/lib/scoring/simScoringUtils.ts
+++ b/src/lib/scoring/simScoringUtils.ts
@@ -348,45 +348,75 @@ export function applyScoringFunction(
   result.simScore = unpenalizedSimScore * (penalty ? penaltyMultiplier : 1)
 }
 
+type PenaltyRecord = {
+  stat: StatsValues
+  multiplier: number
+}
+
+function collectPenaltyRecords(
+  x: ComputedStatsContainer,
+  metadata: SimulationMetadata,
+  user: boolean,
+  configType: ScoringConfigType,
+): PenaltyRecord[] {
+  const records: PenaltyRecord[] = []
+
+  if (metadata.breakpoints) {
+    for (const stat of Object.keys(metadata.breakpoints)) {
+      const statValue = x.getSelfValue(StatsToStatKey[stat as StatsValues])
+      if (stat == Stats.SPD && statValue < metadata.breakpoints[stat]) {
+        if (user) {
+          records.push({ stat: stat as StatsValues, multiplier: 0.75 })
+        }
+      } else if (isFlat(stat)) {
+        const multiplier = (Math.min(1, statValue / metadata.breakpoints[stat]) + 1) / 2
+        if (multiplier < 1) {
+          records.push({ stat: stat as StatsValues, multiplier })
+        }
+      } else {
+        const multiplier = Math.min(
+          1,
+          1
+            - (metadata.breakpoints[stat] - statValue)
+              / StatCalculator.getMaxedSubstatValue(stat as SubStats, 1.0),
+        )
+        if (multiplier < 1) {
+          records.push({ stat: stat as StatsValues, multiplier })
+        }
+      }
+    }
+  }
+
+  if (user && configType !== ScoringConfigType.DPS && ornament2p(SetKeys.BrokenKeel, x.c.sets)) {
+    if (x.getSelfValue(StatKey.RES) < 0.30) {
+      records.push({ stat: Stats.RES, multiplier: 0.75 })
+    }
+  }
+
+  return records
+}
+
 function calculatePenaltyMultiplier(
   simulationResult: RunStatSimulationsResult,
   metadata: SimulationMetadata,
   user = false,
   configType: ScoringConfigType = ScoringConfigType.DPS,
 ) {
-  const x = simulationResult.x
+  const records = collectPenaltyRecords(simulationResult.x, metadata, user, configType)
   let newPenaltyMultiplier = 1
-  if (metadata.breakpoints) {
-    for (const stat of Object.keys(metadata.breakpoints)) {
-      const statValue = x.getSelfValue(StatsToStatKey[stat as StatsValues])
-      if (stat == Stats.SPD && statValue < metadata.breakpoints[stat]) {
-        if (user) {
-          // Cyrene case
-          newPenaltyMultiplier *= 0.75
-        }
-      } else if (isFlat(stat)) {
-        // Flats are penalized by their percentage
-        newPenaltyMultiplier *= (Math.min(1, statValue / metadata.breakpoints[stat]) + 1) / 2
-      } else {
-        // Percents are penalize by half of the missing stat's breakpoint roll percentage
-        newPenaltyMultiplier *= Math.min(
-          1,
-          1
-            - (metadata.breakpoints[stat] - statValue)
-              / StatCalculator.getMaxedSubstatValue(stat as SubStats, 1.0),
-        )
-      }
-    }
+  for (const record of records) {
+    newPenaltyMultiplier *= record.multiplier
   }
-
-  if (user && configType !== ScoringConfigType.DPS && ornament2p(SetKeys.BrokenKeel, x.c.sets)) {
-    const combatRes = x.getSelfValue(StatKey.RES)
-    if (combatRes < 0.30) {
-      newPenaltyMultiplier *= 0.75
-    }
-  }
-
   return newPenaltyMultiplier
+}
+
+export function getPenalizedStats(
+  x: ComputedStatsContainer,
+  metadata: SimulationMetadata,
+  configType: ScoringConfigType,
+): Set<StatsValues> {
+  const records = collectPenaltyRecords(x, metadata, true, configType)
+  return new Set(records.map((r) => r.stat))
 }
 
 export function cloneSimResult(result: RunStatSimulationsResult) {

--- a/src/lib/stores/scoring/scoringDelta.test.ts
+++ b/src/lib/stores/scoring/scoringDelta.test.ts
@@ -153,8 +153,26 @@ describe('mergeDeltaWithDefaults', () => {
     expect(result.stats[Stats.CD]).toBe(1)
   })
 
-  it('sets modified=true when has stats override', () => {
+  it('sets modified=false when only SPD weight differs', () => {
     const override: ScoringMetadataOverride = { stats: { [Stats.SPD]: 1 } }
+    const defaults = makeDefaults()
+
+    const result = mergeDeltaWithDefaults(override, defaults)
+
+    expect(result.modified).toBe(false)
+  })
+
+  it('sets modified=true when non-SPD stat weight differs', () => {
+    const override: ScoringMetadataOverride = { stats: { [Stats.ATK_P]: 0.5 } }
+    const defaults = makeDefaults()
+
+    const result = mergeDeltaWithDefaults(override, defaults)
+
+    expect(result.modified).toBe(true)
+  })
+
+  it('sets modified=true when SPD and non-SPD stats both differ', () => {
+    const override: ScoringMetadataOverride = { stats: { [Stats.SPD]: 1, [Stats.CR]: 0.5 } }
     const defaults = makeDefaults()
 
     const result = mergeDeltaWithDefaults(override, defaults)

--- a/src/lib/stores/scoring/scoringDelta.ts
+++ b/src/lib/stores/scoring/scoringDelta.ts
@@ -1,5 +1,6 @@
 import {
   MainStatPartsArray,
+  Stats,
   SubStats,
 } from 'lib/constants/constants'
 import type { MainStats } from 'lib/constants/constants'
@@ -138,8 +139,8 @@ export function mergeDeltaWithDefaults(
     }
   }
 
-  // Derive modified flag from override existence (replaces setModifiedScoringMetadata)
-  result.modified = !!(override?.stats && Object.keys(override.stats).length > 0)
+  // SPD weight changes alone don't show the asterisk
+  result.modified = !!(override?.stats && Object.keys(override.stats).some((key) => key !== Stats.SPD))
 
   return result
 }


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

- Highlight penalized combat stats in red in the Character Preview, covering breakpoint shortfalls (EHR, SPD, DEF, ATK) and missing Broken Keel RES activation
- Increase SPD breakpoint and Broken Keel RES penalties from -25% to a full score zeroing
- Fix SPD-only weight overrides incorrectly showing the modified asterisk on relic scores
- Update benchmark scoring documentation to reflect the new penalty severity and red stat indicators
- 
## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [ ] I have added commit messages that are descriptive and meaningful.
- [ ] I have tested the changes locally.
- [ ] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
