### PR TITLE
feat: leaderboard self position

### DIFF
--- a/src/leaderboard/cache/leaderboardBuildScoreCacheValue.ts
+++ b/src/leaderboard/cache/leaderboardBuildScoreCacheValue.ts
@@ -1,3 +1,4 @@
+import { isFiniteNumber } from 'leaderboard/shared/typeGuards'
 import type {
   LeaderboardBuildScore,
   LeaderboardBuildScoreCacheValue,
@@ -61,6 +62,3 @@ function isLeaderboardBuildScore(value: unknown): value is LeaderboardBuildScore
     && score.simulationFlags != null
 }
 
-function isFiniteNumber(value: unknown): value is number {
-  return typeof value === 'number' && Number.isFinite(value)
-}

--- a/src/leaderboard/output/publicOutput.ts
+++ b/src/leaderboard/output/publicOutput.ts
@@ -1,6 +1,9 @@
-import type { LeaderboardConfigType } from 'leaderboard/shared/configTypeMapping'
-import { computeBuildId, hashObject } from 'leaderboard/shared/hash'
 import { atomicWriteJsonFile } from 'leaderboard/output/atomicWrite'
+import type { LeaderboardConfigType } from 'leaderboard/shared/configTypeMapping'
+import {
+  computeBuildId,
+  computeCandidateId,
+} from 'leaderboard/shared/hash'
 import {
   gunzipBase64Text,
   gzipTextToBase64,
@@ -75,7 +78,7 @@ export function buildPublicOutputFromPrivate(input: {
           rank: entry.rank,
           characterId: entry.characterId as CharacterId,
           buildId: computeBuildId(entry.uidHash, entry.characterId, board.configType, board.teamId),
-          candidateId: hashObject(`${entry.uidHash}#${entry.characterId}`).slice(0, 12),
+          candidateId: computeCandidateId(entry.uidHash, entry.characterId),
           score: entry.score,
           data: entry.data,
         }))

--- a/src/leaderboard/shared/configTypeMapping.ts
+++ b/src/leaderboard/shared/configTypeMapping.ts
@@ -1,20 +1,31 @@
 import { ScoringConfigType } from 'types/metadata'
 
-export const LEADERBOARD_CONFIG_TYPES = ['dps', 'support', 'heal', 'shield'] as const
-export type LeaderboardConfigType = typeof LEADERBOARD_CONFIG_TYPES[number]
+export enum LeaderboardConfigType {
+  DPS = 'dps',
+  SUPPORT = 'support',
+  HEAL = 'heal',
+  SHIELD = 'shield',
+}
+
+export const LEADERBOARD_CONFIG_TYPES = [
+  LeaderboardConfigType.DPS,
+  LeaderboardConfigType.SUPPORT,
+  LeaderboardConfigType.HEAL,
+  LeaderboardConfigType.SHIELD,
+] as const
 
 const CONFIG_TYPE_TO_PUBLIC: Record<ScoringConfigType, LeaderboardConfigType> = {
-  [ScoringConfigType.DPS]: 'dps',
-  [ScoringConfigType.BUFFER]: 'support',
-  [ScoringConfigType.HEAL]: 'heal',
-  [ScoringConfigType.SHIELD]: 'shield',
+  [ScoringConfigType.DPS]: LeaderboardConfigType.DPS,
+  [ScoringConfigType.BUFFER]: LeaderboardConfigType.SUPPORT,
+  [ScoringConfigType.HEAL]: LeaderboardConfigType.HEAL,
+  [ScoringConfigType.SHIELD]: LeaderboardConfigType.SHIELD,
 }
 
 const PUBLIC_TO_CONFIG_TYPE: Record<LeaderboardConfigType, ScoringConfigType> = {
-  dps: ScoringConfigType.DPS,
-  support: ScoringConfigType.BUFFER,
-  heal: ScoringConfigType.HEAL,
-  shield: ScoringConfigType.SHIELD,
+  [LeaderboardConfigType.DPS]: ScoringConfigType.DPS,
+  [LeaderboardConfigType.SUPPORT]: ScoringConfigType.BUFFER,
+  [LeaderboardConfigType.HEAL]: ScoringConfigType.HEAL,
+  [LeaderboardConfigType.SHIELD]: ScoringConfigType.SHIELD,
 }
 
 export function isLeaderboardConfigType(value: string): value is LeaderboardConfigType {

--- a/src/leaderboard/shared/hash.ts
+++ b/src/leaderboard/shared/hash.ts
@@ -23,6 +23,10 @@ export function hashUid(uid: string): HashString {
   return sha256Text(uid)
 }
 
+export function computeCandidateId(uidHash: string, characterId: string): string {
+  return hashObject(`${uidHash}#${characterId}`).slice(0, 12)
+}
+
 export function computeBuildId(uidHash: string, characterId: string, configType: string, teamId: string): string {
   return hashObject(`${uidHash}#${characterId}#${configType}#${teamId}`).slice(0, 12)
 }

--- a/src/leaderboard/shared/typeGuards.ts
+++ b/src/leaderboard/shared/typeGuards.ts
@@ -1,0 +1,3 @@
+export function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value)
+}

--- a/src/leaderboard/tests/leaderboardScriptContracts.test.ts
+++ b/src/leaderboard/tests/leaderboardScriptContracts.test.ts
@@ -26,6 +26,7 @@ import {
   countScoringVariants,
   expandScoringVariants,
 } from 'leaderboard/scoring/scoringVariants'
+import { LeaderboardConfigType } from 'leaderboard/shared/configTypeMapping'
 import type { EidolonTierValue } from 'leaderboard/shared/eidolonConfig'
 import {
   deleteFile,
@@ -272,7 +273,7 @@ function makeEntry(
 function privateOutput(entries: PrivateRankedEntry[]): PrivateRankedOutput {
   const board: PrivateBoard = {
     characterId: CHARACTER_ID,
-    configType: 'dps',
+    configType: LeaderboardConfigType.DPS,
     teamId: TEAM_ID,
     entries,
     completeness: makeCompleteness({

--- a/src/leaderboard/tests/leaderboardTimeline.test.ts
+++ b/src/leaderboard/tests/leaderboardTimeline.test.ts
@@ -28,7 +28,6 @@ import {
   deriveSnapshotPath,
   deriveTimelinePath,
   readTimeline,
-  validateNoUidInPublicTimeline,
   writeTimelineArtifacts,
 } from 'leaderboard/timeline/timelineStorage'
 import { TimelineEventType } from 'leaderboard/timeline/timelineTypes'
@@ -706,8 +705,6 @@ describe('timeline identity migration', () => {
       }],
     }
     Object.assign(timeline.events[0], { uidHash: 'should-not-publish' })
-
-    expect(() => validateNoUidInPublicTimeline(timeline)).toThrow('forbidden field "uidHash"')
 
     const timelinePath = joinPath(cwd(), `.leaderboard-timeline-${crypto.randomUUID()}.json`)
     const snapshotPath = joinPath(cwd(), `.leaderboard-snapshot-${crypto.randomUUID()}.json`)

--- a/src/leaderboard/tests/leaderboardTimeline.test.ts
+++ b/src/leaderboard/tests/leaderboardTimeline.test.ts
@@ -1,14 +1,45 @@
-import { TimelineEventType } from 'leaderboard/timeline/timelineTypes'
-import type { LeaderboardSnapshot, LeaderboardSnapshotEntry, UserCharacterWatermark } from 'leaderboard/timeline/timelineTypes'
-import { extractSnapshot, userCharKey, type UserCharCurrentEntry } from 'leaderboard/timeline/extractSnapshot'
-import { deduplicateAndMerge, diffSnapshots, displayScore } from 'leaderboard/timeline/computeTimeline'
-import { deriveTimelinePath, deriveSnapshotPath } from 'leaderboard/timeline/timelineStorage'
-import type { PrivateBoard, PrivateBoardCompleteness, PrivateRankedEntry, PrivateRankedOutput } from 'leaderboard/shared/types'
 import type { LeaderboardConfigType } from 'leaderboard/shared/configTypeMapping'
 import type { LeaderboardEidolonGroup } from 'leaderboard/shared/eidolonConfig'
-import { ScoringConfigType } from 'types/metadata'
+import { computeCandidateId } from 'leaderboard/shared/hash'
+import {
+  cwd,
+  deleteFile,
+  fileExists,
+  joinPath,
+  writeTextFile,
+} from 'leaderboard/shared/nodeFacade'
+import type {
+  PrivateBoard,
+  PrivateBoardCompleteness,
+  PrivateRankedEntry,
+  PrivateRankedOutput,
+} from 'leaderboard/shared/types'
+import {
+  deduplicateAndMerge,
+  diffSnapshots,
+  displayScore,
+} from 'leaderboard/timeline/computeTimeline'
+import {
+  extractSnapshot,
+  type UserCharCurrentEntry,
+  userCharKey,
+} from 'leaderboard/timeline/extractSnapshot'
+import {
+  deriveSnapshotPath,
+  deriveTimelinePath,
+  readTimeline,
+  validateNoUidInPublicTimeline,
+  writeTimelineArtifacts,
+} from 'leaderboard/timeline/timelineStorage'
+import { TimelineEventType } from 'leaderboard/timeline/timelineTypes'
+import type {
+  LeaderboardSnapshot,
+  LeaderboardSnapshotEntry,
+  LeaderboardTimeline,
+  UserCharacterWatermark,
+} from 'leaderboard/timeline/timelineTypes'
 import type { CharacterId } from 'types/character'
-import { cwd } from 'leaderboard/shared/nodeFacade'
+import { ScoringConfigType } from 'types/metadata'
 import {
   describe,
   expect,
@@ -64,7 +95,9 @@ const DEFAULT_FETCHED_AT = 1782259200 // 2026-06-24T00:00:00Z
 
 const CONFIG_TYPE = 'dps' as LeaderboardConfigType
 
-function makeUserCharEntries(entries: Array<{ uidHash: string, characterId: CharacterId, score: number, rank: number, fetchedAt?: number, configType?: LeaderboardConfigType }>): Map<string, UserCharCurrentEntry> {
+function makeUserCharEntries(
+  entries: Array<{ uidHash: string, characterId: CharacterId, score: number, rank: number, fetchedAt?: number, configType?: LeaderboardConfigType }>,
+): Map<string, UserCharCurrentEntry> {
   const map = new Map<string, UserCharCurrentEntry>()
   for (const e of entries) {
     const ct = e.configType ?? CONFIG_TYPE
@@ -247,7 +280,7 @@ describe('diffSnapshots', () => {
     expect(events[0]).toMatchObject({
       type: TimelineEventType.NEW_CHARACTER,
       characterId: '1001',
-      uidHash: 'user-a',
+      candidateId: computeCandidateId('user-a', '1001'),
       date: '2026-06-24T00:00:00.000Z',
       score: 2.0,
       rank: 1,
@@ -281,7 +314,7 @@ describe('diffSnapshots', () => {
     expect(events[0]).toMatchObject({
       type: TimelineEventType.NEW_BEST,
       characterId: '1001',
-      uidHash: 'user-a',
+      candidateId: computeCandidateId('user-a', '1001'),
       date: '2026-06-24T00:00:00.000Z',
       score: 1.502,
       previousScore: 1.5,
@@ -360,8 +393,8 @@ describe('diffSnapshots', () => {
     const events = diffSnapshots(current, previous, entries)
 
     expect(events).toHaveLength(2)
-    expect(events.find((e) => e.uidHash === 'user-a')).toBeDefined()
-    expect(events.find((e) => e.uidHash === 'user-b')).toBeDefined()
+    expect(events.find((e) => e.candidateId === computeCandidateId('user-a', '1001'))).toBeDefined()
+    expect(events.find((e) => e.candidateId === computeCandidateId('user-b', '1001'))).toBeDefined()
   })
 
   test('build cycling blocked: score returns to previous level after drop does not exceed watermark', () => {
@@ -439,8 +472,8 @@ describe('deduplicateAndMerge', () => {
     const newEvent = {
       type: TimelineEventType.NEW_BEST as const,
       characterId: '1001' as CharacterId,
-      configType: 'dps',
-      uidHash: 'user-a',
+      configType: CONFIG_TYPE,
+      candidateId: 'aaaaaaaaaaaa',
       date: '2026-06-24',
       score: 2.5,
       previousScore: 2.0,
@@ -451,8 +484,8 @@ describe('deduplicateAndMerge', () => {
     const existingEvent = {
       type: TimelineEventType.NEW_BEST as const,
       characterId: '1001' as CharacterId,
-      configType: 'dps',
-      uidHash: 'user-a',
+      configType: CONFIG_TYPE,
+      candidateId: 'aaaaaaaaaaaa',
       date: '2026-06-24',
       score: 2.2,
       previousScore: 2.0,
@@ -471,8 +504,8 @@ describe('deduplicateAndMerge', () => {
     const userA = {
       type: TimelineEventType.NEW_BEST as const,
       characterId: '1001' as CharacterId,
-      configType: 'dps',
-      uidHash: 'user-a',
+      configType: CONFIG_TYPE,
+      candidateId: 'aaaaaaaaaaaa',
       date: '2026-06-24',
       score: 2.5,
       previousScore: 2.0,
@@ -483,8 +516,8 @@ describe('deduplicateAndMerge', () => {
     const userB = {
       type: TimelineEventType.NEW_BEST as const,
       characterId: '1001' as CharacterId,
-      configType: 'dps',
-      uidHash: 'user-b',
+      configType: CONFIG_TYPE,
+      candidateId: 'bbbbbbbbbbbb',
       date: '2026-06-24',
       score: 2.2,
       previousScore: 2.0,
@@ -501,8 +534,8 @@ describe('deduplicateAndMerge', () => {
     const day1 = {
       type: TimelineEventType.NEW_BEST as const,
       characterId: '1001' as CharacterId,
-      configType: 'dps',
-      uidHash: 'user-a',
+      configType: CONFIG_TYPE,
+      candidateId: 'aaaaaaaaaaaa',
       date: '2026-06-23',
       score: 2.0,
       previousScore: 1.5,
@@ -513,8 +546,8 @@ describe('deduplicateAndMerge', () => {
     const day2 = {
       type: TimelineEventType.NEW_BEST as const,
       characterId: '1001' as CharacterId,
-      configType: 'dps',
-      uidHash: 'user-a',
+      configType: CONFIG_TYPE,
+      candidateId: 'aaaaaaaaaaaa',
       date: '2026-06-24',
       score: 2.5,
       previousScore: 2.0,
@@ -532,8 +565,8 @@ describe('deduplicateAndMerge', () => {
       {
         type: TimelineEventType.NEW_BEST as const,
         characterId: '1001' as CharacterId,
-        configType: 'dps',
-        uidHash: 'user-a',
+        configType: CONFIG_TYPE,
+        candidateId: 'aaaaaaaaaaaa',
         date: '2026-06-22',
         score: 1.5,
         previousScore: 1.0,
@@ -544,8 +577,8 @@ describe('deduplicateAndMerge', () => {
       {
         type: TimelineEventType.NEW_BEST as const,
         characterId: '1002' as CharacterId,
-        configType: 'dps',
-        uidHash: 'user-b',
+        configType: CONFIG_TYPE,
+        candidateId: 'bbbbbbbbbbbb',
         date: '2026-06-24',
         score: 2.5,
         previousScore: 2.0,
@@ -556,8 +589,8 @@ describe('deduplicateAndMerge', () => {
       {
         type: TimelineEventType.NEW_CHARACTER as const,
         characterId: '1003' as CharacterId,
-        configType: 'dps',
-        uidHash: 'user-c',
+        configType: CONFIG_TYPE,
+        candidateId: 'cccccccccccc',
         date: '2026-06-23',
         score: 1.8,
         rank: 1,
@@ -576,8 +609,8 @@ describe('deduplicateAndMerge', () => {
     const events = Array.from({ length: 10 }, (_, i) => ({
       type: TimelineEventType.NEW_BEST as const,
       characterId: `char-${i}` as CharacterId,
-      configType: 'dps',
-      uidHash: `user-${i}`,
+      configType: CONFIG_TYPE,
+      candidateId: i.toString(16).padStart(12, '0'),
       date: `2026-06-${String(10 + i).padStart(2, '0')}`,
       score: i + 1,
       previousScore: i,
@@ -590,6 +623,107 @@ describe('deduplicateAndMerge', () => {
     expect(merged).toHaveLength(3)
     expect(merged[0].date).toBe('2026-06-19')
     expect(merged[2].date).toBe('2026-06-17')
+  })
+})
+
+describe('timeline identity migration', () => {
+  test('reads legacy and sanitized v2 events without resetting valid history', () => {
+    const path = joinPath(cwd(), `.leaderboard-timeline-${crypto.randomUUID()}.json`)
+    const uidHash = '31050e4f5f4bb895ba7ba9326e6dead67ca90d494d548632db2f4b0cab5436a3'
+    const candidateId = computeCandidateId(uidHash, '1001')
+
+    try {
+      writeTextFile(
+        path,
+        JSON.stringify({
+          schemaVersion: 2,
+          generatedAt: '2026-06-24T00:00:00Z',
+          events: [
+            {
+              type: TimelineEventType.NEW_BEST,
+              characterId: '1001',
+              configType: 'dps',
+              uidHash,
+              date: '2026-06-24T00:00:00Z',
+              score: 2,
+              previousScore: 1.9,
+              rank: 1,
+              previousRank: 2,
+              buildId: '111111111111',
+            },
+            {
+              type: TimelineEventType.NEW_CHARACTER,
+              characterId: '1002',
+              configType: 'support',
+              candidateId: '222222222222',
+              date: '2026-06-23T00:00:00Z',
+              score: 1.8,
+              rank: 3,
+              entryCount: 12,
+              buildId: '333333333333',
+            },
+            {
+              type: TimelineEventType.NEW_CHARACTER,
+              characterId: '1001',
+              configType: 'dps',
+              uidHash,
+              candidateId: 'ffffffffffff',
+              date: '2026-06-22T00:00:00Z',
+              score: 1.7,
+              rank: 4,
+              entryCount: 8,
+              buildId: '444444444444',
+            },
+          ],
+        }),
+      )
+
+      const events = readTimeline(path)
+
+      expect(events).toHaveLength(2)
+      expect(events[0].candidateId).toBe(candidateId)
+      expect(events[1].candidateId).toBe('222222222222')
+      expect(JSON.stringify(events)).not.toContain('uidHash')
+    } finally {
+      deleteFile(path)
+    }
+  })
+
+  test('public timeline validator rejects UID fields before publication', () => {
+    const timeline: LeaderboardTimeline = {
+      schemaVersion: 2,
+      generatedAt: '2026-06-24T00:00:00Z',
+      events: [{
+        type: TimelineEventType.NEW_CHARACTER,
+        characterId: '1001' as CharacterId,
+        configType: 'dps' as LeaderboardConfigType,
+        candidateId: 'aaaaaaaaaaaa',
+        date: '2026-06-24T00:00:00Z',
+        score: 2,
+        rank: 1,
+        entryCount: 10,
+        buildId: 'bbbbbbbbbbbb',
+      }],
+    }
+    Object.assign(timeline.events[0], { uidHash: 'should-not-publish' })
+
+    expect(() => validateNoUidInPublicTimeline(timeline)).toThrow('forbidden field "uidHash"')
+
+    const timelinePath = joinPath(cwd(), `.leaderboard-timeline-${crypto.randomUUID()}.json`)
+    const snapshotPath = joinPath(cwd(), `.leaderboard-snapshot-${crypto.randomUUID()}.json`)
+    expect(() =>
+      writeTimelineArtifacts({
+        timeline,
+        timelinePath,
+        snapshot: {
+          generatedAt: timeline.generatedAt,
+          characters: {},
+        },
+        snapshotPath,
+      })
+    ).toThrow('forbidden field "uidHash"')
+    expect(fileExists(timelinePath)).toBe(false)
+    expect(fileExists(snapshotPath)).toBe(false)
   })
 })
 

--- a/src/leaderboard/timeline/computeTimeline.ts
+++ b/src/leaderboard/timeline/computeTimeline.ts
@@ -1,14 +1,26 @@
-import type {
-  TimelineEvent,
-  LeaderboardTimeline,
-  LeaderboardSnapshot,
-} from 'leaderboard/timeline/timelineTypes'
-import { TIMELINE_MIN_SCORE, TIMELINE_SCHEMA_VERSION, TimelineEventType } from 'leaderboard/timeline/timelineTypes'
-import { readTimeline, readSnapshot } from 'leaderboard/timeline/timelineStorage'
-import { extractSnapshot, type UserCharCurrentEntry } from 'leaderboard/timeline/extractSnapshot'
-import { computeBuildId } from 'leaderboard/shared/hash'
+import {
+  computeBuildId,
+  computeCandidateId,
+} from 'leaderboard/shared/hash'
 import type { PrivateRankedOutput } from 'leaderboard/shared/types'
-
+import {
+  extractSnapshot,
+  type UserCharCurrentEntry,
+} from 'leaderboard/timeline/extractSnapshot'
+import {
+  readSnapshot,
+  readTimeline,
+} from 'leaderboard/timeline/timelineStorage'
+import type {
+  LeaderboardSnapshot,
+  LeaderboardTimeline,
+  TimelineEvent,
+} from 'leaderboard/timeline/timelineTypes'
+import {
+  TIMELINE_MIN_SCORE,
+  TIMELINE_SCHEMA_VERSION,
+  TimelineEventType,
+} from 'leaderboard/timeline/timelineTypes'
 
 export function displayScore(score: number): number {
   return Math.trunc(score * 1000)
@@ -45,7 +57,7 @@ export function diffSnapshots(
         type: TimelineEventType.NEW_CHARACTER,
         characterId: entry.characterId,
         configType: entry.configType,
-        uidHash: entry.uidHash,
+        candidateId: computeCandidateId(entry.uidHash, entry.characterId),
         date,
         score: entry.score,
         rank: entry.rank,
@@ -57,7 +69,7 @@ export function diffSnapshots(
         type: TimelineEventType.NEW_BEST,
         characterId: entry.characterId,
         configType: entry.configType,
-        uidHash: entry.uidHash,
+        candidateId: computeCandidateId(entry.uidHash, entry.characterId),
         date,
         score: entry.score,
         previousScore: prev.highWatermark,
@@ -79,11 +91,11 @@ export function deduplicateAndMerge(
   const seen = new Map<string, TimelineEvent>()
 
   for (const event of newEvents) {
-    seen.set(`${event.uidHash}#${event.characterId}#${event.configType}#${event.type}#${dedupDay(event.date)}`, event)
+    seen.set(`${event.candidateId}#${event.configType}#${event.type}#${dedupDay(event.date)}`, event)
   }
 
   for (const event of existingEvents) {
-    const key = `${event.uidHash}#${event.characterId}#${event.configType}#${event.type}#${dedupDay(event.date)}`
+    const key = `${event.candidateId}#${event.configType}#${event.type}#${dedupDay(event.date)}`
     if (!seen.has(key)) {
       seen.set(key, event)
     }

--- a/src/leaderboard/timeline/computeTimeline.ts
+++ b/src/leaderboard/timeline/computeTimeline.ts
@@ -50,32 +50,30 @@ export function diffSnapshots(
     if (entry.score < TIMELINE_MIN_SCORE || entry.rank > maxRank) continue
 
     const prev = prevUserBests[key]
-    const date = fetchedAtToISOString(entry.fetchedAt)
+    if (prev && displayScore(entry.score) <= displayScore(prev.highWatermark)) continue
+
+    const common = {
+      characterId: entry.characterId,
+      configType: entry.configType,
+      candidateId: computeCandidateId(entry.uidHash, entry.characterId),
+      date: fetchedAtToISOString(entry.fetchedAt),
+      score: entry.score,
+      rank: entry.rank,
+      buildId: computeBuildId(entry.uidHash, entry.characterId, entry.configType, entry.teamId),
+    }
 
     if (!prev) {
       events.push({
+        ...common,
         type: TimelineEventType.NEW_CHARACTER,
-        characterId: entry.characterId,
-        configType: entry.configType,
-        candidateId: computeCandidateId(entry.uidHash, entry.characterId),
-        date,
-        score: entry.score,
-        rank: entry.rank,
         entryCount: current.characters[entry.characterId]?.entryCount ?? 0,
-        buildId: computeBuildId(entry.uidHash, entry.characterId, entry.configType, entry.teamId),
       })
-    } else if (displayScore(entry.score) > displayScore(prev.highWatermark)) {
+    } else {
       events.push({
+        ...common,
         type: TimelineEventType.NEW_BEST,
-        characterId: entry.characterId,
-        configType: entry.configType,
-        candidateId: computeCandidateId(entry.uidHash, entry.characterId),
-        date,
-        score: entry.score,
         previousScore: prev.highWatermark,
-        rank: entry.rank,
         previousRank: Math.min(prev.rank, maxRank + 1),
-        buildId: computeBuildId(entry.uidHash, entry.characterId, entry.configType, entry.teamId),
       })
     }
   }

--- a/src/leaderboard/timeline/timelineEventValidation.ts
+++ b/src/leaderboard/timeline/timelineEventValidation.ts
@@ -87,30 +87,6 @@ export function parseTimelineEventWire(value: unknown): TimelineEventWire | null
 }
 
 export function buildTimelineEvent(event: TimelineEventWire, candidateId: string): TimelineEvent {
-  if (event.type === TimelineEventType.NEW_BEST) {
-    return {
-      type: event.type,
-      characterId: event.characterId,
-      configType: event.configType,
-      candidateId,
-      date: event.date,
-      score: event.score,
-      previousScore: event.previousScore,
-      rank: event.rank,
-      previousRank: event.previousRank,
-      buildId: event.buildId,
-    }
-  }
-
-  return {
-    type: event.type,
-    characterId: event.characterId,
-    configType: event.configType,
-    candidateId,
-    date: event.date,
-    score: event.score,
-    rank: event.rank,
-    entryCount: event.entryCount,
-    buildId: event.buildId,
-  }
+  const { uidHash: _, candidateId: __, ...rest } = event
+  return { ...rest, candidateId } as TimelineEvent
 }

--- a/src/leaderboard/timeline/timelineEventValidation.ts
+++ b/src/leaderboard/timeline/timelineEventValidation.ts
@@ -1,4 +1,5 @@
 import { isLeaderboardConfigType } from 'leaderboard/shared/configTypeMapping'
+import { isFiniteNumber } from 'leaderboard/shared/typeGuards'
 import {
   type TimelineEvent,
   TimelineEventType,
@@ -9,13 +10,14 @@ import type { CharacterId } from 'types/character'
 
 const CANDIDATE_ID_PATTERN = /^[0-9a-f]{12}$/
 
-type TimelineWireIdentity = {
+type TimelineNewBestEventWire = TimelineNewBestEventBase & {
   candidateId?: string,
   uidHash?: string,
 }
-
-type TimelineNewBestEventWire = TimelineNewBestEventBase & TimelineWireIdentity
-type TimelineNewCharacterEventWire = TimelineNewCharacterEventBase & TimelineWireIdentity
+type TimelineNewCharacterEventWire = TimelineNewCharacterEventBase & {
+  candidateId?: string,
+  uidHash?: string,
+}
 type TimelineEventWire = TimelineNewBestEventWire | TimelineNewCharacterEventWire
 
 export type RawTimelineEvent = Partial<{
@@ -32,10 +34,6 @@ export type RawTimelineEvent = Partial<{
   entryCount: number,
   buildId: string,
 }>
-
-function isFiniteNumber(value: number | undefined): value is number {
-  return typeof value === 'number' && Number.isFinite(value)
-}
 
 function isCandidateId(value: string | undefined): value is string {
   return value != null && CANDIDATE_ID_PATTERN.test(value)

--- a/src/leaderboard/timeline/timelineEventValidation.ts
+++ b/src/leaderboard/timeline/timelineEventValidation.ts
@@ -2,8 +2,8 @@ import { isLeaderboardConfigType } from 'leaderboard/shared/configTypeMapping'
 import {
   type TimelineEvent,
   TimelineEventType,
-  type TimelineNewBestEvent,
-  type TimelineNewCharacterEvent,
+  type TimelineNewBestEventBase,
+  type TimelineNewCharacterEventBase,
 } from 'leaderboard/timeline/timelineTypes'
 import type { CharacterId } from 'types/character'
 
@@ -14,26 +14,26 @@ type TimelineWireIdentity = {
   uidHash?: string,
 }
 
-type TimelineNewBestEventWire = Omit<TimelineNewBestEvent, 'candidateId'> & TimelineWireIdentity
-type TimelineNewCharacterEventWire = Omit<TimelineNewCharacterEvent, 'candidateId'> & TimelineWireIdentity
+type TimelineNewBestEventWire = TimelineNewBestEventBase & TimelineWireIdentity
+type TimelineNewCharacterEventWire = TimelineNewCharacterEventBase & TimelineWireIdentity
 type TimelineEventWire = TimelineNewBestEventWire | TimelineNewCharacterEventWire
 
-type UnknownTimelineEvent = {
-  type?: unknown,
-  characterId?: unknown,
-  configType?: unknown,
-  candidateId?: unknown,
-  uidHash?: unknown,
-  date?: unknown,
-  score?: unknown,
-  previousScore?: unknown,
-  rank?: unknown,
-  previousRank?: unknown,
-  entryCount?: unknown,
-  buildId?: unknown,
-}
+export type RawTimelineEvent = Partial<{
+  type: string,
+  characterId: string,
+  configType: string,
+  candidateId: string,
+  uidHash: string,
+  date: string,
+  score: number,
+  previousScore: number,
+  rank: number,
+  previousRank: number,
+  entryCount: number,
+  buildId: string,
+}>
 
-function isFiniteNumber(value: unknown): value is number {
+function isFiniteNumber(value: number | undefined): value is number {
   return typeof value === 'number' && Number.isFinite(value)
 }
 
@@ -41,55 +41,46 @@ function isCandidateId(value: string | undefined): value is string {
   return value != null && CANDIDATE_ID_PATTERN.test(value)
 }
 
-export function parseTimelineEventWire(value: unknown): TimelineEventWire | null {
-  if (value == null || typeof value !== 'object' || Array.isArray(value)) return null
-
-  const event = value as UnknownTimelineEvent
+export function parseTimelineEventWire(value: RawTimelineEvent): TimelineEventWire | null {
   if (
-    typeof event.characterId !== 'string'
-    || typeof event.configType !== 'string'
-    || !isLeaderboardConfigType(event.configType)
-    || typeof event.date !== 'string'
-    || !isFiniteNumber(event.score)
-    || !isFiniteNumber(event.rank)
-    || typeof event.buildId !== 'string'
+    typeof value.characterId !== 'string'
+    || typeof value.configType !== 'string'
+    || !isLeaderboardConfigType(value.configType)
+    || typeof value.date !== 'string'
+    || !isFiniteNumber(value.score)
+    || !isFiniteNumber(value.rank)
+    || typeof value.buildId !== 'string'
   ) {
     return null
   }
 
-  const identity = {
-    ...(typeof event.candidateId === 'string' ? { candidateId: event.candidateId } : {}),
-    ...(typeof event.uidHash === 'string' ? { uidHash: event.uidHash } : {}),
+  const common = {
+    characterId: value.characterId as CharacterId,
+    configType: value.configType,
+    candidateId: typeof value.candidateId === 'string' ? value.candidateId : undefined,
+    uidHash: typeof value.uidHash === 'string' ? value.uidHash : undefined,
+    date: value.date,
+    score: value.score,
+    rank: value.rank,
+    buildId: value.buildId,
   }
 
-  if (event.type === TimelineEventType.NEW_BEST) {
-    if (!isFiniteNumber(event.previousScore) || !isFiniteNumber(event.previousRank)) return null
+  if (value.type === TimelineEventType.NEW_BEST) {
+    if (!isFiniteNumber(value.previousScore) || !isFiniteNumber(value.previousRank)) return null
     return {
+      ...common,
       type: TimelineEventType.NEW_BEST,
-      characterId: event.characterId as CharacterId,
-      configType: event.configType,
-      ...identity,
-      date: event.date,
-      score: event.score,
-      previousScore: event.previousScore,
-      rank: event.rank,
-      previousRank: event.previousRank,
-      buildId: event.buildId,
+      previousScore: value.previousScore,
+      previousRank: value.previousRank,
     }
   }
 
-  if (event.type === TimelineEventType.NEW_CHARACTER) {
-    if (!isFiniteNumber(event.entryCount)) return null
+  if (value.type === TimelineEventType.NEW_CHARACTER) {
+    if (!isFiniteNumber(value.entryCount)) return null
     return {
+      ...common,
       type: TimelineEventType.NEW_CHARACTER,
-      characterId: event.characterId as CharacterId,
-      configType: event.configType,
-      ...identity,
-      date: event.date,
-      score: event.score,
-      rank: event.rank,
-      entryCount: event.entryCount,
-      buildId: event.buildId,
+      entryCount: value.entryCount,
     }
   }
 

--- a/src/leaderboard/timeline/timelineEventValidation.ts
+++ b/src/leaderboard/timeline/timelineEventValidation.ts
@@ -2,11 +2,21 @@ import { isLeaderboardConfigType } from 'leaderboard/shared/configTypeMapping'
 import {
   type TimelineEvent,
   TimelineEventType,
-  type TimelineEventWire,
+  type TimelineNewBestEvent,
+  type TimelineNewCharacterEvent,
 } from 'leaderboard/timeline/timelineTypes'
 import type { CharacterId } from 'types/character'
 
 const CANDIDATE_ID_PATTERN = /^[0-9a-f]{12}$/
+
+type TimelineWireIdentity = {
+  candidateId?: string,
+  uidHash?: string,
+}
+
+type TimelineNewBestEventWire = Omit<TimelineNewBestEvent, 'candidateId'> & TimelineWireIdentity
+type TimelineNewCharacterEventWire = Omit<TimelineNewCharacterEvent, 'candidateId'> & TimelineWireIdentity
+type TimelineEventWire = TimelineNewBestEventWire | TimelineNewCharacterEventWire
 
 type UnknownTimelineEvent = {
   type?: unknown,
@@ -27,7 +37,7 @@ function isFiniteNumber(value: unknown): value is number {
   return typeof value === 'number' && Number.isFinite(value)
 }
 
-export function isCandidateId(value: string | undefined): value is string {
+function isCandidateId(value: string | undefined): value is string {
   return value != null && CANDIDATE_ID_PATTERN.test(value)
 }
 
@@ -86,7 +96,15 @@ export function parseTimelineEventWire(value: unknown): TimelineEventWire | null
   return null
 }
 
-export function buildTimelineEvent(event: TimelineEventWire, candidateId: string): TimelineEvent {
+export function completeTimelineEventIdentity(
+  event: TimelineEventWire,
+  legacyCandidateId: string | undefined,
+): TimelineEvent | null {
+  if (event.candidateId != null && legacyCandidateId != null && event.candidateId !== legacyCandidateId) return null
+
+  const candidateId = event.candidateId ?? legacyCandidateId
+  if (!isCandidateId(candidateId)) return null
+
   const { uidHash: _, candidateId: __, ...rest } = event
   return { ...rest, candidateId } as TimelineEvent
 }

--- a/src/leaderboard/timeline/timelineEventValidation.ts
+++ b/src/leaderboard/timeline/timelineEventValidation.ts
@@ -1,0 +1,116 @@
+import { isLeaderboardConfigType } from 'leaderboard/shared/configTypeMapping'
+import {
+  type TimelineEvent,
+  TimelineEventType,
+  type TimelineEventWire,
+} from 'leaderboard/timeline/timelineTypes'
+import type { CharacterId } from 'types/character'
+
+const CANDIDATE_ID_PATTERN = /^[0-9a-f]{12}$/
+
+type UnknownTimelineEvent = {
+  type?: unknown,
+  characterId?: unknown,
+  configType?: unknown,
+  candidateId?: unknown,
+  uidHash?: unknown,
+  date?: unknown,
+  score?: unknown,
+  previousScore?: unknown,
+  rank?: unknown,
+  previousRank?: unknown,
+  entryCount?: unknown,
+  buildId?: unknown,
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value)
+}
+
+export function isCandidateId(value: string | undefined): value is string {
+  return value != null && CANDIDATE_ID_PATTERN.test(value)
+}
+
+export function parseTimelineEventWire(value: unknown): TimelineEventWire | null {
+  if (value == null || typeof value !== 'object' || Array.isArray(value)) return null
+
+  const event = value as UnknownTimelineEvent
+  if (
+    typeof event.characterId !== 'string'
+    || typeof event.configType !== 'string'
+    || !isLeaderboardConfigType(event.configType)
+    || typeof event.date !== 'string'
+    || !isFiniteNumber(event.score)
+    || !isFiniteNumber(event.rank)
+    || typeof event.buildId !== 'string'
+  ) {
+    return null
+  }
+
+  const identity = {
+    ...(typeof event.candidateId === 'string' ? { candidateId: event.candidateId } : {}),
+    ...(typeof event.uidHash === 'string' ? { uidHash: event.uidHash } : {}),
+  }
+
+  if (event.type === TimelineEventType.NEW_BEST) {
+    if (!isFiniteNumber(event.previousScore) || !isFiniteNumber(event.previousRank)) return null
+    return {
+      type: TimelineEventType.NEW_BEST,
+      characterId: event.characterId as CharacterId,
+      configType: event.configType,
+      ...identity,
+      date: event.date,
+      score: event.score,
+      previousScore: event.previousScore,
+      rank: event.rank,
+      previousRank: event.previousRank,
+      buildId: event.buildId,
+    }
+  }
+
+  if (event.type === TimelineEventType.NEW_CHARACTER) {
+    if (!isFiniteNumber(event.entryCount)) return null
+    return {
+      type: TimelineEventType.NEW_CHARACTER,
+      characterId: event.characterId as CharacterId,
+      configType: event.configType,
+      ...identity,
+      date: event.date,
+      score: event.score,
+      rank: event.rank,
+      entryCount: event.entryCount,
+      buildId: event.buildId,
+    }
+  }
+
+  return null
+}
+
+export function buildTimelineEvent(event: TimelineEventWire, candidateId: string): TimelineEvent {
+  if (event.type === TimelineEventType.NEW_BEST) {
+    return {
+      type: event.type,
+      characterId: event.characterId,
+      configType: event.configType,
+      candidateId,
+      date: event.date,
+      score: event.score,
+      previousScore: event.previousScore,
+      rank: event.rank,
+      previousRank: event.previousRank,
+      buildId: event.buildId,
+    }
+  }
+
+  return {
+    type: event.type,
+    characterId: event.characterId,
+    configType: event.configType,
+    candidateId,
+    date: event.date,
+    score: event.score,
+    rank: event.rank,
+    entryCount: event.entryCount,
+    buildId: event.buildId,
+  }
+}

--- a/src/leaderboard/timeline/timelineStorage.ts
+++ b/src/leaderboard/timeline/timelineStorage.ts
@@ -10,8 +10,7 @@ import {
 } from 'leaderboard/shared/nodeFacade'
 import type { TimelineUpdateResult } from 'leaderboard/timeline/computeTimeline'
 import {
-  buildTimelineEvent,
-  isCandidateId,
+  completeTimelineEventIdentity,
   parseTimelineEventWire,
 } from 'leaderboard/timeline/timelineEventValidation'
 import type {
@@ -55,17 +54,12 @@ export function readTimeline(path: string): LeaderboardTimeline['events'] {
       const legacyCandidateId = event.uidHash == null
         ? undefined
         : computeCandidateId(event.uidHash, event.characterId)
-      if (event.candidateId != null && legacyCandidateId != null && event.candidateId !== legacyCandidateId) {
-        console.warn(`Ignoring timeline event with mismatched identity in ${path}`)
-        continue
-      }
-
-      const candidateId = event.candidateId ?? legacyCandidateId
-      if (!isCandidateId(candidateId)) {
+      const completedEvent = completeTimelineEventIdentity(event, legacyCandidateId)
+      if (!completedEvent) {
         console.warn(`Ignoring timeline event with invalid identity in ${path}`)
         continue
       }
-      events.push(buildTimelineEvent(event, candidateId))
+      events.push(completedEvent)
     }
     return events
   } catch (err) {

--- a/src/leaderboard/timeline/timelineStorage.ts
+++ b/src/leaderboard/timeline/timelineStorage.ts
@@ -1,4 +1,5 @@
 import { atomicWriteJsonFile } from 'leaderboard/output/atomicWrite'
+import { computeCandidateId } from 'leaderboard/shared/hash'
 import {
   cwd,
   dirnamePath,
@@ -7,9 +8,17 @@ import {
   readTextFile,
   resolvePath,
 } from 'leaderboard/shared/nodeFacade'
-import type { LeaderboardTimeline, LeaderboardSnapshot } from 'leaderboard/timeline/timelineTypes'
-import { TIMELINE_SCHEMA_VERSION } from 'leaderboard/timeline/timelineTypes'
 import type { TimelineUpdateResult } from 'leaderboard/timeline/computeTimeline'
+import {
+  buildTimelineEvent,
+  isCandidateId,
+  parseTimelineEventWire,
+} from 'leaderboard/timeline/timelineEventValidation'
+import type {
+  LeaderboardSnapshot,
+  LeaderboardTimeline,
+} from 'leaderboard/timeline/timelineTypes'
+import { TIMELINE_SCHEMA_VERSION } from 'leaderboard/timeline/timelineTypes'
 
 export function readSnapshot(path: string): LeaderboardSnapshot | null {
   if (!fileExists(path)) return null
@@ -29,11 +38,36 @@ export function readSnapshot(path: string): LeaderboardSnapshot | null {
 export function readTimeline(path: string): LeaderboardTimeline['events'] {
   if (!fileExists(path)) return []
   try {
-    const parsed = JSON.parse(readTextFile(path)) as LeaderboardTimeline
+    const parsed = JSON.parse(readTextFile(path)) as { schemaVersion?: number, events?: unknown[] }
     if ((parsed.schemaVersion ?? 1) < TIMELINE_SCHEMA_VERSION) {
       return []
     }
-    return parsed.events ?? []
+    if (!Array.isArray(parsed.events)) return []
+
+    const events: LeaderboardTimeline['events'] = []
+    for (const value of parsed.events) {
+      const event = parseTimelineEventWire(value)
+      if (!event) {
+        console.warn(`Ignoring malformed timeline event in ${path}`)
+        continue
+      }
+
+      const legacyCandidateId = event.uidHash == null
+        ? undefined
+        : computeCandidateId(event.uidHash, event.characterId)
+      if (event.candidateId != null && legacyCandidateId != null && event.candidateId !== legacyCandidateId) {
+        console.warn(`Ignoring timeline event with mismatched identity in ${path}`)
+        continue
+      }
+
+      const candidateId = event.candidateId ?? legacyCandidateId
+      if (!isCandidateId(candidateId)) {
+        console.warn(`Ignoring timeline event with invalid identity in ${path}`)
+        continue
+      }
+      events.push(buildTimelineEvent(event, candidateId))
+    }
+    return events
   } catch (err) {
     console.warn(`Failed to parse timeline at ${path}:`, err)
     return []
@@ -41,9 +75,32 @@ export function readTimeline(path: string): LeaderboardTimeline['events'] {
 }
 
 export function writeTimelineArtifacts(result: TimelineUpdateResult): void {
+  validateNoUidInPublicTimeline(result.timeline)
   atomicWriteJsonFile(result.timelinePath, JSON.stringify(result.timeline, null, 2))
   const snapshot = { ...result.snapshot, schemaVersion: TIMELINE_SCHEMA_VERSION }
   atomicWriteJsonFile(result.snapshotPath, JSON.stringify(snapshot, null, 2))
+}
+
+export function validateNoUidInPublicTimeline(timeline: LeaderboardTimeline): void {
+  validateNoUidFields(timeline, 'timeline')
+}
+
+function validateNoUidFields(value: unknown, path: string): void {
+  if (value == null || typeof value !== 'object') return
+
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i++) {
+      validateNoUidFields(value[i], `${path}[${i}]`)
+    }
+    return
+  }
+
+  for (const [field, child] of Object.entries(value)) {
+    if (field === 'uid' || field === 'uidHash') {
+      throw new Error(`Public timeline contains forbidden field "${field}" in ${path}`)
+    }
+    validateNoUidFields(child, `${path}.${field}`)
+  }
 }
 
 export function deriveTimelinePath(publicOutputPath: string): string {

--- a/src/leaderboard/timeline/timelineStorage.ts
+++ b/src/leaderboard/timeline/timelineStorage.ts
@@ -12,10 +12,12 @@ import type { TimelineUpdateResult } from 'leaderboard/timeline/computeTimeline'
 import {
   completeTimelineEventIdentity,
   parseTimelineEventWire,
+  type RawTimelineEvent,
 } from 'leaderboard/timeline/timelineEventValidation'
 import type {
   LeaderboardSnapshot,
   LeaderboardTimeline,
+  TimelineEvent,
 } from 'leaderboard/timeline/timelineTypes'
 import { TIMELINE_SCHEMA_VERSION } from 'leaderboard/timeline/timelineTypes'
 
@@ -34,16 +36,16 @@ export function readSnapshot(path: string): LeaderboardSnapshot | null {
   }
 }
 
-export function readTimeline(path: string): LeaderboardTimeline['events'] {
+export function readTimeline(path: string): TimelineEvent[] {
   if (!fileExists(path)) return []
   try {
-    const parsed = JSON.parse(readTextFile(path)) as { schemaVersion?: number, events?: unknown[] }
+    const parsed = JSON.parse(readTextFile(path)) as { schemaVersion?: number, events?: RawTimelineEvent[] }
     if ((parsed.schemaVersion ?? 1) < TIMELINE_SCHEMA_VERSION) {
       return []
     }
     if (!Array.isArray(parsed.events)) return []
 
-    const events: LeaderboardTimeline['events'] = []
+    const events: TimelineEvent[] = []
     for (const value of parsed.events) {
       const event = parseTimelineEventWire(value)
       if (!event) {
@@ -75,25 +77,15 @@ export function writeTimelineArtifacts(result: TimelineUpdateResult): void {
   atomicWriteJsonFile(result.snapshotPath, JSON.stringify(snapshot, null, 2))
 }
 
-export function validateNoUidInPublicTimeline(timeline: LeaderboardTimeline): void {
-  validateNoUidFields(timeline, 'timeline')
-}
-
-function validateNoUidFields(value: unknown, path: string): void {
-  if (value == null || typeof value !== 'object') return
-
-  if (Array.isArray(value)) {
-    for (let i = 0; i < value.length; i++) {
-      validateNoUidFields(value[i], `${path}[${i}]`)
+function validateNoUidInPublicTimeline(timeline: LeaderboardTimeline): void {
+  for (let i = 0; i < timeline.events.length; i++) {
+    const event = timeline.events[i]
+    if ('uid' in event) {
+      throw new Error(`Public timeline contains forbidden field "uid" in timeline.events[${i}]`)
     }
-    return
-  }
-
-  for (const [field, child] of Object.entries(value)) {
-    if (field === 'uid' || field === 'uidHash') {
-      throw new Error(`Public timeline contains forbidden field "${field}" in ${path}`)
+    if ('uidHash' in event) {
+      throw new Error(`Public timeline contains forbidden field "uidHash" in timeline.events[${i}]`)
     }
-    validateNoUidFields(child, `${path}.${field}`)
   }
 }
 

--- a/src/leaderboard/timeline/timelineTypes.ts
+++ b/src/leaderboard/timeline/timelineTypes.ts
@@ -36,15 +36,6 @@ export type TimelineNewCharacterEvent = {
 
 export type TimelineEvent = TimelineNewBestEvent | TimelineNewCharacterEvent
 
-type TimelineWireIdentity = {
-  candidateId?: string,
-  uidHash?: string,
-}
-
-export type TimelineNewBestEventWire = Omit<TimelineNewBestEvent, 'candidateId'> & TimelineWireIdentity
-export type TimelineNewCharacterEventWire = Omit<TimelineNewCharacterEvent, 'candidateId'> & TimelineWireIdentity
-export type TimelineEventWire = TimelineNewBestEventWire | TimelineNewCharacterEventWire
-
 export type LeaderboardTimeline = {
   schemaVersion: number,
   generatedAt: string,

--- a/src/leaderboard/timeline/timelineTypes.ts
+++ b/src/leaderboard/timeline/timelineTypes.ts
@@ -9,11 +9,10 @@ export enum TimelineEventType {
   NEW_CHARACTER = 'new_character',
 }
 
-export type TimelineNewBestEvent = {
+export type TimelineNewBestEventBase = {
   type: TimelineEventType.NEW_BEST,
   characterId: CharacterId,
   configType: LeaderboardConfigType,
-  candidateId: string,
   date: string,
   score: number,
   previousScore: number,
@@ -22,17 +21,20 @@ export type TimelineNewBestEvent = {
   buildId: string,
 }
 
-export type TimelineNewCharacterEvent = {
+export type TimelineNewBestEvent = TimelineNewBestEventBase & { candidateId: string }
+
+export type TimelineNewCharacterEventBase = {
   type: TimelineEventType.NEW_CHARACTER,
   characterId: CharacterId,
   configType: LeaderboardConfigType,
-  candidateId: string,
   date: string,
   score: number,
   rank: number,
   entryCount: number,
   buildId: string,
 }
+
+export type TimelineNewCharacterEvent = TimelineNewCharacterEventBase & { candidateId: string }
 
 export type TimelineEvent = TimelineNewBestEvent | TimelineNewCharacterEvent
 

--- a/src/leaderboard/timeline/timelineTypes.ts
+++ b/src/leaderboard/timeline/timelineTypes.ts
@@ -1,3 +1,4 @@
+import type { LeaderboardConfigType } from 'leaderboard/shared/configTypeMapping'
 import type { CharacterId } from 'types/character'
 
 export const TIMELINE_SCHEMA_VERSION = 2
@@ -11,8 +12,8 @@ export enum TimelineEventType {
 export type TimelineNewBestEvent = {
   type: TimelineEventType.NEW_BEST,
   characterId: CharacterId,
-  configType: string,
-  uidHash: string,
+  configType: LeaderboardConfigType,
+  candidateId: string,
   date: string,
   score: number,
   previousScore: number,
@@ -24,8 +25,8 @@ export type TimelineNewBestEvent = {
 export type TimelineNewCharacterEvent = {
   type: TimelineEventType.NEW_CHARACTER,
   characterId: CharacterId,
-  configType: string,
-  uidHash: string,
+  configType: LeaderboardConfigType,
+  candidateId: string,
   date: string,
   score: number,
   rank: number,
@@ -34,6 +35,15 @@ export type TimelineNewCharacterEvent = {
 }
 
 export type TimelineEvent = TimelineNewBestEvent | TimelineNewCharacterEvent
+
+type TimelineWireIdentity = {
+  candidateId?: string,
+  uidHash?: string,
+}
+
+export type TimelineNewBestEventWire = Omit<TimelineNewBestEvent, 'candidateId'> & TimelineWireIdentity
+export type TimelineNewCharacterEventWire = Omit<TimelineNewCharacterEvent, 'candidateId'> & TimelineWireIdentity
+export type TimelineEventWire = TimelineNewBestEventWire | TimelineNewCharacterEventWire
 
 export type LeaderboardTimeline = {
   schemaVersion: number,

--- a/src/lib/conditionals/character/1300/BlackSwanB1.ts
+++ b/src/lib/conditionals/character/1300/BlackSwanB1.ts
@@ -1,4 +1,5 @@
 import { KafkaB1 } from 'lib/conditionals/character/1000/KafkaB1'
+import { HuohuoB1 } from 'lib/conditionals/character/1200/HuohuoB1'
 import { Hysilens } from 'lib/conditionals/character/1400/Hysilens'
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
 import {
@@ -8,6 +9,7 @@ import {
   createEnum,
 } from 'lib/conditionals/conditionalUtils'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
+import { NightOfFright } from 'lib/conditionals/lightcone/5star/NightOfFright'
 import { PatienceIsAllYouNeed } from 'lib/conditionals/lightcone/5star/PatienceIsAllYouNeed'
 import { ReforgedRemembrance } from 'lib/conditionals/lightcone/5star/ReforgedRemembrance'
 import { ThoughWorldsApart } from 'lib/conditionals/lightcone/5star/ThoughWorldsApart'
@@ -385,6 +387,13 @@ const simulation = (): SimulationMetadata => ({
         { characterId: KafkaB1.id, lightCones: [PatienceIsAllYouNeed.id] },
         { characterId: Hysilens.id, lightCones: [WhyDoesTheOceanSing.id] },
         { characterId: PermansorTerrae.id, lightCones: [ThoughWorldsApart.id] },
+      ],
+    },
+    {
+      teammates: [
+        { characterId: KafkaB1.id, lightCones: [PatienceIsAllYouNeed.id] },
+        { characterId: Hysilens.id, lightCones: [WhyDoesTheOceanSing.id] },
+        { characterId: HuohuoB1.id, lightCones: [NightOfFright.id] },
       ],
     },
   ],

--- a/src/lib/conditionals/character/1400/TheHerta.ts
+++ b/src/lib/conditionals/character/1400/TheHerta.ts
@@ -3,6 +3,7 @@ import {
   ashblazingMulti,
 } from 'lib/conditionals/ashblazingCompute'
 import { Huohuo } from 'lib/conditionals/character/1200/Huohuo'
+import { HuohuoB1 } from 'lib/conditionals/character/1200/HuohuoB1'
 import { Jade } from 'lib/conditionals/character/1300/Jade'
 import { Sunday } from 'lib/conditionals/character/1300/Sunday'
 import { Anaxa } from 'lib/conditionals/character/1400/Anaxa'
@@ -380,7 +381,7 @@ const simulation = (): SimulationMetadata => ({
       teammates: [
         { characterId: Jade.id, lightCones: [YetHopeIsPriceless.id] },
         { characterId: Sunday.id, lightCones: [AGroundedAscent.id] },
-        { characterId: Huohuo.id, lightCones: [NightOfFright.id] },
+        { characterId: HuohuoB1.id, lightCones: [NightOfFright.id] },
       ],
     },
   ],

--- a/src/lib/conditionals/character/1400/TheHerta.ts
+++ b/src/lib/conditionals/character/1400/TheHerta.ts
@@ -381,7 +381,7 @@ const simulation = (): SimulationMetadata => ({
       teammates: [
         { characterId: Jade.id, lightCones: [YetHopeIsPriceless.id] },
         { characterId: Sunday.id, lightCones: [AGroundedAscent.id] },
-        { characterId: HuohuoB1.id, lightCones: [NightOfFright.id] },
+        { characterId: PermansorTerrae.id, lightCones: [ThoughWorldsApart.id] },
       ],
     },
   ],

--- a/src/lib/conditionals/character/1400/TheHerta.ts
+++ b/src/lib/conditionals/character/1400/TheHerta.ts
@@ -2,7 +2,9 @@ import {
   aoe,
   ashblazingMulti,
 } from 'lib/conditionals/ashblazingCompute'
+import { Huohuo } from 'lib/conditionals/character/1200/Huohuo'
 import { Jade } from 'lib/conditionals/character/1300/Jade'
+import { Sunday } from 'lib/conditionals/character/1300/Sunday'
 import { Anaxa } from 'lib/conditionals/character/1400/Anaxa'
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
 import { Tribbie } from 'lib/conditionals/character/1400/Tribbie'
@@ -21,9 +23,11 @@ import {
 } from 'lib/conditionals/conditionalUtils'
 import { HitDefinitionBuilder } from 'lib/conditionals/hitDefinitionBuilder'
 import { FlyIntoAPinkTomorrow } from 'lib/conditionals/lightcone/4star/FlyIntoAPinkTomorrow'
+import { AGroundedAscent } from 'lib/conditionals/lightcone/5star/AGroundedAscent'
 import { IfTimeWereAFlower } from 'lib/conditionals/lightcone/5star/IfTimeWereAFlower'
 import { IntotheUnreachableVeil } from 'lib/conditionals/lightcone/5star/IntotheUnreachableVeil'
 import { LifeShouldBeCastToFlames } from 'lib/conditionals/lightcone/5star/LifeShouldBeCastToFlames'
+import { NightOfFright } from 'lib/conditionals/lightcone/5star/NightOfFright'
 import { ThoughWorldsApart } from 'lib/conditionals/lightcone/5star/ThoughWorldsApart'
 import { YetHopeIsPriceless } from 'lib/conditionals/lightcone/5star/YetHopeIsPriceless'
 import {
@@ -370,6 +374,13 @@ const simulation = (): SimulationMetadata => ({
         { characterId: Jade.id, lightCones: [YetHopeIsPriceless.id] },
         { characterId: TrailblazerRemembranceStelle.id, lightCones: [FlyIntoAPinkTomorrow.id] },
         { characterId: PermansorTerrae.id, lightCones: [ThoughWorldsApart.id] },
+      ],
+    },
+    {
+      teammates: [
+        { characterId: Jade.id, lightCones: [YetHopeIsPriceless.id] },
+        { characterId: Sunday.id, lightCones: [AGroundedAscent.id] },
+        { characterId: Huohuo.id, lightCones: [NightOfFright.id] },
       ],
     },
   ],

--- a/src/lib/tabs/tabHome/HomeTab.tsx
+++ b/src/lib/tabs/tabHome/HomeTab.tsx
@@ -210,15 +210,21 @@ interface FeatureCardProps {
   align: 'left' | 'right'
 }
 
+const EMPTY_FEATURES: string[] = []
+
 function FeatureCard({ feature, background, image, align }: FeatureCardProps) {
   const { t } = useTranslation('hometab', { keyPrefix: `FeatureCard.${feature}`! })
   const isLeft = align === 'left'
+  const translatedFeatures = t('Features', { returnObjects: true })
+  const features = Array.isArray(translatedFeatures)
+    ? translatedFeatures.filter((item): item is string => typeof item === 'string')
+    : EMPTY_FEATURES
 
   const textBlock = (
     <div className={classes.textBlock}>
       <h2 className={classes.sectionTitle}>{t('Title')}</h2>
       <p className={classes.sectionDescription}>{t('Description')}</p>
-      <FeatureList features={t('Features', { returnObjects: true })} />
+      <FeatureList features={features} />
     </div>
   )
 

--- a/src/lib/tabs/tabHome/HomeTab.tsx
+++ b/src/lib/tabs/tabHome/HomeTab.tsx
@@ -217,7 +217,7 @@ function FeatureCard({ feature, background, image, align }: FeatureCardProps) {
   const isLeft = align === 'left'
   const translatedFeatures = t('Features', { returnObjects: true })
   const features = Array.isArray(translatedFeatures)
-    ? translatedFeatures.filter((item): item is string => typeof item === 'string')
+    ? translatedFeatures
     : EMPTY_FEATURES
 
   const textBlock = (

--- a/src/lib/tabs/tabLeaderboard/LeaderboardHeader.module.css
+++ b/src/lib/tabs/tabLeaderboard/LeaderboardHeader.module.css
@@ -104,6 +104,108 @@
   border: 1px solid var(--lb-divider);
 }
 
+.userRanksPanel {
+  flex-basis: 330px;
+}
+
+/* ── Saved UID ranks ── */
+
+.rankContainer {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+  min-height: 0;
+}
+
+.rankHeaderRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.rankScope {
+  color: var(--lb-text-3);
+  font-size: 11px;
+}
+
+.rankState {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--lb-text-3);
+  font-size: 13px;
+  text-align: center;
+}
+
+.rankGrid {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255, 255, 255, 0.15) transparent;
+}
+
+.rankRow {
+  width: 100%;
+  display: grid;
+  grid-template-columns: 24px minmax(0, 1fr) 52px 40px 52px;
+  align-items: center;
+  gap: 7px;
+  padding: 4px 5px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+}
+
+.rankRow:hover {
+  background: rgba(255, 255, 255, 0.07);
+}
+
+.rankAvatar {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.rankName {
+  overflow: hidden;
+  color: var(--lb-text-2);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.rankConfig,
+.rankNumber,
+.rankScore {
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.rankConfig {
+  color: var(--lb-text-3);
+}
+
+.rankNumber {
+  color: #8cc8ff;
+  font-weight: 600;
+  text-align: right;
+}
+
+.rankScore {
+  color: var(--lb-text-1);
+  text-align: right;
+}
+
 /* ── Feed container ── */
 
 .feedContainer {

--- a/src/lib/tabs/tabLeaderboard/LeaderboardHeader.module.css
+++ b/src/lib/tabs/tabLeaderboard/LeaderboardHeader.module.css
@@ -44,7 +44,7 @@
   height: 100%;
   display: flex;
   padding: 12px 12px 12px 44px;
-  gap: 20px;
+  gap: 12px;
 }
 
 /* ── Title column ── */
@@ -105,7 +105,7 @@
 }
 
 .userRanksPanel {
-  flex-basis: 330px;
+  flex-basis: 350px;
 }
 
 /* ── Saved UID ranks ── */
@@ -150,7 +150,7 @@
   grid-template-columns: 42px 24px minmax(0, 1fr) 52px 52px;
   align-items: center;
   gap: 7px;
-  padding: 4px 6px 4px 0;
+  padding: 4px 6px;
   border: 0;
   border-radius: 4px;
   background: transparent;

--- a/src/lib/tabs/tabLeaderboard/LeaderboardHeader.module.css
+++ b/src/lib/tabs/tabLeaderboard/LeaderboardHeader.module.css
@@ -212,7 +212,7 @@
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 6px;
   min-height: 0;
   overflow: hidden;
 }
@@ -237,7 +237,7 @@
   min-height: 0;
   overflow-y: auto;
   overflow-x: hidden;
-  mask-image: linear-gradient(to bottom, black calc(100% - 24px), transparent);
+  mask-image: linear-gradient(to bottom, black calc(100% - 16px), transparent);
   scrollbar-width: thin;
   scrollbar-color: transparent transparent;
   padding: 0 6px 16px;

--- a/src/lib/tabs/tabLeaderboard/LeaderboardHeader.module.css
+++ b/src/lib/tabs/tabLeaderboard/LeaderboardHeader.module.css
@@ -126,11 +126,6 @@
   gap: 12px;
 }
 
-.rankScope {
-  color: var(--lb-text-3);
-  font-size: 11px;
-}
-
 .rankState {
   flex: 1;
   display: flex;
@@ -152,10 +147,10 @@
 .rankRow {
   width: 100%;
   display: grid;
-  grid-template-columns: 36px 24px minmax(0, 1fr) 52px 52px;
+  grid-template-columns: 42px 24px minmax(0, 1fr) 52px 52px;
   align-items: center;
   gap: 7px;
-  padding: 4px 0;
+  padding: 4px 6px 4px 0;
   border: 0;
   border-radius: 4px;
   background: transparent;

--- a/src/lib/tabs/tabLeaderboard/LeaderboardHeader.module.css
+++ b/src/lib/tabs/tabLeaderboard/LeaderboardHeader.module.css
@@ -152,10 +152,10 @@
 .rankRow {
   width: 100%;
   display: grid;
-  grid-template-columns: 24px minmax(0, 1fr) 52px 40px 52px;
+  grid-template-columns: 36px 24px minmax(0, 1fr) 52px 52px;
   align-items: center;
   gap: 7px;
-  padding: 4px 5px;
+  padding: 4px 0;
   border: 0;
   border-radius: 4px;
   background: transparent;
@@ -174,6 +174,7 @@
   height: 24px;
   border-radius: 50%;
   object-fit: cover;
+  vertical-align: middle;
 }
 
 .rankName {
@@ -193,12 +194,13 @@
 
 .rankConfig {
   color: var(--lb-text-3);
+  text-align: right;
 }
 
 .rankNumber {
   color: #8cc8ff;
-  font-weight: 600;
-  text-align: right;
+  padding-left: 4px;
+  line-height: 24px;
 }
 
 .rankScore {

--- a/src/lib/tabs/tabLeaderboard/LeaderboardHeader.tsx
+++ b/src/lib/tabs/tabLeaderboard/LeaderboardHeader.tsx
@@ -28,7 +28,7 @@ export function LeaderboardHeader() {
         <div className={classes.titleColumn}>
           <span className={classes.title}>Leaderboards</span>
           <span className={classes.subtitle}>
-            Benchmark rankings based on Showcase tab AEON builds, scores refreshed daily.
+            Benchmark rankings based on Showcase tab Aeon builds, scores refreshed daily.
           </span>
           <button type='button' className={classes.showcaseButton} onClick={goToShowcase}>
             Go to Showcase &rarr;

--- a/src/lib/tabs/tabLeaderboard/LeaderboardHeader.tsx
+++ b/src/lib/tabs/tabLeaderboard/LeaderboardHeader.tsx
@@ -2,6 +2,7 @@ import { Assets } from 'lib/rendering/assets'
 import { AppPages } from 'lib/tabs/navigation/constants'
 import { navigateTo } from 'lib/tabs/navigation/utils'
 import classes from 'lib/tabs/tabLeaderboard/LeaderboardHeader.module.css'
+import { LeaderboardUserRanksCard } from 'lib/tabs/tabLeaderboard/LeaderboardUserRanksCard'
 import { TimelineFeed } from 'lib/tabs/tabLeaderboard/TimelineFeed'
 import { useLeaderboardTabStore } from 'lib/tabs/tabLeaderboard/useLeaderboardTabStore'
 
@@ -29,9 +30,13 @@ export function LeaderboardHeader() {
           <span className={classes.subtitle}>
             Benchmark rankings based on Showcase tab builds, scores refreshed daily.
           </span>
-          <button type="button" className={classes.showcaseButton} onClick={goToShowcase}>
+          <button type='button' className={classes.showcaseButton} onClick={goToShowcase}>
             Go to Showcase &rarr;
           </button>
+        </div>
+
+        <div className={`${classes.glassPanel} ${classes.userRanksPanel}`}>
+          <LeaderboardUserRanksCard />
         </div>
 
         {timelineEvents.length > 0 && (

--- a/src/lib/tabs/tabLeaderboard/LeaderboardHeader.tsx
+++ b/src/lib/tabs/tabLeaderboard/LeaderboardHeader.tsx
@@ -28,7 +28,7 @@ export function LeaderboardHeader() {
         <div className={classes.titleColumn}>
           <span className={classes.title}>Leaderboards</span>
           <span className={classes.subtitle}>
-            Benchmark rankings based on Showcase tab builds, scores refreshed daily.
+            Benchmark rankings based on Showcase tab AEON builds, scores refreshed daily.
           </span>
           <button type='button' className={classes.showcaseButton} onClick={goToShowcase}>
             Go to Showcase &rarr;

--- a/src/lib/tabs/tabLeaderboard/LeaderboardHeader.tsx
+++ b/src/lib/tabs/tabLeaderboard/LeaderboardHeader.tsx
@@ -35,9 +35,7 @@ export function LeaderboardHeader() {
           </button>
         </div>
 
-        <div className={`${classes.glassPanel} ${classes.userRanksPanel}`}>
-          <LeaderboardUserRanksCard />
-        </div>
+        <LeaderboardUserRanksCard />
 
         {timelineEvents.length > 0 && (
           <div className={classes.glassPanel}>

--- a/src/lib/tabs/tabLeaderboard/LeaderboardUserRanksCard.tsx
+++ b/src/lib/tabs/tabLeaderboard/LeaderboardUserRanksCard.tsx
@@ -1,6 +1,5 @@
 import { LeaderboardConfigType } from 'leaderboard/shared/configTypeMapping'
 import { LEADERBOARD_FILTER_ALL } from 'leaderboard/shared/eidolonConfig'
-import { LEADERBOARD_DISPLAY_TOP_N } from 'lib/tabs/tabLeaderboard/deriveVisibleEntries'
 import { Assets } from 'lib/rendering/assets'
 import { loadCharacterData } from 'lib/tabs/tabLeaderboard/leaderboardDataLoader'
 import classes from 'lib/tabs/tabLeaderboard/LeaderboardHeader.module.css'
@@ -62,7 +61,7 @@ function statusMessage(state: UserRanksState): string | null {
     case UserRanksStatus.UNAVAILABLE:
       return 'Ranks are temporarily unavailable.'
     case UserRanksStatus.READY:
-      return state.ranks.length === 0 ? `No current top ${LEADERBOARD_DISPLAY_TOP_N} ranks.` : null
+      return null
   }
 }
 
@@ -117,10 +116,13 @@ export function LeaderboardUserRanksCard() {
     }
   }, [availableCharacters, loading, scorerId])
 
+  if (state.status === UserRanksStatus.READY && state.ranks.length === 0) return null
+
   const message = statusMessage(state)
 
   return (
-    <div className={classes.rankContainer}>
+    <div className={`${classes.glassPanel} ${classes.userRanksPanel}`}>
+      <div className={classes.rankContainer}>
       <div className={classes.rankHeaderRow}>
         <span className={classes.feedHeader}>Your Ranks</span>
         <span className={classes.rankScope}>All Teams</span>
@@ -156,6 +158,7 @@ export function LeaderboardUserRanksCard() {
           })}
         </div>
       )}
+      </div>
     </div>
   )
 }

--- a/src/lib/tabs/tabLeaderboard/LeaderboardUserRanksCard.tsx
+++ b/src/lib/tabs/tabLeaderboard/LeaderboardUserRanksCard.tsx
@@ -11,6 +11,7 @@ import {
 } from 'lib/tabs/tabLeaderboard/leaderboardUidLookup'
 import { useLeaderboardTabStore } from 'lib/tabs/tabLeaderboard/useLeaderboardTabStore'
 import { useShowcaseTabStore } from 'lib/tabs/tabShowcase/useShowcaseTabStore'
+import { truncate10ths } from 'lib/utils/mathUtils'
 import { validateUuid } from 'lib/utils/miscUtils'
 import {
   useEffect,
@@ -148,7 +149,7 @@ export function LeaderboardUserRanksCard() {
                 <span className={classes.rankName}>{name}</span>
                 <span className={classes.rankConfig}>{CONFIG_LABELS[rank.configType]}</span>
                 <span className={classes.rankNumber}>#{rank.rank}</span>
-                <span className={classes.rankScore}>{(rank.score * 100).toFixed(1)}%</span>
+                <span className={classes.rankScore}>{truncate10ths(rank.score * 100).toFixed(1)}%</span>
               </button>
             )
           })}

--- a/src/lib/tabs/tabLeaderboard/LeaderboardUserRanksCard.tsx
+++ b/src/lib/tabs/tabLeaderboard/LeaderboardUserRanksCard.tsx
@@ -45,7 +45,7 @@ type UserRanksState =
 function selectRank(rank: UserLeaderboardRank) {
   selectLeaderboardCharacter(rank.characterId, {
     configType: rank.configType,
-    teamId: LEADERBOARD_FILTER_ALL,
+    teamId: rank.teamId,
     buildId: rank.buildId,
   })
 }
@@ -124,8 +124,7 @@ export function LeaderboardUserRanksCard() {
     <div className={`${classes.glassPanel} ${classes.userRanksPanel}`}>
       <div className={classes.rankContainer}>
       <div className={classes.rankHeaderRow}>
-        <span className={classes.feedHeader}>Your Ranks</span>
-        <span className={classes.rankScope}>All Teams</span>
+        <span className={classes.feedHeader}>Your Characters</span>
       </div>
 
       {message && <div className={classes.rankState}>{message}</div>}
@@ -135,6 +134,7 @@ export function LeaderboardUserRanksCard() {
           {state.ranks.map((rank) => {
             const nameKey = rank.characterId.startsWith('80') ? 'LongName' : 'Name'
             const name = tGame(`Characters.${rank.characterId}.${nameKey}`)
+            const isTeamRank = rank.teamId !== LEADERBOARD_FILTER_ALL
 
             return (
               <button
@@ -143,7 +143,14 @@ export function LeaderboardUserRanksCard() {
                 className={classes.rankRow}
                 onClick={() => selectRank(rank)}
               >
-                <span className={classes.rankNumber}># {rank.rank}</span>
+                <span
+                  className={classes.rankNumber}
+                  title={isTeamRank ? 'Best team rank' : undefined}
+                  aria-label={isTeamRank ? `Team rank ${rank.rank}` : `All teams rank ${rank.rank}`}
+                >
+                  # {rank.rank}
+                  {isTeamRank && ' ᵀ'}
+                </span>
                 <img
                   src={Assets.getCharacterAvatarById(rank.characterId)}
                   className={classes.rankAvatar}

--- a/src/lib/tabs/tabLeaderboard/LeaderboardUserRanksCard.tsx
+++ b/src/lib/tabs/tabLeaderboard/LeaderboardUserRanksCard.tsx
@@ -142,8 +142,8 @@ export function LeaderboardUserRanksCard() {
                 key={`${rank.characterId}#${rank.configType}`}
                 className={classes.rankRow}
                 onClick={() => selectRank(rank)}
-                title={`${name} ${CONFIG_LABELS[rank.configType]} rank ${rank.rank}`}
               >
+                <span className={classes.rankNumber}># {rank.rank}</span>
                 <img
                   src={Assets.getCharacterAvatarById(rank.characterId)}
                   className={classes.rankAvatar}
@@ -151,7 +151,6 @@ export function LeaderboardUserRanksCard() {
                 />
                 <span className={classes.rankName}>{name}</span>
                 <span className={classes.rankConfig}>{CONFIG_LABELS[rank.configType]}</span>
-                <span className={classes.rankNumber}>#{rank.rank}</span>
                 <span className={classes.rankScore}>{truncate10ths(rank.score * 100).toFixed(1)}%</span>
               </button>
             )

--- a/src/lib/tabs/tabLeaderboard/LeaderboardUserRanksCard.tsx
+++ b/src/lib/tabs/tabLeaderboard/LeaderboardUserRanksCard.tsx
@@ -1,5 +1,6 @@
-import type { LeaderboardConfigType } from 'leaderboard/shared/configTypeMapping'
+import { LeaderboardConfigType } from 'leaderboard/shared/configTypeMapping'
 import { LEADERBOARD_FILTER_ALL } from 'leaderboard/shared/eidolonConfig'
+import { LEADERBOARD_DISPLAY_TOP_N } from 'lib/tabs/tabLeaderboard/deriveVisibleEntries'
 import { Assets } from 'lib/rendering/assets'
 import { loadCharacterData } from 'lib/tabs/tabLeaderboard/leaderboardDataLoader'
 import classes from 'lib/tabs/tabLeaderboard/LeaderboardHeader.module.css'
@@ -21,18 +22,18 @@ import { useTranslation } from 'react-i18next'
 import { useShallow } from 'zustand/react/shallow'
 
 const CONFIG_LABELS: Record<LeaderboardConfigType, string> = {
-  dps: 'DPS',
-  support: 'Support',
-  heal: 'Heal',
-  shield: 'Shield',
+  [LeaderboardConfigType.DPS]: 'DPS',
+  [LeaderboardConfigType.SUPPORT]: 'Support',
+  [LeaderboardConfigType.HEAL]: 'Heal',
+  [LeaderboardConfigType.SHIELD]: 'Shield',
 }
 
 enum UserRanksStatus {
-  NO_UID = 'no_uid',
-  INVALID_UID = 'invalid_uid',
-  LOADING = 'loading',
-  READY = 'ready',
-  UNAVAILABLE = 'unavailable',
+  NO_UID = 'NO_UID',
+  INVALID_UID = 'INVALID_UID',
+  LOADING = 'LOADING',
+  READY = 'READY',
+  UNAVAILABLE = 'UNAVAILABLE',
 }
 
 type UserRanksState =
@@ -61,7 +62,7 @@ function statusMessage(state: UserRanksState): string | null {
     case UserRanksStatus.UNAVAILABLE:
       return 'Ranks are temporarily unavailable.'
     case UserRanksStatus.READY:
-      return state.ranks.length === 0 ? 'No current top 100 ranks.' : null
+      return state.ranks.length === 0 ? `No current top ${LEADERBOARD_DISPLAY_TOP_N} ranks.` : null
   }
 }
 

--- a/src/lib/tabs/tabLeaderboard/LeaderboardUserRanksCard.tsx
+++ b/src/lib/tabs/tabLeaderboard/LeaderboardUserRanksCard.tsx
@@ -1,0 +1,159 @@
+import type { LeaderboardConfigType } from 'leaderboard/shared/configTypeMapping'
+import { LEADERBOARD_FILTER_ALL } from 'leaderboard/shared/eidolonConfig'
+import { Assets } from 'lib/rendering/assets'
+import { loadCharacterData } from 'lib/tabs/tabLeaderboard/leaderboardDataLoader'
+import classes from 'lib/tabs/tabLeaderboard/LeaderboardHeader.module.css'
+import { selectLeaderboardCharacter } from 'lib/tabs/tabLeaderboard/leaderboardTabController'
+import {
+  type LoadedLeaderboardCharacter,
+  lookupUserLeaderboardRanks,
+  type UserLeaderboardRank,
+} from 'lib/tabs/tabLeaderboard/leaderboardUidLookup'
+import { useLeaderboardTabStore } from 'lib/tabs/tabLeaderboard/useLeaderboardTabStore'
+import { useShowcaseTabStore } from 'lib/tabs/tabShowcase/useShowcaseTabStore'
+import { validateUuid } from 'lib/utils/miscUtils'
+import {
+  useEffect,
+  useState,
+} from 'react'
+import { useTranslation } from 'react-i18next'
+import { useShallow } from 'zustand/react/shallow'
+
+const CONFIG_LABELS: Record<LeaderboardConfigType, string> = {
+  dps: 'DPS',
+  support: 'Support',
+  heal: 'Heal',
+  shield: 'Shield',
+}
+
+enum UserRanksStatus {
+  NO_UID = 'no_uid',
+  INVALID_UID = 'invalid_uid',
+  LOADING = 'loading',
+  READY = 'ready',
+  UNAVAILABLE = 'unavailable',
+}
+
+type UserRanksState =
+  | { status: UserRanksStatus.NO_UID }
+  | { status: UserRanksStatus.INVALID_UID }
+  | { status: UserRanksStatus.LOADING }
+  | { status: UserRanksStatus.READY, ranks: UserLeaderboardRank[] }
+  | { status: UserRanksStatus.UNAVAILABLE }
+
+function selectRank(rank: UserLeaderboardRank) {
+  selectLeaderboardCharacter(rank.characterId, {
+    configType: rank.configType,
+    teamId: LEADERBOARD_FILTER_ALL,
+    buildId: rank.buildId,
+  })
+}
+
+function statusMessage(state: UserRanksState): string | null {
+  switch (state.status) {
+    case UserRanksStatus.NO_UID:
+      return 'No saved UID found.'
+    case UserRanksStatus.INVALID_UID:
+      return 'The saved UID is invalid.'
+    case UserRanksStatus.LOADING:
+      return 'Finding your leaderboard ranks...'
+    case UserRanksStatus.UNAVAILABLE:
+      return 'Ranks are temporarily unavailable.'
+    case UserRanksStatus.READY:
+      return state.ranks.length === 0 ? 'No current top 100 ranks.' : null
+  }
+}
+
+export function LeaderboardUserRanksCard() {
+  const scorerId = useShowcaseTabStore((state) => state.savedSession.scorerId)
+  const { availableCharacters, loading } = useLeaderboardTabStore(useShallow((state) => ({
+    availableCharacters: state.availableCharacters,
+    loading: state.loading,
+  })))
+  const [state, setState] = useState<UserRanksState>({ status: UserRanksStatus.LOADING })
+  const { t: tGame } = useTranslation('gameData')
+
+  useEffect(() => {
+    if (!scorerId) {
+      setState({ status: UserRanksStatus.NO_UID })
+      return
+    }
+
+    const uid = validateUuid(scorerId)
+    if (!uid) {
+      setState({ status: UserRanksStatus.INVALID_UID })
+      return
+    }
+
+    if (loading) {
+      setState({ status: UserRanksStatus.LOADING })
+      return
+    }
+
+    const loadedCharacters: LoadedLeaderboardCharacter[] = []
+    for (const characterId of availableCharacters) {
+      const characterData = loadCharacterData(characterId)
+      if (characterData) loadedCharacters.push({ characterId, characterData })
+    }
+    if (loadedCharacters.length === 0) {
+      setState({ status: UserRanksStatus.UNAVAILABLE })
+      return
+    }
+
+    let cancelled = false
+    setState({ status: UserRanksStatus.LOADING })
+    void lookupUserLeaderboardRanks(uid, loadedCharacters)
+      .then((ranks) => {
+        if (!cancelled) setState({ status: UserRanksStatus.READY, ranks })
+      })
+      .catch(() => {
+        if (!cancelled) setState({ status: UserRanksStatus.UNAVAILABLE })
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [availableCharacters, loading, scorerId])
+
+  const message = statusMessage(state)
+
+  return (
+    <div className={classes.rankContainer}>
+      <div className={classes.rankHeaderRow}>
+        <span className={classes.feedHeader}>Your Ranks</span>
+        <span className={classes.rankScope}>All Teams</span>
+      </div>
+
+      {message && <div className={classes.rankState}>{message}</div>}
+
+      {state.status === UserRanksStatus.READY && state.ranks.length > 0 && (
+        <div className={classes.rankGrid}>
+          {state.ranks.map((rank) => {
+            const nameKey = rank.characterId.startsWith('80') ? 'LongName' : 'Name'
+            const name = tGame(`Characters.${rank.characterId}.${nameKey}`)
+
+            return (
+              <button
+                type='button'
+                key={`${rank.characterId}#${rank.configType}`}
+                className={classes.rankRow}
+                onClick={() => selectRank(rank)}
+                title={`${name} ${CONFIG_LABELS[rank.configType]} rank ${rank.rank}`}
+              >
+                <img
+                  src={Assets.getCharacterAvatarById(rank.characterId)}
+                  className={classes.rankAvatar}
+                  alt=''
+                />
+                <span className={classes.rankName}>{name}</span>
+                <span className={classes.rankConfig}>{CONFIG_LABELS[rank.configType]}</span>
+                <span className={classes.rankNumber}>#{rank.rank}</span>
+                <span className={classes.rankScore}>{(rank.score * 100).toFixed(1)}%</span>
+              </button>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/lib/tabs/tabLeaderboard/TimelineFeed.tsx
+++ b/src/lib/tabs/tabLeaderboard/TimelineFeed.tsx
@@ -59,7 +59,7 @@ export function TimelineFeed({ events }: { events: TimelineEvent[] }) {
 
   return (
     <div className={classes.feedContainer}>
-      <span className={classes.feedHeader}>New Bests</span>
+      <span className={classes.feedHeader}>Global Timeline</span>
       <div className={classes.feedGrid}>
         {displayed.map((event) => {
           const characterId = event.characterId

--- a/src/lib/tabs/tabLeaderboard/TimelineFeed.tsx
+++ b/src/lib/tabs/tabLeaderboard/TimelineFeed.tsx
@@ -1,8 +1,11 @@
-import { TIMELINE_MIN_SCORE, TimelineEventType } from 'leaderboard/timeline/timelineTypes'
+import {
+  TIMELINE_MIN_SCORE,
+  TimelineEventType,
+} from 'leaderboard/timeline/timelineTypes'
 import type { TimelineEvent } from 'leaderboard/timeline/timelineTypes'
 import { Assets } from 'lib/rendering/assets'
-import classes from 'lib/tabs/tabLeaderboard/LeaderboardHeader.module.css'
 import { getBuildIndex } from 'lib/tabs/tabLeaderboard/leaderboardDataLoader'
+import classes from 'lib/tabs/tabLeaderboard/LeaderboardHeader.module.css'
 import { selectLeaderboardCharacter } from 'lib/tabs/tabLeaderboard/leaderboardTabController'
 import { useTranslation } from 'react-i18next'
 
@@ -64,7 +67,11 @@ export function TimelineFeed({ events }: { events: TimelineEvent[] }) {
           const scorePercent = (event.score * 100).toFixed(1)
 
           return (
-            <div key={`${event.uidHash}#${characterId}#${event.configType}#${event.type}#${event.date}`} className={classes.feedRow} onClick={() => handleRowClick(event)}>
+            <div
+              key={`${event.candidateId}#${event.configType}#${event.type}#${event.date}`}
+              className={classes.feedRow}
+              onClick={() => handleRowClick(event)}
+            >
               <span className={classes.cellTime}>{formatRelativeTime(event.date)}</span>
               <span className={classes.cellDivider} />
               <span className={classes.cellRankDelta}>{renderRank(event)}</span>

--- a/src/lib/tabs/tabLeaderboard/TimelineFeed.tsx
+++ b/src/lib/tabs/tabLeaderboard/TimelineFeed.tsx
@@ -4,6 +4,7 @@ import {
 } from 'leaderboard/timeline/timelineTypes'
 import type { TimelineEvent } from 'leaderboard/timeline/timelineTypes'
 import { Assets } from 'lib/rendering/assets'
+import { truncate10ths } from 'lib/utils/mathUtils'
 import { getBuildIndex } from 'lib/tabs/tabLeaderboard/leaderboardDataLoader'
 import classes from 'lib/tabs/tabLeaderboard/LeaderboardHeader.module.css'
 import { selectLeaderboardCharacter } from 'lib/tabs/tabLeaderboard/leaderboardTabController'
@@ -64,7 +65,7 @@ export function TimelineFeed({ events }: { events: TimelineEvent[] }) {
           const characterId = event.characterId
           const nameKey = characterId.startsWith('80') ? 'LongName' : 'Name'
           const name = tGame(`Characters.${characterId}.${nameKey}`)
-          const scorePercent = (event.score * 100).toFixed(1)
+          const scorePercent = truncate10ths(event.score * 100).toFixed(1)
 
           return (
             <div

--- a/src/lib/tabs/tabLeaderboard/leaderboardBrowserHash.ts
+++ b/src/lib/tabs/tabLeaderboard/leaderboardBrowserHash.ts
@@ -1,0 +1,16 @@
+import type { CharacterId } from 'types/character'
+
+async function sha256Hex(text: string): Promise<string> {
+  const bytes = new TextEncoder().encode(text)
+  const digest = await globalThis.crypto.subtle.digest('SHA-256', bytes)
+  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, '0')).join('')
+}
+
+export function hashLeaderboardUid(uid: string): Promise<string> {
+  return sha256Hex(uid)
+}
+
+export async function computeBrowserCandidateId(uidHash: string, characterId: CharacterId): Promise<string> {
+  const hash = await sha256Hex(JSON.stringify(`${uidHash}#${characterId}`))
+  return hash.slice(0, 12)
+}

--- a/src/lib/tabs/tabLeaderboard/leaderboardDataLoader.ts
+++ b/src/lib/tabs/tabLeaderboard/leaderboardDataLoader.ts
@@ -4,8 +4,7 @@ import type {
   PublicLeaderboardEntry,
 } from 'leaderboard/shared/types'
 import {
-  buildTimelineEvent,
-  isCandidateId,
+  completeTimelineEventIdentity,
   parseTimelineEventWire,
 } from 'leaderboard/timeline/timelineEventValidation'
 import {
@@ -101,17 +100,12 @@ export async function normalizeBrowserTimelineEvent(value: unknown): Promise<Tim
     const legacyCandidateId = event.uidHash == null
       ? undefined
       : await computeBrowserCandidateId(event.uidHash, event.characterId)
-    if (event.candidateId != null && legacyCandidateId != null && event.candidateId !== legacyCandidateId) {
-      console.warn('Ignoring leaderboard timeline event with mismatched identity')
-      return null
-    }
-
-    const candidateId = event.candidateId ?? legacyCandidateId
-    if (!isCandidateId(candidateId)) {
+    const completedEvent = completeTimelineEventIdentity(event, legacyCandidateId)
+    if (!completedEvent) {
       console.warn('Ignoring leaderboard timeline event with invalid identity')
       return null
     }
-    return buildTimelineEvent(event, candidateId)
+    return completedEvent
   } catch (error) {
     console.warn('Failed to normalize leaderboard timeline event', error)
     return null

--- a/src/lib/tabs/tabLeaderboard/leaderboardDataLoader.ts
+++ b/src/lib/tabs/tabLeaderboard/leaderboardDataLoader.ts
@@ -6,6 +6,7 @@ import type {
 import {
   completeTimelineEventIdentity,
   parseTimelineEventWire,
+  type RawTimelineEvent,
 } from 'leaderboard/timeline/timelineEventValidation'
 import {
   TIMELINE_SCHEMA_VERSION,
@@ -86,10 +87,10 @@ let cachedTimelinePromise: Promise<TimelineEvent[]> | null = null
 
 type RawLeaderboardTimeline = {
   schemaVersion?: number,
-  events?: unknown[],
+  events?: RawTimelineEvent[],
 }
 
-export async function normalizeBrowserTimelineEvent(value: unknown): Promise<TimelineEvent | null> {
+export async function normalizeBrowserTimelineEvent(value: RawTimelineEvent): Promise<TimelineEvent | null> {
   const event = parseTimelineEventWire(value)
   if (!event) {
     console.warn('Ignoring malformed leaderboard timeline event')

--- a/src/lib/tabs/tabLeaderboard/leaderboardDataLoader.ts
+++ b/src/lib/tabs/tabLeaderboard/leaderboardDataLoader.ts
@@ -3,9 +3,21 @@ import type {
   PublicCharacterData,
   PublicLeaderboardEntry,
 } from 'leaderboard/shared/types'
-import type { LeaderboardTimeline, TimelineEvent } from 'leaderboard/timeline/timelineTypes'
+import {
+  buildTimelineEvent,
+  isCandidateId,
+  parseTimelineEventWire,
+} from 'leaderboard/timeline/timelineEventValidation'
+import {
+  TIMELINE_SCHEMA_VERSION,
+  type TimelineEvent,
+} from 'leaderboard/timeline/timelineTypes'
+import {
+  BASE_PATH,
+  BasePath,
+} from 'lib/tabs/navigation/constants'
+import { computeBrowserCandidateId } from 'lib/tabs/tabLeaderboard/leaderboardBrowserHash'
 import { IS_LOCALHOST } from 'lib/tabs/tabLeaderboard/leaderboardCharacterHelpers'
-import { BASE_PATH, BasePath } from 'lib/tabs/navigation/constants'
 import {
   type LeaderboardEntry,
   type LeaderboardTeammate,
@@ -73,10 +85,47 @@ export async function loadLeaderboardData(): Promise<RawLeaderboardOutput> {
 
 let cachedTimelinePromise: Promise<TimelineEvent[]> | null = null
 
+type RawLeaderboardTimeline = {
+  schemaVersion?: number,
+  events?: unknown[],
+}
+
+export async function normalizeBrowserTimelineEvent(value: unknown): Promise<TimelineEvent | null> {
+  const event = parseTimelineEventWire(value)
+  if (!event) {
+    console.warn('Ignoring malformed leaderboard timeline event')
+    return null
+  }
+
+  try {
+    const legacyCandidateId = event.uidHash == null
+      ? undefined
+      : await computeBrowserCandidateId(event.uidHash, event.characterId)
+    if (event.candidateId != null && legacyCandidateId != null && event.candidateId !== legacyCandidateId) {
+      console.warn('Ignoring leaderboard timeline event with mismatched identity')
+      return null
+    }
+
+    const candidateId = event.candidateId ?? legacyCandidateId
+    if (!isCandidateId(candidateId)) {
+      console.warn('Ignoring leaderboard timeline event with invalid identity')
+      return null
+    }
+    return buildTimelineEvent(event, candidateId)
+  } catch (error) {
+    console.warn('Failed to normalize leaderboard timeline event', error)
+    return null
+  }
+}
+
 export async function loadLeaderboardTimeline(): Promise<TimelineEvent[]> {
   if (!cachedTimelinePromise) {
-    cachedTimelinePromise = fetchJsonWithFallback<LeaderboardTimeline>('leaderboard-timeline.json')
-      .then((t) => t.events)
+    cachedTimelinePromise = fetchJsonWithFallback<RawLeaderboardTimeline>('leaderboard-timeline.json')
+      .then(async (timeline) => {
+        if ((timeline.schemaVersion ?? 1) < TIMELINE_SCHEMA_VERSION || !Array.isArray(timeline.events)) return []
+        const events = await Promise.all(timeline.events.map(normalizeBrowserTimelineEvent))
+        return events.filter((event): event is TimelineEvent => event !== null)
+      })
       .catch(() => {
         cachedTimelinePromise = null
         return []

--- a/src/lib/tabs/tabLeaderboard/leaderboardDataLoader.ts
+++ b/src/lib/tabs/tabLeaderboard/leaderboardDataLoader.ts
@@ -54,7 +54,7 @@ function betaFallbackUrl(filename: string): string {
 }
 
 async function fetchJsonWithFallback<T>(filename: string): Promise<T> {
-  const localResponse = await fetch(leaderboardUrl(filename))
+  const localResponse = await fetch(leaderboardUrl(filename), IS_LOCALHOST ? { cache: 'reload' } : undefined)
   const contentType = localResponse.headers.get('content-type') ?? ''
   if (localResponse.ok && contentType.includes('json')) {
     return localResponse.json() as Promise<T>

--- a/src/lib/tabs/tabLeaderboard/leaderboardUidLookup.test.ts
+++ b/src/lib/tabs/tabLeaderboard/leaderboardUidLookup.test.ts
@@ -1,3 +1,5 @@
+import { LeaderboardConfigType } from 'leaderboard/shared/configTypeMapping'
+import { LEADERBOARD_FILTER_ALL } from 'leaderboard/shared/eidolonConfig'
 import { computeCandidateId } from 'leaderboard/shared/hash'
 import type {
   PublicCharacterData,
@@ -128,6 +130,7 @@ describe('lookupUserLeaderboardRanks', () => {
       {
         characterId: CHARACTER_ID,
         configType: 'support',
+        teamId: LEADERBOARD_FILTER_ALL,
         rank: 1,
         score: 1.7,
         buildId: '444444444444',
@@ -135,10 +138,59 @@ describe('lookupUserLeaderboardRanks', () => {
       {
         characterId: CHARACTER_ID,
         configType: 'dps',
+        teamId: LEADERBOARD_FILTER_ALL,
         rank: 2,
         score: 1.9,
         buildId: '333333333333',
       },
     ])
+  })
+
+  test('falls back to the best visible team rank', async () => {
+    const bestTeamId = 'best-team'
+    const otherTeamId = 'other-team'
+    const strongerTeamId = 'stronger-team'
+    const strongerEntries = Array.from({ length: 100 }, (_, index) => {
+      const id = String(index).padStart(12, '0')
+      return makeEntry(id, 2.5 - index * 0.001, id, strongerTeamId)
+    })
+
+    const ranks = await lookupUserLeaderboardRanks(UID, [{
+      characterId: CHARACTER_ID,
+      characterData: {
+        configs: {
+          dps: {
+            teams: [],
+            teamsById: {
+              [otherTeamId]: {
+                entries: [
+                  makeEntry('aaaaaaaaaaaa', 2, 'aaaaaaaaaaaa', otherTeamId),
+                  makeEntry(CANDIDATE_ID, 1.9, 'bbbbbbbbbbbb', otherTeamId),
+                ],
+                totalEntries: 2,
+              },
+              [bestTeamId]: {
+                entries: [makeEntry(CANDIDATE_ID, 1.8, 'cccccccccccc', bestTeamId)],
+                totalEntries: 1,
+              },
+              [strongerTeamId]: {
+                entries: strongerEntries,
+                totalEntries: strongerEntries.length,
+              },
+            },
+            totalEntries: 103,
+          },
+        },
+      },
+    }])
+
+    expect(ranks).toEqual([{
+      characterId: CHARACTER_ID,
+      configType: LeaderboardConfigType.DPS,
+      teamId: bestTeamId,
+      rank: 1,
+      score: 1.8,
+      buildId: 'cccccccccccc',
+    }])
   })
 })

--- a/src/lib/tabs/tabLeaderboard/leaderboardUidLookup.test.ts
+++ b/src/lib/tabs/tabLeaderboard/leaderboardUidLookup.test.ts
@@ -1,0 +1,144 @@
+import { computeCandidateId } from 'leaderboard/shared/hash'
+import type {
+  PublicCharacterData,
+  PublicLeaderboardEntry,
+} from 'leaderboard/shared/types'
+import {
+  computeBrowserCandidateId,
+  hashLeaderboardUid,
+} from 'lib/tabs/tabLeaderboard/leaderboardBrowserHash'
+import { normalizeBrowserTimelineEvent } from 'lib/tabs/tabLeaderboard/leaderboardDataLoader'
+import { lookupUserLeaderboardRanks } from 'lib/tabs/tabLeaderboard/leaderboardUidLookup'
+import type { CharacterId } from 'types/character'
+import {
+  describe,
+  expect,
+  test,
+} from 'vitest'
+
+const UID = '601069336'
+const UID_HASH = '31050e4f5f4bb895ba7ba9326e6dead67ca90d494d548632db2f4b0cab5436a3'
+const CHARACTER_ID = '1001' as CharacterId
+const CANDIDATE_ID = '6de86cffb601'
+
+function makeEntry(candidateId: string, score: number, buildId: string, teamId: string): PublicLeaderboardEntry {
+  return {
+    rank: 1,
+    characterId: CHARACTER_ID,
+    candidateId,
+    buildId,
+    score,
+    data: {
+      character: { a: 1001, r: 0 },
+      team: [],
+      teamEidolon: 0,
+      characterEidolon: 0,
+      teamId,
+      baselineSimScore: 0,
+      benchmarkSimScore: 0,
+      maximumSimScore: 0,
+      fetchedAt: 1782259200,
+    },
+  }
+}
+
+function makeCharacterData(): PublicCharacterData {
+  const dpsTeamA = 'dps-team-a'
+  const dpsTeamB = 'dps-team-b'
+  const supportTeam = 'support-team'
+  const healTeam = 'heal-team'
+
+  return {
+    configs: {
+      dps: {
+        teams: [],
+        teamsById: {
+          [dpsTeamA]: {
+            entries: [
+              makeEntry('aaaaaaaaaaaa', 2, '111111111111', dpsTeamA),
+              makeEntry(CANDIDATE_ID, 1.8, '222222222222', dpsTeamA),
+            ],
+            totalEntries: 2,
+          },
+          [dpsTeamB]: {
+            entries: [makeEntry(CANDIDATE_ID, 1.9, '333333333333', dpsTeamB)],
+            totalEntries: 1,
+          },
+        },
+        totalEntries: 3,
+      },
+      support: {
+        teams: [],
+        teamsById: {
+          [supportTeam]: {
+            entries: [makeEntry(CANDIDATE_ID, 1.7, '444444444444', supportTeam)],
+            totalEntries: 1,
+          },
+        },
+        totalEntries: 1,
+      },
+      heal: {
+        teams: [],
+        teamsById: {
+          [healTeam]: {
+            entries: [makeEntry(CANDIDATE_ID, 1.49, '555555555555', healTeam)],
+            totalEntries: 1,
+          },
+        },
+        totalEntries: 1,
+      },
+    },
+  }
+}
+
+describe('leaderboard browser hashing', () => {
+  test('matches the Node candidate identity vectors', async () => {
+    expect(await hashLeaderboardUid(UID)).toBe(UID_HASH)
+    expect(await computeBrowserCandidateId(UID_HASH, CHARACTER_ID)).toBe(CANDIDATE_ID)
+    expect(computeCandidateId(UID_HASH, CHARACTER_ID)).toBe(CANDIDATE_ID)
+  })
+
+  test('normalizes a legacy v2 timeline event before UI consumption', async () => {
+    const event = await normalizeBrowserTimelineEvent({
+      type: 'new_best',
+      characterId: CHARACTER_ID,
+      configType: 'dps',
+      uidHash: UID_HASH,
+      date: '2026-06-24T00:00:00Z',
+      score: 2,
+      previousScore: 1.9,
+      rank: 1,
+      previousRank: 2,
+      buildId: '111111111111',
+    })
+
+    expect(event?.candidateId).toBe(CANDIDATE_ID)
+    expect(JSON.stringify(event)).not.toContain('uidHash')
+  })
+})
+
+describe('lookupUserLeaderboardRanks', () => {
+  test('returns only visible all-teams matches in leaderboard rank order', async () => {
+    const ranks = await lookupUserLeaderboardRanks(UID, [{
+      characterId: CHARACTER_ID,
+      characterData: makeCharacterData(),
+    }])
+
+    expect(ranks).toEqual([
+      {
+        characterId: CHARACTER_ID,
+        configType: 'support',
+        rank: 1,
+        score: 1.7,
+        buildId: '444444444444',
+      },
+      {
+        characterId: CHARACTER_ID,
+        configType: 'dps',
+        rank: 2,
+        score: 1.9,
+        buildId: '333333333333',
+      },
+    ])
+  })
+})

--- a/src/lib/tabs/tabLeaderboard/leaderboardUidLookup.ts
+++ b/src/lib/tabs/tabLeaderboard/leaderboardUidLookup.ts
@@ -24,15 +24,6 @@ export type UserLeaderboardRank = {
   buildId: string,
 }
 
-function hasCandidate(characterData: PublicCharacterData, configType: LeaderboardConfigType, candidateId: string): boolean {
-  const configData = characterData.configs[configType]
-  if (!configData) return false
-  for (const board of Object.values(configData.teamsById)) {
-    if (board.entries.some((e) => e.candidateId === candidateId)) return true
-  }
-  return false
-}
-
 export async function lookupUserLeaderboardRanks(
   uid: string,
   characters: readonly LoadedLeaderboardCharacter[],
@@ -48,8 +39,6 @@ export async function lookupUserLeaderboardRanks(
     const candidateId = candidateIds[characterIndex]
 
     for (const configType of LEADERBOARD_CONFIG_TYPES) {
-      if (!hasCandidate(characterData, configType, candidateId)) continue
-
       const entry = deriveVisibleEntries({
         characterData,
         activeConfigType: configType,

--- a/src/lib/tabs/tabLeaderboard/leaderboardUidLookup.ts
+++ b/src/lib/tabs/tabLeaderboard/leaderboardUidLookup.ts
@@ -1,0 +1,69 @@
+import {
+  LEADERBOARD_CONFIG_TYPES,
+  type LeaderboardConfigType,
+} from 'leaderboard/shared/configTypeMapping'
+import { LEADERBOARD_FILTER_ALL } from 'leaderboard/shared/eidolonConfig'
+import type { PublicCharacterData } from 'leaderboard/shared/types'
+import { deriveVisibleEntries } from 'lib/tabs/tabLeaderboard/deriveVisibleEntries'
+import {
+  computeBrowserCandidateId,
+  hashLeaderboardUid,
+} from 'lib/tabs/tabLeaderboard/leaderboardBrowserHash'
+import type { CharacterId } from 'types/character'
+
+export type LoadedLeaderboardCharacter = {
+  characterId: CharacterId,
+  characterData: PublicCharacterData,
+}
+
+export type UserLeaderboardRank = {
+  characterId: CharacterId,
+  configType: LeaderboardConfigType,
+  rank: number,
+  score: number,
+  buildId: string,
+}
+
+type OrderedUserLeaderboardRank = UserLeaderboardRank & { order: number }
+
+export async function lookupUserLeaderboardRanks(
+  uid: string,
+  characters: readonly LoadedLeaderboardCharacter[],
+): Promise<UserLeaderboardRank[]> {
+  const uidHash = await hashLeaderboardUid(uid)
+  const candidateIds = await Promise.all(
+    characters.map(({ characterId }) => computeBrowserCandidateId(uidHash, characterId)),
+  )
+  const matches: OrderedUserLeaderboardRank[] = []
+
+  for (let characterIndex = 0; characterIndex < characters.length; characterIndex++) {
+    const { characterId, characterData } = characters[characterIndex]
+    const candidateId = candidateIds[characterIndex]
+
+    for (let configIndex = 0; configIndex < LEADERBOARD_CONFIG_TYPES.length; configIndex++) {
+      const configType = LEADERBOARD_CONFIG_TYPES[configIndex]
+      if (!characterData.configs[configType]) continue
+
+      const entry = deriveVisibleEntries({
+        characterData,
+        activeConfigType: configType,
+        activeTeamId: LEADERBOARD_FILTER_ALL,
+        filterCharacterEidolon: LEADERBOARD_FILTER_ALL,
+      }).find((candidate) => candidate.candidateId === candidateId)
+      if (!entry) continue
+
+      matches.push({
+        characterId,
+        configType,
+        rank: entry.rank,
+        score: entry.score,
+        buildId: entry.buildId,
+        order: characterIndex * LEADERBOARD_CONFIG_TYPES.length + configIndex,
+      })
+    }
+  }
+
+  return matches
+    .sort((a, b) => a.rank - b.rank || a.order - b.order)
+    .map(({ order: _order, ...rank }) => rank)
+}

--- a/src/lib/tabs/tabLeaderboard/leaderboardUidLookup.ts
+++ b/src/lib/tabs/tabLeaderboard/leaderboardUidLookup.ts
@@ -43,16 +43,24 @@ export async function lookupUserLeaderboardRanks(
       const configData = characterData.configs[configType]
       if (!configData) continue
 
+      const teamsWithCandidate: string[] = []
+      for (const [tid, board] of Object.entries(configData.teamsById)) {
+        if (board.entries.some((e) => e.candidateId === candidateId)) {
+          teamsWithCandidate.push(tid)
+        }
+      }
+      if (teamsWithCandidate.length === 0) continue
+
       let teamId: string = LEADERBOARD_FILTER_ALL
       let entry = deriveVisibleEntries({
         characterData,
         activeConfigType: configType,
-        activeTeamId: teamId,
+        activeTeamId: LEADERBOARD_FILTER_ALL,
         filterCharacterEidolon: LEADERBOARD_FILTER_ALL,
       }).find((candidate) => candidate.candidateId === candidateId)
 
       if (!entry) {
-        for (const candidateTeamId of Object.keys(configData.teamsById)) {
+        for (const candidateTeamId of teamsWithCandidate) {
           const candidateEntry = deriveVisibleEntries({
             characterData,
             activeConfigType: configType,

--- a/src/lib/tabs/tabLeaderboard/leaderboardUidLookup.ts
+++ b/src/lib/tabs/tabLeaderboard/leaderboardUidLookup.ts
@@ -24,7 +24,14 @@ export type UserLeaderboardRank = {
   buildId: string,
 }
 
-type OrderedUserLeaderboardRank = UserLeaderboardRank & { order: number }
+function hasCandidate(characterData: PublicCharacterData, configType: LeaderboardConfigType, candidateId: string): boolean {
+  const configData = characterData.configs[configType]
+  if (!configData) return false
+  for (const board of Object.values(configData.teamsById)) {
+    if (board.entries.some((e) => e.candidateId === candidateId)) return true
+  }
+  return false
+}
 
 export async function lookupUserLeaderboardRanks(
   uid: string,
@@ -34,15 +41,14 @@ export async function lookupUserLeaderboardRanks(
   const candidateIds = await Promise.all(
     characters.map(({ characterId }) => computeBrowserCandidateId(uidHash, characterId)),
   )
-  const matches: OrderedUserLeaderboardRank[] = []
+  const matches: UserLeaderboardRank[] = []
 
   for (let characterIndex = 0; characterIndex < characters.length; characterIndex++) {
     const { characterId, characterData } = characters[characterIndex]
     const candidateId = candidateIds[characterIndex]
 
-    for (let configIndex = 0; configIndex < LEADERBOARD_CONFIG_TYPES.length; configIndex++) {
-      const configType = LEADERBOARD_CONFIG_TYPES[configIndex]
-      if (!characterData.configs[configType]) continue
+    for (const configType of LEADERBOARD_CONFIG_TYPES) {
+      if (!hasCandidate(characterData, configType, candidateId)) continue
 
       const entry = deriveVisibleEntries({
         characterData,
@@ -58,12 +64,9 @@ export async function lookupUserLeaderboardRanks(
         rank: entry.rank,
         score: entry.score,
         buildId: entry.buildId,
-        order: characterIndex * LEADERBOARD_CONFIG_TYPES.length + configIndex,
       })
     }
   }
 
-  return matches
-    .sort((a, b) => a.rank - b.rank || a.order - b.order)
-    .map(({ order: _order, ...rank }) => rank)
+  return matches.sort((a, b) => a.rank - b.rank)
 }

--- a/src/lib/tabs/tabLeaderboard/leaderboardUidLookup.ts
+++ b/src/lib/tabs/tabLeaderboard/leaderboardUidLookup.ts
@@ -19,6 +19,7 @@ export type LoadedLeaderboardCharacter = {
 export type UserLeaderboardRank = {
   characterId: CharacterId,
   configType: LeaderboardConfigType,
+  teamId: string,
   rank: number,
   score: number,
   buildId: string,
@@ -39,17 +40,49 @@ export async function lookupUserLeaderboardRanks(
     const candidateId = candidateIds[characterIndex]
 
     for (const configType of LEADERBOARD_CONFIG_TYPES) {
-      const entry = deriveVisibleEntries({
+      const configData = characterData.configs[configType]
+      if (!configData) continue
+
+      let teamId: string = LEADERBOARD_FILTER_ALL
+      let entry = deriveVisibleEntries({
         characterData,
         activeConfigType: configType,
-        activeTeamId: LEADERBOARD_FILTER_ALL,
+        activeTeamId: teamId,
         filterCharacterEidolon: LEADERBOARD_FILTER_ALL,
       }).find((candidate) => candidate.candidateId === candidateId)
+
+      if (!entry) {
+        for (const candidateTeamId of Object.keys(configData.teamsById)) {
+          const candidateEntry = deriveVisibleEntries({
+            characterData,
+            activeConfigType: configType,
+            activeTeamId: candidateTeamId,
+            filterCharacterEidolon: LEADERBOARD_FILTER_ALL,
+          }).find((candidate) => candidate.candidateId === candidateId)
+          if (!candidateEntry) continue
+
+          if (
+            !entry
+            || candidateEntry.rank < entry.rank
+            || (candidateEntry.rank === entry.rank && candidateEntry.score > entry.score)
+            || (
+              candidateEntry.rank === entry.rank
+              && candidateEntry.score === entry.score
+              && candidateEntry.buildId < entry.buildId
+            )
+          ) {
+            entry = candidateEntry
+            teamId = candidateTeamId
+          }
+        }
+      }
+
       if (!entry) continue
 
       matches.push({
         characterId,
         configType,
+        teamId,
         rank: entry.rank,
         score: entry.score,
         buildId: entry.buildId,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,36 @@
+import { readFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
 import react from '@vitejs/plugin-react'
-import { resolve } from 'node:path'
+import type { Plugin } from 'vite'
 import { defineConfig } from 'vite'
+
+function serveLeaderboardJson(): Plugin {
+  return {
+    name: 'serve-leaderboard-json',
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        if (req.url?.startsWith('/hsr-optimizer/leaderboard/') && req.url.endsWith('.json')) {
+          const filename = req.url.replace('/hsr-optimizer/leaderboard/', '')
+          const filePath = join(server.config.root, 'public', 'leaderboard', filename)
+          try {
+            const content = readFileSync(filePath, 'utf-8')
+            res.setHeader('Content-Type', 'application/json')
+            res.end(content)
+          } catch {
+            next()
+          }
+          return
+        }
+        next()
+      })
+    },
+  }
+}
 
 export default defineConfig({
   base: '/hsr-optimizer',
   plugins: [
+    serveLeaderboardJson(),
     react(),
   ],
   resolve: {


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

  - Add a Your Characters card that uses the saved Showcase UID to show each character's All Teams or best team rank and open
    the matching build.

  - Remove UID hashes from the public timeline by publishing candidate IDs while preserving existing v2 history.
  - Update the leaderboard layout and rename New Bests to Global Timeline.
  - Add new leaderboard team configurations for Black Swan and The Herta.
  - Improve local leaderboard development by serving and refreshing local leaderboard JSON data.

## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [ ] I have added commit messages that are descriptive and meaningful.
- [ ] I have tested the changes locally.
- [ ] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
