### PR TITLE
feat: minor tweaks

### DIFF
--- a/src/lib/characterPreview/characterPreviewController.tsx
+++ b/src/lib/characterPreview/characterPreviewController.tsx
@@ -151,15 +151,17 @@ function getRelic(relicsById: Partial<Record<string, Relic>>, character: Charact
 }
 
 export function resolveScoringType(
-  storedScoringType: ScoringType,
+  storedScoringType: ScoringType | undefined,
   scoringMetadata: ScoringMetadata,
 ) {
   if (storedScoringType === ScoringType.NONE || storedScoringType === ScoringType.SUBSTAT_SCORE) {
     return storedScoringType
   }
-  for (const configType of CONFIG_DISPLAY_ORDER) {
-    if (SCORING_CONFIG_REGISTRY[configType].scoringType === storedScoringType && hasConfig(scoringMetadata, configType)) {
-      return storedScoringType
+  if (storedScoringType != null) {
+    for (const configType of CONFIG_DISPLAY_ORDER) {
+      if (SCORING_CONFIG_REGISTRY[configType].scoringType === storedScoringType && hasConfig(scoringMetadata, configType)) {
+        return storedScoringType
+      }
     }
   }
   for (const configType of CONFIG_DISPLAY_ORDER) {

--- a/src/lib/characterPreview/scoring/ShowcaseBuildAnalysis.tsx
+++ b/src/lib/characterPreview/scoring/ShowcaseBuildAnalysis.tsx
@@ -5,8 +5,8 @@ import type {
   PreviewRelics,
   ShowcaseMetadata,
 } from 'lib/characterPreview/characterPreviewController'
+import { editShowcasePreferences } from 'lib/characterPreview/customization/showcaseCustomizationController'
 import { EstimatedTbpRelicsDisplay } from 'lib/characterPreview/summary/EstimatedTbpRelicsDisplay'
-import { SavedSessionKeys } from 'lib/constants/constantsSession'
 import {
   CONFIG_DISPLAY_ORDER,
   hasConfig,
@@ -14,8 +14,6 @@ import {
   SCORING_CONFIG_REGISTRY,
   ScoringType,
 } from 'lib/scoring/scoringConfig'
-import { SaveState } from 'lib/state/saveState'
-import { useGlobalStore } from 'lib/stores/app/appStore'
 import { ColorizedTitleWithInfo } from 'lib/ui/ColorizedLink'
 import {
   memo,
@@ -69,11 +67,10 @@ export const ShowcaseBuildAnalysis = memo(function ShowcaseBuildAnalysis({
     return segments
   }, [scoringMeta, t])
 
+  const characterId = showcaseMetadata.characterId
   const handleScoringTypeChange = useCallback((selection: string) => {
-    const value = Number(selection) as ScoringType
-    useGlobalStore.getState().setSavedSessionKey(SavedSessionKeys.scoringType, value)
-    SaveState.delayedSave()
-  }, [])
+    editShowcasePreferences(characterId, { scoringType: Number(selection) })
+  }, [characterId])
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', minHeight: 1000 }}>

--- a/src/lib/characterPreview/showcaseDerivedData.ts
+++ b/src/lib/characterPreview/showcaseDerivedData.ts
@@ -42,7 +42,7 @@ import type {
 interface ShowcaseLayoutParams {
   character: Character
   teamSelections: Partial<Record<ScoringConfigType, TeamSelection>>
-  storedScoringType: ScoringType
+  storedScoringType: ScoringType | undefined
   savedBuildOverride?: SavedBuild | null
   t: TFunction<'gameData'>
 }

--- a/src/lib/characterPreview/useCharacterPreviewState.ts
+++ b/src/lib/characterPreview/useCharacterPreviewState.ts
@@ -13,6 +13,7 @@ import type {
 import { SavedSessionKeys } from 'lib/constants/constantsSession'
 import { useScoringMetadata } from 'lib/hooks/useScoringMetadata'
 import { useRelicModalStore } from 'lib/overlays/modals/relicModal/relicModalStore'
+import type { ScoringType } from 'lib/scoring/scoringConfig'
 import { useGlobalStore } from 'lib/stores/app/appStore'
 import { useRelicStore } from 'lib/stores/relic/relicStore'
 import type { ShowcaseTabCharacter } from 'lib/tabs/tabShowcase/showcaseTabTypes'
@@ -84,15 +85,16 @@ export function useCharacterPreviewState(
     })),
   )
 
-  const { globalColorMode, storedScoringType, darkMode } = useGlobalStore(
+  const { globalColorMode, darkMode } = useGlobalStore(
     useShallow((s) => ({
       globalColorMode: s.savedSession[SavedSessionKeys.showcaseStandardMode]
         ? ShowcaseColorMode.STANDARD
         : ShowcaseColorMode.AUTO,
-      storedScoringType: s.savedSession.scoringType,
       darkMode: s.savedSession.showcaseDarkMode,
     })),
   )
+
+  const storedScoringType: ScoringType | undefined = showcasePreferences?.scoringType
 
   const relicsById = useRelicStore(useShallow((s) => {
     if (source === ShowcaseSource.SHOWCASE_TAB) return EMPTY_RELICS

--- a/src/lib/conditionals/character/1300/SparkleB1.ts
+++ b/src/lib/conditionals/character/1300/SparkleB1.ts
@@ -167,7 +167,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
         skillCdBuffBase: precisionRound(100 * skillCdBuffBase),
       }),
       min: 0,
-      max: 3.50,
+      max: 5.00,
       percent: true,
     },
     cipherBuff: content.cipherBuff,

--- a/src/lib/services/buildService.ts
+++ b/src/lib/services/buildService.ts
@@ -57,7 +57,7 @@ export function saveBuild(
     build = serializeFromOptimizer(name, characterId, state as typeof state & { lightCone: LightConeId }, equipped)
   } else {
     const scoringMetadata = getScoringMetadata(character.id)
-    const storedScoringType = useGlobalStore.getState().savedSession.scoringType
+    const storedScoringType = useShowcaseTabStore.getState().showcasePreferences[characterId]?.scoringType
     const effectiveScoringType = resolveScoringType(storedScoringType, scoringMetadata)
     const configType = configTypeForScoringType(effectiveScoringType) ?? ScoringConfigType.DPS
     const metadataField = CONFIG_FIELD_MAP[configType]

--- a/src/lib/tabs/tabWarp/WarpCalculatorTab.tsx
+++ b/src/lib/tabs/tabWarp/WarpCalculatorTab.tsx
@@ -84,6 +84,7 @@ function WarpPlanner() {
             <Select
               w={210}
               size='xs'
+              maxDropdownHeight={400}
               leftSection={<span style={{ fontSize: 12, whiteSpace: 'nowrap', paddingLeft: 2 }}>{t('Strategy')/* Strategy */}:</span>}
               leftSectionWidth={62} leftSectionPointerEvents='none'
               styles={{ input: { paddingLeft: 68 } }}

--- a/src/lib/tabs/tabWarp/warpCalculatorController.ts
+++ b/src/lib/tabs/tabWarp/warpCalculatorController.ts
@@ -37,7 +37,7 @@ export const WarpIncomeOptions: WarpIncomeDefinition[] = [
   //   generateOption('3.8', 3, WarpIncomeType.BP_EXPRESS, 31),
   // ],
   // ...generateOptions('4.0', 115, 96, 138, 107, 146, 115),
-  ...generateOptions('4.1', 98, 81, 114, 89, 122, 97),
+  // ...generateOptions('4.1', 98, 81, 114, 89, 122, 97),
   ...generateOptions('4.2', 117, 91, 140, 103, 149, 112),
   ...generateOptions('4.3', 91, 66, 116, 78, 124, 86),
 ]
@@ -74,9 +74,19 @@ function normalizeWarpTarget(raw: Partial<WarpTarget>, index: number): WarpTarge
     characterId: raw.characterId ?? null,
     lightConeId: raw.lightConeId ?? null,
     targetEidolonLevel: clampLevel(raw.targetEidolonLevel, DEFAULT_WARP_TARGET.targetEidolonLevel, EidolonLevel.NONE, EidolonLevel.E6),
-    targetSuperimpositionLevel: clampLevel(raw.targetSuperimpositionLevel, DEFAULT_WARP_TARGET.targetSuperimpositionLevel, SuperimpositionLevel.NONE, SuperimpositionLevel.S5),
+    targetSuperimpositionLevel: clampLevel(
+      raw.targetSuperimpositionLevel,
+      DEFAULT_WARP_TARGET.targetSuperimpositionLevel,
+      SuperimpositionLevel.NONE,
+      SuperimpositionLevel.S5,
+    ),
     currentEidolonLevel: clampLevel(raw.currentEidolonLevel, DEFAULT_WARP_TARGET.currentEidolonLevel, EidolonLevel.NONE, EidolonLevel.E6),
-    currentSuperimpositionLevel: clampLevel(raw.currentSuperimpositionLevel, DEFAULT_WARP_TARGET.currentSuperimpositionLevel, SuperimpositionLevel.NONE, SuperimpositionLevel.S5),
+    currentSuperimpositionLevel: clampLevel(
+      raw.currentSuperimpositionLevel,
+      DEFAULT_WARP_TARGET.currentSuperimpositionLevel,
+      SuperimpositionLevel.NONE,
+      SuperimpositionLevel.S5,
+    ),
   }
 }
 
@@ -206,7 +216,7 @@ function generateWarpMilestones(target: WarpTarget, startingState: StartingBanne
   // Walk the ordered path once: skip levels already owned, label the survivors from the running
   // eidolon/superimposition counters, and apply the banner's starting pity/guaranteed to the
   // first emitted pull of each type. Truncate at the milestone that first reaches the goal.
-  let skipCharacters = currentEidolonLevel       // owns E0..currentEidolon -> skip currentEidolon + 1 (NONE = -1 -> skip 0)
+  let skipCharacters = currentEidolonLevel // owns E0..currentEidolon -> skip currentEidolon + 1 (NONE = -1 -> skip 0)
   let skipLightCones = currentSuperimpositionLevel // owns S1..currentSi     -> skip currentSi      (NONE =  0 -> skip 0)
   let e = currentEidolonLevel
   let s = currentSuperimpositionLevel
@@ -239,7 +249,9 @@ function generateWarpMilestones(target: WarpTarget, startingState: StartingBanne
     const bannerStart = isCharacter ? startingState.character : startingState.lightCone
     const label = e === EidolonLevel.NONE
       ? `S${s}`
-      : targetSuperimpositionLevel === SuperimpositionLevel.NONE ? `E${e}` : `E${e}S${s}`
+      : targetSuperimpositionLevel === SuperimpositionLevel.NONE
+      ? `E${e}`
+      : `E${e}S${s}`
 
     milestones.push({
       warpType,

--- a/src/types/metadata.ts
+++ b/src/types/metadata.ts
@@ -37,6 +37,7 @@ export type ScoringConfig = {
 export type ShowcasePreferences = {
   color?: string,
   colorMode?: ShowcaseColorMode,
+  scoringType?: number,
 }
 
 export type ShowcaseTemporaryOptions = {


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

- Store the selected showcase scoring view (DPS Score / Substat Rolls / None) per character instead of globally, so switching characters no longer carries over the previous character's view selection
- Fix Sparkle B1's teammate Combat CD slider max from 350% to 500%
- Fix warp calculator Strategy dropdown showing a scrollbar by increasing the max dropdown height
- Remove v4.1 from warp income options
- Format long lines in warp calculator controller

## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [ ] I have added commit messages that are descriptive and meaningful.
- [ ] I have tested the changes locally.
- [ ] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
