### PR TITLE
feat: add per-filter clear button to FilterPill dropdown

### DIFF
--- a/src/lib/tabs/tabRelics/topBar/FilterPill.tsx
+++ b/src/lib/tabs/tabRelics/topBar/FilterPill.tsx
@@ -6,14 +6,13 @@ import {
   Group,
   useCombobox,
 } from '@mantine/core'
-import { IconEraser, IconFilter } from '@tabler/icons-react'
+import { IconFilter, IconXMark } from '@tabler/icons-react'
 import {
   memo,
   type ReactNode,
   useMemo,
   useState,
 } from 'react'
-import { useTranslation } from 'react-i18next'
 
 export type FilterOption<T> = {
   value: T,
@@ -40,7 +39,6 @@ function FilterPillInner<T extends string | number | boolean>({
   flex = 1,
   columns = 1,
 }: FilterPillProps<T>) {
-  const { t } = useTranslation('relicsTab')
   const [search, setSearch] = useState('')
   const optionValues = useMemo(() => new Set(options.map((o) => o.value)), [options])
   const activeCount = useMemo(() => selected.filter((v) => optionValues.has(v)).length, [selected, optionValues])
@@ -83,7 +81,9 @@ function FilterPillInner<T extends string | number | boolean>({
           variant={activeCount > 0 ? 'light' : 'default'}
           size='xs'
           onClick={() => combobox.toggleDropdown()}
-          leftSection={<IconFilter size={12} />}
+          leftSection={activeCount > 0
+            ? <IconXMark size={14} onClick={(e) => { e.stopPropagation(); onChange([]) }} />
+            : <IconFilter size={12} />}
           rightSection={activeCount > 0 ? <Badge size='xs' circle variant='filled'>{activeCount}</Badge> : undefined}
           style={{ flex, minWidth: 0, width: '100%' }}
         >
@@ -130,19 +130,6 @@ function FilterPillInner<T extends string | number | boolean>({
           })}
           {combobox.dropdownOpened && filteredOptions.length === 0 && <Combobox.Empty>No results</Combobox.Empty>}
         </Combobox.Options>
-        <div style={{ padding: '4px 8px', borderTop: '1px solid var(--mantine-color-default-border)' }}>
-          <Button
-            size='xs'
-            variant='subtle'
-            color='dimmed'
-            fullWidth
-            disabled={activeCount === 0}
-            leftSection={<IconEraser size={12} />}
-            onClick={() => onChange([])}
-          >
-            {t('RelicFilterBar.Clear')}
-          </Button>
-        </div>
       </Combobox.Dropdown>
     </Combobox>
   )

--- a/src/lib/tabs/tabRelics/topBar/FilterPill.tsx
+++ b/src/lib/tabs/tabRelics/topBar/FilterPill.tsx
@@ -2,11 +2,12 @@ import {
   Badge,
   Button,
   Checkbox,
+  CloseButton,
   Combobox,
   Group,
   useCombobox,
 } from '@mantine/core'
-import { IconFilter, IconXMark } from '@tabler/icons-react'
+import { IconFilter } from '@tabler/icons-react'
 import {
   memo,
   type ReactNode,
@@ -82,7 +83,7 @@ function FilterPillInner<T extends string | number | boolean>({
           size='xs'
           onClick={() => combobox.toggleDropdown()}
           leftSection={activeCount > 0
-            ? <IconXMark size={14} onClick={(e) => { e.stopPropagation(); onChange([]) }} />
+            ? <CloseButton size={16} iconSize={16} variant='transparent' onClick={(e) => { e.stopPropagation(); onChange([]) }} />
             : <IconFilter size={12} />}
           rightSection={activeCount > 0 ? <Badge size='xs' circle variant='filled'>{activeCount}</Badge> : undefined}
           style={{ flex, minWidth: 0, width: '100%' }}

--- a/src/lib/tabs/tabRelics/topBar/FilterPill.tsx
+++ b/src/lib/tabs/tabRelics/topBar/FilterPill.tsx
@@ -6,13 +6,14 @@ import {
   Group,
   useCombobox,
 } from '@mantine/core'
-import { IconFilter } from '@tabler/icons-react'
+import { IconEraser, IconFilter } from '@tabler/icons-react'
 import {
   memo,
   type ReactNode,
   useMemo,
   useState,
 } from 'react'
+import { useTranslation } from 'react-i18next'
 
 export type FilterOption<T> = {
   value: T,
@@ -39,6 +40,7 @@ function FilterPillInner<T extends string | number | boolean>({
   flex = 1,
   columns = 1,
 }: FilterPillProps<T>) {
+  const { t } = useTranslation('relicsTab')
   const [search, setSearch] = useState('')
   const optionValues = useMemo(() => new Set(options.map((o) => o.value)), [options])
   const activeCount = useMemo(() => selected.filter((v) => optionValues.has(v)).length, [selected, optionValues])
@@ -128,6 +130,19 @@ function FilterPillInner<T extends string | number | boolean>({
           })}
           {combobox.dropdownOpened && filteredOptions.length === 0 && <Combobox.Empty>No results</Combobox.Empty>}
         </Combobox.Options>
+        <div style={{ padding: '4px 8px', borderTop: '1px solid var(--mantine-color-default-border)' }}>
+          <Button
+            size='xs'
+            variant='subtle'
+            color='dimmed'
+            fullWidth
+            disabled={activeCount === 0}
+            leftSection={<IconEraser size={12} />}
+            onClick={() => onChange([])}
+          >
+            {t('RelicFilterBar.Clear')}
+          </Button>
+        </div>
       </Combobox.Dropdown>
     </Combobox>
   )


### PR DESCRIPTION
Each FilterPill dropdown now shows a Clear button at the bottom of the options list. The button is disabled when no options are selected, and clears only that specific filter when clicked without affecting other active filters or closing the dropdown.

# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

Added

- Added a per-filter Clear button to the bottom of each FilterPill dropdown
- The button uses the existing `IconEraser` icon and `RelicFilterBar.Clear` translation key, consistent with the global Clear button in the top bar
- The button is disabled when no options are selected for that filter
- Clicking Clear resets only that specific filter without affecting other active filters or closing the dropdown

## Related Issue

-

## Checklist

- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots

**Clear button disabled (no active filters):**
<img width="224" height="236" alt="image" src="https://github.com/user-attachments/assets/d73201fe-fa58-44b6-bf44-03b4f8cce0f5" />

**Clear button enabled (with active filters):**
<img width="182" height="245" alt="image" src="https://github.com/user-attachments/assets/776df477-1436-4a12-b75c-fd87bf543fa2" />
