### PR TITLE
chore: reduce lb cpu consumption

### DIFF
--- a/src/leaderboard/cache/leaderboardBuildScoreCache.ts
+++ b/src/leaderboard/cache/leaderboardBuildScoreCache.ts
@@ -12,6 +12,7 @@ import { emptyBuildScoreCacheStats } from 'leaderboard/shared/metrics'
 import {
   homeDir,
   resolvePath,
+  sleepSync,
   type SqliteDatabase,
   type SqliteStatement,
 } from 'leaderboard/shared/nodeFacade'
@@ -28,10 +29,32 @@ export { buildLeaderboardBuildScoreCacheKey, buildStrippedRelicHash } from 'lead
 const DEFAULT_DB_PATH = resolvePath(homeDir(), 'leaderboard-cache/leaderboard-build-score-cache.sqlite')
 const DEFAULT_FLUSH_INTERVAL = 100
 
+// Bounds buffered work lost when the pool terminates without draining.
+const DEFAULT_FLUSH_INTERVAL_MS = 5000
+
+const FLUSH_MAX_ATTEMPTS = 5
+const FLUSH_RETRY_BASE_MS = 100
+
 export type LeaderboardBuildScoreCacheOptions = {
   dbPath?: string,
   leaderboardVersionsHash: string,
   flushInterval?: number,
+  flushIntervalMs?: number,
+}
+
+// node:sqlite exposes the SQLite result code as `errcode`; message is a fallback.
+const SQLITE_BUSY_ERRCODE = 5
+const SQLITE_LOCKED_ERRCODE = 6
+
+type SqliteErrorLike = Error & { errcode?: number }
+
+function isBusyError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false
+
+  const errcode = (error as SqliteErrorLike).errcode
+  if (errcode === SQLITE_BUSY_ERRCODE || errcode === SQLITE_LOCKED_ERRCODE) return true
+
+  return error.message.includes('database is locked')
 }
 
 type LeaderboardBuildScorePendingWrite = {
@@ -48,6 +71,8 @@ type LeaderboardBuildScoreCacheRow = {
 export class LeaderboardBuildScoreCache implements LeaderboardBuildScoreCacheContract {
   private readonly leaderboardVersionsHash: string
   private readonly flushInterval: number
+  private readonly flushIntervalMs: number
+  private lastFlushMs = performance.now()
   private readonly db: SqliteDatabase
 
   private readonly stmtSelect: SqliteStatement<LeaderboardBuildScoreCacheRow>
@@ -67,6 +92,7 @@ export class LeaderboardBuildScoreCache implements LeaderboardBuildScoreCacheCon
   constructor(options: LeaderboardBuildScoreCacheOptions) {
     this.leaderboardVersionsHash = options.leaderboardVersionsHash
     this.flushInterval = options.flushInterval ?? DEFAULT_FLUSH_INTERVAL
+    this.flushIntervalMs = options.flushIntervalMs ?? DEFAULT_FLUSH_INTERVAL_MS
     this.db = openLeaderboardBuildScoreCacheDatabase(options.dbPath ?? DEFAULT_DB_PATH)
 
     this.stmtSelect = this.db.prepare<LeaderboardBuildScoreCacheRow>(
@@ -110,7 +136,10 @@ export class LeaderboardBuildScoreCache implements LeaderboardBuildScoreCacheCon
       createdAt,
     })
 
-    if (this.writeBuffer.length >= this.flushInterval) {
+    if (
+      this.writeBuffer.length >= this.flushInterval
+      || performance.now() - this.lastFlushMs >= this.flushIntervalMs
+    ) {
       this.flush()
     }
   }
@@ -144,6 +173,31 @@ export class LeaderboardBuildScoreCache implements LeaderboardBuildScoreCacheCon
   flush(): void {
     if (this.writeBuffer.length === 0) return
 
+    const startedAt = performance.now()
+    const rowCount = this.writeBuffer.length
+
+    for (let attempt = 1; attempt <= FLUSH_MAX_ATTEMPTS; attempt++) {
+      try {
+        this.commitWriteBuffer()
+
+        const elapsedMs = performance.now() - startedAt
+        this.cacheStats.flushes++
+        this.cacheStats.flushedRows += rowCount
+        this.cacheStats.flushMs += elapsedMs
+        this.cacheStats.maxFlushMs = Math.max(this.cacheStats.maxFlushMs, elapsedMs)
+        this.lastFlushMs = performance.now()
+        return
+      } catch (error) {
+        // Only lock contention is transient; corruption and disk-full must surface.
+        if (!isBusyError(error) || attempt === FLUSH_MAX_ATTEMPTS) throw error
+
+        this.cacheStats.flushRetries++
+        sleepSync(FLUSH_RETRY_BASE_MS * attempt)
+      }
+    }
+  }
+
+  private commitWriteBuffer(): void {
     let transactionStarted = false
     try {
       this.stmtBegin.run()

--- a/src/leaderboard/cache/leaderboardBuildScoreCacheDb.ts
+++ b/src/leaderboard/cache/leaderboardBuildScoreCacheDb.ts
@@ -14,7 +14,9 @@ export function openLeaderboardBuildScoreCacheDatabase(dbPath: string): SqliteDa
   const absPath = dbPath === ':memory:' ? ':memory:' : resolvePath(cwd(), dbPath)
   if (absPath !== ':memory:') ensureDirectory(dirnamePath(absPath))
   const db = openSqliteDatabase(absPath)
-  db.exec('PRAGMA busy_timeout = 5000')
+  // Every worker thread opens its own connection and WAL allows a single
+  // writer, so a checkpoint can hold the write lock for seconds.
+  db.exec('PRAGMA busy_timeout = 30000')
   db.exec('PRAGMA journal_mode = WAL')
   db.exec('PRAGMA synchronous = NORMAL')
 

--- a/src/leaderboard/pipeline/leaderboardPipeline.ts
+++ b/src/leaderboard/pipeline/leaderboardPipeline.ts
@@ -33,6 +33,7 @@ import {
 } from 'leaderboard/pipeline/scoringStage'
 import type { LeaderboardCliOptions } from 'leaderboard/shared/cliOptions'
 import { hashObject } from 'leaderboard/shared/hash'
+import { residentSetSizeBytes } from 'leaderboard/shared/nodeFacade'
 import type {
   ParsedExport,
   PrivateRankedEntry,
@@ -115,6 +116,7 @@ export async function runLeaderboardPipeline(options: LeaderboardCliOptions, wor
         (parseElapsedMs / 1000).toFixed(1)
       }s`,
     )
+    logPhaseMemory('parse')
     if (exportProfileCount === 0) {
       throw new Error('Parsed export contained no profiles; refusing to publish empty leaderboard')
     }
@@ -137,6 +139,7 @@ export async function runLeaderboardPipeline(options: LeaderboardCliOptions, wor
 
     const totalCandidates = profiles.reduce((n, p) => n + p.characters.length, 0)
     console.log(`Pre-filter: kept ${totalCandidates} candidates across ${profiles.length} profiles in ${(prefilterElapsedMs / 1000).toFixed(1)}s`)
+    logPhaseMemory('prefilter')
 
     console.log(`Scoring ${totalCandidates} candidates across ${profiles.length} profiles`)
 
@@ -222,6 +225,11 @@ async function withSequentialBenchmarks<T>(run: () => Promise<T>): Promise<T> {
   } finally {
     globalThis.SEQUENTIAL_BENCHMARKS = previousSequentialBenchmarks
   }
+}
+
+function logPhaseMemory(phase: string): void {
+  const rssMb = (residentSetSizeBytes() / (1024 * 1024)).toFixed(0)
+  console.log(`[mem] after ${phase}: rss ${rssMb}MB`)
 }
 
 function runBuildScoreCacheMaintenance(input: {

--- a/src/leaderboard/pipeline/leaderboardReporting.ts
+++ b/src/leaderboard/pipeline/leaderboardReporting.ts
@@ -523,6 +523,15 @@ export function printRunSummary(input: RunSummaryInput): void {
   console.log(`  misses: ${buildScoreCacheStats.misses}`)
   console.log(`  writes: ${buildScoreCacheStats.writes}`)
   console.log(`  corruptRowsDeleted: ${buildScoreCacheStats.corruptRowsDeleted}`)
+  console.log(`  flushes: ${buildScoreCacheStats.flushes}`)
+  console.log(`  flushedRows: ${buildScoreCacheStats.flushedRows}`)
+  if (buildScoreCacheStats.flushes > 0) {
+    console.log(`  rowsPerFlush: ${(buildScoreCacheStats.flushedRows / buildScoreCacheStats.flushes).toFixed(1)}`)
+    console.log(`  avgFlushMs: ${(buildScoreCacheStats.flushMs / buildScoreCacheStats.flushes).toFixed(1)}`)
+  }
+  console.log(`  maxFlushMs: ${buildScoreCacheStats.maxFlushMs.toFixed(1)}`)
+  // Non-zero means workers are exhausting busy_timeout on the WAL write lock.
+  console.log(`  flushRetries: ${buildScoreCacheStats.flushRetries}`)
   const cacheHits = buildScoreCacheStats.l1Hits + buildScoreCacheStats.sqliteHits
   if (cacheHits + buildScoreCacheStats.misses > 0) {
     console.log(`  hitRate: ${((cacheHits / (cacheHits + buildScoreCacheStats.misses)) * 100).toFixed(1)}%`)

--- a/src/leaderboard/pipeline/scoringStage.ts
+++ b/src/leaderboard/pipeline/scoringStage.ts
@@ -235,7 +235,8 @@ async function runPerCharacterBatchedScoring(
   const sortedEntries = [...candidatesByChar.entries()].sort((a, b) => a[1].length - b[1].length)
 
   const CHARACTER_CONCURRENCY = 4
-  const characterResults: CharacterResult[] = new Array(sortedEntries.length)
+  // Transiently sparse while filled by index; dense once the await below resolves.
+  const characterResults: CharacterResult[] = []
   let nextIndex = 0
 
   async function processNextCharacter(): Promise<void> {

--- a/src/leaderboard/shared/metrics.ts
+++ b/src/leaderboard/shared/metrics.ts
@@ -27,6 +27,11 @@ export function emptyBuildScoreCacheStats(): LeaderboardBuildScoreCacheStats {
     misses: 0,
     writes: 0,
     corruptRowsDeleted: 0,
+    flushes: 0,
+    flushedRows: 0,
+    flushMs: 0,
+    maxFlushMs: 0,
+    flushRetries: 0,
   }
 }
 
@@ -37,6 +42,11 @@ export function sumBuildScoreCacheStats(stats: LeaderboardBuildScoreCacheStats[]
     misses: sum.misses + stat.misses,
     writes: sum.writes + stat.writes,
     corruptRowsDeleted: sum.corruptRowsDeleted + stat.corruptRowsDeleted,
+    flushes: sum.flushes + stat.flushes,
+    flushedRows: sum.flushedRows + stat.flushedRows,
+    flushMs: sum.flushMs + stat.flushMs,
+    maxFlushMs: Math.max(sum.maxFlushMs, stat.maxFlushMs),
+    flushRetries: sum.flushRetries + stat.flushRetries,
   }), emptyBuildScoreCacheStats())
 }
 

--- a/src/leaderboard/shared/nodeFacade.ts
+++ b/src/leaderboard/shared/nodeFacade.ts
@@ -96,6 +96,16 @@ export function commandLineArgs(): string[] {
   return process.argv.slice(2)
 }
 
+export function residentSetSizeBytes(): number {
+  return process.memoryUsage().rss
+}
+
+// Blocking sleep for the synchronous SQLite write path.
+export function sleepSync(ms: number): void {
+  if (ms <= 0) return
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms)
+}
+
 export function setExitCode(code: number): void {
   process.exitCode = code
 }

--- a/src/leaderboard/shared/types.ts
+++ b/src/leaderboard/shared/types.ts
@@ -275,6 +275,11 @@ export type LeaderboardBuildScoreCacheStats = {
   misses: number,
   writes: number,
   corruptRowsDeleted: number,
+  flushes: number,
+  flushedRows: number,
+  flushMs: number,
+  maxFlushMs: number,
+  flushRetries: number,
 }
 
 export type LeaderboardBuildScoreCachePruneOptions = {

--- a/src/leaderboard/tests/leaderboardBuildScoreCacheFlush.test.ts
+++ b/src/leaderboard/tests/leaderboardBuildScoreCacheFlush.test.ts
@@ -1,0 +1,100 @@
+// @vitest-environment node
+import { LeaderboardBuildScoreCache } from 'leaderboard/cache/leaderboardBuildScoreCache'
+import type { LeaderboardBuildScore } from 'leaderboard/shared/scoreLeaderboardBuild'
+import {
+  afterEach,
+  describe,
+  expect,
+  test,
+} from 'vitest'
+
+const VERSIONS_HASH = 'test-versions-hash'
+
+const openCaches: LeaderboardBuildScoreCache[] = []
+
+function createCache(options?: { flushInterval?: number, flushIntervalMs?: number }): LeaderboardBuildScoreCache {
+  const cache = new LeaderboardBuildScoreCache({
+    dbPath: ':memory:',
+    leaderboardVersionsHash: VERSIONS_HASH,
+    flushInterval: options?.flushInterval ?? 100,
+    // Disabled by default so count-based behaviour is machine-speed independent.
+    flushIntervalMs: options?.flushIntervalMs ?? Number.MAX_SAFE_INTEGER,
+  })
+  openCaches.push(cache)
+  return cache
+}
+
+function makeScore(value: number): LeaderboardBuildScore {
+  return { score: value } as unknown as LeaderboardBuildScore
+}
+
+afterEach(() => {
+  openCaches.length = 0
+})
+
+describe('LeaderboardBuildScoreCache flush batching', () => {
+  test('buffers writes instead of committing one transaction per set', () => {
+    const cache = createCache({ flushInterval: 100 })
+
+    for (let i = 0; i < 99; i++) {
+      cache.set(`key-${i}`, makeScore(i))
+    }
+
+    expect(cache.stats().writes).toBe(99)
+    expect(cache.stats().flushes).toBe(0)
+  })
+
+  test('commits a single transaction once the buffer reaches flushInterval', () => {
+    const cache = createCache({ flushInterval: 100 })
+
+    for (let i = 0; i < 100; i++) {
+      cache.set(`key-${i}`, makeScore(i))
+    }
+
+    const stats = cache.stats()
+    expect(stats.flushes).toBe(1)
+    expect(stats.flushedRows).toBe(100)
+  })
+
+  test('flushes on elapsed time even when the buffer is not full', () => {
+    const cache = createCache({ flushInterval: 100, flushIntervalMs: 0 })
+
+    cache.set('key-a', makeScore(1))
+
+    const stats = cache.stats()
+    expect(stats.flushes).toBe(1)
+    expect(stats.flushedRows).toBe(1)
+  })
+
+  test('explicit flush drains a partial buffer and is idempotent', () => {
+    const cache = createCache({ flushInterval: 100 })
+
+    cache.set('key-a', makeScore(1))
+    cache.flush()
+    cache.flush()
+
+    const stats = cache.stats()
+    expect(stats.flushes).toBe(1)
+    expect(stats.flushedRows).toBe(1)
+  })
+
+  test('flushed rows are readable back through the cache', () => {
+    const cache = createCache({ flushInterval: 100 })
+
+    cache.set('key-a', makeScore(42))
+    cache.flush()
+
+    expect(cache.get('key-a')).not.toBeNull()
+    expect(cache.get('missing-key')).toBeNull()
+  })
+
+  test('a healthy flush records no retries', () => {
+    const cache = createCache({ flushInterval: 10 })
+
+    for (let i = 0; i < 10; i++) {
+      cache.set(`key-${i}`, makeScore(i))
+    }
+
+    expect(cache.stats().flushRetries).toBe(0)
+  })
+})

--- a/src/leaderboard/workers/profileWorkerThread.ts
+++ b/src/leaderboard/workers/profileWorkerThread.ts
@@ -52,8 +52,6 @@ parentPort.on<LeaderboardScoreWorkerRequest>('message', async (request) => {
       buildScoreCache: workerState.buildScoreCache,
     })
 
-    workerState.buildScoreCache.flush()
-
     const response: LeaderboardScoreWorkerResponse = {
       id: request.id,
       ok: true,
@@ -111,5 +109,11 @@ function diffBuildScoreCacheStats(
     misses: after.misses - before.misses,
     writes: after.writes - before.writes,
     corruptRowsDeleted: after.corruptRowsDeleted - before.corruptRowsDeleted,
+    flushes: after.flushes - before.flushes,
+    flushedRows: after.flushedRows - before.flushedRows,
+    flushMs: after.flushMs - before.flushMs,
+    // A running max, not a counter; the aggregator combines with Math.max.
+    maxFlushMs: after.maxFlushMs,
+    flushRetries: after.flushRetries - before.flushRetries,
   }
 }


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

- Fix leaderboard runs aborting with "database is locked" under worker thread contention.
- Reduce build score cache write contention by committing buffered batches rather than one transaction per profile.
- Add build score cache flush metrics to the run summary.
- Add resident memory logging after the parse and pre-filter stages.
- Add tests for build score cache flush batching.

## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [ ] I have added commit messages that are descriptive and meaningful.
- [ ] I have tested the changes locally.
- [ ] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
