### PR TITLE
feat: disabled leaderboards

### DIFF
--- a/src/lib/conditionals/character/1000/Archer.ts
+++ b/src/lib/conditionals/character/1000/Archer.ts
@@ -283,6 +283,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [
       Stats.CR,

--- a/src/lib/conditionals/character/1000/Arlan.ts
+++ b/src/lib/conditionals/character/1000/Arlan.ts
@@ -186,6 +186,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [
       Stats.CR,

--- a/src/lib/conditionals/character/1000/DanHeng.ts
+++ b/src/lib/conditionals/character/1000/DanHeng.ts
@@ -205,6 +205,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [
       Stats.CR,

--- a/src/lib/conditionals/character/1000/Herta.ts
+++ b/src/lib/conditionals/character/1000/Herta.ts
@@ -307,6 +307,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [
       Stats.CR,

--- a/src/lib/conditionals/character/1000/Himeko.ts
+++ b/src/lib/conditionals/character/1000/Himeko.ts
@@ -259,6 +259,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: false,
   parts: {
     [Parts.Body]: [
       Stats.CR,

--- a/src/lib/conditionals/character/1000/KafkaB1.ts
+++ b/src/lib/conditionals/character/1000/KafkaB1.ts
@@ -338,6 +338,7 @@ if (ehrValue >= 0.75 && stateValue == 0) {
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [
       Stats.ATK_P,

--- a/src/lib/conditionals/character/1000/March7th.ts
+++ b/src/lib/conditionals/character/1000/March7th.ts
@@ -173,6 +173,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const shieldSimulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [Stats.DEF_P],
     [Parts.Feet]: [Stats.DEF_P, Stats.SPD],

--- a/src/lib/conditionals/character/1000/Saber.ts
+++ b/src/lib/conditionals/character/1000/Saber.ts
@@ -353,6 +353,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [
       Stats.CR,

--- a/src/lib/conditionals/character/1000/WeltB1.ts
+++ b/src/lib/conditionals/character/1000/WeltB1.ts
@@ -394,6 +394,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: false,
   parts: {
     [Parts.Body]: [
       Stats.CR,

--- a/src/lib/conditionals/character/1100/Bronya.ts
+++ b/src/lib/conditionals/character/1100/Bronya.ts
@@ -301,6 +301,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const supportSimulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [Stats.CD],
     [Parts.Feet]: [Stats.SPD],

--- a/src/lib/conditionals/character/1100/Clara.ts
+++ b/src/lib/conditionals/character/1100/Clara.ts
@@ -222,6 +222,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [
       Stats.CR,

--- a/src/lib/conditionals/character/1100/Gepard.ts
+++ b/src/lib/conditionals/character/1100/Gepard.ts
@@ -192,6 +192,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const shieldSimulation = (): SimulationMetadata => ({
+  leaderboardEnabled: false,
   parts: {
     [Parts.Body]: [Stats.DEF_P],
     [Parts.Feet]: [Stats.DEF_P, Stats.SPD],

--- a/src/lib/conditionals/character/1100/Hook.ts
+++ b/src/lib/conditionals/character/1100/Hook.ts
@@ -224,6 +224,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [
       Stats.CR,

--- a/src/lib/conditionals/character/1100/Luka.ts
+++ b/src/lib/conditionals/character/1100/Luka.ts
@@ -260,6 +260,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [
       Stats.ATK_P,

--- a/src/lib/conditionals/character/1100/Lynx.ts
+++ b/src/lib/conditionals/character/1100/Lynx.ts
@@ -295,6 +295,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const healSimulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [Stats.OHB],
     [Parts.Feet]: [Stats.SPD, Stats.HP_P],

--- a/src/lib/conditionals/character/1100/Natasha.ts
+++ b/src/lib/conditionals/character/1100/Natasha.ts
@@ -138,6 +138,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const healSimulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [Stats.OHB],
     [Parts.Feet]: [Stats.SPD, Stats.HP_P],

--- a/src/lib/conditionals/character/1100/Sampo.ts
+++ b/src/lib/conditionals/character/1100/Sampo.ts
@@ -241,6 +241,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [
       Stats.ATK_P,

--- a/src/lib/conditionals/character/1100/SeeleB1.ts
+++ b/src/lib/conditionals/character/1100/SeeleB1.ts
@@ -212,6 +212,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [
       Stats.CR,

--- a/src/lib/conditionals/character/1100/Serval.ts
+++ b/src/lib/conditionals/character/1100/Serval.ts
@@ -217,6 +217,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [
       Stats.CR,

--- a/src/lib/conditionals/character/1100/Topaz.ts
+++ b/src/lib/conditionals/character/1100/Topaz.ts
@@ -269,6 +269,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [
       Stats.CR,

--- a/src/lib/conditionals/character/1200/Bailu.ts
+++ b/src/lib/conditionals/character/1200/Bailu.ts
@@ -222,6 +222,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const healSimulation = (): SimulationMetadata => ({
+  leaderboardEnabled: false,
   parts: {
     [Parts.Body]: [Stats.OHB],
     [Parts.Feet]: [Stats.SPD, Stats.HP_P],

--- a/src/lib/conditionals/character/1200/BladeB1.ts
+++ b/src/lib/conditionals/character/1200/BladeB1.ts
@@ -227,6 +227,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [
       Stats.CR,

--- a/src/lib/conditionals/character/1200/Feixiao.ts
+++ b/src/lib/conditionals/character/1200/Feixiao.ts
@@ -299,6 +299,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [
       Stats.CR,

--- a/src/lib/conditionals/character/1200/Fugue.ts
+++ b/src/lib/conditionals/character/1200/Fugue.ts
@@ -289,6 +289,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [
       Stats.CR,

--- a/src/lib/conditionals/character/1200/HuohuoB1.ts
+++ b/src/lib/conditionals/character/1200/HuohuoB1.ts
@@ -203,6 +203,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const healSimulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [Stats.OHB],
     [Parts.Feet]: [Stats.SPD, Stats.HP_P],

--- a/src/lib/conditionals/character/1200/ImbibitorLunae.ts
+++ b/src/lib/conditionals/character/1200/ImbibitorLunae.ts
@@ -234,6 +234,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [
       Stats.CR,

--- a/src/lib/conditionals/character/1200/JingYuan.ts
+++ b/src/lib/conditionals/character/1200/JingYuan.ts
@@ -280,6 +280,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [
       Stats.CR,

--- a/src/lib/conditionals/character/1200/JingliuB1.ts
+++ b/src/lib/conditionals/character/1200/JingliuB1.ts
@@ -242,6 +242,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [
       Stats.CD,

--- a/src/lib/conditionals/character/1200/Luocha.ts
+++ b/src/lib/conditionals/character/1200/Luocha.ts
@@ -207,6 +207,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const healSimulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [Stats.OHB],
     [Parts.Feet]: [Stats.SPD],

--- a/src/lib/conditionals/character/1200/March7thImaginary.ts
+++ b/src/lib/conditionals/character/1200/March7thImaginary.ts
@@ -304,6 +304,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [
       Stats.CR,

--- a/src/lib/conditionals/character/1200/Moze.ts
+++ b/src/lib/conditionals/character/1200/Moze.ts
@@ -290,6 +290,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [
       Stats.CR,

--- a/src/lib/conditionals/character/1200/Qingque.ts
+++ b/src/lib/conditionals/character/1200/Qingque.ts
@@ -229,6 +229,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [
       Stats.CR,

--- a/src/lib/conditionals/character/1200/Sushang.ts
+++ b/src/lib/conditionals/character/1200/Sushang.ts
@@ -245,6 +245,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [
       Stats.CR,

--- a/src/lib/conditionals/character/1200/Xueyi.ts
+++ b/src/lib/conditionals/character/1200/Xueyi.ts
@@ -271,6 +271,7 @@ if (${wgslTrue(r.beToDmgBoost)}) {
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [
       Stats.CR,

--- a/src/lib/conditionals/character/1200/Yanqing.ts
+++ b/src/lib/conditionals/character/1200/Yanqing.ts
@@ -296,6 +296,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: false,
   parts: {
     [Parts.Body]: [
       Stats.CD,

--- a/src/lib/conditionals/character/1200/Yunli.ts
+++ b/src/lib/conditionals/character/1200/Yunli.ts
@@ -317,6 +317,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [
       Stats.CR,

--- a/src/lib/conditionals/character/1300/Acheron.ts
+++ b/src/lib/conditionals/character/1300/Acheron.ts
@@ -305,6 +305,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [
       Stats.ATK_P,

--- a/src/lib/conditionals/character/1300/Argenti.ts
+++ b/src/lib/conditionals/character/1300/Argenti.ts
@@ -247,6 +247,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [
       Stats.CR,

--- a/src/lib/conditionals/character/1300/Aventurine.ts
+++ b/src/lib/conditionals/character/1300/Aventurine.ts
@@ -305,6 +305,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const shieldSimulation = (): SimulationMetadata => ({
+  leaderboardEnabled: false,
   parts: {
     [Parts.Body]: [Stats.DEF_P],
     [Parts.Feet]: [Stats.DEF_P, Stats.SPD],

--- a/src/lib/conditionals/character/1300/BlackSwanB1.ts
+++ b/src/lib/conditionals/character/1300/BlackSwanB1.ts
@@ -310,6 +310,7 @@ if (${wgslTrue(r.ehrToDmgBoost)}) {
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [
       Stats.EHR,

--- a/src/lib/conditionals/character/1300/Boothill.ts
+++ b/src/lib/conditionals/character/1300/Boothill.ts
@@ -362,6 +362,7 @@ ${p_containerActionVal(SELF_ENTITY_INDEX, StatKey.CD, action.config)} += cdBuffV
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [
       Stats.CR,

--- a/src/lib/conditionals/character/1300/DrRatio.ts
+++ b/src/lib/conditionals/character/1300/DrRatio.ts
@@ -225,6 +225,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [
       Stats.CR,

--- a/src/lib/conditionals/character/1300/FireflyB1.ts
+++ b/src/lib/conditionals/character/1300/FireflyB1.ts
@@ -352,6 +352,7 @@ if (${wgslTrue(r.superBreakDmg && r.enhancedStateActive)} && be >= 3.00) {
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [
       Stats.ATK_P,

--- a/src/lib/conditionals/character/1300/Jade.ts
+++ b/src/lib/conditionals/character/1300/Jade.ts
@@ -273,6 +273,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [
       Stats.CR,

--- a/src/lib/conditionals/character/1300/Misha.ts
+++ b/src/lib/conditionals/character/1300/Misha.ts
@@ -237,6 +237,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [
       Stats.CR,

--- a/src/lib/conditionals/character/1300/Rappa.ts
+++ b/src/lib/conditionals/character/1300/Rappa.ts
@@ -331,6 +331,7 @@ if (${wgslTrue(r.atkToBreakVulnerability)}) {
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [
       Stats.ATK_P,

--- a/src/lib/conditionals/character/1300/Robin.ts
+++ b/src/lib/conditionals/character/1300/Robin.ts
@@ -337,6 +337,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const supportSimulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [Stats.ATK_P],
     [Parts.Feet]: [Stats.ATK_P, Stats.SPD],

--- a/src/lib/conditionals/character/1300/SparkleB1.ts
+++ b/src/lib/conditionals/character/1300/SparkleB1.ts
@@ -316,6 +316,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const supportSimulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [Stats.CD],
     [Parts.Feet]: [Stats.SPD],

--- a/src/lib/conditionals/character/1300/Sunday.ts
+++ b/src/lib/conditionals/character/1300/Sunday.ts
@@ -420,6 +420,7 @@ if (cr > 1.00) {
 }
 
 const supportSimulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [Stats.CD],
     [Parts.Feet]: [Stats.SPD],

--- a/src/lib/conditionals/character/1300/TheDahlia.ts
+++ b/src/lib/conditionals/character/1300/TheDahlia.ts
@@ -442,6 +442,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [
       Stats.CR,

--- a/src/lib/conditionals/character/1400/Aglaea.ts
+++ b/src/lib/conditionals/character/1400/Aglaea.ts
@@ -453,6 +453,7 @@ ${p_containerActionVal(memoEntityIndex, StatKey.ATK, config)} += buffValue - sta
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [
       Stats.CR,

--- a/src/lib/conditionals/character/1400/Anaxa.ts
+++ b/src/lib/conditionals/character/1400/Anaxa.ts
@@ -347,6 +347,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [
       Stats.CR,

--- a/src/lib/conditionals/character/1400/Castorice.ts
+++ b/src/lib/conditionals/character/1400/Castorice.ts
@@ -402,6 +402,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [
       Stats.CR,

--- a/src/lib/conditionals/character/1400/Cerydra.ts
+++ b/src/lib/conditionals/character/1400/Cerydra.ts
@@ -389,6 +389,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const supportSimulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [Stats.ATK_P],
     [Parts.Feet]: [Stats.ATK_P, Stats.SPD],

--- a/src/lib/conditionals/character/1400/Cipher.ts
+++ b/src/lib/conditionals/character/1400/Cipher.ts
@@ -446,6 +446,7 @@ if (
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [
       Stats.CR,

--- a/src/lib/conditionals/character/1400/Cyrene.ts
+++ b/src/lib/conditionals/character/1400/Cyrene.ts
@@ -448,6 +448,7 @@ if (${containerActionVal(SELF_ENTITY_INDEX, StatKey.SPD, action.config)} >= 180.
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [
       Stats.CR,

--- a/src/lib/conditionals/character/1400/Evernight.ts
+++ b/src/lib/conditionals/character/1400/Evernight.ts
@@ -541,6 +541,7 @@ ${p_containerActionVal(memoEntityIndex, StatKey.CD, config)} += finalBuffCd;
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [
       Stats.CR,

--- a/src/lib/conditionals/character/1400/Hyacine.ts
+++ b/src/lib/conditionals/character/1400/Hyacine.ts
@@ -524,6 +524,7 @@ if (${wgslTrue(e >= 4 && r.e4CdBuff)}) {
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [
       Stats.CD,
@@ -610,6 +611,7 @@ const simulation = (): SimulationMetadata => ({
 })
 
 const healSimulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [Stats.OHB],
     [Parts.Feet]: [Stats.SPD, Stats.HP_P],

--- a/src/lib/conditionals/character/1400/Hysilens.ts
+++ b/src/lib/conditionals/character/1400/Hysilens.ts
@@ -393,6 +393,7 @@ if (${wgslTrue(r.ehrToDmg)}) {
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [
       Stats.EHR,

--- a/src/lib/conditionals/character/1400/Mydei.ts
+++ b/src/lib/conditionals/character/1400/Mydei.ts
@@ -318,6 +318,7 @@ if (${wgslTrue(r.vendettaState)}) {
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [
       Stats.CD,

--- a/src/lib/conditionals/character/1400/PermansorTerrae.ts
+++ b/src/lib/conditionals/character/1400/PermansorTerrae.ts
@@ -336,6 +336,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const supportSimulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [Stats.ATK_P],
     [Parts.Feet]: [Stats.SPD, Stats.ATK_P],

--- a/src/lib/conditionals/character/1400/Phainon.ts
+++ b/src/lib/conditionals/character/1400/Phainon.ts
@@ -406,6 +406,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [
       Stats.CR,

--- a/src/lib/conditionals/character/1400/TheHerta.ts
+++ b/src/lib/conditionals/character/1400/TheHerta.ts
@@ -296,6 +296,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [
       Stats.CR,

--- a/src/lib/conditionals/character/1400/Tribbie.ts
+++ b/src/lib/conditionals/character/1400/Tribbie.ts
@@ -366,6 +366,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [
       Stats.CR,

--- a/src/lib/conditionals/character/1500/Ashveil.ts
+++ b/src/lib/conditionals/character/1500/Ashveil.ts
@@ -346,6 +346,7 @@ const conditionals: CharacterConditionalFunction = (e, withContent) => {
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [
       Stats.CR,

--- a/src/lib/conditionals/character/1500/Evanescia.ts
+++ b/src/lib/conditionals/character/1500/Evanescia.ts
@@ -415,6 +415,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [
       Stats.CR,

--- a/src/lib/conditionals/character/1500/Gilgamesh.ts
+++ b/src/lib/conditionals/character/1500/Gilgamesh.ts
@@ -324,6 +324,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: false,
   parts: {
     [Parts.Body]: [
       Stats.CR,

--- a/src/lib/conditionals/character/1500/HimekoNova.ts
+++ b/src/lib/conditionals/character/1500/HimekoNova.ts
@@ -304,6 +304,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: false,
   parts: {
     [Parts.Body]: [
       Stats.CR,

--- a/src/lib/conditionals/character/1500/MortenaxBlade.ts
+++ b/src/lib/conditionals/character/1500/MortenaxBlade.ts
@@ -303,6 +303,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [
       Stats.CD,

--- a/src/lib/conditionals/character/1500/RinTohsaka.ts
+++ b/src/lib/conditionals/character/1500/RinTohsaka.ts
@@ -348,6 +348,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: false,
   parts: {
     [Parts.Body]: [
       Stats.CR,

--- a/src/lib/conditionals/character/1500/SilverWolfLv999.ts
+++ b/src/lib/conditionals/character/1500/SilverWolfLv999.ts
@@ -501,6 +501,7 @@ ${p_containerActionVal(SELF_ENTITY_INDEX, StatKey.CD, config)} += cdDelta;
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [
       Stats.CR,

--- a/src/lib/conditionals/character/1500/Sparxie.ts
+++ b/src/lib/conditionals/character/1500/Sparxie.ts
@@ -419,6 +419,7 @@ const conditionals: CharacterConditionalFunction = (e, withContent) => {
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [
       Stats.CR,

--- a/src/lib/conditionals/character/1500/Yaoguang.ts
+++ b/src/lib/conditionals/character/1500/Yaoguang.ts
@@ -477,6 +477,7 @@ const conditionals: CharacterConditionalFunction = (e, withContent) => {
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [
       Stats.CR,

--- a/src/lib/conditionals/character/8000/TrailblazerDestruction.ts
+++ b/src/lib/conditionals/character/8000/TrailblazerDestruction.ts
@@ -196,6 +196,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const simulation = (): SimulationMetadata => ({
+  leaderboardEnabled: false,
   parts: {
     [Parts.Body]: [
       Stats.CR,

--- a/src/lib/conditionals/character/8000/TrailblazerHarmony.ts
+++ b/src/lib/conditionals/character/8000/TrailblazerHarmony.ts
@@ -252,6 +252,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const supportSimulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [Stats.HP_P, Stats.DEF_P],
     [Parts.Feet]: [Stats.SPD],

--- a/src/lib/conditionals/character/8000/TrailblazerPreservation.ts
+++ b/src/lib/conditionals/character/8000/TrailblazerPreservation.ts
@@ -233,6 +233,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 }
 
 const shieldSimulation = (): SimulationMetadata => ({
+  leaderboardEnabled: false,
   parts: {
     [Parts.Body]: [Stats.DEF_P],
     [Parts.Feet]: [Stats.DEF_P, Stats.SPD],

--- a/src/lib/conditionals/character/8000/TrailblazerRemembrance.ts
+++ b/src/lib/conditionals/character/8000/TrailblazerRemembrance.ts
@@ -450,6 +450,7 @@ ${p_containerActionVal(memoEntityIndex, StatKey.CD, config)} += finalBuffCd;
 }
 
 const supportSimulation = (): SimulationMetadata => ({
+  leaderboardEnabled: true,
   parts: {
     [Parts.Body]: [Stats.CD],
     [Parts.Feet]: [Stats.SPD],

--- a/src/lib/tabs/tabLeaderboard/CharacterListPanel.module.css
+++ b/src/lib/tabs/tabLeaderboard/CharacterListPanel.module.css
@@ -188,3 +188,36 @@
   font-size: 12px;
   text-align: center;
 }
+
+.growingDivider {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px 6px;
+  color: rgba(255, 255, 255, 0.28);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.growingDivider::before,
+.growingDivider::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.growingRow {
+  opacity: 0.40;
+  cursor: default;
+}
+
+.growingRow:hover {
+  background: transparent;
+}
+
+.growingAvatar {
+  filter: grayscale(0.6);
+}

--- a/src/lib/tabs/tabLeaderboard/CharacterListPanel.module.css
+++ b/src/lib/tabs/tabLeaderboard/CharacterListPanel.module.css
@@ -218,6 +218,14 @@
   background: transparent;
 }
 
+.growingRowClickable {
+  cursor: pointer;
+}
+
+.growingRowClickable:hover {
+  background: var(--lb-hover-bg);
+}
+
 .growingAvatar {
   filter: grayscale(0.6);
 }

--- a/src/lib/tabs/tabLeaderboard/CharacterListPanel.tsx
+++ b/src/lib/tabs/tabLeaderboard/CharacterListPanel.tsx
@@ -66,9 +66,18 @@ function ActiveRow({ row, index, selectedId, selectedType }: {
   )
 }
 
-function GrowingRow({ row }: { row: CharacterRow }) {
+const IS_LOCALHOST = location.hostname === 'localhost' || location.hostname === '127.0.0.1'
+
+function GrowingRow({ row, selectedId, selectedType }: {
+  row: CharacterRow
+  selectedId: string | null
+  selectedType: ScoringConfigType | null
+}) {
   return (
-    <div className={`${classes.row} ${classes.growingRow}`}>
+    <div
+      className={`${classes.row} ${classes.growingRow} ${IS_LOCALHOST ? classes.growingRowClickable : ''} ${IS_LOCALHOST && row.id === selectedId ? classes.selected : ''}`}
+      onClick={IS_LOCALHOST ? () => selectLeaderboardCharacter(row.id, selectedType ? { configType: configTypeToPublic(selectedType) } : undefined) : undefined}
+    >
       <span className={classes.rank}>—</span>
       <span className={classes.nameCell}>
         <img src={Assets.getCharacterAvatarById(row.id)} className={`${classes.avatar} ${classes.growingAvatar}`} />
@@ -179,7 +188,7 @@ export function CharacterListPanel() {
               <span>Insufficient data</span>
             </div>
             {growingRows.map((row) => (
-              <GrowingRow key={row.id} row={row} />
+              <GrowingRow key={row.id} row={row} selectedId={selectedId} selectedType={selectedType} />
             ))}
           </>
         )}

--- a/src/lib/tabs/tabLeaderboard/CharacterListPanel.tsx
+++ b/src/lib/tabs/tabLeaderboard/CharacterListPanel.tsx
@@ -7,6 +7,7 @@ import { Assets } from 'lib/rendering/assets'
 import classes from 'lib/tabs/tabLeaderboard/CharacterListPanel.module.css'
 import {
   getCharacterLeaderboardConfigTypes,
+  isCharacterLeaderboardEnabled,
 } from 'lib/tabs/tabLeaderboard/leaderboardCharacterHelpers'
 import { getPublicEntryCount } from 'lib/tabs/tabLeaderboard/leaderboardDataLoader'
 import { selectLeaderboardCharacter } from 'lib/tabs/tabLeaderboard/leaderboardTabController'
@@ -19,6 +20,7 @@ import {
   useState,
 } from 'react'
 import { useTranslation } from 'react-i18next'
+import type { CharacterId } from 'types/character'
 import { ScoringConfigType } from 'types/metadata'
 
 function abbreviateCount(n: number): string {
@@ -26,12 +28,57 @@ function abbreviateCount(n: number): string {
   return String(n)
 }
 
+
 const CONFIG_TABS = [
   { type: ScoringConfigType.DPS, label: 'DPS' },
   { type: ScoringConfigType.BUFFER, label: 'Support' },
   { type: ScoringConfigType.HEAL, label: 'Heal' },
   { type: ScoringConfigType.SHIELD, label: 'Shield' },
 ]
+
+type CharacterRow = {
+  id: CharacterId
+  name: string
+  topScore: number
+  entryCount: number
+  publicEntryCount: number
+}
+
+function ActiveRow({ row, index, selectedId, selectedType }: {
+  row: CharacterRow
+  index: number
+  selectedId: string | null
+  selectedType: ScoringConfigType | null
+}) {
+  return (
+    <div
+      className={`${classes.row} ${row.id === selectedId ? classes.selected : ''}`}
+      onClick={() => selectLeaderboardCharacter(row.id, selectedType ? { configType: configTypeToPublic(selectedType) } : undefined)}
+    >
+      <span className={classes.rank}>{index + 1}</span>
+      <span className={classes.nameCell}>
+        <img src={Assets.getCharacterAvatarById(row.id)} className={classes.avatar} />
+        <span className={classes.name}>{row.name}</span>
+      </span>
+      <span className={classes.score}>{row.topScore > 0 ? `${truncate10ths(row.topScore * 100).toFixed(1)}%` : '—'}</span>
+      <span className={classes.count}>{row.entryCount > 0 ? `${abbreviateCount(row.publicEntryCount)} / ${abbreviateCount(row.entryCount)}` : '—'}</span>
+    </div>
+  )
+}
+
+function GrowingRow({ row }: { row: CharacterRow }) {
+  return (
+    <div className={`${classes.row} ${classes.growingRow}`}>
+      <span className={classes.rank}>—</span>
+      <span className={classes.nameCell}>
+        <img src={Assets.getCharacterAvatarById(row.id)} className={`${classes.avatar} ${classes.growingAvatar}`} />
+        <span className={classes.name}>{row.name}</span>
+      </span>
+      <span className={classes.score}>—</span>
+      <span className={classes.count}>{row.entryCount > 0 ? abbreviateCount(row.entryCount) : '—'}</span>
+    </div>
+  )
+}
 
 export function CharacterListPanel() {
   const characters = useLeaderboardTabStore((s) => s.availableCharacters)
@@ -53,10 +100,10 @@ export function CharacterListPanel() {
     ? activeType
     : null
 
-  const rows = useMemo(() => {
+  const { activeRows, growingRows } = useMemo(() => {
     const normalizedSearch = search.trim().toLowerCase()
 
-    return characters
+    const all = characters
       .filter((id) => selectedType == null || getCharacterLeaderboardConfigTypes(id).includes(selectedType))
       .map((id) => {
         const topScore = topScores[id] ?? 0
@@ -71,7 +118,22 @@ export function CharacterListPanel() {
         }
       })
       .filter((row) => normalizedSearch.length === 0 || row.name.toLowerCase().includes(normalizedSearch))
-      .sort((a, b) => b.topScore - a.topScore)
+
+    const active: CharacterRow[] = []
+    const growing: CharacterRow[] = []
+
+    for (const row of all) {
+      if (isCharacterLeaderboardEnabled(row.id)) {
+        active.push(row)
+      } else {
+        growing.push(row)
+      }
+    }
+
+    active.sort((a, b) => b.topScore - a.topScore)
+    growing.sort((a, b) => b.entryCount - a.entryCount)
+
+    return { activeRows: active, growingRows: growing }
   }, [characters, search, selectedType, topScores, totalEntries, t])
 
   return (
@@ -105,22 +167,22 @@ export function CharacterListPanel() {
       </div>
 
       <OverlayScrollbarsComponent className={classes.list} options={OVERLAY_SCROLLBAR_OPTIONS} defer>
-        {rows.map((row, index) => (
-          <div
-            key={row.id}
-            className={`${classes.row} ${row.id === selectedId ? classes.selected : ''}`}
-            onClick={() => selectLeaderboardCharacter(row.id, selectedType ? { configType: configTypeToPublic(selectedType) } : undefined)}
-          >
-            <span className={classes.rank}>{index + 1}</span>
-            <span className={classes.nameCell}>
-              <img src={Assets.getCharacterAvatarById(row.id)} className={classes.avatar} />
-              <span className={classes.name}>{row.name}</span>
-            </span>
-            <span className={classes.score}>{row.topScore > 0 ? `${truncate10ths(row.topScore * 100).toFixed(1)}%` : '—'}</span>
-            <span className={classes.count}>{row.entryCount > 0 ? `${abbreviateCount(row.publicEntryCount)} / ${abbreviateCount(row.entryCount)}` : '—'}</span>
-          </div>
+        {activeRows.map((row, index) => (
+          <ActiveRow key={row.id} row={row} index={index} selectedId={selectedId} selectedType={selectedType} />
         ))}
-        {rows.length === 0 && <div className={classes.empty}>No matching characters</div>}
+        {activeRows.length === 0 && growingRows.length === 0 && (
+          <div className={classes.empty}>No matching characters</div>
+        )}
+        {growingRows.length > 0 && (
+          <>
+            <div className={classes.growingDivider}>
+              <span>Insufficient data</span>
+            </div>
+            {growingRows.map((row) => (
+              <GrowingRow key={row.id} row={row} />
+            ))}
+          </>
+        )}
       </OverlayScrollbarsComponent>
     </div>
   )

--- a/src/lib/tabs/tabLeaderboard/LeaderboardHeader.module.css
+++ b/src/lib/tabs/tabLeaderboard/LeaderboardHeader.module.css
@@ -130,6 +130,7 @@
   font-size: 14px;
   grid-template-columns: 20px 1px 32px 20px 1fr 52px 42px;
   gap: 4px 7px;
+  align-content: start;
   flex: 1;
   min-height: 0;
   overflow-y: auto;

--- a/src/lib/tabs/tabLeaderboard/leaderboardCharacterHelpers.ts
+++ b/src/lib/tabs/tabLeaderboard/leaderboardCharacterHelpers.ts
@@ -23,3 +23,15 @@ export function getCharacterLeaderboardConfigTypes(characterId: CharacterId): Sc
   if (scoringMetadata?.shieldSimulation) configTypes.push(ScoringConfigType.SHIELD)
   return configTypes
 }
+
+export function isCharacterLeaderboardEnabled(characterId: CharacterId): boolean {
+  const scoringMetadata = getGameMetadata().characters[characterId]?.scoringMetadata
+  if (!scoringMetadata) return false
+  const sims = [
+    scoringMetadata.simulation,
+    scoringMetadata.supportSimulation,
+    scoringMetadata.healSimulation,
+    scoringMetadata.shieldSimulation,
+  ]
+  return sims.some((sim) => sim?.leaderboardEnabled === true)
+}

--- a/src/types/metadata.ts
+++ b/src/types/metadata.ts
@@ -88,6 +88,7 @@ export type SimulationMetadata = {
    * flat filler (`Stats.ATK` / `Stats.HP` / `Stats.DEF`) — SPD is implicit and doesn't count.
    */
   substats: SubStats[],
+  leaderboardEnabled?: boolean,
   errRopeEidolon?: number,
   deprioritizeBuffs?: boolean,
   comboTurnAbilities: TurnAbilityName[],


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

- Add per-simulation leaderboardEnabled flag to control which characters appear on the public leaderboard
- Split leaderboard character list into active and "Insufficient data" sections with a centered divider
- Grey out disabled characters with reduced opacity and grayscale avatars, non-clickable in production
- Allow clicking disabled characters on localhost for development
- Disable leaderboards for low-data characters: Welt, Yanqing, Himeko, Trailblazer (Destruction/Preservation), Bailu, Gepard, Aventurine (shield), Rin Tohsaka, Gilgamesh, Himeko Nova

## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [ ] I have added commit messages that are descriptive and meaningful.
- [ ] I have tested the changes locally.
- [ ] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
