### PR TITLE
feat: robin / rmc support sim

### DIFF
--- a/src/lib/conditionals/character/1500/RobinSummeretto.ts
+++ b/src/lib/conditionals/character/1500/RobinSummeretto.ts
@@ -51,8 +51,10 @@ import {
 import { SortOption } from 'lib/optimization/sortOptions'
 import { PresetEffects } from 'lib/scoring/presetEffects'
 import {
+  SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
   SPREAD_ORNAMENTS_2P_SUPPORT,
   SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+  SPREAD_RELICS_4P_SUPPORT,
 } from 'lib/scoring/scoringConstants'
 import { wrappedFixedT } from 'lib/utils/i18nUtils'
 import { type Eidolon } from 'types/character'
@@ -76,6 +78,7 @@ export const RobinSummerettoAbilities: AbilityKind[] = [
   AbilityKind.BASIC,
   AbilityKind.MEMO_SKILL,
   AbilityKind.BREAK,
+  AbilityKind.BUFF,
 ]
 
 const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsController => {
@@ -115,6 +118,9 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 
   const traceCdBuff = 0.40
   const traceCdBuffPerVibe = 0.015
+
+  const traceAtkBuff = 0.16
+  const traceAtkBuffPerVibe = 0.004
 
   const defaults = {
     buffPriority: BuffPriority.MEMO,
@@ -286,6 +292,17 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
             HitDefinitionBuilder.standardBreak(ElementTag.Wind).build(),
           ],
         },
+        // Deviated Chord's ATK branch, scaling off Robin's own HP. The support benchmark always
+        // reports the ATK value and ignores the CRIT DMG branch that lower-ATK allies would take.
+        [AbilityKind.BUFF]: {
+          hits: [
+            HitDefinitionBuilder.linearBuff()
+              .buffStat(StatKey.ATK)
+              .sourceStat(StatKey.HP)
+              .scaling(traceAtkBuff + r.vibes * traceAtkBuffPerVibe)
+              .build(),
+          ],
+        },
       }
     },
 
@@ -371,7 +388,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
         },
         effect: function(x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) {
           const t = action.teammateCharacterConditionals as Conditionals<typeof teammateContent>
-          const atkBuff = (0.16 + t.vibes * 0.004) * t.teammateHPValue
+          const atkBuff = (traceAtkBuff + t.vibes * traceAtkBuffPerVibe) * t.teammateHPValue
 
           dynamicStatConversionContainer(
             Stats.ATK,
@@ -387,7 +404,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
         },
         gpu: function(action: OptimizerAction, context: OptimizerContext) {
           const t = action.teammateCharacterConditionals as Conditionals<typeof teammateContent>
-          const atkBuff = (0.16 + t.vibes * 0.004) * t.teammateHPValue
+          const atkBuff = (traceAtkBuff + t.vibes * traceAtkBuffPerVibe) * t.teammateHPValue
 
           return gpuDynamicStatConversion(
             Stats.ATK,
@@ -488,12 +505,74 @@ const simulation = (): SimulationMetadata => ({
   relicSets: [
     [Sets.WorldRemakingDeliverer, Sets.WorldRemakingDeliverer],
     ...SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+    ...SPREAD_RELICS_4P_SUPPORT,
   ],
   ornamentSets: [
     Sets.AmphoreusTheEternalLand,
+    ...SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
     ...SPREAD_ORNAMENTS_2P_SUPPORT,
   ],
   deprioritizeBuffs: true,
+  teammates: [
+    {
+      characterId: Aglaea.id,
+      lightCone: TimeWovenIntoGold.id,
+      characterEidolon: 0,
+      lightConeSuperimposition: 1,
+    },
+    {
+      characterId: Cyrene.id,
+      lightCone: ThisLoveForever.id,
+      characterEidolon: 0,
+      lightConeSuperimposition: 1,
+    },
+    {
+      characterId: Hyacine.id,
+      lightCone: MayRainbowsRemainInTheSky.id,
+      characterEidolon: 0,
+      lightConeSuperimposition: 1,
+    },
+  ],
+})
+
+const supportSimulation = (): SimulationMetadata => ({
+  parts: {
+    [Parts.Body]: [
+      Stats.HP_P,
+    ],
+    [Parts.Feet]: [
+      Stats.SPD,
+      Stats.HP_P,
+    ],
+    [Parts.PlanarSphere]: [
+      Stats.HP_P,
+    ],
+    [Parts.LinkRope]: [
+      Stats.HP_P,
+    ],
+  },
+  substats: [
+    Stats.HP_P,
+    Stats.HP,
+    Stats.SPD,
+    Stats.RES,
+    Stats.DEF_P,
+  ],
+  buffStat: StatKey.ATK,
+  errRopeEidolon: 0,
+  comboTurnAbilities: [
+    NULL_TURN_ABILITY_NAME,
+  ],
+  relicSets: [
+    [Sets.WorldRemakingDeliverer, Sets.WorldRemakingDeliverer],
+    ...SPREAD_RELICS_4P_GENERAL_CONDITIONALS,
+    ...SPREAD_RELICS_4P_SUPPORT,
+  ],
+  ornamentSets: [
+    Sets.LushakaTheSunkenSeas,
+    ...SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
+    ...SPREAD_ORNAMENTS_2P_SUPPORT,
+  ],
   teammates: [
     {
       characterId: Aglaea.id,
@@ -560,6 +639,7 @@ const scoring = (): ScoringMetadata => ({
   hiddenColumns: [SortOption.SKILL, SortOption.ULT, SortOption.FUA, SortOption.DOT],
   addedColumns: [SortOption.MEMO_SKILL],
   simulation: simulation(),
+  supportSimulation: supportSimulation(),
 })
 
 const display = {

--- a/src/lib/conditionals/character/1500/RobinSummeretto.ts
+++ b/src/lib/conditionals/character/1500/RobinSummeretto.ts
@@ -570,6 +570,7 @@ const supportSimulation = (): SimulationMetadata => ({
   ],
   ornamentSets: [
     Sets.LushakaTheSunkenSeas,
+    Sets.AmphoreusTheEternalLand,
     ...SPREAD_ORNAMENTS_2P_GENERAL_CONDITIONALS,
     ...SPREAD_ORNAMENTS_2P_SUPPORT,
   ],

--- a/src/lib/conditionals/character/8000/TrailblazerRemembrance.ts
+++ b/src/lib/conditionals/character/8000/TrailblazerRemembrance.ts
@@ -470,7 +470,7 @@ const supportSimulation = (): SimulationMetadata => ({
     NULL_TURN_ABILITY_NAME,
   ],
   relicSets: [
-    [Sets.SacerdosRelivedOrdeal, Sets.SacerdosRelivedOrdeal],
+    [Sets.WorldRemakingDeliverer, Sets.WorldRemakingDeliverer],
     ...SPREAD_RELICS_4P_SUPPORT,
   ],
   ornamentSets: [

--- a/src/lib/simulations/tests/supportScore/supportScoreTest.test.ts
+++ b/src/lib/simulations/tests/supportScore/supportScoreTest.test.ts
@@ -3,12 +3,16 @@ import { Bronya } from 'lib/conditionals/character/1100/Bronya'
 import { Robin } from 'lib/conditionals/character/1300/Robin'
 import { RuanMei } from 'lib/conditionals/character/1300/RuanMei'
 import { SparkleB1 } from 'lib/conditionals/character/1300/SparkleB1'
+import { RobinSummeretto } from 'lib/conditionals/character/1500/RobinSummeretto'
 import { Yaoguang } from 'lib/conditionals/character/1500/Yaoguang'
+import { RiseAndSing } from 'lib/conditionals/lightcone/5star/RiseAndSing'
 import {
   Parts,
   Sets,
   Stats,
 } from 'lib/constants/constants'
+import { StatKey } from 'lib/optimization/engine/config/keys'
+import { SELF_ENTITY_INDEX } from 'lib/optimization/engine/config/tag'
 import { NULL_TURN_ABILITY_NAME } from 'lib/optimization/rotation/turnAbilityConfig'
 import {
   executeOrchestrator,
@@ -38,6 +42,7 @@ void SparkleB1
 void Robin
 void RuanMei
 void Yaoguang
+void RobinSummeretto
 
 Metadata.initialize()
 
@@ -289,4 +294,65 @@ test('Yaoguang support score prepare', () => {
   const orchestrator = prepareOrchestrator(character, bufferConfig(clone(yaoguangSimulation)), singleRelicByPart, {})
   expect(orchestrator.originalSimResult).toBeDefined()
   expect(orchestrator.originalSimResult!.simScore).toBeGreaterThan(0)
+})
+
+function robinSummerettoSupportScore(characterEidolon: number, hpRolls: number = 10) {
+  const character = {
+    form: {
+      characterId: RobinSummeretto.id,
+      characterEidolon,
+      lightCone: RiseAndSing.id,
+      lightConeSuperimposition: 5,
+    },
+  } as Character
+
+  const statSpread = testStatSpread()
+  statSpread[Stats.HP_P] = hpRolls
+
+  const singleRelicByPart = generateTestSingleRelicsByPart(
+    testSets(Sets.WorldRemakingDeliverer, Sets.WorldRemakingDeliverer, Sets.LushakaTheSunkenSeas),
+    testMains(Stats.HP_P, Stats.SPD, Stats.HP_P, Stats.HP_P),
+    statSpread,
+  )
+
+  return prepareOrchestrator(
+    character,
+    bufferConfig(clone(RobinSummeretto.scoring.supportSimulation!)),
+    singleRelicByPart,
+    {},
+  )
+}
+
+test('RobinSummeretto support score prepare', () => {
+  globalThis.SEQUENTIAL_BENCHMARKS = true
+
+  const orchestrator = robinSummerettoSupportScore(6)
+
+  expect(orchestrator.originalSimResult).toBeDefined()
+  expect(orchestrator.originalSimResult!.simScore).toBeGreaterThan(0)
+  expect(orchestrator.baselineSim!.request.simFeet).toBe(Stats.SPD)
+})
+
+test('RobinSummeretto support score scales with HP', () => {
+  globalThis.SEQUENTIAL_BENCHMARKS = true
+
+  // Her ATK buff is a percentage of her own HP, so the buff output must track HP monotonically
+  const lowHp = robinSummerettoSupportScore(6, 0)
+  const highHp = robinSummerettoSupportScore(6, 20)
+
+  expect(highHp.originalSimResult!.simScore).toBeGreaterThan(lowHp.originalSimResult!.simScore)
+})
+
+test('RobinSummeretto support score applies the Deviated Chord Vibes scaling', () => {
+  globalThis.SEQUENTIAL_BENCHMARKS = true
+
+  // Vibes cap at 50 below E2 and 70 from E2 onward, so the default Vibes differ by 10 across these
+  // two builds while HP stays identical. Deviated Chord grants 0.4% of her HP per Vibe, and the flat
+  // Lushaka contribution cancels out of the difference.
+  const e1 = robinSummerettoSupportScore(1)
+  const e6 = robinSummerettoSupportScore(6)
+
+  const hp = e6.originalSimResult!.x.getActionValueByIndex(StatKey.HP, SELF_ENTITY_INDEX)
+  expect(e1.originalSimResult!.x.getActionValueByIndex(StatKey.HP, SELF_ENTITY_INDEX)).toBeCloseTo(hp, 6)
+  expect(e6.originalSimResult!.simScore - e1.originalSimResult!.simScore).toBeCloseTo(10 * 0.004 * hp, 6)
 })


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

- Add a support benchmark for Summeretto Robin, scoring her Deviated Chord ATK buff off her own HP.
- Expand the relic and ornament set options available to Summeretto Robin's damage benchmark.
- Update Remembrance Trailblazer's support benchmark to use World-Remaking Deliverer instead of Sacerdos' Relived Ordeal.
- Add support score tests covering Summeretto Robin's HP scaling and Vibes-based buff growth across eidolons.

## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [ ] I have added commit messages that are descriptive and meaningful.
- [ ] I have tested the changes locally.
- [ ] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
