### PR TITLE
fix: rin sp / set dupe bugs

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
   <meta
     content="A Honkai Star Rail optimizer, relic scorer, damage calculator, warp planner, and various other tools for building and showcasing characters."
     property="og:description"/>
-  <meta content="https://fribbels.github.io/hsr-optimizer/assets/misc/embed.webp" property="og:image"/>
+  <meta content="https://fribbels.github.io/hsr-optimizer/assets/misc/changelog/2026-06-02/himekonova.webp" property="og:image"/>
 
   <!-- Twitter -->
   <meta content="summary_large_image" name="twitter:card"/>
@@ -36,7 +36,7 @@
   <meta
     content="A Honkai Star Rail optimizer, relic scorer, damage calculator, warp planner, and various other tools for building and showcasing characters."
     name="twitter:description"/>
-  <meta content="https://fribbels.github.io/hsr-optimizer/assets/misc/embed.webp" name="twitter:image"/>
+  <meta content="https://fribbels.github.io/hsr-optimizer/assets/misc/changelog/2026-06-02/himekonova.webp" name="twitter:image"/>
 
   <!-- Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-NTQSZLBGGL"></script>

--- a/src/lib/conditionals/character/1500/RinTohsaka.ts
+++ b/src/lib/conditionals/character/1500/RinTohsaka.ts
@@ -93,7 +93,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   const enhancedSkillAoeScaling = skill(e, 0.90, 0.99)
   const enhancedSkillBounceScaling = skill(e, 0.90, 0.99)
   const maxBounces = 33
-  const maxSpConsumed = 5
+  const maxSpConsumed = 14
 
   const ultScaling = ult(e, 6.00, 6.60)
   const ultVulnerabilityValue = ult(e, 0.20, 0.22)
@@ -107,7 +107,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
   const defaults = {
     enhancedSkill: true,
     skillBounces: 10,
-    enhancedSkillSpConsumed: 5,
+    enhancedSkillSpConsumed: 11,
     talentCdBuff: true,
     elegantConduct: true,
     ladylikePoise: true,

--- a/src/lib/sets/relics/SelfEnshroudedRecluse.ts
+++ b/src/lib/sets/relics/SelfEnshroudedRecluse.ts
@@ -2,7 +2,6 @@ import {
   ConditionalDataType,
   Sets,
 } from 'lib/constants/constants'
-import { wgslFalse } from 'lib/gpu/injection/wgslUtils'
 import { Source } from 'lib/optimization/buffSource'
 import {
   AKey,
@@ -48,7 +47,7 @@ const conditionals: SetConditionals = {
   },
   p4x: (x: ComputedStatsContainer, context: OptimizerContext, setConditionals: SetConditional) => {
     x.buff(StatKey.BOOST, 0.12, x.outputType(OutputTag.SHIELD).source(Source.SelfEnshroudedRecluse))
-    if (setConditionals.enabledSelfEnshroudedRecluse && !x.config.teammateSetEffects[Sets.SelfEnshroudedRecluse]) {
+    if (setConditionals.enabledSelfEnshroudedRecluse) {
       x.buff(StatKey.CD, 0.15, x.targets(TargetTag.FullTeam).source(Source.SelfEnshroudedRecluse))
       x.buff(StatKey.BOOST, 0.15, x.outputBuff(StatKey.CD).source(Source.SelfEnshroudedRecluse))
     }
@@ -58,7 +57,7 @@ const conditionals: SetConditionals = {
       ${buff.hit(HKey.BOOST, 0.10).outputType(OutputTag.SHIELD).wgsl(action, 2)}
       if (relic4p(*p_sets, SET_SelfEnshroudedRecluse) >= 1) {
         ${buff.hit(HKey.BOOST, 0.12).outputType(OutputTag.SHIELD).wgsl(action, 3)}
-        if (setConditionals.enabledSelfEnshroudedRecluse == true && ${wgslFalse(action.config.teammateSetEffects[Sets.SelfEnshroudedRecluse])}) {
+        if (setConditionals.enabledSelfEnshroudedRecluse == true) {
           ${buff.action(AKey.CD, 0.15).targets(TargetTag.FullTeam).wgsl(action, 4)}
           ${buff.hit(HKey.BOOST, 0.15).outputBuff(StatKey.CD).wgsl(action, 5)}
         }

--- a/src/lib/sets/relics/WorldRemakingDeliverer.ts
+++ b/src/lib/sets/relics/WorldRemakingDeliverer.ts
@@ -4,7 +4,6 @@ import {
   Stats,
 } from 'lib/constants/constants'
 import { basicP2 } from 'lib/gpu/injection/generateBasicSetEffects'
-import { wgslFalse } from 'lib/gpu/injection/wgslUtils'
 import {
   type BasicStatsArray,
   WgslStatName,
@@ -51,9 +50,7 @@ const conditionals: SetConditionals = {
   p4x: (x: ComputedStatsContainer, context: OptimizerContext, setConditionals: SetConditional) => {
     if (setConditionals.enabledWorldRemakingDeliverer) {
       x.buff(StatKey.HP_P, 0.24, x.targets(TargetTag.SelfAndMemosprite).source(Source.WorldRemakingDeliverer))
-      if (!x.config.teammateSetEffects[Sets.WorldRemakingDeliverer]) {
-        x.buff(StatKey.BOOST, 0.15, x.targets(TargetTag.FullTeam).source(Source.WorldRemakingDeliverer))
-      }
+      x.buff(StatKey.BOOST, 0.15, x.targets(TargetTag.FullTeam).source(Source.WorldRemakingDeliverer))
     }
   },
   gpuBasic: () => [
@@ -65,9 +62,7 @@ const conditionals: SetConditionals = {
       && setConditionals.enabledWorldRemakingDeliverer == true
     ) {
       ${buff.action(AKey.HP_P, 0.24).targets(TargetTag.SelfAndMemosprite).wgsl(action, 2)}
-      if (${wgslFalse(action.config.teammateSetEffects[Sets.WorldRemakingDeliverer])}) {
-        ${buff.action(AKey.BOOST, 0.15).targets(TargetTag.FullTeam).wgsl(action, 2)}
-      }
+      ${buff.action(AKey.BOOST, 0.15).targets(TargetTag.FullTeam).wgsl(action, 2)}
     }
   `,
   teammate: [{


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

- Fix Deliverer and Self-Enshrouded Recluse team buffs being suppressed when the wearer and a teammate both equip the same set (stackable sets should not deduplicate against teammate copies)
- Fix Rin Tohsaka max SP consumed and default SP consumed values

## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [ ] I have added commit messages that are descriptive and meaningful.
- [ ] I have tested the changes locally.
- [ ] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
