### PR TITLE
feat: style / label tweaks

### DIFF
--- a/src/lib/characterPreview/scoring/ShowcaseSetBonuses.module.css
+++ b/src/lib/characterPreview/scoring/ShowcaseSetBonuses.module.css
@@ -1,7 +1,7 @@
 .container {
   display: flex;
   flex-direction: column;
-  padding: 0 6px;
+  padding: 6px 4px 6px 6px;
   align-items: center;
 }
 
@@ -27,8 +27,8 @@
 }
 
 .setIconMd {
-  width: 36px;
-  height: 36px;
+  width: 44px;
+  height: 44px;
   border-radius: 3px;
   flex-shrink: 0;
 }
@@ -36,13 +36,13 @@
 .cardPlain {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
 }
 
 .separatorCol {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 2px;
   width: 100%;
 }
 

--- a/src/lib/characterPreview/scoring/ShowcaseSetBonuses.tsx
+++ b/src/lib/characterPreview/scoring/ShowcaseSetBonuses.tsx
@@ -84,7 +84,7 @@ function ActiveSetEntry({ entry }: { entry: DisplayEntry & { active: true } }) {
   const name = useSetName(entry.ingameId)
   return (
     <div className={classes.cardPlain}>
-      <img src={Assets.getSetImage(entry.set)} className={classes.setIconMd} />
+      <img src={Assets.getSetImage(entry.set, undefined, true)} className={classes.setIconMd} />
       <div className={classes.cardText}>
         <span className={classes.cardPiece}>{entry.count}pc</span>
         <StatTextSm className={classes.cardName}>{name}</StatTextSm>

--- a/src/lib/characterPreview/scoring/ShowcaseSubstatRolls.module.css
+++ b/src/lib/characterPreview/scoring/ShowcaseSubstatRolls.module.css
@@ -12,7 +12,7 @@
   flex-direction: column;
   width: 100%;
   gap: 4px;
-  margin-bottom: 9px;
+  margin-bottom: 8px;
 }
 
 .statLine {

--- a/src/lib/characterPreview/scoring/ShowcaseSubstatRolls.tsx
+++ b/src/lib/characterPreview/scoring/ShowcaseSubstatRolls.tsx
@@ -101,7 +101,7 @@ export const ShowcaseSubstatRolls = memo(function ShowcaseSubstatRolls({
 
   return (
     <div className={classes.container}>
-      <HeaderText style={{ fontSize: 16, textDecoration: 'none', marginBottom: 6 }}>
+      <HeaderText style={{ fontSize: 16, textDecoration: 'none', marginBottom: 4 }}>
         Substat Rolls
       </HeaderText>
       {aggregated.map((entry) => (

--- a/src/lib/tabs/tabCalculators/AhaPanelContent.module.css
+++ b/src/lib/tabs/tabCalculators/AhaPanelContent.module.css
@@ -13,6 +13,21 @@
   transition: transform 250ms ease;
 }
 
+.headerRow {
+  height: 28px;
+  margin-bottom: 2px;
+}
+
+.headerCell {
+  color: rgba(255, 255, 255, 0.45);
+  font-size: 11px;
+  font-weight: 400;
+  line-height: 1.3;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  text-align: center;
+}
+
 .baseRow {
   color: rgba(255, 255, 255, 0.72);
 }

--- a/src/lib/tabs/tabCalculators/AhaPanelContent.tsx
+++ b/src/lib/tabs/tabCalculators/AhaPanelContent.tsx
@@ -94,6 +94,7 @@ function IntegratedRows({ form, rows, ahaSpeed }: {
 
   return (
     <div className={classes.integratedRows}>
+      <HeaderRow />
       <BaseIntegratedRow ahaSpeed={ahaSpeed} />
       {rows.map((row, domIndex) => {
         const visualPos = visualPositions[domIndex]
@@ -124,10 +125,20 @@ function getVisualPositions(rows: TeammateRow[]): number[] {
   })
 }
 
+function HeaderRow() {
+  return (
+    <div className={`${classes.integratedRow} ${classes.headerRow}`}>
+      <div className={classes.headerCell}>Elation<br />Teammate</div>
+      <div className={classes.headerCell}>Combat<br />Speed</div>
+      <div className={classes.headerCell}>Speed<br />Added</div>
+    </div>
+  )
+}
+
 function BaseIntegratedRow({ ahaSpeed }: { ahaSpeed: number }) {
   return (
     <div className={`${classes.integratedRow} ${classes.baseRow}`}>
-      <div className={classes.rowSource}>Aha Base</div>
+      <div className={classes.rowSource}>Aha</div>
       <div className={classes.rowInputPlaceholder} />
       <div className={classes.rowTrack}>
         <div


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

- Add column headers to the Aha Speed Calculator: Elation Teammate, Combat Speed, and Speed Added
- Rename "Aha Base" label to "Aha" in the speed calculator
- Update set bonus icons in Substat Rolls view to use base set icons instead of piece-specific icons
- Increase set bonus icon size from 36px to 44px
- Tighten spacing throughout the Substat Rolls character preview panel

## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [ ] I have added commit messages that are descriptive and meaningful.
- [ ] I have tested the changes locally.
- [ ] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
