### PR TITLE
feat: subdps default to main dps on non dps teams

### DIFF
--- a/src/lib/characterPreview/customization/ShowcaseCustomizationSidebar.tsx
+++ b/src/lib/characterPreview/customization/ShowcaseCustomizationSidebar.tsx
@@ -17,6 +17,7 @@ import {
 } from '@tabler/icons-react'
 import i18next from 'i18next'
 import { ShowcaseSource } from 'lib/characterPreview/CharacterPreviewComponents'
+import { resolveEffectiveDeprioritizeBuffs } from 'lib/characterPreview/showcaseDerivedData'
 import { withAlpha } from 'lib/characterPreview/color/colorUtils'
 import {
   buildCardBgPipelineConfig,
@@ -163,7 +164,9 @@ const ScoringPanel = memo(function ScoringPanel({ characterId, scoringType }: {
   const spdBenchmark = useShowcaseTabStore((s) => s.showcaseTemporaryOptionsByCharacter[characterId]?.spdBenchmark)
   const scoringMetadata = useScoringMetadata(characterId)
   const spdValue = scoringMetadata.stats[Stats.SPD]
-  const deprioritizeBuffs = scoringMetadata.simulation?.deprioritizeBuffs ?? false
+  const deprioritizeBuffs = scoringMetadata.simulation
+    ? resolveEffectiveDeprioritizeBuffs(characterId, scoringMetadata.simulation)
+    : false
 
   function onSpdPrecisionChange(preciseSpd: boolean) {
     useGlobalStore.getState().setSavedSessionKey(SavedSessionKeys.showcasePreciseSpd, preciseSpd)

--- a/src/lib/characterPreview/showcaseDerivedData.ts
+++ b/src/lib/characterPreview/showcaseDerivedData.ts
@@ -25,10 +25,15 @@ import {
   ScoringType,
 } from 'lib/scoring/scoringConfig'
 import { resolveSimulationMetadata } from 'lib/simulations/orchestrator/runDpsScoreBenchmarkOrchestrator'
+import { getGameMetadata } from 'lib/state/gameMetadata'
 import { getCharacterById } from 'lib/stores/character/characterStore'
-import { getScoringMetadata } from 'lib/stores/scoring/scoringStore'
+import {
+  getScoringMetadata,
+  useScoringStore,
+} from 'lib/stores/scoring/scoringStore'
 import type {
   Character,
+  CharacterId,
   SavedBuild,
 } from 'types/character'
 import type { CustomImageConfig } from 'types/customImage'
@@ -77,7 +82,10 @@ export function resolveShowcaseLayout(params: ShowcaseLayoutParams): ShowcaseLay
   const configMetadata: Partial<Record<ScoringConfigType, SimulationMetadata>> = {}
   for (const configType of CONFIG_DISPLAY_ORDER) {
     const meta = resolveSimulationMetadata(character, configType, resolvedTeamSelections[configType], savedBuildOverride)
-    if (meta) configMetadata[configType] = meta
+    if (meta) {
+      meta.deprioritizeBuffs = resolveEffectiveDeprioritizeBuffs(character.id, meta)
+      configMetadata[configType] = meta
+    }
   }
 
   const hasSimulation = CONFIG_DISPLAY_ORDER.some((configType) => configMetadata[configType] != null)
@@ -112,4 +120,31 @@ export function resolveShowcaseLayout(params: ShowcaseLayoutParams): ShowcaseLay
     displayDimensions,
     artistName,
   }
+}
+
+/**
+ * Sub DPS characters default to main DPS when no teammate has a DPS simulation,
+ * since the showcased character is the sole damage source. If the user has
+ * explicitly overridden deprioritizeBuffs, their choice takes precedence.
+ */
+export function resolveEffectiveDeprioritizeBuffs(
+  characterId: CharacterId,
+  simulation: SimulationMetadata,
+): boolean {
+  const rawOverride = useScoringStore.getState().scoringMetadataOverrides[characterId]
+  if (rawOverride?.simulation != null && 'deprioritizeBuffs' in rawOverride.simulation) {
+    return simulation.deprioritizeBuffs ?? false
+  }
+
+  if (simulation.deprioritizeBuffs) {
+    const characters = getGameMetadata().characters
+    const hasTeammateDpsSim = simulation.teammates.some((tm) =>
+      characters[tm.characterId]?.scoringMetadata?.simulation != null
+    )
+    if (!hasTeammateDpsSim) {
+      return false
+    }
+  }
+
+  return simulation.deprioritizeBuffs ?? false
 }

--- a/src/lib/characterPreview/showcaseDerivedData.ts
+++ b/src/lib/characterPreview/showcaseDerivedData.ts
@@ -24,6 +24,16 @@ import {
   isSimScoreMode,
   ScoringType,
 } from 'lib/scoring/scoringConfig'
+import { Aventurine } from 'lib/conditionals/character/1300/Aventurine'
+import { Jade } from 'lib/conditionals/character/1300/Jade'
+import { TheDahlia } from 'lib/conditionals/character/1300/TheDahlia'
+import { Cipher } from 'lib/conditionals/character/1400/Cipher'
+import { Hyacine } from 'lib/conditionals/character/1400/Hyacine'
+import { Tribbie } from 'lib/conditionals/character/1400/Tribbie'
+import { Yaoguang } from 'lib/conditionals/character/1500/Yaoguang'
+import { KafkaB1 } from 'lib/conditionals/character/1000/KafkaB1'
+import { Fugue } from 'lib/conditionals/character/1200/Fugue'
+import { SilverWolfB1 } from 'lib/conditionals/character/1000/SilverWolfB1'
 import { resolveSimulationMetadata } from 'lib/simulations/orchestrator/runDpsScoreBenchmarkOrchestrator'
 import { getGameMetadata } from 'lib/state/gameMetadata'
 import { getCharacterById } from 'lib/stores/character/characterStore'
@@ -122,6 +132,22 @@ export function resolveShowcaseLayout(params: ShowcaseLayoutParams): ShowcaseLay
   }
 }
 
+// Characters whose DPS simulation is secondary to their support/heal/shield role.
+// When these are teammates, they don't count as a "real DPS" for the purpose of
+// keeping another sub DPS in sub mode.
+const SUB_SUB_DPS_CHARACTERS: Set<CharacterId> = new Set([
+  Aventurine.id,
+  Hyacine.id,
+  TheDahlia.id,
+  Tribbie.id,
+  KafkaB1.id,
+  Fugue.id,
+  Yaoguang.id,
+  Jade.id,
+  Cipher.id,
+  SilverWolfB1.id,
+])
+
 /**
  * Sub DPS characters default to main DPS when no teammate has a DPS simulation,
  * since the showcased character is the sole damage source. If the user has
@@ -138,9 +164,10 @@ export function resolveEffectiveDeprioritizeBuffs(
 
   if (simulation.deprioritizeBuffs) {
     const characters = getGameMetadata().characters
-    const hasTeammateDpsSim = simulation.teammates.some((tm) =>
-      characters[tm.characterId]?.scoringMetadata?.simulation != null
-    )
+    const hasTeammateDpsSim = simulation.teammates.some((teammate) => {
+      if (!characters[teammate.characterId]?.scoringMetadata?.simulation) return false
+      return !SUB_SUB_DPS_CHARACTERS.has(teammate.characterId)
+    })
     if (!hasTeammateDpsSim) {
       return false
     }

--- a/src/lib/conditionals/character/1300/Jade.ts
+++ b/src/lib/conditionals/character/1300/Jade.ts
@@ -317,6 +317,7 @@ const simulation = (): SimulationMetadata => ({
     ...SPREAD_ORNAMENTS_2P_FUA,
     ...SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
   ],
+  deprioritizeBuffs: true,
   teammates: [
     {
       characterId: TheHerta.id,

--- a/src/lib/conditionals/character/1400/Hyacine.ts
+++ b/src/lib/conditionals/character/1400/Hyacine.ts
@@ -576,6 +576,7 @@ const simulation = (): SimulationMetadata => ({
     Sets.ArcadiaOfWovenDreams,
     ...SPREAD_ORNAMENTS_2P_HEAL,
   ],
+  deprioritizeBuffs: true,
   teammates: [
     {
       characterId: Castorice.id,


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

- Default showcase DPS mode to Main when a sub DPS character has no real DPS teammate, instead of always following the character config
- Add a maintained list of "sub-sub DPS" characters (Aventurine, Hyacine, Jade, Tribbie, etc.) who don't count as real DPS teammates for the purpose of this defaulting
- Respect explicit user overrides of the DPS mode toggle regardless of team composition
- Add missing deprioritizeBuffs: true to Jade and Hyacine DPS simulations

## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [ ] I have added commit messages that are descriptive and meaningful.
- [ ] I have tested the changes locally.
- [ ] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
