### PR TITLE
feat: 4.4v2, avatar/warp fixes

### DIFF
--- a/src/lib/conditionals/character/1500/HimekoNova.ts
+++ b/src/lib/conditionals/character/1500/HimekoNova.ts
@@ -96,8 +96,8 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 
   const assistAoeScaling = skill(e, 2.50, 2.75)
   const assistRandomScaling = skill(e, 0.40, 0.44)
-  const verdictUltCdValue = skill(e, 1.00, 1.10)
-  const decimationCdValue = skill(e, 0.80, 0.88)
+  const verdictUltCdValue = skill(e, 2.00, 2.20)
+  const decimationCdValue = skill(e, 0.50, 0.55)
 
   const defaults = {
     navigatorsSemaphore: true,

--- a/src/lib/conditionals/character/1500/HimekoNova.ts
+++ b/src/lib/conditionals/character/1500/HimekoNova.ts
@@ -264,6 +264,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 
       x.buff(StatKey.CD, r.companionVerdict ? verdictUltCdValue : 0, x.damageType(DamageTag.ULT).source(SOURCE_UNIQUE))
       x.buff(StatKey.CD, !r.companionVerdict ? decimationCdValue : 0, x.source(SOURCE_UNIQUE))
+      x.buff(StatKey.CD, !r.companionVerdict ? decimationCdValue : 0, x.damageType(DamageTag.SKILL).source(SOURCE_UNIQUE))
     },
 
     precomputeMutualEffectsContainer: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {

--- a/src/lib/conditionals/lightcone/5star/AStarThatLightsTheNight.ts
+++ b/src/lib/conditionals/lightcone/5star/AStarThatLightsTheNight.ts
@@ -26,8 +26,8 @@ const conditionals = (s: SuperImpositionLevel, _withContent: boolean): LightCone
 
   const sValuesAtk = [0.40, 0.50, 0.60, 0.70, 0.80]
   const sValuesDefPen = [0.20, 0.25, 0.30, 0.35, 0.40]
-  const sValuesAssistSkillDmg = [0.20, 0.25, 0.30, 0.35, 0.40]
-  const sValuesUltDmg = [0.60, 0.75, 0.90, 1.05, 1.20]
+  const sValuesAssistSkillDmg = [0.25, 0.3125, 0.375, 0.4375, 0.50]
+  const sValuesUltDmg = [0.30, 0.375, 0.45, 0.525, 0.60]
   const formatPercent = (value: number) => `${precisionRound(100 * value)}%`
 
   const defaults = {
@@ -54,7 +54,7 @@ const conditionals = (s: SuperImpositionLevel, _withContent: boolean): LightCone
 
       x.buff(StatKey.ATK_P, sValuesAtk[s], x.source(SOURCE_LC))
       x.buff(StatKey.DEF_PEN, countTeamTrailblazeCompanion(context) >= 2 ? sValuesDefPen[s] : 0, x.source(SOURCE_LC))
-      x.buff(StatKey.BOOST, r.safeEscortStacks * sValuesAssistSkillDmg[s], x.damageType(DamageTag.SKILL).source(SOURCE_LC))
+      x.buff(StatKey.BOOST, r.safeEscortStacks * sValuesAssistSkillDmg[s], x.damageType(DamageTag.ASSIST).source(SOURCE_LC))
       x.buff(StatKey.BOOST, r.safeEscortStacks === 3 ? r.safeEscortStacks * sValuesUltDmg[s] : 0, x.damageType(DamageTag.ULT).source(SOURCE_LC))
     },
   }

--- a/src/lib/constants/constants.ts
+++ b/src/lib/constants/constants.ts
@@ -7,7 +7,7 @@ import type { StatKeyValue } from 'lib/optimization/engine/config/keys'
 export const CURRENT_OPTIMIZER_VERSION = 'v4.4.2'
 
 // Represents the beta data content version, used for display but not for update notifications
-export const CURRENT_DATA_VERSION = '4.4v1'
+export const CURRENT_DATA_VERSION = '4.4v2'
 
 // Controls downtime messaging
 export const SHOWCASE_DOWNTIME = false

--- a/src/lib/tabs/tabOptimizer/optimizerForm/components/TeammateCard.module.css
+++ b/src/lib/tabs/tabOptimizer/optimizerForm/components/TeammateCard.module.css
@@ -17,15 +17,35 @@
 /* ---- Avatar ---- */
 
 .avatar {
-  border: 1px solid rgba(255, 255, 255, 0.15);
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
-  transition: border-color 150ms ease, box-shadow 150ms ease;
+  display: block;
+  flex: 0 0 96px;
+  width: 96px;
+  height: 96px;
+  align-self: center;
+  padding: 0;
+  border: 0;
+  background-color: transparent;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: cover;
   cursor: pointer;
+  overflow: hidden;
 }
 
-.avatar:hover {
+.characterAvatar {
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 50%;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+  transition: border-color 150ms ease, box-shadow 150ms ease;
+}
+
+.characterAvatar:hover {
   border-color: rgba(255, 255, 255, 0.3);
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.5);
+}
+
+.lightConeAvatar {
+  border-radius: var(--mantine-radius-sm);
 }
 
 /* ---- Segmented control ---- */
@@ -34,4 +54,3 @@
   padding-inline: 0;
   min-width: 0;
 }
-

--- a/src/lib/tabs/tabOptimizer/optimizerForm/components/TeammateCard.tsx
+++ b/src/lib/tabs/tabOptimizer/optimizerForm/components/TeammateCard.tsx
@@ -1,6 +1,5 @@
 import {
   ActionIcon,
-  Avatar,
   CheckIcon,
   CloseButton,
   Combobox,
@@ -155,13 +154,12 @@ export const TeammateCard = memo(function TeammateCard({ index, dbMetadata }: {
             disabled={disabled}
           />
 
-          <Avatar
-            src={Assets.getCharacterAvatarById(teammateCharacterId)}
-            size={96}
-            radius={96}
-            className={classes.avatar}
+          <button
+            type='button'
+            aria-label='Select teammate character'
+            className={`${classes.avatar} ${classes.characterAvatar}`}
             onClick={() => setTeammateSelectModalOpen(true)}
-            style={{ alignSelf: 'center' }}
+            style={{ backgroundImage: `url(${Assets.getCharacterAvatarById(teammateCharacterId)})` }}
           />
 
           <Flex direction='column' w='100%' gap={6}>
@@ -240,11 +238,11 @@ export const TeammateCard = memo(function TeammateCard({ index, dbMetadata }: {
             disabled={disabled}
           />
 
-          <Avatar
-            src={Assets.getLightConeIconById(teammateLightConeId)}
-            size={96}
-            radius='sm'
-            style={{ cursor: 'pointer', alignSelf: 'center' }}
+          <button
+            type='button'
+            aria-label='Select teammate light cone'
+            className={`${classes.avatar} ${classes.lightConeAvatar}`}
+            style={{ backgroundImage: `url(${Assets.getLightConeIconById(teammateLightConeId)})` }}
             onClick={() => setTeammateLightConeSelectOpen(true)}
           />
         </Flex>

--- a/src/lib/tabs/tabWarp/warpTargetMutations.test.ts
+++ b/src/lib/tabs/tabWarp/warpTargetMutations.test.ts
@@ -245,7 +245,7 @@ test('a chained goal capped at E6 is kept as a redundant goal with no room to po
   expect(t[1]).toMatchObject({ currentEidolonLevel: EidolonLevel.E6, targetEidolonLevel: EidolonLevel.E6 })
 })
 
-// --- Add buttons pre-fill the owned eidolon / superimposition from the save ---
+// --- Add buttons pre-fill owned character eidolons from the save ---
 
 test('addCharGoal seeds the owned eidolon from the save', () => {
   storeMock.byId[CHAR_A] = { form: { characterEidolon: EidolonLevel.E3, lightCone: '99999', lightConeSuperimposition: SuperimpositionLevel.S1 } }
@@ -256,7 +256,7 @@ test('addCharGoal seeds the owned eidolon from the save', () => {
   expect(t[0]).toMatchObject({ currentEidolonLevel: EidolonLevel.E3, targetEidolonLevel: EidolonLevel.E4 })
 })
 
-test('addCharAndSignatureGoal seeds owned eidolon and the signature superimposition', () => {
+test('addCharAndSignatureGoal seeds owned eidolon but starts the signature from NONE', () => {
   configMock.byId[CHAR_A] = { defaultLightCone: SIG_LC }
   storeMock.byId[CHAR_A] = { form: { characterEidolon: EidolonLevel.E3, lightCone: SIG_LC, lightConeSuperimposition: SuperimpositionLevel.S2 } }
   const { form, current } = fakeForm([])
@@ -264,7 +264,7 @@ test('addCharAndSignatureGoal seeds owned eidolon and the signature superimposit
   const t = current()
   expect(t).toHaveLength(2)
   expect(t[0]).toMatchObject({ characterId: CHAR_A, lightConeId: null, currentEidolonLevel: EidolonLevel.E3, targetEidolonLevel: EidolonLevel.E4 })
-  expect(t[1]).toMatchObject({ lightConeId: SIG_LC, currentSuperimpositionLevel: SuperimpositionLevel.S2, targetSuperimpositionLevel: SuperimpositionLevel.S3 })
+  expect(t[1]).toMatchObject({ lightConeId: SIG_LC, currentSuperimpositionLevel: SuperimpositionLevel.NONE, targetSuperimpositionLevel: SuperimpositionLevel.S1 })
 })
 
 test('addCharAndSignatureGoal starts the signature from NONE when a different cone is equipped', () => {

--- a/src/lib/tabs/tabWarp/warpTargetMutations.ts
+++ b/src/lib/tabs/tabWarp/warpTargetMutations.ts
@@ -38,15 +38,6 @@ function getOwnedEidolon(characterId: CharacterId | null): EidolonLevel {
   return form.characterEidolon as EidolonLevel
 }
 
-// The superimposition already owned of a character's signature light cone. Only counts when that
-// character actually has the signature equipped; any other equipped cone reads as NONE.
-function getOwnedSignatureSuperimposition(characterId: CharacterId | null, signatureLcId: LightConeId | null): SuperimpositionLevel {
-  if (!characterId || !signatureLcId) return SuperimpositionLevel.NONE
-  const form = getCharacterById(characterId)?.form
-  if (!form || form.lightCone !== signatureLcId) return SuperimpositionLevel.NONE
-  return form.lightConeSuperimposition as SuperimpositionLevel
-}
-
 // --- Single gateway: every mutation goes through here ---
 
 function setTargets(form: UseFormReturnType<WarpRequest>, targets: WarpTarget[]) {
@@ -148,7 +139,7 @@ export function addCharAndSignatureGoal(form: UseFormReturnType<WarpRequest>, ch
   const eidolonFloor = getCharacterEidolonFloor(existing, characterId, existing.length)
   const lcFloor = getLightConeSuperimpositionFloor(existing, signatureLcId, existing.length)
   const eidolonFrom = Math.max(eidolonFloor, getOwnedEidolon(characterId))
-  const superimpositionFrom = Math.max(lcFloor, getOwnedSignatureSuperimposition(characterId, signatureLcId))
+  const superimpositionFrom = lcFloor
   const charTarget = makeTarget({
     characterId,
     lightConeId: null,


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

  - Update 4.4v2 data version and tuning values for Himeko Nova and A Star That Lights The Night.
  - Fix A Star That Lights The Night assist damage buff tagging.
  - Fix teammate card portrait and light cone rendering to avoid Mantine avatar placeholders.
  - Fix Multi Target warp character + signature adds so signature light cones start at `- -> S1`.

## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [ ] I have added commit messages that are descriptive and meaningful.
- [ ] I have tested the changes locally.
- [ ] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
