### PR TITLE
fix: advanced rotation bugs

### DIFF
--- a/src/lib/optimization/calculateConditionals.ts
+++ b/src/lib/optimization/calculateConditionals.ts
@@ -30,6 +30,8 @@ export function calculateContextConditionalRegistry(
   registerConditionals(conditionalRegistry, characterConditionals.dynamicConditionals ?? [])
   registerConditionals(conditionalRegistry, getAllSetDynamicConditionals())
 
+  // Authoritative populator: rebuilt from scratch so repeat calls (worker rehydration) don't accumulate
+  action.teammateDynamicConditionals = []
   registerTeammateConditionals(conditionalRegistry, context.teammate0Metadata, action, 0)
   registerTeammateConditionals(conditionalRegistry, context.teammate1Metadata, action, 1)
   registerTeammateConditionals(conditionalRegistry, context.teammate2Metadata, action, 2)

--- a/src/lib/optimization/calculateConditionals.ts
+++ b/src/lib/optimization/calculateConditionals.ts
@@ -30,7 +30,7 @@ export function calculateContextConditionalRegistry(
   registerConditionals(conditionalRegistry, characterConditionals.dynamicConditionals ?? [])
   registerConditionals(conditionalRegistry, getAllSetDynamicConditionals())
 
-  // Authoritative populator: rebuilt from scratch so repeat calls (worker rehydration) don't accumulate
+  // Rebuild the derived list so repeated initialization stays idempotent.
   action.teammateDynamicConditionals = []
   registerTeammateConditionals(conditionalRegistry, context.teammate0Metadata, action, 0)
   registerTeammateConditionals(conditionalRegistry, context.teammate1Metadata, action, 1)

--- a/src/lib/optimization/rotation/actionTransform.test.ts
+++ b/src/lib/optimization/rotation/actionTransform.test.ts
@@ -2,6 +2,7 @@
 import {
   ABILITY_LIMIT,
   ConditionalDataType,
+  Stats,
 } from 'lib/constants/constants'
 import { initializeComboState } from 'lib/optimization/combo/comboInitializers'
 import type { ComboNumberConditional } from 'lib/optimization/combo/comboTypes'
@@ -11,6 +12,10 @@ import { ComboType } from 'lib/optimization/rotation/comboType'
 import { initializeContextConditionals } from 'lib/simulations/contextConditionals'
 import { generateFullDefaultForm } from 'lib/simulations/utils/benchmarkForm'
 import { Metadata } from 'lib/state/metadataInitializer'
+import { clone } from 'lib/utils/objectUtils'
+import type { CharacterId } from 'types/character'
+import type { LightConeId } from 'types/lightCone'
+import type { OptimizerAction } from 'types/optimizer'
 import {
   describe,
   expect,
@@ -19,10 +24,17 @@ import {
 
 Metadata.initialize()
 
-const SUNDAY = { id: '1313', lightCone: '23000' }
+const SUNDAY = {
+  id: '1313',
+  lightCone: '23000',
+} satisfies { id: CharacterId, lightCone: LightConeId }
 const SLOT_PROBE = 'slotProbe'
+const SUNDAY_CONDITIONAL_IDS = [
+  'SundayMemoCrConditional_Teammate0',
+  'SundayCrConditional_Teammate0',
+]
 
-// A conditional whose value at slot N is exactly N, so a misread of any size is detectable.
+// Returns its rotation slot so any index mismatch is visible.
 function slotProbeConditional(): ComboNumberConditional {
   const length = ABILITY_LIMIT + 1
   return {
@@ -34,19 +46,38 @@ function slotProbeConditional(): ComboNumberConditional {
   }
 }
 
-// Rotations that name an AbilityKind the character never declares. actionTransform drops those
-// actions, which must not renumber the surviving ones for teammate conditional lookups.
+// Covers skipped abilities before and between survivors, plus an unfiltered control.
 const CHARACTERS = [
-  { name: 'Robin Summeretto', id: '1512', lightCone: '23063' }, // drops START_ULT + END_SKILL
-  { name: 'Topaz', id: '1112', lightCone: '23000' }, // drops START_ULT
-  { name: 'Hyacine', id: '1409', lightCone: '23037' }, // drops START_ULT + 2x START_SKILL, interleaved
-  { name: 'Seele', id: '1102', lightCone: '23000' }, // drops nothing - control
-]
+  { name: 'Robin Summeretto', id: '1512', lightCone: '23063', hasIndexGap: true },
+  { name: 'Topaz', id: '1112', lightCone: '23000', hasIndexGap: true },
+  { name: 'Hyacine', id: '1409', lightCone: '23037', hasIndexGap: true },
+  { name: 'Seele', id: '1102', lightCone: '23000', hasIndexGap: false },
+] satisfies { name: string, id: CharacterId, lightCone: LightConeId, hasIndexGap: boolean }[]
 
-describe('teammate conditionals bind to the rotation slot their action owns', () => {
-  test.each(CHARACTERS)('$name', ({ id, lightCone }) => {
-    const form = generateFullDefaultForm(id as never, lightCone as never, 0, 1)
-    form.teammate0 = generateFullDefaultForm(SUNDAY.id as never, SUNDAY.lightCone as never, 0, 1, true)
+function expectSundayConditionals(actions: OptimizerAction[]) {
+  expect(actions.length).toBeGreaterThan(0)
+
+  for (const action of actions) {
+    const conditionals = action.teammateDynamicConditionals
+    expect(conditionals.map((conditional) => conditional.id)).toEqual(SUNDAY_CONDITIONAL_IDS)
+
+    for (const conditional of conditionals) {
+      expect(conditional.teammateIndex).toBe(0)
+      expect(conditional.condition).toBeTypeOf('function')
+      expect(conditional.effect).toBeTypeOf('function')
+      expect(conditional.gpu).toBeTypeOf('function')
+    }
+
+    const registered = action.conditionalRegistry[Stats.CR]
+      .filter((conditional) => conditional.teammateIndex === 0)
+    expect(registered).toEqual(conditionals)
+  }
+}
+
+describe('teammate conditionals preserve source rotation slots', () => {
+  test.each(CHARACTERS)('$name', ({ id, lightCone, hasIndexGap }) => {
+    const form = generateFullDefaultForm(id, lightCone, 0, 1)
+    form.teammate0 = generateFullDefaultForm(SUNDAY.id, SUNDAY.lightCone, 0, 1, true)
     form.comboType = ComboType.ADVANCED
 
     const context = generateContext(form)
@@ -56,36 +87,26 @@ describe('teammate conditionals bind to the rotation slot their action owns', ()
     newTransformStateActions(comboState, form, context)
 
     expect(context.rotationActions.length).toBeGreaterThan(0)
+    expect(context.rotationActions.some((action, index) => action.conditionalIndex !== index + 1)).toBe(hasIndexGap)
     for (const action of context.rotationActions) {
       expect(action.teammate0.characterConditionals[SLOT_PROBE]).toBe(action.conditionalIndex)
     }
   })
 })
 
-// Registration runs on both the main thread and again after a context crosses a worker
-// boundary, so it has to be idempotent rather than accumulate.
 describe('teammate dynamic conditionals are registered exactly once', () => {
-  test('no duplicates after repeated registration', () => {
-    const form = generateFullDefaultForm('1112' as never, '23000' as never, 0, 6) // Topaz
-    form.teammate0 = generateFullDefaultForm(SUNDAY.id as never, SUNDAY.lightCone as never, 6, 5, true)
+  test('rebuilds serialized actions without duplicates', () => {
+    const form = generateFullDefaultForm('1112', '23000', 0, 6)
+    form.teammate0 = generateFullDefaultForm(SUNDAY.id, SUNDAY.lightCone, 6, 5, true)
 
-    const context = generateContext(form)
-
-    const actions = [...context.rotationActions, ...context.defaultActions]
-    expect(actions.length).toBeGreaterThan(0)
-
-    const counts = actions.map((a) => a.teammateDynamicConditionals.length)
-    expect(Math.max(...counts)).toBeGreaterThan(0) // the teammate really does contribute some
-
-    for (const action of actions) {
-      const ids = action.teammateDynamicConditionals.map((c) => c.id)
-      expect(ids).toEqual([...new Set(ids)])
-    }
-
-    // Re-running registration (as worker rehydration does) must not accumulate.
-    const before = actions.map((a) => a.teammateDynamicConditionals.length)
+    // Worker transport strips functions from the serialized context.
+    const context = clone(generateContext(form))
     initializeContextConditionals(context)
-    const after = actions.map((a) => a.teammateDynamicConditionals.length)
-    expect(after).toEqual(before)
+    expectSundayConditionals(context.rotationActions)
+    expectSundayConditionals(context.defaultActions)
+
+    initializeContextConditionals(context)
+    expectSundayConditionals(context.rotationActions)
+    expectSundayConditionals(context.defaultActions)
   })
 })

--- a/src/lib/optimization/rotation/actionTransform.test.ts
+++ b/src/lib/optimization/rotation/actionTransform.test.ts
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+import {
+  ABILITY_LIMIT,
+  ConditionalDataType,
+} from 'lib/constants/constants'
+import { initializeComboState } from 'lib/optimization/combo/comboInitializers'
+import type { ComboNumberConditional } from 'lib/optimization/combo/comboTypes'
+import { generateContext } from 'lib/optimization/context/calculateContext'
+import { newTransformStateActions } from 'lib/optimization/rotation/actionTransform'
+import { ComboType } from 'lib/optimization/rotation/comboType'
+import { generateFullDefaultForm } from 'lib/simulations/utils/benchmarkForm'
+import { Metadata } from 'lib/state/metadataInitializer'
+import {
+  describe,
+  expect,
+  test,
+} from 'vitest'
+
+Metadata.initialize()
+
+const SUNDAY = { id: '1313', lightCone: '23000' }
+const SLOT_PROBE = 'slotProbe'
+
+// A conditional whose value at slot N is exactly N, so a misread of any size is detectable.
+function slotProbeConditional(): ComboNumberConditional {
+  const length = ABILITY_LIMIT + 1
+  return {
+    type: ConditionalDataType.NUMBER,
+    partitions: Array.from({ length }, (_, slot) => ({
+      value: slot,
+      activations: Array.from({ length }, (_, i) => i === slot),
+    })),
+  }
+}
+
+// Rotations that name an AbilityKind the character never declares. actionTransform drops those
+// actions, which must not renumber the surviving ones for teammate conditional lookups.
+const CHARACTERS = [
+  { name: 'Robin Summeretto', id: '1512', lightCone: '23063' }, // drops START_ULT + END_SKILL
+  { name: 'Topaz', id: '1112', lightCone: '23000' }, // drops START_ULT
+  { name: 'Hyacine', id: '1409', lightCone: '23037' }, // drops START_ULT + 2x START_SKILL, interleaved
+  { name: 'Seele', id: '1102', lightCone: '23000' }, // drops nothing - control
+]
+
+describe('teammate conditionals bind to the rotation slot their action owns', () => {
+  test.each(CHARACTERS)('$name', ({ id, lightCone }) => {
+    const form = generateFullDefaultForm(id as never, lightCone as never, 0, 1)
+    form.teammate0 = generateFullDefaultForm(SUNDAY.id as never, SUNDAY.lightCone as never, 0, 1, true)
+    form.comboType = ComboType.ADVANCED
+
+    const context = generateContext(form)
+    const comboState = initializeComboState(form, false)
+    comboState.comboTeammate0!.characterConditionals[SLOT_PROBE] = slotProbeConditional()
+
+    newTransformStateActions(comboState, form, context)
+
+    expect(context.rotationActions.length).toBeGreaterThan(0)
+    for (const action of context.rotationActions) {
+      expect(action.teammate0.characterConditionals[SLOT_PROBE]).toBe(action.conditionalIndex)
+    }
+  })
+})

--- a/src/lib/optimization/rotation/actionTransform.test.ts
+++ b/src/lib/optimization/rotation/actionTransform.test.ts
@@ -8,6 +8,7 @@ import type { ComboNumberConditional } from 'lib/optimization/combo/comboTypes'
 import { generateContext } from 'lib/optimization/context/calculateContext'
 import { newTransformStateActions } from 'lib/optimization/rotation/actionTransform'
 import { ComboType } from 'lib/optimization/rotation/comboType'
+import { initializeContextConditionals } from 'lib/simulations/contextConditionals'
 import { generateFullDefaultForm } from 'lib/simulations/utils/benchmarkForm'
 import { Metadata } from 'lib/state/metadataInitializer'
 import {
@@ -58,5 +59,33 @@ describe('teammate conditionals bind to the rotation slot their action owns', ()
     for (const action of context.rotationActions) {
       expect(action.teammate0.characterConditionals[SLOT_PROBE]).toBe(action.conditionalIndex)
     }
+  })
+})
+
+// Registration runs on both the main thread and again after a context crosses a worker
+// boundary, so it has to be idempotent rather than accumulate.
+describe('teammate dynamic conditionals are registered exactly once', () => {
+  test('no duplicates after repeated registration', () => {
+    const form = generateFullDefaultForm('1112' as never, '23000' as never, 0, 6) // Topaz
+    form.teammate0 = generateFullDefaultForm(SUNDAY.id as never, SUNDAY.lightCone as never, 6, 5, true)
+
+    const context = generateContext(form)
+
+    const actions = [...context.rotationActions, ...context.defaultActions]
+    expect(actions.length).toBeGreaterThan(0)
+
+    const counts = actions.map((a) => a.teammateDynamicConditionals.length)
+    expect(Math.max(...counts)).toBeGreaterThan(0) // the teammate really does contribute some
+
+    for (const action of actions) {
+      const ids = action.teammateDynamicConditionals.map((c) => c.id)
+      expect(ids).toEqual([...new Set(ids)])
+    }
+
+    // Re-running registration (as worker rehydration does) must not accumulate.
+    const before = actions.map((a) => a.teammateDynamicConditionals.length)
+    initializeContextConditionals(context)
+    const after = actions.map((a) => a.teammateDynamicConditionals.length)
+    expect(after).toEqual(before)
   })
 })

--- a/src/lib/optimization/rotation/actionTransform.ts
+++ b/src/lib/optimization/rotation/actionTransform.ts
@@ -18,7 +18,6 @@ import {
   defineAction,
   getComboTypeAbilities,
   precomputeConditionals,
-  transformConditionals,
 } from 'lib/optimization/rotation/comboStateTransform'
 import { precomputeExtraCombatBuffs } from 'lib/optimization/rotation/precomputeExtraCombatBuffs'
 import { type TurnAbilityName } from 'lib/optimization/rotation/turnAbilityConfig'
@@ -115,8 +114,6 @@ export function newTransformStateActions(comboState: ComboState, request: Form, 
 
   for (let i = 0; i < allActions.length; i++) {
     const action = allActions[i]
-    const isDefault = i < defaultActions.length
-    const comboIndex = isDefault ? 0 : (i - defaultActions.length + 1)
 
     const { primaryEntityRegistry, teammateEntityRegistry } = prepareEntitiesForAction(action, context)
 
@@ -137,24 +134,6 @@ export function newTransformStateActions(comboState: ComboState, request: Form, 
       container.enableTracing()
     }
     action.precomputedStats = container
-
-    if (comboState.comboTeammate0) {
-      action.teammate0.actorId = comboState.comboTeammate0.metadata.characterId
-      action.teammate0.characterConditionals = transformConditionals(comboIndex, comboState.comboTeammate0.characterConditionals)
-      action.teammate0.lightConeConditionals = transformConditionals(comboIndex, comboState.comboTeammate0.lightConeConditionals)
-    }
-
-    if (comboState.comboTeammate1) {
-      action.teammate1.actorId = comboState.comboTeammate1.metadata.characterId
-      action.teammate1.characterConditionals = transformConditionals(comboIndex, comboState.comboTeammate1.characterConditionals)
-      action.teammate1.lightConeConditionals = transformConditionals(comboIndex, comboState.comboTeammate1.lightConeConditionals)
-    }
-
-    if (comboState.comboTeammate2) {
-      action.teammate2.actorId = comboState.comboTeammate2.metadata.characterId
-      action.teammate2.characterConditionals = transformConditionals(comboIndex, comboState.comboTeammate2.characterConditionals)
-      action.teammate2.lightConeConditionals = transformConditionals(comboIndex, comboState.comboTeammate2.lightConeConditionals)
-    }
   }
 
   // ========== CALCULATE MAX ARRAY LENGTH ==========

--- a/src/lib/optimization/rotation/actionTransform.ts
+++ b/src/lib/optimization/rotation/actionTransform.ts
@@ -112,10 +112,8 @@ export function newTransformStateActions(comboState: ComboState, request: Form, 
 
   // ========== PHASE 3: CONFIGURATION ==========
 
-  for (let i = 0; i < allActions.length; i++) {
-    const action = allActions[i]
-
-    const { primaryEntityRegistry, teammateEntityRegistry } = prepareEntitiesForAction(action, context)
+  for (const action of allActions) {
+    const { primaryEntityRegistry } = prepareEntitiesForAction(action, context)
 
     for (const hit of action.hits!) {
       hit.sourceEntityIndex = hit.sourceEntity

--- a/src/lib/simulations/contextConditionals.ts
+++ b/src/lib/simulations/contextConditionals.ts
@@ -9,10 +9,10 @@ export function initializeContextConditionals(context: OptimizerContext) {
   context.lightConeController = LightConeConditionalsResolver.get(context)
 
   for (const action of [...context.rotationActions, ...context.defaultActions]) {
-    // Reconstruct arrays after transfer
+    // Restore values serialized from the typed array.
     action.precomputedStats.a = new Float64Array(Object.values(action.precomputedStats.a))
 
-    // Rebuild entityRegistry from entitiesArray after serialization
+    // Restore the lookup map omitted during serialization.
     if (action.config) {
       rebuildEntityRegistry(action.config)
     }

--- a/src/lib/simulations/contextConditionals.ts
+++ b/src/lib/simulations/contextConditionals.ts
@@ -1,27 +1,14 @@
 import { CharacterConditionalsResolver } from 'lib/conditionals/resolver/characterConditionalsResolver'
 import { LightConeConditionalsResolver } from 'lib/conditionals/resolver/lightConeConditionalsResolver'
-import type { DynamicConditional } from 'lib/gpu/conditionals/dynamicConditionals'
-import {
-  calculateContextConditionalRegistry,
-  wrapTeammateDynamicConditional,
-} from 'lib/optimization/calculateConditionals'
+import { calculateContextConditionalRegistry } from 'lib/optimization/calculateConditionals'
 import { rebuildEntityRegistry } from 'lib/optimization/engine/container/computedStatsContainer'
-import type {
-  CharacterMetadata,
-  OptimizerAction,
-  OptimizerContext,
-} from 'types/optimizer'
+import type { OptimizerContext } from 'types/optimizer'
 
 export function initializeContextConditionals(context: OptimizerContext) {
   context.characterController = CharacterConditionalsResolver.get(context)
   context.lightConeController = LightConeConditionalsResolver.get(context)
 
   for (const action of [...context.rotationActions, ...context.defaultActions]) {
-    action.teammateDynamicConditionals = []
-    if (context.teammate0Metadata?.characterId) calculateTeammateDynamicConditionals(action, context.teammate0Metadata, 0)
-    if (context.teammate1Metadata?.characterId) calculateTeammateDynamicConditionals(action, context.teammate1Metadata, 1)
-    if (context.teammate2Metadata?.characterId) calculateTeammateDynamicConditionals(action, context.teammate2Metadata, 2)
-
     // Reconstruct arrays after transfer
     action.precomputedStats.a = new Float64Array(Object.values(action.precomputedStats.a))
 
@@ -31,17 +18,5 @@ export function initializeContextConditionals(context: OptimizerContext) {
     }
 
     calculateContextConditionalRegistry(action, context, context.characterController, context.lightConeController)
-  }
-}
-
-// For Sunday E6 / etc
-function calculateTeammateDynamicConditionals(action: OptimizerAction, teammateMetadata: CharacterMetadata, index: number) {
-  if (teammateMetadata?.characterId) {
-    const teammateCharacterConditionalController = CharacterConditionalsResolver.get(teammateMetadata)
-    const dynamicConditionals = teammateCharacterConditionalController.teammateDynamicConditionals ?? []
-    dynamicConditionals.forEach((dynamicConditional: DynamicConditional) => {
-      const wrapped = wrapTeammateDynamicConditional(dynamicConditional, index)
-      action.teammateDynamicConditionals.push(wrapped)
-    })
   }
 }

--- a/src/lib/worker/optimizerWorker.ts
+++ b/src/lib/worker/optimizerWorker.ts
@@ -1,5 +1,3 @@
-import { CharacterConditionalsResolver } from 'lib/conditionals/resolver/characterConditionalsResolver'
-import { LightConeConditionalsResolver } from 'lib/conditionals/resolver/lightConeConditionalsResolver'
 import { Constants } from 'lib/constants/constants'
 import {
   type BasicStatsArray,
@@ -10,7 +8,6 @@ import {
   type BasicKeyType,
 } from 'lib/optimization/basicStatsArray'
 import { BufferPacker } from 'lib/optimization/bufferPacker'
-import { calculateContextConditionalRegistry } from 'lib/optimization/calculateConditionals'
 import { calculateBaseMultis } from 'lib/optimization/calculateDamage'
 import {
   calculateBaseStats,
@@ -28,10 +25,7 @@ import {
   type StatKeyValue,
 } from 'lib/optimization/engine/config/keys'
 import { OutputTag } from 'lib/optimization/engine/config/tag'
-import {
-  ComputedStatsContainer,
-  rebuildEntityRegistry,
-} from 'lib/optimization/engine/container/computedStatsContainer'
+import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
 import {
   calculateEhp,
   getDamageFunction,
@@ -49,6 +43,7 @@ import {
   type SetsOrnaments,
   type SetsRelics,
 } from 'lib/sets/setConfigRegistry'
+import { initializeContextConditionals } from 'lib/simulations/contextConditionals'
 import { type SimulationRelicArrayByPart } from 'lib/simulations/statSimulationTypes'
 import type { BaseWorkerInput } from 'lib/worker/workerPool'
 import type { WorkerType } from 'lib/worker/workerUtils'
@@ -108,35 +103,7 @@ export function optimizerWorker(e: MessageEvent<OptimizerWorkerInput>) {
 
   const { failsBasicThresholdFilter, failsComputedThresholdFilter } = generateResultMinFilter(request, context)
 
-  // Calculate conditional registry for all actions
-  for (const action of context.rotationActions) {
-    calculateContextConditionalRegistry(action, context)
-  }
-  for (const action of context.defaultActions) {
-    calculateContextConditionalRegistry(action, context)
-  }
-
-  context.characterController = CharacterConditionalsResolver.get(context)
-  context.lightConeController = LightConeConditionalsResolver.get(context)
-
-  for (const action of context.rotationActions) {
-    // Reconstruct arrays after transfer
-    action.precomputedStats.a = new Float64Array(Object.values(action.precomputedStats.a))
-
-    // Rebuild entityRegistry from entitiesArray after serialization
-    if (action.config) {
-      rebuildEntityRegistry(action.config)
-    }
-  }
-  for (const action of context.defaultActions) {
-    // Reconstruct arrays after transfer
-    action.precomputedStats.a = new Float64Array(Object.values(action.precomputedStats.a))
-
-    // Rebuild entityRegistry from entitiesArray after serialization
-    if (action.config) {
-      rebuildEntityRegistry(action.config)
-    }
-  }
+  initializeContextConditionals(context)
 
   const limit = Math.min(data.permutations, data.WIDTH)
 

--- a/src/lib/worker/optimizerWorker.ts
+++ b/src/lib/worker/optimizerWorker.ts
@@ -1,7 +1,6 @@
 import { CharacterConditionalsResolver } from 'lib/conditionals/resolver/characterConditionalsResolver'
 import { LightConeConditionalsResolver } from 'lib/conditionals/resolver/lightConeConditionalsResolver'
 import { Constants } from 'lib/constants/constants'
-import { type DynamicConditional } from 'lib/gpu/conditionals/dynamicConditionals'
 import {
   type BasicStatsArray,
   BasicStatsArrayCore,
@@ -11,10 +10,7 @@ import {
   type BasicKeyType,
 } from 'lib/optimization/basicStatsArray'
 import { BufferPacker } from 'lib/optimization/bufferPacker'
-import {
-  calculateContextConditionalRegistry,
-  wrapTeammateDynamicConditional,
-} from 'lib/optimization/calculateConditionals'
+import { calculateContextConditionalRegistry } from 'lib/optimization/calculateConditionals'
 import { calculateBaseMultis } from 'lib/optimization/calculateDamage'
 import {
   calculateBaseStats,
@@ -57,11 +53,7 @@ import { type SimulationRelicArrayByPart } from 'lib/simulations/statSimulationT
 import type { BaseWorkerInput } from 'lib/worker/workerPool'
 import type { WorkerType } from 'lib/worker/workerUtils'
 import { type Form } from 'types/form'
-import {
-  type CharacterMetadata,
-  type OptimizerAction,
-  type OptimizerContext,
-} from 'types/optimizer'
+import { type OptimizerContext } from 'types/optimizer'
 import { type Relic } from 'types/relic'
 
 export interface OptimizerWorkerInput extends BaseWorkerInput, OptimizerEventData {
@@ -127,24 +119,7 @@ export function optimizerWorker(e: MessageEvent<OptimizerWorkerInput>) {
   context.characterController = CharacterConditionalsResolver.get(context)
   context.lightConeController = LightConeConditionalsResolver.get(context)
 
-  function calculateTeammateDynamicConditionals(action: OptimizerAction, teammateMetadata: CharacterMetadata, index: number) {
-    if (teammateMetadata?.characterId) {
-      const teammateCharacterConditionalController = CharacterConditionalsResolver.get(teammateMetadata)
-      ;(teammateCharacterConditionalController.teammateDynamicConditionals ?? [])
-        .forEach((dynamicConditional: DynamicConditional) => {
-          const wrapped = wrapTeammateDynamicConditional(dynamicConditional, index)
-          action.teammateDynamicConditionals.push(wrapped)
-        })
-    }
-  }
-
-  // Setup teammate dynamic conditionals for all actions
   for (const action of context.rotationActions) {
-    action.teammateDynamicConditionals = []
-    if (context.teammate0Metadata?.characterId) calculateTeammateDynamicConditionals(action, context.teammate0Metadata, 0)
-    if (context.teammate1Metadata?.characterId) calculateTeammateDynamicConditionals(action, context.teammate1Metadata, 1)
-    if (context.teammate2Metadata?.characterId) calculateTeammateDynamicConditionals(action, context.teammate2Metadata, 2)
-
     // Reconstruct arrays after transfer
     action.precomputedStats.a = new Float64Array(Object.values(action.precomputedStats.a))
 
@@ -154,11 +129,6 @@ export function optimizerWorker(e: MessageEvent<OptimizerWorkerInput>) {
     }
   }
   for (const action of context.defaultActions) {
-    action.teammateDynamicConditionals = []
-    if (context.teammate0Metadata?.characterId) calculateTeammateDynamicConditionals(action, context.teammate0Metadata, 0)
-    if (context.teammate1Metadata?.characterId) calculateTeammateDynamicConditionals(action, context.teammate1Metadata, 1)
-    if (context.teammate2Metadata?.characterId) calculateTeammateDynamicConditionals(action, context.teammate2Metadata, 2)
-
     // Reconstruct arrays after transfer
     action.precomputedStats.a = new Float64Array(Object.values(action.precomputedStats.a))
 


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

• - Fix advanced rotations reading teammate conditionals from shifted turn slots after unsupported actions are removed.
  - Fix teammate dynamic conditionals being registered multiple times when optimizer contexts are rebuilt or transferred
    to workers.

## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [ ] I have added commit messages that are descriptive and meaningful.
- [ ] I have tested the changes locally.
- [ ] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
