### PR TITLE
feat: hard/soft breakpoints config

### DIFF
--- a/src/leaderboard/pipeline/leaderboardReporting.ts
+++ b/src/leaderboard/pipeline/leaderboardReporting.ts
@@ -11,6 +11,7 @@ import type {
   LeaderboardBuildScoreCacheStats,
   LeaderboardMetricsSnapshot,
   LeaderboardScoringProfile,
+  PrivateBoard,
   PrivateRankedEntry,
   PrivateRankedOutput,
 } from 'leaderboard/shared/types'
@@ -55,8 +56,6 @@ export function printLeaderboardResults(privateOutput: PrivateRankedOutput, topN
 }
 
 export function printTopNCoverageAnalysis(privateOutput: PrivateRankedOutput, topNPublic: number): void {
-  const MIN_AEON_SCORE = 1.50
-
   type CharStats = {
     boards: number,
     survivors: number,
@@ -199,11 +198,26 @@ function getBuildSummary(char: MinifiedCharacter): { body: string, feet: string,
   }
 }
 
+const MIN_AEON_SCORE = 1.50
 const DIAGNOSTIC_LIMIT = 20
 
-function printDeepAeonDiagnostic(charId: string, charName: string, privateOutput: PrivateRankedOutput, topNPublic: number): void {
-  const MIN_AEON_SCORE = 1.50
+function printEntryTable(entries: PrivateRankedEntry[], title: string): void {
+  const limited = entries.slice(0, DIAGNOSTIC_LIMIT)
+  const summaries = limited.map((entry) => getBuildSummary(entry.data.character))
+  console.log(`\n-- ${title} --`)
+  console.log(`${'Rank'.padStart(5)} ${'Score'.padStart(6)} ${'E'.padStart(1)} ${'Body'.padEnd(10)} ${'Feet'.padEnd(10)} ${'Sphere'.padEnd(14)} ${'Rope'.padEnd(10)} LC`)
+  for (let i = 0; i < limited.length; i++) {
+    const entry = limited[i]
+    const b = summaries[i]
+    const pct = (entry.score * 100).toFixed(0)
+    console.log(
+      `${String(entry.preFilterRank).padStart(5)} ${(pct + '%').padStart(6)} ${String(b.eidolon).padStart(1)} ${b.body.padEnd(10)} ${b.feet.padEnd(10)} ${b.sphere.padEnd(14)} ${b.rope.padEnd(10)} S${b.lcSuper} ${b.lc}`,
+    )
+  }
+  console.log(`  Sets: ${summaries.map((b) => b.sets).join(' | ')}`)
+}
 
+function printDeepAeonDiagnostic(charId: string, charName: string, privateOutput: PrivateRankedOutput, topNPublic: number): void {
   const aeonEntries: PrivateRankedEntry[] = []
   const nonAeonEntries: PrivateRankedEntry[] = []
 
@@ -224,27 +238,8 @@ function printDeepAeonDiagnostic(charId: string, charName: string, privateOutput
 
   console.log(`\n===== DEEP AEON DIAGNOSTIC: ${charName} (${aeonEntries.length} aeons, ${nonAeonEntries.length} non-aeons in top-${topNPublic}) =====`)
 
-  console.log(`\n-- Deepest-ranked aeons (worst prefilter rank first) --`)
-  console.log(`${'Rank'.padStart(5)} ${'Score'.padStart(6)} ${'E'.padStart(1)} ${'Body'.padEnd(10)} ${'Feet'.padEnd(10)} ${'Sphere'.padEnd(14)} ${'Rope'.padEnd(10)} LC`)
-  for (const entry of aeonEntries.slice(0, DIAGNOSTIC_LIMIT)) {
-    const b = getBuildSummary(entry.data.character)
-    const pct = (entry.score * 100).toFixed(0)
-    console.log(
-      `${String(entry.preFilterRank).padStart(5)} ${(pct + '%').padStart(6)} ${String(b.eidolon).padStart(1)} ${b.body.padEnd(10)} ${b.feet.padEnd(10)} ${b.sphere.padEnd(14)} ${b.rope.padEnd(10)} S${b.lcSuper} ${b.lc}`,
-    )
-  }
-  console.log(`  Sets: ${aeonEntries.slice(0, DIAGNOSTIC_LIMIT).map((e) => getBuildSummary(e.data.character).sets).join(' | ')}`)
-
-  console.log(`\n-- Top-ranked non-aeons (best prefilter rank first) --`)
-  console.log(`${'Rank'.padStart(5)} ${'Score'.padStart(6)} ${'E'.padStart(1)} ${'Body'.padEnd(10)} ${'Feet'.padEnd(10)} ${'Sphere'.padEnd(14)} ${'Rope'.padEnd(10)} LC`)
-  for (const entry of nonAeonEntries.slice(0, DIAGNOSTIC_LIMIT)) {
-    const b = getBuildSummary(entry.data.character)
-    const pct = (entry.score * 100).toFixed(0)
-    console.log(
-      `${String(entry.preFilterRank).padStart(5)} ${(pct + '%').padStart(6)} ${String(b.eidolon).padStart(1)} ${b.body.padEnd(10)} ${b.feet.padEnd(10)} ${b.sphere.padEnd(14)} ${b.rope.padEnd(10)} S${b.lcSuper} ${b.lc}`,
-    )
-  }
-  console.log(`  Sets: ${nonAeonEntries.slice(0, DIAGNOSTIC_LIMIT).map((e) => getBuildSummary(e.data.character).sets).join(' | ')}`)
+  printEntryTable(aeonEntries, 'Deepest-ranked aeons (worst prefilter rank first)')
+  printEntryTable(nonAeonEntries, 'Top-ranked non-aeons (best prefilter rank first)')
   console.log()
 }
 
@@ -307,12 +302,11 @@ type SubstatAnalysisResult = {
   weights: number[],
 }
 
-function analyzeSubstatAllocation(charId: string, privateOutput: PrivateRankedOutput, topNPublic: number): SubstatAnalysisResult | null {
+function analyzeSubstatAllocation(charId: string, boards: PrivateBoard[], topNPublic: number): SubstatAnalysisResult | null {
   type EntryData = { units: Record<string, number>, isTop: boolean }
   const entryMap = new Map<string, EntryData>()
 
-  for (const [, board] of Object.entries(privateOutput.boards)) {
-    if (board.characterId !== charId) continue
+  for (const board of boards) {
     for (const entry of board.entries) {
       const existing = entryMap.get(entry.uidHash)
       if (!existing) {
@@ -364,10 +358,20 @@ type CoverageCharStat = { charId: string, name: string, aeons: number, topN: num
 function printWeightAnalysisSummary(chars: CoverageCharStat[], privateOutput: PrivateRankedOutput, topNPublic: number): void {
 
   console.log('\n========== SUBSTAT ANALYSIS: top-100 substat allocation (normalized to 1.00) ==========')
-  const results: SubstatAnalysisResult[] = []
 
+  const boardsByCharId = new Map<string, PrivateBoard[]>()
+  for (const board of Object.values(privateOutput.boards)) {
+    const existing = boardsByCharId.get(board.characterId)
+    if (existing) {
+      existing.push(board)
+    } else {
+      boardsByCharId.set(board.characterId, [board])
+    }
+  }
+
+  const results: SubstatAnalysisResult[] = []
   for (const c of chars) {
-    const result = analyzeSubstatAllocation(c.charId, privateOutput, topNPublic)
+    const result = analyzeSubstatAllocation(c.charId, boardsByCharId.get(c.charId) ?? [], topNPublic)
     if (result) results.push(result)
   }
 

--- a/src/lib/conditionals/character/1000/KafkaB1.ts
+++ b/src/lib/conditionals/character/1000/KafkaB1.ts
@@ -362,9 +362,12 @@ const simulation = (): SimulationMetadata => ({
     Stats.CR,
     Stats.CD,
   ],
-  breakpoints: {
-    [Stats.EHR]: 0.75,
-  },
+  hardBreakpoints: [
+    {
+      stat: Stats.EHR,
+      threshold: 0.75,
+    },
+  ],
   comboTurnAbilities: [
     NULL_TURN_ABILITY_NAME,
     START_ULT,

--- a/src/lib/conditionals/character/1000/KafkaB1.ts
+++ b/src/lib/conditionals/character/1000/KafkaB1.ts
@@ -363,10 +363,7 @@ const simulation = (): SimulationMetadata => ({
     Stats.CD,
   ],
   hardBreakpoints: [
-    {
-      stat: Stats.EHR,
-      threshold: 0.75,
-    },
+    { stat: Stats.EHR, threshold: 0.75 },
   ],
   comboTurnAbilities: [
     NULL_TURN_ABILITY_NAME,

--- a/src/lib/conditionals/character/1000/SilverWolfB1.ts
+++ b/src/lib/conditionals/character/1000/SilverWolfB1.ts
@@ -361,9 +361,9 @@ const simulation = (): SimulationMetadata => ({
     Stats.ATK,
     Stats.EHR,
   ],
-  breakpoints: {
-    [Stats.EHR]: 0.50,
-  },
+  softBreakpoints: [
+    { stat: Stats.EHR, threshold: 0.50 },
+  ],
   comboTurnAbilities: [
     NULL_TURN_ABILITY_NAME,
     START_ULT,

--- a/src/lib/conditionals/character/1200/Fugue.ts
+++ b/src/lib/conditionals/character/1200/Fugue.ts
@@ -315,9 +315,9 @@ const simulation = (): SimulationMetadata => ({
     Stats.EHR,
   ],
   errRopeEidolon: 0,
-  breakpoints: {
-    [Stats.EHR]: 0.67,
-  },
+  softBreakpoints: [
+    { stat: Stats.EHR, threshold: 0.67 },
+  ],
   comboTurnAbilities: [
     NULL_TURN_ABILITY_NAME,
     START_ULT,

--- a/src/lib/conditionals/character/1300/BlackSwanB1.ts
+++ b/src/lib/conditionals/character/1300/BlackSwanB1.ts
@@ -334,9 +334,9 @@ const simulation = (): SimulationMetadata => ({
     Stats.CR,
     Stats.CD,
   ],
-  breakpoints: {
-    [Stats.EHR]: 1.20,
-  },
+  softBreakpoints: [
+    { stat: Stats.EHR, threshold: 1.20 },
+  ],
   comboTurnAbilities: [
     NULL_TURN_ABILITY_NAME,
     START_ULT,

--- a/src/lib/conditionals/character/1300/Rappa.ts
+++ b/src/lib/conditionals/character/1300/Rappa.ts
@@ -353,9 +353,9 @@ const simulation = (): SimulationMetadata => ({
     Stats.CD,
     Stats.CR,
   ],
-  breakpoints: {
-    [Stats.ATK]: 3200,
-  },
+  softBreakpoints: [
+    { stat: Stats.ATK, threshold: 3200 },
+  ],
   comboTurnAbilities: [
     NULL_TURN_ABILITY_NAME,
     START_ULT,

--- a/src/lib/conditionals/character/1400/Cipher.ts
+++ b/src/lib/conditionals/character/1400/Cipher.ts
@@ -470,9 +470,9 @@ const simulation = (): SimulationMetadata => ({
     Stats.ATK,
     Stats.EHR,
   ],
-  breakpoints: {
-    [Stats.EHR]: 0.19,
-  },
+  softBreakpoints: [
+    { stat: Stats.EHR, threshold: 0.19 },
+  ],
   comboTurnAbilities: [
     NULL_TURN_ABILITY_NAME,
     DEFAULT_ULT,

--- a/src/lib/conditionals/character/1400/Cyrene.ts
+++ b/src/lib/conditionals/character/1400/Cyrene.ts
@@ -473,7 +473,9 @@ const simulation = (): SimulationMetadata => ({
     Stats.HP,
     Stats.SPD,
   ],
-  softBreakpoints: [{ stat: Stats.SPD, threshold: 180 }],
+  softBreakpoints: [
+    { stat: Stats.SPD, threshold: 180 },
+  ],
   comboTurnAbilities: [
     NULL_TURN_ABILITY_NAME,
     DEFAULT_ULT,

--- a/src/lib/conditionals/character/1400/Cyrene.ts
+++ b/src/lib/conditionals/character/1400/Cyrene.ts
@@ -473,7 +473,7 @@ const simulation = (): SimulationMetadata => ({
     Stats.HP,
     Stats.SPD,
   ],
-  breakpoints: { [Stats.SPD]: 180 },
+  softBreakpoints: [{ stat: Stats.SPD, threshold: 180 }],
   comboTurnAbilities: [
     NULL_TURN_ABILITY_NAME,
     DEFAULT_ULT,

--- a/src/lib/conditionals/character/1400/Cyrene.ts
+++ b/src/lib/conditionals/character/1400/Cyrene.ts
@@ -473,7 +473,7 @@ const simulation = (): SimulationMetadata => ({
     Stats.HP,
     Stats.SPD,
   ],
-  softBreakpoints: [
+  hardBreakpoints: [
     { stat: Stats.SPD, threshold: 180 },
   ],
   comboTurnAbilities: [

--- a/src/lib/conditionals/character/1400/Hyacine.ts
+++ b/src/lib/conditionals/character/1400/Hyacine.ts
@@ -559,9 +559,9 @@ const simulation = (): SimulationMetadata => ({
     START_SKILL,
     END_MEMO_SKILL,
   ],
-  breakpoints: {
-    [Stats.SPD]: 200,
-  },
+  softBreakpoints: [
+    { stat: Stats.SPD, threshold: 200 },
+  ],
   relicSets: [
     [Sets.WarriorGoddessOfSunAndThunder, Sets.WarriorGoddessOfSunAndThunder],
     [Sets.WorldRemakingDeliverer, Sets.WorldRemakingDeliverer],

--- a/src/lib/conditionals/character/1400/Hyacine.ts
+++ b/src/lib/conditionals/character/1400/Hyacine.ts
@@ -559,7 +559,7 @@ const simulation = (): SimulationMetadata => ({
     START_SKILL,
     END_MEMO_SKILL,
   ],
-  softBreakpoints: [
+  hardBreakpoints: [
     { stat: Stats.SPD, threshold: 200 },
   ],
   relicSets: [

--- a/src/lib/conditionals/character/1400/Hysilens.ts
+++ b/src/lib/conditionals/character/1400/Hysilens.ts
@@ -417,7 +417,7 @@ const simulation = (): SimulationMetadata => ({
     Stats.CR,
     Stats.CD,
   ],
-  softBreakpoints: [
+  hardBreakpoints: [
     { stat: Stats.EHR, threshold: 1.20 },
   ],
   comboTurnAbilities: [

--- a/src/lib/conditionals/character/1400/Hysilens.ts
+++ b/src/lib/conditionals/character/1400/Hysilens.ts
@@ -417,9 +417,9 @@ const simulation = (): SimulationMetadata => ({
     Stats.CR,
     Stats.CD,
   ],
-  breakpoints: {
-    [Stats.EHR]: 1.20,
-  },
+  softBreakpoints: [
+    { stat: Stats.EHR, threshold: 1.20 },
+  ],
   comboTurnAbilities: [
     NULL_TURN_ABILITY_NAME,
     START_ULT,

--- a/src/lib/conditionals/character/1500/SilverWolfLv999.ts
+++ b/src/lib/conditionals/character/1500/SilverWolfLv999.ts
@@ -523,7 +523,7 @@ const simulation = (): SimulationMetadata => ({
     Stats.DEF_P,
     Stats.HP_P,
   ],
-  breakpoints: { [Stats.SPD]: 160 },
+  softBreakpoints: [{ stat: Stats.SPD, threshold: 160 }],
   comboTurnAbilities: [
     NULL_TURN_ABILITY_NAME,
     START_ULT,

--- a/src/lib/conditionals/character/1500/SilverWolfLv999.ts
+++ b/src/lib/conditionals/character/1500/SilverWolfLv999.ts
@@ -523,7 +523,9 @@ const simulation = (): SimulationMetadata => ({
     Stats.DEF_P,
     Stats.HP_P,
   ],
-  softBreakpoints: [{ stat: Stats.SPD, threshold: 160 }],
+  softBreakpoints: [
+    { stat: Stats.SPD, threshold: 160 },
+  ],
   comboTurnAbilities: [
     NULL_TURN_ABILITY_NAME,
     START_ULT,

--- a/src/lib/conditionals/character/1500/SilverWolfLv999.ts
+++ b/src/lib/conditionals/character/1500/SilverWolfLv999.ts
@@ -523,7 +523,7 @@ const simulation = (): SimulationMetadata => ({
     Stats.DEF_P,
     Stats.HP_P,
   ],
-  softBreakpoints: [
+  hardBreakpoints: [
     { stat: Stats.SPD, threshold: 160 },
   ],
   comboTurnAbilities: [

--- a/src/lib/conditionals/character/1500/Yaoguang.ts
+++ b/src/lib/conditionals/character/1500/Yaoguang.ts
@@ -513,7 +513,7 @@ const simulation = (): SimulationMetadata => ({
   ],
   errRopeEidolon: 0,
   deprioritizeBuffs: true,
-  softBreakpoints: [
+  hardBreakpoints: [
     { stat: Stats.SPD, threshold: 120 },
   ],
   relicSets: [

--- a/src/lib/conditionals/character/1500/Yaoguang.ts
+++ b/src/lib/conditionals/character/1500/Yaoguang.ts
@@ -513,9 +513,9 @@ const simulation = (): SimulationMetadata => ({
   ],
   errRopeEidolon: 0,
   deprioritizeBuffs: true,
-  breakpoints: {
-    [Stats.SPD]: 120,
-  },
+  softBreakpoints: [
+    { stat: Stats.SPD, threshold: 120 },
+  ],
   relicSets: [
     [Sets.EverGloriousMagicalGirl, Sets.EverGloriousMagicalGirl],
     [Sets.DivinerOfDistantReach, Sets.DivinerOfDistantReach],

--- a/src/lib/scoring/rollCounter.ts
+++ b/src/lib/scoring/rollCounter.ts
@@ -17,6 +17,7 @@ import type {
   RunStatSimulationsResult,
   SubstatCounts,
 } from 'lib/simulations/statSimulationTypes'
+import { precisionRound } from 'lib/utils/mathUtils'
 import {
   isFlat,
   isSubstat,
@@ -69,7 +70,7 @@ export function calculateBreakpointRollRequirements(
     // Percent stats are stored as fractions (0.75) but roll values are display-scale (3.456), so scale down
     const baseRollValue = StatCalculator.getMaxedSubstatValue(stat, scoringParams.quality)
     const rollValue = isFlat(stat) ? baseRollValue : baseRollValue * 0.01
-    const requiredRolls = Math.ceil(gap / rollValue)
+    const requiredRolls = Math.ceil(precisionRound(gap / rollValue))
     // Already covered by the baseline freeRolls allocation
     if (requiredRolls <= scoringParams.freeRolls) continue
 

--- a/src/lib/scoring/rollCounter.ts
+++ b/src/lib/scoring/rollCounter.ts
@@ -66,9 +66,11 @@ export function calculateBreakpointRollRequirements(
     const gap = threshold - statValue
     if (gap <= 0) continue
 
+    // Percent stats are stored as fractions (0.75) but roll values are display-scale (3.456), so scale down
     const baseRollValue = StatCalculator.getMaxedSubstatValue(stat, scoringParams.quality)
     const rollValue = isFlat(stat) ? baseRollValue : baseRollValue * 0.01
     const requiredRolls = Math.ceil(gap / rollValue)
+    // Already covered by the baseline freeRolls allocation
     if (requiredRolls <= scoringParams.freeRolls) continue
 
     requirements.push({ stat, requiredRolls })
@@ -293,6 +295,7 @@ export function calculateMaxSubstatRollCounts(
     maxCounts[stat] = Math.max(scoringParams.baselineFreeRolls, Math.min(maxCounts[stat], 36 - totalDeductions))
   }
 
+  // Hard breakpoint floors override all caps — applied last so the required allocation is guaranteed
   if (partialSimulationWrapper.breakpointRequirements) {
     for (const req of partialSimulationWrapper.breakpointRequirements) {
       maxCounts[req.stat] = Math.max(maxCounts[req.stat], req.requiredRolls)

--- a/src/lib/scoring/rollCounter.ts
+++ b/src/lib/scoring/rollCounter.ts
@@ -6,45 +6,96 @@ import { StatKey } from 'lib/optimization/engine/config/keys'
 import { SELF_ENTITY_INDEX } from 'lib/optimization/engine/config/tag'
 import { StatCalculator } from 'lib/relics/statCalculator'
 import { SCORING_CONFIG_REGISTRY } from 'lib/scoring/scoringConfig'
-import type {
-  PartialSimulationWrapper,
-  ScoringParams,
-  SimulationFlags,
+import {
+  StatsToStatKey,
+  type BreakpointRollRequirement,
+  type PartialSimulationWrapper,
+  type ScoringParams,
+  type SimulationFlags,
 } from 'lib/scoring/simScoringUtils'
 import type {
   RunStatSimulationsResult,
   SubstatCounts,
 } from 'lib/simulations/statSimulationTypes'
-import { isSubstat } from 'lib/utils/statUtils'
-import type { ScoringConfigType } from 'types/metadata'
+import {
+  isFlat,
+  isSubstat,
+} from 'lib/utils/statUtils'
+import type {
+  ScoringConfigType,
+  SimulationMetadata,
+} from 'types/metadata'
 
 function computeResRollTarget(
   partialSimulationWrapper: PartialSimulationWrapper,
   scoringParams: ScoringParams,
 ): number {
-  const ceiledResDeduction = Math.ceil(partialSimulationWrapper.resRollsDeduction)
+  const resTarget = computeForcedResRollTarget(partialSimulationWrapper, scoringParams)
   const resBudget = scoringParams.substatGoal - Math.ceil(partialSimulationWrapper.speedRollsDeduction) - 10 * scoringParams.freeRolls
   return Math.min(
-    Math.max(ceiledResDeduction, scoringParams.freeRolls),
+    resTarget,
     Math.max(resBudget, scoringParams.freeRolls),
   )
 }
 
-export function calculateMinSubstatRollCounts(
+function computeForcedResRollTarget(
   partialSimulationWrapper: PartialSimulationWrapper,
   scoringParams: ScoringParams,
-  simulationFlags: SimulationFlags,
-) {
-  const resMin = computeResRollTarget(partialSimulationWrapper, scoringParams)
+): number {
+  return Math.max(Math.ceil(partialSimulationWrapper.resRollsDeduction), scoringParams.freeRolls)
+}
 
-  const minCounts: SubstatCounts = {
+export function calculateSubstatRollCountTotal(counts: SubstatCounts): number {
+  return SubStats.reduce((sum, stat) => sum + (counts[stat] ?? 0), 0)
+}
+
+// Converts hard breakpoint metadata into concrete roll requirements using the zero-substat simulation result.
+// SPD is excluded — it's handled by the existing speed deduction system.
+export function calculateBreakpointRollRequirements(
+  simulationResult: RunStatSimulationsResult,
+  metadata: SimulationMetadata,
+  scoringParams: Pick<ScoringParams, 'quality' | 'freeRolls'>,
+): BreakpointRollRequirement[] {
+  const hardBreakpoints = metadata.hardBreakpoints ?? []
+
+  const requirements: BreakpointRollRequirement[] = []
+
+  for (const { stat, threshold } of hardBreakpoints) {
+    if (stat === Stats.SPD) continue
+    const statValue = simulationResult.x.getActionValueByIndex(StatsToStatKey[stat], SELF_ENTITY_INDEX)
+    const gap = threshold - statValue
+    if (gap <= 0) continue
+
+    const baseRollValue = StatCalculator.getMaxedSubstatValue(stat, scoringParams.quality)
+    const rollValue = isFlat(stat) ? baseRollValue : baseRollValue * 0.01
+    const requiredRolls = Math.ceil(gap / rollValue)
+    if (requiredRolls <= scoringParams.freeRolls) continue
+
+    requirements.push({ stat, requiredRolls })
+  }
+
+  return requirements
+}
+
+export type HardBreakpointRollBudget = {
+  speedRollsDeduction: number,
+  feasible: boolean,
+}
+
+function buildMinSubstatRollCounts(
+  speedRollsDeduction: number,
+  breakpointRequirements: BreakpointRollRequirement[] | undefined,
+  scoringParams: ScoringParams,
+  resMin: number,
+): SubstatCounts {
+  const counts: SubstatCounts = {
     [Stats.HP_P]: scoringParams.freeRolls,
     [Stats.ATK_P]: scoringParams.freeRolls,
     [Stats.DEF_P]: scoringParams.freeRolls,
     [Stats.HP]: scoringParams.freeRolls,
     [Stats.ATK]: scoringParams.freeRolls,
     [Stats.DEF]: scoringParams.freeRolls,
-    [Stats.SPD]: partialSimulationWrapper.speedRollsDeduction,
+    [Stats.SPD]: speedRollsDeduction,
     [Stats.CR]: scoringParams.freeRolls,
     [Stats.CD]: scoringParams.freeRolls,
     [Stats.EHR]: scoringParams.freeRolls,
@@ -52,7 +103,69 @@ export function calculateMinSubstatRollCounts(
     [Stats.BE]: scoringParams.freeRolls,
   }
 
-  return minCounts
+  if (breakpointRequirements) {
+    for (const req of breakpointRequirements) {
+      counts[req.stat] = Math.max(counts[req.stat], req.requiredRolls)
+    }
+  }
+
+  return counts
+}
+
+// Caps SPD to fit within the roll budget after non-SPD forced costs (freeRolls, RES, breakpoints).
+// Returns feasible=false when forced non-SPD costs alone exceed the budget.
+export function calculateHardBreakpointRollBudget(
+  partialSimulationWrapper: PartialSimulationWrapper,
+  scoringParams: ScoringParams,
+): HardBreakpointRollBudget {
+  const forcedResRollTarget = computeForcedResRollTarget(partialSimulationWrapper, scoringParams)
+  const minCountsWithoutSpeed = buildMinSubstatRollCounts(
+    0,
+    partialSimulationWrapper.breakpointRequirements,
+    scoringParams,
+    forcedResRollTarget,
+  )
+  const totalWithoutSpeed = calculateSubstatRollCountTotal(minCountsWithoutSpeed)
+  const speedRollsDeduction = Math.min(
+    partialSimulationWrapper.speedRollsDeduction,
+    Math.max(0, scoringParams.substatGoal - totalWithoutSpeed),
+  )
+  const totalForcedRolls = totalWithoutSpeed + speedRollsDeduction
+
+  return {
+    speedRollsDeduction,
+    feasible: totalForcedRolls <= scoringParams.substatGoal,
+  }
+}
+
+// Detects hard breakpoints, caps SPD, and mutates the wrapper. Returns false if infeasible.
+export function applyHardBreakpoints(
+  partialSimulationWrapper: PartialSimulationWrapper,
+  simulationResult: RunStatSimulationsResult,
+  metadata: SimulationMetadata,
+  scoringParams: ScoringParams,
+): boolean {
+  const breakpointReqs = calculateBreakpointRollRequirements(simulationResult, metadata, scoringParams)
+  if (!breakpointReqs.length) return true
+
+  partialSimulationWrapper.breakpointRequirements = breakpointReqs
+  const hardBudget = calculateHardBreakpointRollBudget(partialSimulationWrapper, scoringParams)
+  if (!hardBudget.feasible) return false
+
+  partialSimulationWrapper.speedRollsDeduction = hardBudget.speedRollsDeduction
+  return true
+}
+
+export function calculateMinSubstatRollCounts(
+  partialSimulationWrapper: PartialSimulationWrapper,
+  scoringParams: ScoringParams,
+): SubstatCounts {
+  return buildMinSubstatRollCounts(
+    partialSimulationWrapper.speedRollsDeduction,
+    partialSimulationWrapper.breakpointRequirements,
+    scoringParams,
+    computeResRollTarget(partialSimulationWrapper, scoringParams),
+  )
 }
 
 export function calculateMaxSubstatRollCounts(
@@ -178,6 +291,12 @@ export function calculateMaxSubstatRollCounts(
     if (stat == Stats.SPD) continue
     if (stat == Stats.RES && partialSimulationWrapper.resRollsDeduction > 0) continue
     maxCounts[stat] = Math.max(scoringParams.baselineFreeRolls, Math.min(maxCounts[stat], 36 - totalDeductions))
+  }
+
+  if (partialSimulationWrapper.breakpointRequirements) {
+    for (const req of partialSimulationWrapper.breakpointRequirements) {
+      maxCounts[req.stat] = Math.max(maxCounts[req.stat], req.requiredRolls)
+    }
   }
 
   return maxCounts

--- a/src/lib/scoring/simScoringUtils.ts
+++ b/src/lib/scoring/simScoringUtils.ts
@@ -149,12 +149,18 @@ export type RelicBuild = {
   [key: string]: Relic,
 }
 
+export type BreakpointRollRequirement = {
+  stat: SubStats,
+  requiredRolls: number,
+}
+
 export type PartialSimulationWrapper = {
   simulation: Simulation,
   speedRollsDeduction: number,
   resRollsDeduction: number,
-  effectiveSubstats: string[],
+  effectiveSubstats: SubStats[],
   poolIndex: number,
+  breakpointRequirements?: BreakpointRollRequirement[],
 }
 
 export type PoolComboState = {
@@ -367,28 +373,43 @@ function collectPenaltyRecords(
 ): PenaltyRecord[] {
   const records: PenaltyRecord[] = []
 
-  if (metadata.breakpoints) {
-    for (const stat of Object.keys(metadata.breakpoints)) {
-      const statValue = x.getSelfValue(StatsToStatKey[stat as StatsValues])
-      if (stat == Stats.SPD && statValue < metadata.breakpoints[stat]) {
-        if (user) {
-          records.push({ stat: stat as StatsValues, multiplier: 0 })
-        }
-      } else if (isFlat(stat)) {
-        const multiplier = (Math.min(1, statValue / metadata.breakpoints[stat]) + 1) / 2
-        if (precisionRound(multiplier) < 1) {
-          records.push({ stat: stat as StatsValues, multiplier })
-        }
-      } else {
-        const multiplier = Math.min(
-          1,
-          1
-            - (metadata.breakpoints[stat] - statValue)
-              / StatCalculator.getMaxedSubstatValue(stat as SubStats, 1.0),
-        )
-        if (precisionRound(multiplier) < 1) {
-          records.push({ stat: stat as StatsValues, multiplier })
-        }
+  type PenaltyEntry = { threshold: number, hard: boolean }
+  const penaltyThresholds = new Map<string, PenaltyEntry>()
+  if (metadata.softBreakpoints) {
+    for (const { stat, threshold } of metadata.softBreakpoints) {
+      penaltyThresholds.set(stat, { threshold, hard: false })
+    }
+  }
+  if (metadata.hardBreakpoints) {
+    for (const { stat, threshold } of metadata.hardBreakpoints) {
+      const existing = penaltyThresholds.get(stat)
+      if (!existing || threshold >= existing.threshold) {
+        penaltyThresholds.set(stat, { threshold, hard: true })
+      }
+    }
+  }
+
+  for (const [stat, { threshold, hard }] of penaltyThresholds) {
+    void hard
+    const statValue = x.getSelfValue(StatsToStatKey[stat as StatsValues])
+    if (stat == Stats.SPD && statValue < threshold) {
+      if (user) {
+        records.push({ stat: stat as StatsValues, multiplier: 0 })
+      }
+    } else if (isFlat(stat)) {
+      const multiplier = (Math.min(1, statValue / threshold) + 1) / 2
+      if (precisionRound(multiplier) < 1) {
+        records.push({ stat: stat as StatsValues, multiplier })
+      }
+    } else {
+      const multiplier = Math.min(
+        1,
+        1
+          - (threshold - statValue)
+            / StatCalculator.getMaxedSubstatValue(stat as SubStats, 1.0),
+      )
+      if (precisionRound(multiplier) < 1) {
+        records.push({ stat: stat as StatsValues, multiplier })
       }
     }
   }

--- a/src/lib/scoring/simScoringUtils.ts
+++ b/src/lib/scoring/simScoringUtils.ts
@@ -365,6 +365,11 @@ type PenaltyRecord = {
   multiplier: number,
 }
 
+type PenaltyEntry = {
+  threshold: number,
+  hard: boolean,
+}
+
 function collectPenaltyRecords(
   x: ComputedStatsContainer,
   metadata: SimulationMetadata,
@@ -373,7 +378,7 @@ function collectPenaltyRecords(
 ): PenaltyRecord[] {
   const records: PenaltyRecord[] = []
 
-  type PenaltyEntry = { threshold: number, hard: boolean }
+  // Merge soft and hard breakpoints into a single map, hard takes priority for the same stat
   const penaltyThresholds = new Map<string, PenaltyEntry>()
   if (metadata.softBreakpoints) {
     for (const { stat, threshold } of metadata.softBreakpoints) {
@@ -389,6 +394,7 @@ function collectPenaltyRecords(
     }
   }
 
+  // Apply scoring penalties for missed breakpoints
   for (const [stat, { threshold, hard }] of penaltyThresholds) {
     void hard
     const statValue = x.getSelfValue(StatsToStatKey[stat as StatsValues])

--- a/src/lib/simulations/orchestrator/benchmarkSimulationOrchestrator.ts
+++ b/src/lib/simulations/orchestrator/benchmarkSimulationOrchestrator.ts
@@ -38,6 +38,7 @@ import {
 } from 'lib/scoring/dpsScore'
 import type { SimulationSets } from 'lib/scoring/dpsScore'
 import {
+  applyHardBreakpoints,
   calculateMaxSubstatRollCounts,
   calculateMinSubstatRollCounts,
 } from 'lib/scoring/rollCounter'
@@ -558,8 +559,11 @@ export class BenchmarkSimulationOrchestrator {
 
       partialSimulationWrapper.resRollsDeduction = calculateResRollsDeduction(simulationResult, flags, clonedBenchmarkScoringParams.quality)
 
-      // Define min/max limits
-      const minSubstatRollCounts = calculateMinSubstatRollCounts(partialSimulationWrapper, clonedBenchmarkScoringParams, flags)
+      if (!applyHardBreakpoints(partialSimulationWrapper, simulationResult, metadata, clonedBenchmarkScoringParams)) {
+        return null
+      }
+
+      const minSubstatRollCounts = calculateMinSubstatRollCounts(partialSimulationWrapper, clonedBenchmarkScoringParams)
       const maxSubstatRollCounts = calculateMaxSubstatRollCounts(
         partialSimulationWrapper,
         clonedBenchmarkScoringParams,
@@ -662,7 +666,7 @@ export class BenchmarkSimulationOrchestrator {
       partialSimulationWrapper.resRollsDeduction = calculateResRollsDeduction(simulationResult, flags, clonedPerfectionScoringParams.quality)
 
       // Define min/max limits
-      const minSubstatRollCounts = calculateMinSubstatRollCounts(partialSimulationWrapper, clonedPerfectionScoringParams, flags)
+      const minSubstatRollCounts = calculateMinSubstatRollCounts(partialSimulationWrapper, clonedPerfectionScoringParams)
       const maxSubstatRollCounts = calculateMaxSubstatRollCounts(
         partialSimulationWrapper,
         clonedPerfectionScoringParams,

--- a/src/lib/simulations/tests/dpsScore/breakpointEnforcement.test.ts
+++ b/src/lib/simulations/tests/dpsScore/breakpointEnforcement.test.ts
@@ -1,0 +1,226 @@
+// @vitest-environment jsdom
+import { KafkaB1 } from 'lib/conditionals/character/1000/KafkaB1'
+import {
+  Stats,
+  SubStats,
+  type SubStats as SubStatsType,
+} from 'lib/constants/constants'
+import { StatCalculator } from 'lib/relics/statCalculator'
+import {
+  calculateHardBreakpointRollBudget,
+  calculateMaxSubstatRollCounts,
+  calculateMinSubstatRollCounts,
+  calculateSubstatRollCountTotal,
+} from 'lib/scoring/rollCounter'
+import {
+  benchmarkScoringParams,
+  type BreakpointRollRequirement,
+  type PartialSimulationWrapper,
+} from 'lib/scoring/simScoringUtils'
+import {
+  StatSimTypes,
+} from 'lib/simulations/statSimulationTypes'
+import { Metadata } from 'lib/state/metadataInitializer'
+import { getGameMetadata } from 'lib/state/gameMetadata'
+import { clone } from 'lib/utils/objectUtils'
+import { ScoringConfigType } from 'types/metadata'
+import { describe, expect, test } from 'vitest'
+
+Metadata.initialize()
+
+const defaultFlags = {
+  overcapCritRate: false,
+  simPoetActive: false,
+  characterPoetActive: false,
+  forceErrRope: false,
+  benchmarkBasicSpdTarget: 0,
+  benchmarkBasicResTarget: 0,
+}
+
+const kafkaBreakpointRequirement: BreakpointRollRequirement = {
+  stat: Stats.EHR,
+  requiredRolls: 4,
+}
+
+const zeroMainsMock = {
+  x: {
+    getActionValueByIndex: () => 0,
+  },
+} as unknown as Parameters<typeof calculateMaxSubstatRollCounts>[2]
+
+function makeKafkaWrapper(overrides: Partial<PartialSimulationWrapper> = {}): PartialSimulationWrapper {
+  return {
+    simulation: {
+      simType: StatSimTypes.SubstatRolls,
+      request: {
+        simRelicSet1: 'PrisonerInDeepConfinement' as any,
+        simRelicSet2: 'PrisonerInDeepConfinement' as any,
+        simOrnamentSet: 'FirmamentFrontlineGlamoth' as any,
+        simBody: Stats.EHR,
+        simFeet: Stats.SPD,
+        simPlanarSphere: Stats.Lightning_DMG,
+        simLinkRope: Stats.ATK_P,
+        stats: StatCalculator.getZeroesSubstats(),
+      },
+    },
+    speedRollsDeduction: 25,
+    resRollsDeduction: 0,
+    effectiveSubstats: [Stats.ATK_P, Stats.ATK, Stats.EHR, Stats.CR, Stats.CD],
+    poolIndex: 0,
+    ...overrides,
+  }
+}
+
+function applyHardBudget(wrapper: PartialSimulationWrapper, scoringParams = benchmarkScoringParams) {
+  const hardBudget = calculateHardBreakpointRollBudget(wrapper, clone(scoringParams))
+  wrapper.speedRollsDeduction = hardBudget.speedRollsDeduction
+  return hardBudget
+}
+
+describe('breakpoint enforcement', () => {
+  test('Kafka metadata has EHR breakpoint at 0.75', () => {
+    const metadata = getGameMetadata().characters[KafkaB1.id].scoringMetadata.simulation!
+    expect(metadata.softBreakpoints).toBeUndefined()
+    expect(metadata.hardBreakpoints).toBeDefined()
+    expect(metadata.hardBreakpoints).toEqual([
+      {
+        stat: Stats.EHR,
+        threshold: 0.75,
+      },
+    ])
+    expect(metadata.substats).toContain(Stats.EHR)
+  })
+
+  test('EHR roll value math is correct', () => {
+    const rollValue = StatCalculator.getMaxedSubstatValue(Stats.EHR as SubStatsType, 0.8)
+    expect(rollValue).toBeCloseTo(3.456, 2)
+
+    const scaledValue = rollValue * 0.01
+    expect(scaledValue).toBeCloseTo(0.03456, 4)
+
+    const gap = 0.75 - 0.612
+    const rollsNeeded = Math.ceil(gap / scaledValue)
+    expect(rollsNeeded).toBe(4)
+  })
+
+  test.each([
+    [25, 24],
+    [26, 24],
+    [27, 24],
+  ])('hard budget caps %i requested SPD to %i after EHR breakpoint', (speedRollsDeduction, expectedSpeedRolls) => {
+    const wrapper = makeKafkaWrapper({
+      speedRollsDeduction,
+      breakpointRequirements: [kafkaBreakpointRequirement],
+    })
+
+    const hardBudget = calculateHardBreakpointRollBudget(wrapper, clone(benchmarkScoringParams))
+
+    expect(hardBudget.speedRollsDeduction).toBe(expectedSpeedRolls)
+    expect(hardBudget.feasible).toBe(true)
+  })
+
+  test('min counts enforce breakpoint EHR minimum within the 48-roll budget', () => {
+    const wrapper = makeKafkaWrapper({
+      breakpointRequirements: [kafkaBreakpointRequirement],
+    })
+    applyHardBudget(wrapper)
+
+    const minCounts = calculateMinSubstatRollCounts(wrapper, clone(benchmarkScoringParams))
+
+    expect(minCounts[Stats.EHR]).toBe(4)
+    expect(minCounts[Stats.SPD]).toBe(24)
+    expect(minCounts[Stats.ATK_P]).toBe(2)
+    expect(minCounts[Stats.ATK]).toBe(2)
+    expect(minCounts[Stats.CR]).toBe(2)
+    expect(minCounts[Stats.CD]).toBe(2)
+    expect(calculateSubstatRollCountTotal(minCounts)).toBe(benchmarkScoringParams.substatGoal)
+  })
+
+  test('min counts are unchanged when no breakpoint requirements', () => {
+    const wrapper = makeKafkaWrapper()
+
+    const minCounts = calculateMinSubstatRollCounts(wrapper, clone(benchmarkScoringParams))
+
+    expect(minCounts[Stats.EHR]).toBe(2)
+    expect(minCounts[Stats.SPD]).toBe(25)
+  })
+
+  test('max counts enforce breakpoint floor without pinning non-breakpoint stats', () => {
+    const wrapper = makeKafkaWrapper({
+      breakpointRequirements: [kafkaBreakpointRequirement],
+    })
+    applyHardBudget(wrapper)
+
+    const maxCounts = calculateMaxSubstatRollCounts(
+      wrapper,
+      clone(benchmarkScoringParams),
+      zeroMainsMock,
+      defaultFlags,
+      ScoringConfigType.DPS,
+    )
+
+    expect(maxCounts[Stats.EHR]).toBeGreaterThanOrEqual(4)
+    expect(maxCounts[Stats.SPD]).toBe(24)
+    for (const stat of SubStats) {
+      expect(maxCounts[stat]).toBeGreaterThanOrEqual(benchmarkScoringParams.freeRolls)
+    }
+  })
+
+  test('breakpoints set max floors while normal path allows optimization freedom', () => {
+    const withoutBp = makeKafkaWrapper()
+    const withBp = makeKafkaWrapper({
+      breakpointRequirements: [kafkaBreakpointRequirement],
+    })
+    applyHardBudget(withBp)
+
+    const maxWithout = calculateMaxSubstatRollCounts(
+      withoutBp,
+      clone(benchmarkScoringParams),
+      zeroMainsMock,
+      defaultFlags,
+      ScoringConfigType.DPS,
+    )
+    const maxWith = calculateMaxSubstatRollCounts(
+      withBp,
+      clone(benchmarkScoringParams),
+      zeroMainsMock,
+      defaultFlags,
+      ScoringConfigType.DPS,
+    )
+
+    expect(maxWithout[Stats.ATK_P]).toBeGreaterThan(benchmarkScoringParams.freeRolls)
+    expect(maxWith[Stats.EHR]).toBeGreaterThanOrEqual(4)
+    expect(maxWith[Stats.ATK_P]).toBeGreaterThanOrEqual(benchmarkScoringParams.freeRolls)
+  })
+
+  test('hard budget caps SPD after forced RES and EHR consume budget', () => {
+    const wrapper = makeKafkaWrapper({
+      speedRollsDeduction: 22,
+      resRollsDeduction: 10,
+      breakpointRequirements: [kafkaBreakpointRequirement],
+    })
+    const hardBudget = applyHardBudget(wrapper)
+
+    expect(hardBudget.speedRollsDeduction).toBe(16)
+    expect(hardBudget.feasible).toBe(true)
+
+    const minCounts = calculateMinSubstatRollCounts(wrapper, clone(benchmarkScoringParams))
+
+    expect(minCounts[Stats.SPD]).toBe(16)
+    expect(minCounts[Stats.RES]).toBe(10)
+    expect(minCounts[Stats.EHR]).toBe(4)
+    expect(calculateSubstatRollCountTotal(minCounts)).toBe(benchmarkScoringParams.substatGoal)
+  })
+
+  test('hard budget rejects infeasible candidates when forced non-SPD costs exceed budget', () => {
+    const wrapper = makeKafkaWrapper({
+      speedRollsDeduction: 25,
+      resRollsDeduction: 10,
+      breakpointRequirements: [{ stat: Stats.EHR, requiredRolls: 27 }],
+    })
+    const hardBudget = calculateHardBreakpointRollBudget(wrapper, clone(benchmarkScoringParams))
+
+    expect(hardBudget.feasible).toBe(false)
+    expect(hardBudget.speedRollsDeduction).toBe(0)
+  })
+})

--- a/src/lib/simulations/tests/supportScore/supportScoreTest.test.ts
+++ b/src/lib/simulations/tests/supportScore/supportScoreTest.test.ts
@@ -236,7 +236,7 @@ test('RuanMei support score prepare', () => {
     },
     substats: [Stats.BE, Stats.SPD, Stats.RES, Stats.HP_P, Stats.DEF_P],
     errRopeEidolon: 0,
-    breakpoints: { [Stats.BE]: 1.80 },
+    softBreakpoints: [{ stat: Stats.BE, threshold: 1.80 }],
     comboTurnAbilities: [NULL_TURN_ABILITY_NAME],
     relicSets: [[Sets.ThiefOfShootingMeteor, Sets.ThiefOfShootingMeteor], [Sets.MessengerTraversingHackerspace, Sets.MessengerTraversingHackerspace]],
     ornamentSets: [Sets.BrokenKeel, Sets.PenaconyLandOfTheDreams, Sets.SprightlyVonwacq],

--- a/src/lib/simulations/tests/supportScore/supportScoreTest.test.ts
+++ b/src/lib/simulations/tests/supportScore/supportScoreTest.test.ts
@@ -236,7 +236,9 @@ test('RuanMei support score prepare', () => {
     },
     substats: [Stats.BE, Stats.SPD, Stats.RES, Stats.HP_P, Stats.DEF_P],
     errRopeEidolon: 0,
-    softBreakpoints: [{ stat: Stats.BE, threshold: 1.80 }],
+    softBreakpoints: [
+      { stat: Stats.BE, threshold: 1.80 },
+    ],
     comboTurnAbilities: [NULL_TURN_ABILITY_NAME],
     relicSets: [[Sets.ThiefOfShootingMeteor, Sets.ThiefOfShootingMeteor], [Sets.MessengerTraversingHackerspace, Sets.MessengerTraversingHackerspace]],
     ornamentSets: [Sets.BrokenKeel, Sets.PenaconyLandOfTheDreams, Sets.SprightlyVonwacq],

--- a/src/lib/tabs/Tabs.tsx
+++ b/src/lib/tabs/Tabs.tsx
@@ -90,10 +90,10 @@ const Tabs = () => {
 
   const setActivePage = useCallback((hash: string) => {
     const page: AppPages | undefined = HashToPage[hash as PageHash]
-    if (page && page !== activeKey) {
+    if (page) {
       setActiveKey(page)
     }
-  }, [setActiveKey, activeKey])
+  }, [setActiveKey])
 
   useHashNavigation(setActivePage)
 

--- a/src/lib/tabs/tabCalculators/CalculatorsTab.tsx
+++ b/src/lib/tabs/tabCalculators/CalculatorsTab.tsx
@@ -41,8 +41,8 @@ export function CalculatorsTab() {
 
   const updateActivePanel = useCallback((hash: string) => {
     const panel = HashToPanel[hash]
-    if (panel && panel !== activePanel) setActivePanel(panel)
-  }, [activePanel, setActivePanel])
+    if (panel) setActivePanel(panel)
+  }, [setActivePanel])
 
   useHashNavigation(updateActivePanel)
 

--- a/src/types/metadata.ts
+++ b/src/types/metadata.ts
@@ -29,6 +29,11 @@ export enum ScoringConfigType {
   SHIELD = 'shield',
 }
 
+export type BreakpointThreshold = {
+  stat: SubStats,
+  threshold: number,
+}
+
 export type ScoringConfig = {
   configType: ScoringConfigType,
   simulation: SimulationMetadata,
@@ -98,9 +103,8 @@ export type SimulationMetadata = {
     teamOrnamentSet?: string,
   }[],
   leaderboardTeams?: LeaderboardTeam[],
-  breakpoints?: {
-    [stat: string]: number,
-  },
+  softBreakpoints?: BreakpointThreshold[],
+  hardBreakpoints?: BreakpointThreshold[],
   buffStat?: AKeyValue,
   combatStatsConfig?: Array<{
     add?: StatsValues,


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

- Add hard breakpoint enforcement for benchmark scoring, forcing substat roll allocation to meet declared stat thresholds within the 48-roll budget
- Add SPD capping so hard breakpoint costs are paid first, with speed using whatever budget remains
- Add infeasibility detection that rejects benchmark candidates when forced costs exceed the roll budget
- Add breakpoint floor constraints to the max-count optimizer so remaining budget is distributed optimally
- Unify breakpoint config to a consistent BreakpointThreshold[] array format with explicit soft vs hard distinction
- Update scoring penalties to apply for both soft and hard breakpoints, with hard breakpoint awareness for future stronger penalties
- Classify Kafka, Cyrene, Hyacine, Hysilens, SilverWolf Lv999, and Yaoguang breakpoints as hard; keep SilverWolf, Fugue, BlackSwan, Rappa, and Cipher as soft
- Improve tab navigation callback stability by removing active key from useCallback deps
- Refactor leaderboard diagnostic tables into a shared helper and pre-group boards by character ID

## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [ ] I have added commit messages that are descriptive and meaningful.
- [ ] I have tested the changes locally.
- [ ] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
