### PR TITLE
fix: relic set bit issues beyond the 32 set limit

### DIFF
--- a/src/lib/conditionals/conditionalFinalizers.ts
+++ b/src/lib/conditionals/conditionalFinalizers.ts
@@ -15,7 +15,7 @@ import {
 import type { OptimizerAction } from 'types/optimizer'
 
 export function boostAshblazingAtkContainer(x: ComputedStatsContainer, action: OptimizerAction, hitMulti: number) {
-  if (relic4p(SetKeys.TheAshblazingGrandDuke, x.c.sets)) {
+  if (relic4p(SetKeys.TheAshblazingGrandDuke, x.c.setMatches)) {
     const stacks = action.setConditionals.valueTheAshblazingGrandDuke
     const delta = hitMulti - 0.06 * stacks
     const baseATK = x.config.selfEntity.baseAtk
@@ -39,7 +39,7 @@ export function gpuBoostUltAshblazingAtk(action: OptimizerAction, hitMulti: numb
 export function gpuBoostAshblazingAtkContainer(hitMulti: number, action: OptimizerAction) {
   const config = action.config
   return wgsl`
-if (relic4p(*p_sets, SET_TheAshblazingGrandDuke) >= 1) {
+if (relic4p(*p_sets, SET_TheAshblazingGrandDuke)) {
   let ashblazingDelta = ${hitMulti} - 0.06 * f32(setConditionals.valueTheAshblazingGrandDuke);
   let ashblazingBaseATK = ${config.selfEntity.baseAtk};
   ${buff.hit(HKey.ATK, 'ashblazingDelta * ashblazingBaseATK').damageType(DamageTag.FUA).wgsl(action)}

--- a/src/lib/gpu/conditionals/dynamicConditionals.ts
+++ b/src/lib/gpu/conditionals/dynamicConditionals.ts
@@ -59,7 +59,7 @@ export function evaluateConditional(conditional: DynamicConditional, x: Computed
 
 export function newConditionalWgslWrapper(conditional: DynamicConditional, action: OptimizerAction, context: OptimizerContext, wgsl: string) {
   return `
-fn evaluate${conditional.id}${action.actionIdentifier}(p_container: ptr<function, array<f32, ${context.maxContainerArrayLength}>>, p_sets: ptr<function, Sets>, p_state: ptr<function, ConditionalState>) {
+fn evaluate${conditional.id}${action.actionIdentifier}(p_container: ptr<function, array<f32, ${context.maxContainerArrayLength}>>, p_sets: ptr<function, SetMatches>, p_state: ptr<function, ConditionalState>) {
 ${indent(wgsl.trim(), 1)}
 }
   `

--- a/src/lib/gpu/injection/generateBasicSetEffects.test.ts
+++ b/src/lib/gpu/injection/generateBasicSetEffects.test.ts
@@ -6,6 +6,7 @@ import {
   GpuSetMatcher,
 } from 'lib/gpu/injection/generateBasicSetEffects'
 import { WgslStatName } from 'lib/optimization/basicStatsArray'
+import { setConfigRegistry } from 'lib/sets/setConfigRegistry'
 import { SetType } from 'types/setConfig'
 import {
   describe,
@@ -72,8 +73,7 @@ describe('basicP4', () => {
 describe('generateBasicSetEffectsWgsl', () => {
   const wgsl = generateBasicSetEffectsWgsl()
 
-  it('returns a single flat WGSL string', () => {
-    expect(typeof wgsl).toBe('string')
+  it('includes the generated section header', () => {
     expect(wgsl).toContain('// Generated basic set effects')
   })
 
@@ -82,18 +82,14 @@ describe('generateBasicSetEffectsWgsl', () => {
     expect(wgsl).toMatch(/f32\(relic4p\(sets, SET_\w+\)\)/)
     expect(wgsl).toMatch(/f32\(ornament2p\(sets, SET_\w+\)\)/)
 
-    // Matching stays behind the accessor ABI; SET_X constants remain raw registry indices.
     expect(wgsl).not.toContain('1u <<')
   })
 
   it('preserves the grouped base-stat multiply form (base stat multiplied once against a summed percentage)', () => {
-    // HP_P/ATK_P/etc. are base-scaled: every matching term is summed inside a
-    // single set of parens, and the base stat multiplies that sum exactly once.
     expect(wgsl).toMatch(/c\.HP \+= \(baseHP\) \* \(/)
     expect(wgsl).toMatch(/c\.ATK \+= \(baseATK\) \* \(/)
     expect(wgsl).toMatch(/c\.SPD \+= \(baseSPD\) \* \(/)
 
-    // Non-base-scaled stats (e.g. CR) are summed directly onto `c`, with no base multiply.
     expect(wgsl).toMatch(/c\.CR \+= /)
     expect(wgsl).not.toMatch(/c\.CR \+= \(baseCR\)/)
   })
@@ -111,11 +107,20 @@ describe('generateBasicSetEffectsWgsl', () => {
     expect(wgsl).not.toMatch(/relicMatch2|relicMatch4|ornamentMatch2/)
   })
 
-  it('contributes exactly one term per basicP2/basicP4 entry (33 relic + 24 ornament)', () => {
-    const relicTerms = wgsl.match(/f32\(relic[24]p\(sets, SET_\w+\)\)/g) ?? []
-    const ornamentTerms = wgsl.match(/f32\(ornament2p\(sets, SET_\w+\)\)/g) ?? []
+  it('contributes exactly one term per configured basic set effect', () => {
+    const expected: Record<GpuSetMatcher, number> = {
+      [GpuSetMatcher.RELIC_2P]: 0,
+      [GpuSetMatcher.RELIC_4P]: 0,
+      [GpuSetMatcher.ORNAMENT_2P]: 0,
+    }
+    for (const config of setConfigRegistry.values()) {
+      for (const entry of config.conditionals.gpuBasic?.() ?? []) {
+        expected[entry.matchFn]++
+      }
+    }
 
-    expect(relicTerms.length).toBe(33)
-    expect(ornamentTerms.length).toBe(24)
+    expect(wgsl.match(/f32\(relic2p\(sets, SET_\w+\)\)/g) ?? []).toHaveLength(expected[GpuSetMatcher.RELIC_2P])
+    expect(wgsl.match(/f32\(relic4p\(sets, SET_\w+\)\)/g) ?? []).toHaveLength(expected[GpuSetMatcher.RELIC_4P])
+    expect(wgsl.match(/f32\(ornament2p\(sets, SET_\w+\)\)/g) ?? []).toHaveLength(expected[GpuSetMatcher.ORNAMENT_2P])
   })
 })

--- a/src/lib/gpu/injection/generateBasicSetEffects.test.ts
+++ b/src/lib/gpu/injection/generateBasicSetEffects.test.ts
@@ -2,6 +2,7 @@ import { Sets } from 'lib/constants/constants'
 import {
   basicP2,
   basicP4,
+  generateBasicSetEffectsWgsl,
   GpuSetMatcher,
 } from 'lib/gpu/injection/generateBasicSetEffects'
 import { WgslStatName } from 'lib/optimization/basicStatsArray'
@@ -65,5 +66,56 @@ describe('basicP4', () => {
       matchFn: GpuSetMatcher.RELIC_4P,
       setId: 'PoetOfMourningCollapse',
     })
+  })
+})
+
+describe('generateBasicSetEffectsWgsl', () => {
+  const wgsl = generateBasicSetEffectsWgsl()
+
+  it('returns a single flat WGSL string', () => {
+    expect(typeof wgsl).toBe('string')
+    expect(wgsl).toContain('// Generated basic set effects')
+  })
+
+  it('wraps matcher calls in f32(...) using raw SET_X indices', () => {
+    expect(wgsl).toMatch(/f32\(relic2p\(sets, SET_\w+\)\)/)
+    expect(wgsl).toMatch(/f32\(relic4p\(sets, SET_\w+\)\)/)
+    expect(wgsl).toMatch(/f32\(ornament2p\(sets, SET_\w+\)\)/)
+
+    // Matching stays behind the accessor ABI; SET_X constants remain raw registry indices.
+    expect(wgsl).not.toContain('1u <<')
+  })
+
+  it('preserves the grouped base-stat multiply form (base stat multiplied once against a summed percentage)', () => {
+    // HP_P/ATK_P/etc. are base-scaled: every matching term is summed inside a
+    // single set of parens, and the base stat multiplies that sum exactly once.
+    expect(wgsl).toMatch(/c\.HP \+= \(baseHP\) \* \(/)
+    expect(wgsl).toMatch(/c\.ATK \+= \(baseATK\) \* \(/)
+    expect(wgsl).toMatch(/c\.SPD \+= \(baseSPD\) \* \(/)
+
+    // Non-base-scaled stats (e.g. CR) are summed directly onto `c`, with no base multiply.
+    expect(wgsl).toMatch(/c\.CR \+= /)
+    expect(wgsl).not.toMatch(/c\.CR \+= \(baseCR\)/)
+  })
+
+  it('has no switch-dispatch machinery left over', () => {
+    expect(wgsl).not.toContain('SetStatAccum')
+    expect(wgsl).not.toContain('accumRelic2p')
+    expect(wgsl).not.toContain('accumRelic4p')
+    expect(wgsl).not.toContain('accumOrnament2p')
+    expect(wgsl).not.toContain('switch (setIndex)')
+    expect(wgsl).not.toContain('default: {}')
+  })
+
+  it('does not couple basic effects directly to the generated mask storage fields', () => {
+    expect(wgsl).not.toMatch(/relicMatch2|relicMatch4|ornamentMatch2/)
+  })
+
+  it('contributes exactly one term per basicP2/basicP4 entry (33 relic + 24 ornament)', () => {
+    const relicTerms = wgsl.match(/f32\(relic[24]p\(sets, SET_\w+\)\)/g) ?? []
+    const ornamentTerms = wgsl.match(/f32\(ornament2p\(sets, SET_\w+\)\)/g) ?? []
+
+    expect(relicTerms.length).toBe(33)
+    expect(ornamentTerms.length).toBe(24)
   })
 })

--- a/src/lib/gpu/injection/generateBasicSetEffects.ts
+++ b/src/lib/gpu/injection/generateBasicSetEffects.ts
@@ -34,7 +34,7 @@ export function basicP4(stat: BasicKeyType, value: number, set: SetConfig): Basi
 }
 
 function formatTerm(entry: BasicSetEffectEntry): string {
-  return `${entry.value} * ${entry.matchFn}(sets, SET_${entry.setId})`
+  return `${entry.value} * f32(${entry.matchFn}(sets, SET_${entry.setId}))`
 }
 
 const STAT_ORDER: BasicKeyType[] = [

--- a/src/lib/gpu/injection/generateSetMaskWgsl.test.ts
+++ b/src/lib/gpu/injection/generateSetMaskWgsl.test.ts
@@ -1,0 +1,233 @@
+// @vitest-environment jsdom
+
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest'
+import {
+  assertSetMaskCardinality,
+  generateSetMaskWgsl,
+  getSetMaskLocation,
+} from 'lib/gpu/injection/generateSetMaskWgsl'
+import {
+  injectComputeShader,
+  injectDispatchMode,
+} from 'lib/gpu/injection/generateWgsl'
+import {
+  assertGpuSetRegistryCardinality,
+  getSetRegistryCardinality,
+} from 'lib/gpu/injection/setIndexMap'
+import {
+  MAX_ORNAMENT_SET_COUNT,
+  MAX_RELIC_SET_COUNT,
+} from 'lib/sets/setConfigRegistry'
+import type { GpuConstants } from 'lib/gpu/webgpuTypes'
+import {
+  type SetConfig,
+  SetType,
+} from 'types/setConfig'
+
+type MatchMasks = {
+  relicMatch2: number[],
+  relicMatch4: number[],
+  ornamentMatch2: number[],
+}
+
+function oneHotWords(setIndex: number, setCount: number): number[] {
+  const words = Array.from({ length: Math.ceil(setCount / 32) }, () => 0)
+  const location = getSetMaskLocation(setIndex, setCount)
+  if (location) {
+    words[location.wordIndex] = (2 ** location.bitIndex) >>> 0
+  }
+  return words
+}
+
+function andWords(left: number[], right: number[]): number[] {
+  return left.map((value, index) => (value & right[index]) >>> 0)
+}
+
+function orWords(...values: number[][]): number[] {
+  return values[0].map((_, index) => values.reduce((result, value) => (result | value[index]) >>> 0, 0))
+}
+
+function evaluateGeneratedArithmetic(
+  relicSets: [number, number, number, number],
+  ornamentSets: [number, number],
+  relicSetCount: number,
+  ornamentSetCount: number,
+): MatchMasks {
+  const [h, g, b, f] = relicSets.map((setIndex) => oneHotWords(setIndex, relicSetCount))
+  const [p, l] = ornamentSets.map((setIndex) => oneHotWords(setIndex, ornamentSetCount))
+
+  return {
+    relicMatch2: orWords(
+      andWords(h, g),
+      andWords(h, b),
+      andWords(h, f),
+      andWords(g, b),
+      andWords(g, f),
+      andWords(b, f),
+    ),
+    relicMatch4: andWords(andWords(andWords(h, g), b), f),
+    ornamentMatch2: andWords(p, l),
+  }
+}
+
+function injectCarry(tupleMode: boolean, masks = generateSetMaskWgsl()): string {
+  const template = `
+/* INJECT OFFSET DECODE */
+/* INJECT PERM LIMIT CHECK */
+/* INJECT CARRY CHAIN */
+`
+  return injectDispatchMode(template, { TUPLE_MODE: tupleMode } as GpuConstants, masks)
+}
+
+describe('generateSetMaskWgsl', () => {
+  it('derives the live one-word shape from the 32 relic / 28 ornament registry', () => {
+    expect(getSetRegistryCardinality()).toEqual({ relicSetCount: 32, ornamentSetCount: 28 })
+
+    const generated = generateSetMaskWgsl()
+    expect(generated.relicWordCount).toBe(1)
+    expect(generated.ornamentWordCount).toBe(1)
+    expect(generated.declarations).toContain('// Generated capacity-safe set masks: relicWords=1, ornamentWords=1')
+    expect(generated.declarations).toContain('  relicMatch2: u32,')
+    expect(generated.declarations).toContain('  relicMatch4: u32,')
+    expect(generated.declarations).toContain('  ornamentMatch2: u32,')
+    expect(generated.declarations).not.toContain('Word1')
+  })
+
+  it('emits the beta-equivalent live hot arithmetic with the boolean accessor ABI', () => {
+    const generated = generateSetMaskWgsl({ relicSetCount: 32, ornamentSetCount: 28 })
+
+    expect(generated.declarations).toContain('fn relic2p(s: SetMatches, setId: u32) -> bool {')
+    expect(generated.declarations).toContain('return ((s.relicMatch2 >> setId) & 1u) == 1u;')
+    expect(generated.declarations).toContain('return ((s.relicMatch4 >> setId) & 1u) == 1u;')
+    expect(generated.declarations).toContain('return ((s.ornamentMatch2 >> setId) & 1u) == 1u;')
+
+    expect(generated.outerMaskDeclarations).toContain('var maskH = 1u << setH;')
+    expect(generated.outerMaskDeclarations).toContain('var maskG = 1u << setG;')
+    expect(generated.outerMaskDeclarations).toContain('var maskB = 1u << setB;')
+    expect(generated.outerMaskDeclarations).toContain('var maskF = 1u << setF;')
+    expect(generated.setMatchConstruction).toContain(
+      'sets.relicMatch2 = (maskH & maskG) | (maskH & maskB) | (maskH & maskF)',
+    )
+    expect(generated.setMatchConstruction).toContain('sets.relicMatch4 = maskH & maskG & maskB & maskF;')
+    expect(generated.setMatchConstruction).toContain('sets.ornamentMatch2 = (1u << setP) & (1u << setL);')
+  })
+
+  it('accepts the largest counts below a flattened filter length of 2^32', () => {
+    expect(() => assertSetMaskCardinality({
+      relicSetCount: MAX_RELIC_SET_COUNT,
+      ornamentSetCount: MAX_ORNAMENT_SET_COUNT,
+    })).not.toThrow()
+    expect(() => assertSetMaskCardinality({
+      relicSetCount: MAX_RELIC_SET_COUNT + 1,
+      ornamentSetCount: 1,
+    })).toThrow('exceeds the flattened filter array-length limit 255')
+    expect(() => assertSetMaskCardinality({
+      relicSetCount: 1,
+      ornamentSetCount: MAX_ORNAMENT_SET_COUNT + 1,
+    })).toThrow('exceeds the flattened filter array-length limit 65535')
+  })
+
+  it('rejects a registry Map that lost a set to a cross-family setKey collision', () => {
+    const collidedRegistry = new Map<string, SetConfig>()
+    collidedRegistry.set('DUPLICATE', { info: { setType: SetType.RELIC } } as SetConfig)
+    collidedRegistry.set('DUPLICATE', { info: { setType: SetType.ORNAMENT } } as SetConfig)
+
+    expect(() => assertGpuSetRegistryCardinality(collidedRegistry.values(), {
+      relicSetCount: 1,
+      ornamentSetCount: 1,
+    })).toThrow('cross-family setKey collision')
+  })
+
+  it.each([
+    [31, 32, { wordIndex: 0, bitIndex: 31 }],
+    [32, 33, { wordIndex: 1, bitIndex: 0 }],
+    [63, 64, { wordIndex: 1, bitIndex: 31 }],
+    [64, 65, { wordIndex: 2, bitIndex: 0 }],
+  ])('maps set id %i within cardinality %i without aliasing', (setId, setCount, expected) => {
+    expect(getSetMaskLocation(setId, setCount)).toEqual(expected)
+  })
+
+  it('emits named, word-gated scalars beyond ids 31 and 63, with invalid words false', () => {
+    const twoWords = generateSetMaskWgsl({ relicSetCount: 64, ornamentSetCount: 64 })
+    const threeWords = generateSetMaskWgsl({ relicSetCount: 65, ornamentSetCount: 65 })
+
+    expect(twoWords.relicWordCount).toBe(2)
+    expect(twoWords.declarations).toContain('relicMatch2Word1: u32')
+    expect(twoWords.declarations).not.toContain('relicMatch2Word2')
+
+    expect(threeWords.relicWordCount).toBe(3)
+    expect(threeWords.ornamentWordCount).toBe(3)
+    expect(threeWords.declarations).toContain('relicMatch2Word2: u32')
+    expect(threeWords.declarations).toContain('relicMatch4Word2: u32')
+    expect(threeWords.declarations).toContain('ornamentMatch2Word2: u32')
+    expect(threeWords.declarations).toContain('(word == 2u) & ((s.relicMatch2Word2 & bit) != 0u)')
+    expect(threeWords.declarations).not.toContain('word %')
+    expect(threeWords.declarations).not.toContain('word &')
+
+    expect(getSetMaskLocation(65, 65)).toBeUndefined()
+    expect(getSetMaskLocation(96, 65)).toBeUndefined()
+  })
+
+  it('computes no match, 2p, 2+2, 4p, and ornament matches across word boundaries', () => {
+    expect(evaluateGeneratedArithmetic([31, 32, 63, 64], [31, 32], 65, 65)).toEqual({
+      relicMatch2: [0, 0, 0],
+      relicMatch4: [0, 0, 0],
+      ornamentMatch2: [0, 0, 0],
+    })
+    expect(evaluateGeneratedArithmetic([32, 32, 0, 1], [31, 32], 65, 65).relicMatch2).toEqual([0, 1, 0])
+    expect(evaluateGeneratedArithmetic([31, 31, 64, 64], [31, 32], 65, 65).relicMatch2).toEqual([
+      0x80000000,
+      0,
+      1,
+    ])
+
+    const fourPiece = evaluateGeneratedArithmetic([63, 63, 63, 63], [31, 32], 65, 65)
+    expect(fourPiece.relicMatch2).toEqual([0, 0x80000000, 0])
+    expect(fourPiece.relicMatch4).toEqual([0, 0x80000000, 0])
+    expect(evaluateGeneratedArithmetic([0, 1, 2, 3], [64, 64], 65, 65).ornamentMatch2).toEqual([0, 0, 1])
+  })
+
+  it('assigns every generated match word and refreshes every outer word without stale fields', () => {
+    const generated = generateSetMaskWgsl({ relicSetCount: 65, ornamentSetCount: 65 })
+
+    for (const wordSuffix of ['', 'Word1', 'Word2']) {
+      expect(generated.setMatchConstruction).toContain(`sets.relicMatch2${wordSuffix} =`)
+      expect(generated.setMatchConstruction).toContain(`sets.relicMatch4${wordSuffix} =`)
+      expect(generated.setMatchConstruction).toContain(`sets.ornamentMatch2${wordSuffix} =`)
+      expect(generated.outerMaskRefresh.head).toContain(`maskH${wordSuffix} =`)
+      expect(generated.outerMaskRefresh.hands).toContain(`maskG${wordSuffix} =`)
+      expect(generated.outerMaskRefresh.body).toContain(`maskB${wordSuffix} =`)
+      expect(generated.outerMaskRefresh.feet).toContain(`maskF${wordSuffix} =`)
+    }
+  })
+
+  it('threads one descriptor shape through declarations, construction, and carry refresh', () => {
+    const generated = generateSetMaskWgsl({ relicSetCount: 65, ornamentSetCount: 65 })
+    const moduleWgsl = injectComputeShader('', generated)
+    const carryWgsl = injectCarry(true, generated)
+
+    expect(moduleWgsl).toContain('// Generated capacity-safe set masks: relicWords=3, ornamentWords=3')
+    expect(moduleWgsl).toContain('var maskHWord2 =')
+    expect(moduleWgsl).toContain('sets.relicMatch2Word2 =')
+    expect(moduleWgsl).toContain('sets.ornamentMatch2Word2 =')
+    expect(carryWgsl).toContain('maskHWord2 =')
+    expect(carryWgsl).toContain('maskFWord2 =')
+  })
+
+  it.each([
+    ['tuple', true],
+    ['naive', false],
+  ])('injects all outer carry refreshes in %s mode', (_, tupleMode) => {
+    const generated = generateSetMaskWgsl({ relicSetCount: 65, ornamentSetCount: 65 })
+    const carry = injectCarry(tupleMode, generated)
+
+    expect(carry).toMatch(/setH = u32\(head\.v5\.z\);[\s\S]*maskHWord2 =/)
+    expect(carry).toMatch(/setG = u32\(hands\.v5\.z\);[\s\S]*maskGWord2 =/)
+    expect(carry).toMatch(/setB = u32\(body\.v5\.z\);[\s\S]*maskBWord2 =/)
+    expect(carry).toMatch(/setF = u32\(feet\.v5\.z\);[\s\S]*maskFWord2 =/)
+  })
+})

--- a/src/lib/gpu/injection/generateSetMaskWgsl.ts
+++ b/src/lib/gpu/injection/generateSetMaskWgsl.ts
@@ -1,0 +1,196 @@
+import {
+  getSetRegistryCardinality,
+  type SetRegistryCardinality,
+} from 'lib/gpu/injection/setIndexMap'
+import {
+  MAX_ORNAMENT_SET_COUNT,
+  MAX_RELIC_SET_COUNT,
+} from 'lib/sets/setConfigRegistry'
+
+const SET_MASK_WORD_BITS = 32
+
+type OuterMaskRefresh = {
+  head: string,
+  hands: string,
+  body: string,
+  feet: string,
+}
+
+export type GeneratedSetMaskWgsl = {
+  relicWordCount: number,
+  ornamentWordCount: number,
+  declarations: string,
+  outerMaskDeclarations: string,
+  setMatchConstruction: string,
+  outerMaskRefresh: OuterMaskRefresh,
+}
+
+export type SetMaskLocation = {
+  wordIndex: number,
+  bitIndex: number,
+}
+
+export function getSetMaskLocation(setIndex: number, setCount: number): SetMaskLocation | undefined {
+  if (!Number.isInteger(setIndex) || setIndex < 0 || setIndex >= setCount) {
+    return undefined
+  }
+
+  return {
+    wordIndex: Math.floor(setIndex / SET_MASK_WORD_BITS),
+    bitIndex: setIndex % SET_MASK_WORD_BITS,
+  }
+}
+
+export function assertSetMaskCardinality(cardinality: SetRegistryCardinality): void {
+  if (!Number.isInteger(cardinality.relicSetCount) || cardinality.relicSetCount <= 0) {
+    throw new Error(`Invalid relic set cardinality: ${cardinality.relicSetCount}`)
+  }
+  if (cardinality.relicSetCount > MAX_RELIC_SET_COUNT) {
+    throw new Error(
+      `Relic set cardinality ${cardinality.relicSetCount} exceeds the flattened filter array-length limit ${MAX_RELIC_SET_COUNT}`,
+    )
+  }
+  if (!Number.isInteger(cardinality.ornamentSetCount) || cardinality.ornamentSetCount <= 0) {
+    throw new Error(`Invalid ornament set cardinality: ${cardinality.ornamentSetCount}`)
+  }
+  if (cardinality.ornamentSetCount > MAX_ORNAMENT_SET_COUNT) {
+    throw new Error(
+      `Ornament set cardinality ${cardinality.ornamentSetCount} exceeds the flattened filter array-length limit ${MAX_ORNAMENT_SET_COUNT}`,
+    )
+  }
+}
+
+function wordField(base: string, wordIndex: number): string {
+  return wordIndex === 0 ? base : `${base}Word${wordIndex}`
+}
+
+function oneHot(setId: string, wordIndex: number, wordCount: number): string {
+  if (wordCount === 1) {
+    return `1u << ${setId}`
+  }
+
+  return `select(0u, 1u << (${setId} & 31u), (${setId} >> 5u) == ${wordIndex}u)`
+}
+
+function generateFields(base: string, wordCount: number, comment: string): string[] {
+  return Array.from(
+    { length: wordCount },
+    (_, wordIndex) => `  ${wordField(base, wordIndex)}: u32,${wordIndex === 0 ? ` // ${comment}` : ''}`,
+  )
+}
+
+function generateAccessor(name: string, fieldBase: string, wordCount: number): string {
+  if (wordCount === 1) {
+    return `fn ${name}(s: SetMatches, setId: u32) -> bool {
+  return ((s.${fieldBase} >> setId) & 1u) == 1u;
+}`
+  }
+
+  const matches = Array.from(
+    { length: wordCount },
+    (_, wordIndex) => `((word == ${wordIndex}u) & ((s.${wordField(fieldBase, wordIndex)} & bit) != 0u))`,
+  )
+
+  return `fn ${name}(s: SetMatches, setId: u32) -> bool {
+  let word = setId >> 5u;
+  let bit = 1u << (setId & 31u);
+  return ${matches.join('\n      | ')};
+}`
+}
+
+function maskVariable(slot: string, wordIndex: number): string {
+  return wordField(`mask${slot}`, wordIndex)
+}
+
+function generateOuterMaskLines(
+  keyword: 'var' | '',
+  slot: string,
+  setId: string,
+  wordCount: number,
+  indentation: string,
+): string {
+  return Array.from(
+    { length: wordCount },
+    (_, wordIndex) => {
+      const prefix = keyword ? `${keyword} ` : ''
+      return `${indentation}${prefix}${maskVariable(slot, wordIndex)} = ${oneHot(setId, wordIndex, wordCount)};`
+    },
+  ).join('\n')
+}
+
+function relicPairExpression(wordIndex: number): string {
+  const h = maskVariable('H', wordIndex)
+  const g = maskVariable('G', wordIndex)
+  const b = maskVariable('B', wordIndex)
+  const f = maskVariable('F', wordIndex)
+
+  return `(${h} & ${g}) | (${h} & ${b}) | (${h} & ${f})\n`
+    + `                         | (${g} & ${b}) | (${g} & ${f}) | (${b} & ${f})`
+}
+
+export function generateSetMaskWgsl(
+  cardinality: SetRegistryCardinality = getSetRegistryCardinality(),
+): GeneratedSetMaskWgsl {
+  assertSetMaskCardinality(cardinality)
+
+  const relicWordCount = Math.ceil(cardinality.relicSetCount / SET_MASK_WORD_BITS)
+  const ornamentWordCount = Math.ceil(cardinality.ornamentSetCount / SET_MASK_WORD_BITS)
+
+  const fields = [
+    ...generateFields('relicMatch2', relicWordCount, 'bit N set = relic set N has >= 2 pieces'),
+    ...generateFields('relicMatch4', relicWordCount, 'bit N set = relic set N has 4 pieces'),
+    ...generateFields('ornamentMatch2', ornamentWordCount, 'bit N set = ornament set N has 2 pieces'),
+  ]
+
+  const declarations = `// Generated capacity-safe set masks: relicWords=${relicWordCount}, ornamentWords=${ornamentWordCount}
+struct SetMatches {
+${fields.join('\n')}
+}
+
+// Boolean set accessors. Multi-word forms gate on the selected word, so out-of-range words are false.
+${generateAccessor('relic2p', 'relicMatch2', relicWordCount)}
+${generateAccessor('relic4p', 'relicMatch4', relicWordCount)}
+${generateAccessor('ornament2p', 'ornamentMatch2', ornamentWordCount)}`
+
+  const outerMaskDeclarations = `  // Generated persistent outer relic one-hot masks: relicWords=${relicWordCount}
+${generateOuterMaskLines('var', 'H', 'setH', relicWordCount, '  ')}
+${generateOuterMaskLines('var', 'G', 'setG', relicWordCount, '  ')}
+${generateOuterMaskLines('var', 'B', 'setB', relicWordCount, '  ')}
+${generateOuterMaskLines('var', 'F', 'setF', relicWordCount, '  ')}`
+
+  const relicAssignments: string[] = []
+  for (let wordIndex = 0; wordIndex < relicWordCount; wordIndex++) {
+    const h = maskVariable('H', wordIndex)
+    const g = maskVariable('G', wordIndex)
+    const b = maskVariable('B', wordIndex)
+    const f = maskVariable('F', wordIndex)
+    relicAssignments.push(
+      `    sets.${wordField('relicMatch2', wordIndex)} = ${relicPairExpression(wordIndex)};`,
+      `    sets.${wordField('relicMatch4', wordIndex)} = ${h} & ${g} & ${b} & ${f};`,
+    )
+  }
+
+  const ornamentAssignments = Array.from(
+    { length: ornamentWordCount },
+    (_, wordIndex) => `    sets.${wordField('ornamentMatch2', wordIndex)} = (${oneHot('setP', wordIndex, ornamentWordCount)}) & (${oneHot('setL', wordIndex, ornamentWordCount)});`,
+  )
+
+  const setMatchConstruction = `    // Generated post-filter set mask construction
+    var sets = SetMatches();
+${relicAssignments.join('\n')}
+${ornamentAssignments.join('\n')}`
+
+  return {
+    relicWordCount,
+    ornamentWordCount,
+    declarations,
+    outerMaskDeclarations,
+    setMatchConstruction,
+    outerMaskRefresh: {
+      head: generateOuterMaskLines('', 'H', 'setH', relicWordCount, '                '),
+      hands: generateOuterMaskLines('', 'G', 'setG', relicWordCount, '              '),
+      body: generateOuterMaskLines('', 'B', 'setB', relicWordCount, '            '),
+      feet: generateOuterMaskLines('', 'F', 'setF', relicWordCount, '          '),
+    },
+  }
+}

--- a/src/lib/gpu/injection/generateWgsl.ts
+++ b/src/lib/gpu/injection/generateWgsl.ts
@@ -4,7 +4,11 @@ import { injectComputedStats } from 'lib/gpu/injection/injectComputedStats'
 import { generateDynamicConditionals } from 'lib/gpu/injection/injectConditionals'
 import { injectSettings } from 'lib/gpu/injection/injectSettings'
 import { injectUnrolledActions } from 'lib/gpu/injection/injectUnrolledActions'
-import { generateSetBitConstants } from 'lib/gpu/injection/setIndexMap'
+import {
+  type GeneratedSetMaskWgsl,
+  generateSetMaskWgsl,
+} from 'lib/gpu/injection/generateSetMaskWgsl'
+import { generateSetIndexConstants } from 'lib/gpu/injection/setIndexMap'
 import { indent } from 'lib/gpu/injection/wgslUtils'
 import { uniformCompatible } from 'lib/gpu/webgpuDevice'
 import type {
@@ -44,18 +48,19 @@ function generateShaderVariables(context: OptimizerContext, request: Form, gpuPa
 
 export function generateWgsl(context: OptimizerContext, request: Form, relics: RelicsByPart, gpuParams: GpuConstants) {
   let wgsl = ''
+  const setMasks = generateSetMaskWgsl()
 
   context.shaderVariables = generateShaderVariables(context, request, gpuParams)
 
   wgsl = injectSettings(wgsl, context, request, relics)
-  wgsl = injectComputeShader(wgsl)
+  wgsl = injectComputeShader(wgsl, setMasks)
   wgsl = injectUnrolledActions(wgsl, request, context, gpuParams)
   wgsl = injectConditionalsNew(wgsl, request, context, gpuParams)
   wgsl = injectGpuParams(wgsl, request, context, gpuParams)
   wgsl = injectBasicFilters(wgsl, request)
   wgsl = injectSetFilters(wgsl, request)
   wgsl = injectComputedStats(wgsl)
-  wgsl = injectDispatchMode(wgsl, gpuParams)
+  wgsl = injectDispatchMode(wgsl, gpuParams, setMasks)
 
   return wgsl
 }
@@ -118,11 +123,16 @@ const action${i} = Action( // ${action.actionIndex} ${action.actionName}
   return wgsl
 }
 
-function injectComputeShader(wgsl: string) {
-  wgsl += generateSetBitConstants()
+export function injectComputeShader(wgsl: string, setMasks: GeneratedSetMaskWgsl) {
+  wgsl += generateSetIndexConstants()
   const basicSetEffects = generateBasicSetEffectsWgsl()
-  const injectedComputeShader = computeShader.replace('/* INJECT BASIC SET EFFECTS */', basicSetEffects)
-  const injectedStructs = structs.replace('/* INJECT SET_CONDITIONALS_STRUCT */', generateSetConditionalsStruct())
+  const injectedComputeShader = computeShader
+    .replace('/* INJECT OUTER SET MASKS */', setMasks.outerMaskDeclarations)
+    .replace('/* INJECT SET MATCH CONSTRUCTION */', setMasks.setMatchConstruction)
+    .replace('/* INJECT BASIC SET EFFECTS */', basicSetEffects)
+  const injectedStructs = structs
+    .replace('/* INJECT SET_MASK_DECLARATIONS */', setMasks.declarations)
+    .replace('/* INJECT SET_CONDITIONALS_STRUCT */', generateSetConditionalsStruct())
   wgsl += `
 ${injectedComputeShader}
 
@@ -289,7 +299,11 @@ struct CompactEntry { index: u32, value: f32 }
   return wgsl
 }
 
-function injectDispatchMode(wgsl: string, gpuParams: GpuConstants): string {
+export function injectDispatchMode(
+  wgsl: string,
+  gpuParams: GpuConstants,
+  setMasks: GeneratedSetMaskWgsl,
+): string {
   if (gpuParams.TUPLE_MODE) {
     wgsl = wgsl.replace(
       '/* INJECT OFFSET DECODE */',
@@ -366,19 +380,19 @@ function injectDispatchMode(wgsl: string, gpuParams: GpuConstants): string {
                 curH += 1;
                 head = relics[curH];
                 setH = u32(head.v5.z);
-                maskH = 1u << setH;
+${setMasks.outerMaskRefresh.head}
               }
               hands = relics[curG + handsOffset];
               setG = u32(hands.v5.z);
-              maskG = 1u << setG;
+${setMasks.outerMaskRefresh.hands}
             }
             body = relics[curB + bodyOffset];
             setB = u32(body.v5.z);
-            maskB = 1u << setB;
+${setMasks.outerMaskRefresh.body}
           }
           feet = relics[curF + feetOffset];
           setF = u32(feet.v5.z);
-          maskF = 1u << setF;
+${setMasks.outerMaskRefresh.feet}
 
           outerStats = sumOuterRelics(head, hands, body, feet);
         }
@@ -463,19 +477,19 @@ function injectDispatchMode(wgsl: string, gpuParams: GpuConstants): string {
                 curH = (curH + 1) % hSize;
                 head = relics[curH];
                 setH = u32(head.v5.z);
-                maskH = 1u << setH;
+${setMasks.outerMaskRefresh.head}
               }
               hands = relics[curG + handsOffset];
               setG = u32(hands.v5.z);
-              maskG = 1u << setG;
+${setMasks.outerMaskRefresh.hands}
             }
             body = relics[curB + bodyOffset];
             setB = u32(body.v5.z);
-            maskB = 1u << setB;
+${setMasks.outerMaskRefresh.body}
           }
           feet = relics[curF + feetOffset];
           setF = u32(feet.v5.z);
-          maskF = 1u << setF;
+${setMasks.outerMaskRefresh.feet}
 
           outerStats = sumOuterRelics(head, hands, body, feet);
         }

--- a/src/lib/gpu/injection/injectUnrolledActions.ts
+++ b/src/lib/gpu/injection/injectUnrolledActions.ts
@@ -416,7 +416,7 @@ fn unrolledAction${index}(
   p_comboShield: ptr<function, f32>,
   p_comboBuff: ptr<function, f32>,
   p_container: ptr<function, array<f32, ${context.maxContainerArrayLength}>>,
-  p_sets: ptr<function, Sets>,
+  p_sets: ptr<function, SetMatches>,
   p_c: ptr<function, BasicStats>,
   diffATK: f32,
   diffDEF: f32,
@@ -493,7 +493,7 @@ fn unrolledAction${index}(
 fn unrolledAction${index}(
   p_comboBuff: ptr<function, f32>,
   p_container: ptr<function, array<f32, ${context.maxContainerArrayLength}>>,
-  p_sets: ptr<function, Sets>,
+  p_sets: ptr<function, SetMatches>,
   p_c: ptr<function, BasicStats>,
   diffATK: f32,
   diffDEF: f32,

--- a/src/lib/gpu/injection/setIndexMap.ts
+++ b/src/lib/gpu/injection/setIndexMap.ts
@@ -1,13 +1,60 @@
-import { setConfigRegistry } from 'lib/sets/setConfigRegistry'
-import { SetType } from 'types/setConfig'
+import {
+  OrnamentSetCount,
+  RelicSetCount,
+  setConfigRegistry,
+} from 'lib/sets/setConfigRegistry'
+import {
+  type SetConfig,
+  SetType,
+} from 'types/setConfig'
+
+export type SetRegistryCardinality = {
+  relicSetCount: number,
+  ornamentSetCount: number,
+}
+
+export function assertGpuSetRegistryCardinality(
+  configs: Iterable<SetConfig>,
+  expected: SetRegistryCardinality,
+): void {
+  let relicSetCount = 0
+  let ornamentSetCount = 0
+
+  for (const config of configs) {
+    if (config.info.setType === SetType.RELIC) {
+      relicSetCount++
+    } else {
+      ornamentSetCount++
+    }
+  }
+
+  if (relicSetCount !== expected.relicSetCount || ornamentSetCount !== expected.ornamentSetCount) {
+    throw new Error(
+      'GPU set registry cardinality mismatch: '
+      + `expected ${expected.relicSetCount} relic / ${expected.ornamentSetCount} ornament, `
+      + `got ${relicSetCount} relic / ${ornamentSetCount} ornament. `
+      + 'Check for a cross-family setKey collision before Map construction.',
+    )
+  }
+}
+
+export function getSetRegistryCardinality(): SetRegistryCardinality {
+  const cardinality = {
+    relicSetCount: RelicSetCount,
+    ornamentSetCount: OrnamentSetCount,
+  }
+  assertGpuSetRegistryCardinality(setConfigRegistry.values(), cardinality)
+  return cardinality
+}
 
 /**
- * Generate WGSL constant declarations for set bit indices.
- * These map each set name to its bit position in the bitmask registers.
- * Relic sets use bits 0..N in relicMatch2/relicMatch4.
- * Ornament sets use bits 0..M in ornamentMatch2.
+ * Generate WGSL constant declarations for set indices.
+ * These map each set name to its raw registry index. The generated accessors split
+ * that index into a mask word and bit without changing the caller ABI.
  */
-export function generateSetBitConstants(): string {
+export function generateSetIndexConstants(): string {
+  getSetRegistryCardinality()
+
   const relics: { id: string, index: number }[] = []
   const ornaments: { id: string, index: number }[] = []
 
@@ -23,11 +70,11 @@ export function generateSetBitConstants(): string {
   relics.sort((a, b) => a.index - b.index)
   ornaments.sort((a, b) => a.index - b.index)
 
-  let wgsl = '\n// Relic set bit indices\n'
+  let wgsl = '\n// Relic set indices\n'
   for (const { id, index } of relics) {
     wgsl += `const SET_${id}: u32 = ${index}u;\n`
   }
-  wgsl += '\n// Ornament set bit indices\n'
+  wgsl += '\n// Ornament set indices\n'
   for (const { id, index } of ornaments) {
     wgsl += `const SET_${id}: u32 = ${index}u;\n`
   }

--- a/src/lib/gpu/webgpuDataTransform.test.ts
+++ b/src/lib/gpu/webgpuDataTransform.test.ts
@@ -1,0 +1,43 @@
+import {
+  Parts,
+  Sets,
+  type Sets as SetId,
+} from 'lib/constants/constants'
+import { mergeRelicsIntoArray } from 'lib/gpu/webgpuDataTransform'
+import {
+  SetsOrnamentsNames,
+  SetsRelicsNames,
+} from 'lib/sets/setConfigRegistry'
+import { type Relic } from 'types/relic'
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest'
+
+function makeSerializableRelic(part: Relic['part'], set: SetId): Relic {
+  return {
+    part,
+    set,
+    condensedStats: [],
+  } as unknown as Relic
+}
+
+describe('GPU relic set serialization', () => {
+  it('serializes valid relic and ornament sets into their unchanged family-local indices', () => {
+    const relicSet = Sets.PasserbyOfWanderingCloud
+    const ornamentSet = Sets.SpaceSealingStation
+    const serialized = mergeRelicsIntoArray({
+      Head: [makeSerializableRelic(Parts.Head, relicSet)],
+      Hands: [],
+      Body: [],
+      Feet: [],
+      PlanarSphere: [makeSerializableRelic(Parts.PlanarSphere, ornamentSet)],
+      LinkRope: [],
+    })
+
+    expect(serialized).toHaveLength(48)
+    expect(serialized.at(22)).toBe(SetsRelicsNames.indexOf(relicSet))
+    expect(serialized.at(46)).toBe(SetsOrnamentsNames.indexOf(ornamentSet))
+  })
+})

--- a/src/lib/gpu/webgpuDataTransform.ts
+++ b/src/lib/gpu/webgpuDataTransform.ts
@@ -2,6 +2,7 @@ import {
   type GpuExecutionContext,
   type RelicsByPart,
 } from 'lib/gpu/webgpuTypes'
+import { Parts } from 'lib/constants/constants'
 import { BasicKey } from 'lib/optimization/basicStatsArray'
 import {
   type PerSlotSetRanges,
@@ -247,9 +248,8 @@ export function serializeAssignments(assignments: WorkgroupEntry[]): ArrayBuffer
   return buf
 }
 
-function relicSetToIndex(relic: Relic) {
-  if (relic.set in RelicSetToIndex) {
-    return RelicSetToIndex[relic.set as SetsRelics]
-  }
-  return OrnamentSetToIndex[relic.set as SetsOrnaments]
+function relicSetToIndex(relic: Relic): number {
+  return relic.part === Parts.PlanarSphere || relic.part === Parts.LinkRope
+    ? OrnamentSetToIndex[relic.set as SetsOrnaments]
+    : RelicSetToIndex[relic.set as SetsRelics]
 }

--- a/src/lib/gpu/webgpuInternals.ts
+++ b/src/lib/gpu/webgpuInternals.ts
@@ -16,10 +16,10 @@ import {
   type RelicsByPart,
 } from 'lib/gpu/webgpuTypes'
 import {
-  bitpackBooleanArray,
   buildPerSlotSetRanges,
   enumerateValidQuadsD4,
 } from 'lib/optimization/relicSetSolver'
+import { bitpackBooleanArray } from 'lib/optimization/setSolutionBitset'
 import {
   OrnamentSetToIndex,
   RelicSetToIndex,

--- a/src/lib/gpu/wgsl/computeShader.wgsl
+++ b/src/lib/gpu/wgsl/computeShader.wgsl
@@ -68,10 +68,7 @@ fn main(
   var setF = u32(feet.v5.z);
   var setP = u32(planarSphere.v5.z);
 
-  var maskH = 1u << setH;
-  var maskG = 1u << setG;
-  var maskB = 1u << setB;
-  var maskF = 1u << setF;
+  /* INJECT OUTER SET MASKS */
 
   var localValidCount: u32 = 0u;
 
@@ -99,11 +96,7 @@ fn main(
 
     localValidCount += 1u;
 
-    var sets = Sets();
-    sets.relicMatch2 = (maskH & maskG) | (maskH & maskB) | (maskH & maskF)
-                     | (maskG & maskB) | (maskG & maskF) | (maskB & maskF);
-    sets.relicMatch4 = maskH & maskG & maskB & maskF;
-    sets.ornamentMatch2 = (1u << setP) & (1u << setL);
+    /* INJECT SET MATCH CONSTRUCTION */
 
     var c: BasicStats = BasicStats();
 

--- a/src/lib/gpu/wgsl/structs.wgsl
+++ b/src/lib/gpu/wgsl/structs.wgsl
@@ -53,16 +53,7 @@ struct BasicStats {
   ELATION: f32,
 }
 
-struct Sets {
-  relicMatch2: u32,    // bit N set = relic set N has >= 2 pieces
-  relicMatch4: u32,    // bit N set = relic set N has 4 pieces
-  ornamentMatch2: u32, // bit N set = ornament set N has 2 pieces
-}
-
-// Bitmask set accessors: extract whether set at bit index has 2p/4p
-fn relic2p(s: Sets, bit: u32) -> f32 { return f32((s.relicMatch2 >> bit) & 1u); }
-fn relic4p(s: Sets, bit: u32) -> f32 { return f32((s.relicMatch4 >> bit) & 1u); }
-fn ornament2p(s: Sets, bit: u32) -> f32 { return f32((s.ornamentMatch2 >> bit) & 1u); }
+/* INJECT SET_MASK_DECLARATIONS */
 
 // START SET_CONDITIONALS_STRUCT
 // ═════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗

--- a/src/lib/optimization/basicStatsArray.ts
+++ b/src/lib/optimization/basicStatsArray.ts
@@ -5,7 +5,10 @@ import {
 } from 'lib/constants/constants'
 import { type BuffSource } from 'lib/optimization/buffSource'
 import { type AKeyType } from 'lib/optimization/engine/config/keys'
-import { type SetCounts } from 'lib/optimization/setMatching'
+import {
+  emptySetMatches,
+  type SetMatches,
+} from 'lib/optimization/setMatchState'
 
 export type Buff = {
   stat: AKeyType | BasicKeyType,
@@ -121,8 +124,7 @@ export class BasicStatsArrayCore {
 
   relicSetIndex: number
   ornamentSetIndex: number
-  sets: SetCounts
-  setsArray: number[]
+  setMatches: SetMatches
   id: number
   weight: number
 
@@ -134,8 +136,7 @@ export class BasicStatsArrayCore {
     this.trace = trace
     this.relicSetIndex = 0
     this.ornamentSetIndex = 0
-    this.sets = { relicMatch2: 0, relicMatch4: 0, ornamentMatch2: 0 }
-    this.setsArray = []
+    this.setMatches = emptySetMatches()
     this.id = -1
     this.weight = 0
 
@@ -175,11 +176,10 @@ export class BasicStatsArrayCore {
     })
   }
 
-  init(relicSetIndex: number, ornamentSetIndex: number, sets: SetCounts, setsArray: number[], id: number) {
+  init(relicSetIndex: number, ornamentSetIndex: number, setMatches: SetMatches, id: number) {
     this.relicSetIndex = relicSetIndex
     this.ornamentSetIndex = ornamentSetIndex
-    this.sets = sets
-    this.setsArray = setsArray
+    this.setMatches = setMatches
     this.id = id
 
     this.a.set(cachedBasicBaseStatsArray)

--- a/src/lib/optimization/calculateStats.test.ts
+++ b/src/lib/optimization/calculateStats.test.ts
@@ -1,0 +1,181 @@
+import { type SetKey } from 'lib/constants/constants'
+import {
+  computeSetMatches,
+  computeSetMatchesInPlace,
+} from 'lib/optimization/calculateStats'
+import {
+  ornament2p,
+  relic2p,
+  relic4p,
+} from 'lib/optimization/setMatching'
+import {
+  emptySetMatches,
+  NO_SET,
+  type MutableSetMatches,
+  type SetMatches,
+} from 'lib/optimization/setMatchState'
+import {
+  OrnamentSetKeyToIndex,
+  RelicSetKeyToIndex,
+} from 'lib/sets/setConfigRegistry'
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest'
+
+const relicKeys = Object.keys(RelicSetKeyToIndex) as SetKey[]
+const ornamentKeys = Object.keys(OrnamentSetKeyToIndex) as SetKey[]
+const relicKeyAt = (index: number) => relicKeys[index]
+const ornamentKeyAt = (index: number) => ornamentKeys[index]
+
+// Independent oracle: frequency count per relic slot id, groups ordered by the slot index at
+// which the id was first seen. Deliberately implemented without reusing any branch from
+// computeSetMatchesInPlace so it can catch bugs in that implementation.
+function oracleSetMatches(sets: number[]): SetMatches {
+  const relicSlots = sets.slice(0, 4)
+  const freq = new Map<number, number>()
+  const firstSeenOrder: number[] = []
+
+  for (const id of relicSlots) {
+    if (!freq.has(id)) firstSeenOrder.push(id)
+    freq.set(id, (freq.get(id) ?? 0) + 1)
+  }
+
+  const groups = firstSeenOrder.filter((id) => freq.get(id)! >= 2)
+  const is4p = groups.length === 1 && freq.get(groups[0]) === 4
+
+  return {
+    relic2pSetA: groups[0] ?? NO_SET,
+    relic2pSetB: groups[1] ?? NO_SET,
+    relic4pSet: is4p ? groups[0] : NO_SET,
+    ornament2pSet: sets[4] === sets[5] ? sets[4] : NO_SET,
+  }
+}
+
+describe('computeSetMatches exhaustive ordered pairing', () => {
+  const RELIC_IDS = [0, 1, 2]
+  const ORNAMENT_IDS = [0, 1, 2]
+
+  it('matches an independent frequency + first-seen oracle for every relic x ornament combination', () => {
+    let combinations = 0
+
+    for (const s0 of RELIC_IDS) {
+      for (const s1 of RELIC_IDS) {
+        for (const s2 of RELIC_IDS) {
+          for (const s3 of RELIC_IDS) {
+            for (const s4 of ORNAMENT_IDS) {
+              for (const s5 of ORNAMENT_IDS) {
+                const sets = [s0, s1, s2, s3, s4, s5]
+                const actual = computeSetMatches(sets)
+                const expected = oracleSetMatches(sets)
+
+                expect(actual).toEqual(expected)
+                if (actual.relic4pSet !== NO_SET) {
+                  expect(actual.relic4pSet).toBe(actual.relic2pSetA)
+                  expect(actual.relic2pSetB).toBe(NO_SET)
+                }
+                combinations++
+              }
+            }
+          }
+        }
+      }
+    }
+
+    expect(combinations).toBe(RELIC_IDS.length ** 4 * ORNAMENT_IDS.length ** 2)
+  })
+})
+
+describe('computeSetMatchesInPlace reuse', () => {
+  it('clears every field it does not set, so no value from a prior call survives', () => {
+    const target: MutableSetMatches = emptySetMatches()
+
+    // 1. 4-piece match at raw id 32 (one past the real 0..31 relic index range), exercising the
+    //    exact capacity bug this refactor fixes, alongside a matching ornament pair.
+    computeSetMatchesInPlace(target, [32, 32, 32, 32, 5, 5])
+    expect(target.relic2pSetA).toBe(32)
+    expect(target.relic2pSetB).toBe(NO_SET)
+    expect(target.relic4pSet).toBe(32)
+    expect(target.ornament2pSet).toBe(5)
+    expect(relic4p(relicKeyAt(0), target)).toBe(false)
+    expect(relic2p(relicKeyAt(0), target)).toBe(false)
+    expect(ornament2p(ornamentKeyAt(0), target)).toBe(false)
+
+    // 2. 2+2: two distinct 2-piece groups at real indices 0 and 1, no ornament match.
+    computeSetMatchesInPlace(target, [0, 0, 1, 1, 7, 8])
+    expect(target.relic2pSetA).toBe(0)
+    expect(target.relic2pSetB).toBe(1)
+    expect(target.relic4pSet).toBe(NO_SET)
+    expect(target.ornament2pSet).toBe(NO_SET)
+    expect(relic4p(relicKeyAt(0), target)).toBe(false)
+    expect(relic2p(relicKeyAt(0), target)).toBe(true)
+    expect(relic2p(relicKeyAt(1), target)).toBe(true)
+    expect(relic2p(relicKeyAt(2), target)).toBe(false)
+
+    // 3. One 2p group only: relic2pSetB held index 1 from step 2 and must be cleared, not
+    //    merely hidden behind a guard.
+    computeSetMatchesInPlace(target, [0, 0, 2, 3, 9, 9])
+    expect(target.relic2pSetA).toBe(0)
+    expect(target.relic2pSetB).toBe(NO_SET)
+    expect(relic2p(relicKeyAt(0), target)).toBe(true)
+    expect(relic2p(relicKeyAt(1), target)).toBe(false)
+    expect(target.ornament2pSet).toBe(9)
+    expect(ornament2p(ornamentKeyAt(0), target)).toBe(false)
+    expect(ornament2p(ornamentKeyAt(9), target)).toBe(true)
+
+    // 4. No relic match at all: relic2pSetA held index 0 from step 3 and must be cleared.
+    computeSetMatchesInPlace(target, [4, 5, 6, 7, 9, 9])
+    expect(target.relic2pSetA).toBe(NO_SET)
+    expect(target.relic2pSetB).toBe(NO_SET)
+    expect(target.relic4pSet).toBe(NO_SET)
+    expect(relic2p(relicKeyAt(0), target)).toBe(false)
+    expect(relic4p(relicKeyAt(0), target)).toBe(false)
+
+    // 5. Ornament mismatch: ornament2pSet held index 9 from step 4 and must be cleared.
+    computeSetMatchesInPlace(target, [4, 5, 6, 7, 9, 10])
+    expect(target.ornament2pSet).toBe(NO_SET)
+    expect(ornament2p(ornamentKeyAt(9), target)).toBe(false)
+
+    // 6. Ornament pair again with a fresh id, proving the field updates correctly rather than
+    //    staying cleared forever.
+    computeSetMatchesInPlace(target, [4, 5, 6, 7, 11, 11])
+    expect(target.ornament2pSet).toBe(11)
+    expect(ornament2p(ornamentKeyAt(11), target)).toBe(true)
+  })
+})
+
+describe('computeSetMatches capacity regression (bitmask overflow bug)', () => {
+  // Old bitmask: relicMatch2 |= (1 << setIndex) for pairs. Since `1 << 32 === 1 << 0 === 1` in
+  // JS, a 33rd relic set registered at index 32 would silently alias index 0. SetMatches stores
+  // raw indices directly (no bit shifting), so this class of bug cannot recur.
+
+  it('treats raw ids 0, 32, and 63 as distinct in a 2+2+ornament combination', () => {
+    const matches = computeSetMatches([0, 0, 32, 32, 63, 63])
+    expect(matches.relic2pSetA).toBe(0)
+    expect(matches.relic2pSetB).toBe(32)
+    expect(matches.relic4pSet).toBe(NO_SET)
+    expect(matches.ornament2pSet).toBe(63)
+  })
+
+  it('handles a 4-piece match at raw id 32 without colliding with id 0', () => {
+    const matches = computeSetMatches([32, 32, 32, 32, 1000, 1000])
+    expect(matches.relic2pSetA).toBe(32)
+    expect(matches.relic2pSetA).not.toBe(0)
+    expect(matches.relic4pSet).toBe(32)
+    expect(matches.ornament2pSet).toBe(1000)
+  })
+
+  it('does not let a real relic key at index 0 alias a hypothetical set at raw id 32', () => {
+    const matches = computeSetMatches([32, 32, 32, 32, 5, 5])
+    expect(relic4p(relicKeyAt(0), matches)).toBe(false)
+    expect(relic2p(relicKeyAt(0), matches)).toBe(false)
+  })
+
+  it.each([31, 63, 1000])('round-trips arbitrarily large raw id %i through a 2-piece relic and ornament match', (id) => {
+    const matches = computeSetMatches([id, id, id + 1, id + 2, id, id])
+    expect(matches.relic2pSetA).toBe(id)
+    expect(matches.relic2pSetB).toBe(NO_SET)
+    expect(matches.ornament2pSet).toBe(id)
+  })
+})

--- a/src/lib/optimization/calculateStats.ts
+++ b/src/lib/optimization/calculateStats.ts
@@ -11,7 +11,12 @@ import {
 import { StatKey } from 'lib/optimization/engine/config/keys'
 import { TargetTag } from 'lib/optimization/engine/config/tag'
 import { type ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
-import { type SetCounts } from 'lib/optimization/setMatching'
+import {
+  emptySetMatches,
+  type MutableSetMatches,
+  NO_SET,
+  type SetMatches,
+} from 'lib/optimization/setMatchState'
 import {
   ornamentIndexToSetConfig,
   relicIndexToSetConfig,
@@ -23,55 +28,79 @@ import type {
   SetConditional,
 } from 'types/optimizer'
 
-export function calculateSetCounts(
-  sets: number[],
-): SetCounts {
-  const maskH = 1 << sets[0]
-  const maskG = 1 << sets[1]
-  const maskB = 1 << sets[2]
-  const maskF = 1 << sets[3]
-
-  return {
-    relicMatch2: (maskH & maskG) | (maskH & maskB) | (maskH & maskF)
-      | (maskG & maskB) | (maskG & maskF) | (maskB & maskF),
-    relicMatch4: maskH & maskG & maskB & maskF,
-    ornamentMatch2: (1 << sets[4]) & (1 << sets[5]),
-  }
-}
-
-export function calculateSetCountsInPlace(
-  setCounts: SetCounts,
+export function computeSetMatchesInPlace(
+  target: MutableSetMatches,
   sets: number[],
 ): void {
-  const maskH = 1 << sets[0]
-  const maskG = 1 << sets[1]
-  const maskB = 1 << sets[2]
-  const maskF = 1 << sets[3]
+  const set0 = sets[0]
+  const set1 = sets[1]
+  const set2 = sets[2]
+  const set3 = sets[3]
+  const set4 = sets[4]
+  const set5 = sets[5]
 
-  setCounts.relicMatch2 = (maskH & maskG) | (maskH & maskB) | (maskH & maskF)
-    | (maskG & maskB) | (maskG & maskF) | (maskB & maskF)
-  setCounts.relicMatch4 = maskH & maskG & maskB & maskF
-  setCounts.ornamentMatch2 = (1 << sets[4]) & (1 << sets[5])
-}
+  if (set0 === set1 && set1 === set2 && set2 === set3) {
+    target.relic2pSetA = set0
+    target.relic2pSetB = NO_SET
+    target.relic4pSet = set0
+  } else {
+    target.relic4pSet = NO_SET
+    target.relic2pSetA = NO_SET
+    target.relic2pSetB = NO_SET
 
-export function calculateBasicSetEffects(c: BasicStatsArray, context: OptimizerContext, setCounts: SetCounts, sets: number[]) {
-  for (let i = 0; i < 4; i++) {
-    const set = sets[i]
+    // Does this slot's set appear again in a later slot?
+    const repeated0 = set0 === set1 || set0 === set2 || set0 === set3
+    const repeated1 = set1 === set2 || set1 === set3
+    const repeated2 = set2 === set3
 
-    // Skip if this set was already processed by an earlier slot
-    if ((i > 0 && sets[0] === set) || (i > 1 && sets[1] === set) || (i > 2 && sets[2] === set)) continue
+    // Was it already recorded by an earlier slot holding the same set?
+    const recorded1 = set1 === set0
+    const recorded2 = set2 === set0 || set2 === set1
 
-    const bit = 1 << set
-    if (setCounts.relicMatch2 & bit) {
-      const conditionals = relicIndexToSetConfig[set].conditionals
+    // Four slots hold at most two sets with 2+ pieces, so setA then setB is always enough.
+    if (repeated0) {
+      target.relic2pSetA = set0
+    }
 
-      if (conditionals.p2c) conditionals.p2c(c, context)
-      if ((setCounts.relicMatch4 & bit) && conditionals.p4c) conditionals.p4c(c, context)
+    if (repeated1 && !recorded1) {
+      if (target.relic2pSetA === NO_SET) {
+        target.relic2pSetA = set1
+      } else {
+        target.relic2pSetB = set1
+      }
+    }
+
+    if (repeated2 && !recorded2) {
+      if (target.relic2pSetA === NO_SET) {
+        target.relic2pSetA = set2
+      } else {
+        target.relic2pSetB = set2
+      }
     }
   }
 
-  if (sets[4] == sets[5]) {
-    ornamentIndexToSetConfig[sets[4]].conditionals.p2c?.(c, context)
+  target.ornament2pSet = set4 === set5 ? set4 : NO_SET
+}
+
+export function computeSetMatches(sets: number[]): SetMatches {
+  const target = emptySetMatches()
+  computeSetMatchesInPlace(target, sets)
+  return target
+}
+
+export function calculateBasicSetEffects(c: BasicStatsArray, context: OptimizerContext, matches: SetMatches) {
+  if (matches.relic2pSetA !== NO_SET) {
+    const conditionals = relicIndexToSetConfig[matches.relic2pSetA].conditionals
+    conditionals.p2c?.(c, context)
+    if (matches.relic4pSet !== NO_SET && conditionals.p4c) conditionals.p4c(c, context)
+  }
+
+  if (matches.relic2pSetB !== NO_SET) {
+    relicIndexToSetConfig[matches.relic2pSetB].conditionals.p2c?.(c, context)
+  }
+
+  if (matches.ornament2pSet !== NO_SET) {
+    ornamentIndexToSetConfig[matches.ornament2pSet].conditionals.p2c?.(c, context)
   }
 }
 
@@ -144,16 +173,15 @@ export function calculateComputedStats(x: ComputedStatsContainer, action: Optimi
   const setConditionals = action.setConditionals
   const a = x.a
   const c = x.c
-  const sets = c.sets
-  const setsArray = c.setsArray
+  const matches = c.setMatches
 
   transferBaseStats(x, a, c, context)
   calculateMemospriteBaseStats(x, a, c, context)
-  executeNonDynamicCombatSets(x, context, setConditionals, sets, setsArray)
+  executeNonDynamicCombatSets(x, context, setConditionals, matches)
   applyPercentStats(x, a, context)
-  evaluateDynamicSetConditionals(x, sets, setsArray, action, context)
+  evaluateDynamicSetConditionals(x, matches, action, context)
   evaluateDynamicConditionals(x, action, context)
-  evaluateTerminalSetConditionals(x, a, sets, setsArray, action, context)
+  evaluateTerminalSetConditionals(x, a, matches, action, context)
 
   return x
 }
@@ -260,15 +288,14 @@ function applyPercentStats(x: ComputedStatsContainer, a: Float64Array, context: 
   }
 }
 
-function evaluateDynamicSetConditionals(
+export function evaluateDynamicSetConditionals(
   x: ComputedStatsContainer,
-  sets: SetCounts,
-  setsArray: number[],
+  matches: SetMatches,
   action: OptimizerAction,
   context: OptimizerContext,
 ) {
-  if (setsArray[4] == setsArray[5]) {
-    const conditionals = ornamentIndexToSetConfig[setsArray[4]].conditionals.dynamicConditionals
+  if (matches.ornament2pSet !== NO_SET) {
+    const conditionals = ornamentIndexToSetConfig[matches.ornament2pSet].conditionals.dynamicConditionals
     if (conditionals) {
       for (let i = 0; i < conditionals.length; i++) {
         evaluateConditional(conditionals[i], x, action, context)
@@ -298,58 +325,46 @@ function evaluateDynamicConditionals(x: ComputedStatsContainer, action: Optimize
   }
 }
 
-function evaluateTerminalSetConditionals(
+export function evaluateTerminalSetConditionals(
   x: ComputedStatsContainer,
   a: Float64Array,
-  sets: SetCounts,
-  setsArray: number[],
+  matches: SetMatches,
   action: OptimizerAction,
   context: OptimizerContext,
 ) {
   const setConditionals = action.setConditionals
 
   // Terminal ornament set conditionals
-  if (setsArray[4] == setsArray[5]) {
-    ornamentIndexToSetConfig[setsArray[4]].conditionals.p2t?.(x, context, setConditionals)
+  if (matches.ornament2pSet !== NO_SET) {
+    ornamentIndexToSetConfig[matches.ornament2pSet].conditionals.p2t?.(x, context, setConditionals)
   }
 
   // Terminal relic set conditionals
-  if (setsArray[0] === setsArray[1] && setsArray[1] === setsArray[2] && setsArray[2] === setsArray[3]) {
-    relicIndexToSetConfig[setsArray[0]].conditionals.p4t?.(x, context, setConditionals)
+  if (matches.relic4pSet !== NO_SET) {
+    relicIndexToSetConfig[matches.relic4pSet].conditionals.p4t?.(x, context, setConditionals)
   }
 }
 
-function executeNonDynamicCombatSets(
+export function executeNonDynamicCombatSets(
   x: ComputedStatsContainer,
   context: OptimizerContext,
   setConditionals: SetConditional,
-  sets: SetCounts,
-  setsArray: number[],
+  matches: SetMatches,
 ) {
-  const [set0, set1, set2, set3, set4, set5] = setsArray
+  if (matches.ornament2pSet !== NO_SET) {
+    ornamentIndexToSetConfig[matches.ornament2pSet].conditionals.p2x?.(x, context, setConditionals)
+  }
 
-  if (set4 == set5) {
-    const conditionals = ornamentIndexToSetConfig[set4].conditionals
+  if (matches.relic2pSetA !== NO_SET) {
+    const conditionals = relicIndexToSetConfig[matches.relic2pSetA].conditionals
     conditionals.p2x?.(x, context, setConditionals)
+    if (matches.relic4pSet !== NO_SET) {
+      conditionals.p4x?.(x, context, setConditionals)
+    }
   }
 
-  if (set0 === set1 && set1 === set2 && set2 === set3) {
-    const conditionals = relicIndexToSetConfig[set0].conditionals
-    conditionals.p2x?.(x, context, setConditionals)
-    conditionals.p4x?.(x, context, setConditionals)
-    return
-  }
-
-  if (set0 === set1 || set0 === set2 || set0 === set3) {
-    relicIndexToSetConfig[set0].conditionals.p2x?.(x, context, setConditionals)
-  }
-
-  if ((set1 === set2 || set1 === set3) && set1 !== set0) {
-    relicIndexToSetConfig[set1].conditionals.p2x?.(x, context, setConditionals)
-  }
-
-  if (set2 === set3 && set2 !== set0 && set2 !== set1) {
-    relicIndexToSetConfig[set2].conditionals.p2x?.(x, context, setConditionals)
+  if (matches.relic2pSetB !== NO_SET) {
+    relicIndexToSetConfig[matches.relic2pSetB].conditionals.p2x?.(x, context, setConditionals)
   }
 }
 

--- a/src/lib/optimization/calculateStats.ts
+++ b/src/lib/optimization/calculateStats.ts
@@ -12,8 +12,6 @@ import { StatKey } from 'lib/optimization/engine/config/keys'
 import { TargetTag } from 'lib/optimization/engine/config/tag'
 import { type ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
 import {
-  emptySetMatches,
-  type MutableSetMatches,
   NO_SET,
   type SetMatches,
 } from 'lib/optimization/setMatchState'
@@ -27,66 +25,6 @@ import type {
   OptimizerContext,
   SetConditional,
 } from 'types/optimizer'
-
-export function computeSetMatchesInPlace(
-  target: MutableSetMatches,
-  sets: number[],
-): void {
-  const set0 = sets[0]
-  const set1 = sets[1]
-  const set2 = sets[2]
-  const set3 = sets[3]
-  const set4 = sets[4]
-  const set5 = sets[5]
-
-  if (set0 === set1 && set1 === set2 && set2 === set3) {
-    target.relic2pSetA = set0
-    target.relic2pSetB = NO_SET
-    target.relic4pSet = set0
-  } else {
-    target.relic4pSet = NO_SET
-    target.relic2pSetA = NO_SET
-    target.relic2pSetB = NO_SET
-
-    // Does this slot's set appear again in a later slot?
-    const repeated0 = set0 === set1 || set0 === set2 || set0 === set3
-    const repeated1 = set1 === set2 || set1 === set3
-    const repeated2 = set2 === set3
-
-    // Was it already recorded by an earlier slot holding the same set?
-    const recorded1 = set1 === set0
-    const recorded2 = set2 === set0 || set2 === set1
-
-    // Four slots hold at most two sets with 2+ pieces, so setA then setB is always enough.
-    if (repeated0) {
-      target.relic2pSetA = set0
-    }
-
-    if (repeated1 && !recorded1) {
-      if (target.relic2pSetA === NO_SET) {
-        target.relic2pSetA = set1
-      } else {
-        target.relic2pSetB = set1
-      }
-    }
-
-    if (repeated2 && !recorded2) {
-      if (target.relic2pSetA === NO_SET) {
-        target.relic2pSetA = set2
-      } else {
-        target.relic2pSetB = set2
-      }
-    }
-  }
-
-  target.ornament2pSet = set4 === set5 ? set4 : NO_SET
-}
-
-export function computeSetMatches(sets: number[]): SetMatches {
-  const target = emptySetMatches()
-  computeSetMatchesInPlace(target, sets)
-  return target
-}
 
 export function calculateBasicSetEffects(c: BasicStatsArray, context: OptimizerContext, matches: SetMatches) {
   if (matches.relic2pSetA !== NO_SET) {

--- a/src/lib/optimization/calculateStatsDispatch.test.ts
+++ b/src/lib/optimization/calculateStatsDispatch.test.ts
@@ -1,0 +1,166 @@
+import {
+  ConditionalActivation,
+  ConditionalType,
+} from 'lib/constants/constants'
+import { type DynamicConditional } from 'lib/gpu/conditionals/dynamicConditionals'
+import { type BasicStatsArray } from 'lib/optimization/basicStatsArray'
+import {
+  calculateBasicSetEffects,
+  evaluateDynamicSetConditionals,
+  evaluateTerminalSetConditionals,
+  executeNonDynamicCombatSets,
+} from 'lib/optimization/calculateStats'
+import { type ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
+import { emptySetMatches } from 'lib/optimization/setMatchState'
+import {
+  ornamentIndexToSetConfig,
+  relicIndexToSetConfig,
+} from 'lib/sets/setConfigRegistry'
+import {
+  type OptimizerAction,
+  type OptimizerContext,
+  type SetConditional,
+} from 'types/optimizer'
+import { type SetConditionals } from 'types/setConfig'
+import {
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
+
+// Replaces the real relic/ornament registries with a small, fully-controlled fixture so
+// dispatch order can be observed without depending on any real character set's behavior.
+vi.mock('lib/sets/setConfigRegistry', () => {
+  const relicIndexToSetConfig = [{ conditionals: {} }, { conditionals: {} }]
+  const ornamentIndexToSetConfig = [{ conditionals: {} }]
+  return { relicIndexToSetConfig, ornamentIndexToSetConfig }
+})
+
+const RELIC_A = 0
+const RELIC_B = 1
+const ORNAMENT = 0
+
+let order: string[]
+
+function spyConditionals(label: string): SetConditionals {
+  const dynamicConditional: DynamicConditional = {
+    id: `${label}Dynamic`,
+    type: ConditionalType.SET,
+    activation: ConditionalActivation.SINGLE,
+    dependsOn: [],
+    chainsTo: [],
+    condition: () => {
+      order.push(`${label}.dynamicCondition`)
+      return true
+    },
+    effect: () => {
+      order.push(`${label}.dynamicEffect`)
+    },
+    gpu: () => '',
+  }
+
+  return {
+    p2c: () => {
+      order.push(`${label}.p2c`)
+    },
+    p4c: () => {
+      order.push(`${label}.p4c`)
+    },
+    p2x: () => {
+      order.push(`${label}.p2x`)
+    },
+    p4x: () => {
+      order.push(`${label}.p4x`)
+    },
+    p2t: () => {
+      order.push(`${label}.p2t`)
+    },
+    p4t: () => {
+      order.push(`${label}.p4t`)
+    },
+    dynamicConditionals: [dynamicConditional],
+  }
+}
+
+const fakeContainer = {} as unknown as ComputedStatsContainer
+const fakeContext = {} as unknown as OptimizerContext
+const fakeBasicStats = {} as unknown as BasicStatsArray
+const setConditionals: SetConditional = {}
+let fakeAction: OptimizerAction
+
+beforeEach(() => {
+  order = []
+  // conditionalState is reset per test - evaluateConditional marks SINGLE-activation
+  // conditionals as fired there, so a shared object would suppress re-firing across tests.
+  fakeAction = {
+    conditionalState: {},
+    setConditionals,
+  } as unknown as OptimizerAction
+  relicIndexToSetConfig[RELIC_A].conditionals = spyConditionals('A')
+  relicIndexToSetConfig[RELIC_B].conditionals = spyConditionals('B')
+  ornamentIndexToSetConfig[ORNAMENT].conditionals = spyConditionals('O')
+})
+
+describe('calculateBasicSetEffects dispatch order', () => {
+  it('2+2+ornament: relic A p2c, relic B p2c, then ornament p2c (no p4c)', () => {
+    const matches = { ...emptySetMatches(), relic2pSetA: RELIC_A, relic2pSetB: RELIC_B, ornament2pSet: ORNAMENT }
+    calculateBasicSetEffects(fakeBasicStats, fakeContext, matches)
+    expect(order).toEqual(['A.p2c', 'B.p2c', 'O.p2c'])
+  })
+
+  it('4p+ornament: relic A p2c then p4c immediately, then ornament p2c (no relic B)', () => {
+    const matches = { ...emptySetMatches(), relic2pSetA: RELIC_A, relic4pSet: RELIC_A, ornament2pSet: ORNAMENT }
+    calculateBasicSetEffects(fakeBasicStats, fakeContext, matches)
+    expect(order).toEqual(['A.p2c', 'A.p4c', 'O.p2c'])
+  })
+})
+
+describe('executeNonDynamicCombatSets dispatch order', () => {
+  it('2+2+ornament: ornament p2x first, then relic A p2x, then relic B p2x', () => {
+    const matches = { ...emptySetMatches(), relic2pSetA: RELIC_A, relic2pSetB: RELIC_B, ornament2pSet: ORNAMENT }
+    executeNonDynamicCombatSets(fakeContainer, fakeContext, setConditionals, matches)
+    expect(order).toEqual(['O.p2x', 'A.p2x', 'B.p2x'])
+  })
+
+  it('4p+ornament: ornament p2x first, then relic A p2x immediately followed by p4x', () => {
+    const matches = { ...emptySetMatches(), relic2pSetA: RELIC_A, relic4pSet: RELIC_A, ornament2pSet: ORNAMENT }
+    executeNonDynamicCombatSets(fakeContainer, fakeContext, setConditionals, matches)
+    expect(order).toEqual(['O.p2x', 'A.p2x', 'A.p4x'])
+  })
+})
+
+describe('evaluateTerminalSetConditionals dispatch order', () => {
+  it('2+2+ornament: only ornament p2t fires (no relic terminal without a 4-piece match)', () => {
+    const matches = { ...emptySetMatches(), relic2pSetA: RELIC_A, relic2pSetB: RELIC_B, ornament2pSet: ORNAMENT }
+    evaluateTerminalSetConditionals(fakeContainer, new Float64Array(0), matches, fakeAction, fakeContext)
+    expect(order).toEqual(['O.p2t'])
+  })
+
+  it('4p+ornament: ornament p2t first, then relic A p4t', () => {
+    const matches = { ...emptySetMatches(), relic2pSetA: RELIC_A, relic4pSet: RELIC_A, ornament2pSet: ORNAMENT }
+    evaluateTerminalSetConditionals(fakeContainer, new Float64Array(0), matches, fakeAction, fakeContext)
+    expect(order).toEqual(['O.p2t', 'A.p4t'])
+  })
+})
+
+describe('evaluateDynamicSetConditionals dispatch order', () => {
+  it('2+2+ornament: only the ornament dynamic conditional fires, relic state is ignored', () => {
+    const matches = { ...emptySetMatches(), relic2pSetA: RELIC_A, relic2pSetB: RELIC_B, ornament2pSet: ORNAMENT }
+    evaluateDynamicSetConditionals(fakeContainer, matches, fakeAction, fakeContext)
+    expect(order).toEqual(['O.dynamicCondition', 'O.dynamicEffect'])
+  })
+
+  it('4p+ornament: only the ornament dynamic conditional fires, relic 4p state is ignored', () => {
+    const matches = { ...emptySetMatches(), relic2pSetA: RELIC_A, relic4pSet: RELIC_A, ornament2pSet: ORNAMENT }
+    evaluateDynamicSetConditionals(fakeContainer, matches, fakeAction, fakeContext)
+    expect(order).toEqual(['O.dynamicCondition', 'O.dynamicEffect'])
+  })
+
+  it('does not fire when there is no ornament match', () => {
+    const matches = { ...emptySetMatches(), relic2pSetA: RELIC_A, relic2pSetB: RELIC_B }
+    evaluateDynamicSetConditionals(fakeContainer, matches, fakeAction, fakeContext)
+    expect(order).toEqual([])
+  })
+})

--- a/src/lib/optimization/engine/container/computedStatsContainer.test.ts
+++ b/src/lib/optimization/engine/container/computedStatsContainer.test.ts
@@ -1,0 +1,74 @@
+import {
+  type BasicStatsArray,
+  BasicStatsArrayCore,
+} from 'lib/optimization/basicStatsArray'
+import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
+import {
+  emptySetMatches,
+  type MutableSetMatches,
+  NO_SET,
+} from 'lib/optimization/setMatchState'
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest'
+
+function makeContainerWithMatches(matches: MutableSetMatches): ComputedStatsContainer {
+  const container = new ComputedStatsContainer()
+  container.a = new Float64Array(4)
+  const basic = new BasicStatsArrayCore(false) as BasicStatsArray
+  basic.setMatches = matches
+  container.c = basic
+  return container
+}
+
+describe('ComputedStatsContainer.clone', () => {
+  it('shallow-copies setMatches, isolating the clone from later in-place mutation of the original', () => {
+    // The optimizer worker reuses a single mutable SetMatches object across permutations
+    // (computeSetMatchesInPlace), storing a reference on BasicStatsArray.setMatches. Any "kept"
+    // result must clone that object, not share the reference, or every kept result would end up
+    // reflecting whatever permutation was evaluated last.
+    const sharedMatches: MutableSetMatches = {
+      relic2pSetA: 3,
+      relic2pSetB: NO_SET,
+      relic4pSet: NO_SET,
+      ornament2pSet: 2,
+    }
+    const container = makeContainerWithMatches(sharedMatches)
+
+    const clone = container.clone()
+
+    expect(clone.c.setMatches).not.toBe(sharedMatches)
+    expect(clone.c.setMatches).toEqual({
+      relic2pSetA: 3,
+      relic2pSetB: NO_SET,
+      relic4pSet: NO_SET,
+      ornament2pSet: 2,
+    })
+
+    // Simulate the worker reusing the same mutable object for the next permutation.
+    sharedMatches.relic2pSetA = 99
+    sharedMatches.relic2pSetB = 4
+    sharedMatches.relic4pSet = 99
+    sharedMatches.ornament2pSet = 77
+
+    expect(clone.c.setMatches).toEqual({
+      relic2pSetA: 3,
+      relic2pSetB: NO_SET,
+      relic4pSet: NO_SET,
+      ornament2pSet: 2,
+    })
+  })
+
+  it('produces a clone whose setMatches object is independently mutable', () => {
+    const sharedMatches: MutableSetMatches = emptySetMatches()
+    const container = makeContainerWithMatches(sharedMatches)
+
+    const clone = container.clone()
+    const cloneMatches = clone.c.setMatches as MutableSetMatches
+    cloneMatches.relic2pSetA = 5
+
+    expect(sharedMatches.relic2pSetA).toBe(NO_SET)
+  })
+})

--- a/src/lib/optimization/engine/container/computedStatsContainer.ts
+++ b/src/lib/optimization/engine/container/computedStatsContainer.ts
@@ -355,8 +355,9 @@ export class ComputedStatsContainer {
     clonedBasic.id = this.c.id
     clonedBasic.relicSetIndex = this.c.relicSetIndex
     clonedBasic.ornamentSetIndex = this.c.ornamentSetIndex
-    clonedBasic.sets = this.c.sets
-    clonedBasic.setsArray = this.c.setsArray
+    // Copy, don't share: the optimizer worker reuses one setMatches object across every
+    // permutation, so a shared reference would leave kept clones showing the last one.
+    clonedBasic.setMatches = { ...this.c.setMatches }
     clonedBasic.weight = this.c.weight
     clone.c = clonedBasic as BasicStatsArray
 
@@ -384,7 +385,8 @@ export class ComputedStatsContainer {
 
   /**
    * Creates a minimal container from raw arrays (for worker result reconstruction).
-   * Does not include config - only suitable for array access.
+   * Has no config and no set state - suitable for array access only. Set queries on the
+   * result always answer "no set matched", whatever the build equipped.
    */
   public static fromArrays(xa: Float64Array, ca: Float32Array): ComputedStatsContainer {
     const container = new ComputedStatsContainer()

--- a/src/lib/optimization/optimizer.ts
+++ b/src/lib/optimization/optimizer.ts
@@ -27,11 +27,11 @@ import {
 import { type ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
 import {
   applySemiJoinReduction,
-  bitpackBooleanArray,
   computeValidPermutationCount,
   generateOrnamentSetSolutions,
   generateRelicSetSolutions,
 } from 'lib/optimization/relicSetSolver'
+import { bitpackBooleanArray } from 'lib/optimization/setSolutionBitset'
 import { SortOption } from 'lib/optimization/sortOptions'
 import {
   type PartCountsBySet,

--- a/src/lib/optimization/relicSetSolver.test.ts
+++ b/src/lib/optimization/relicSetSolver.test.ts
@@ -3,11 +3,9 @@ import {
   RelicSetFilterOptions,
 } from 'lib/constants/constants'
 import {
-  bitpackBooleanArray,
   computeValidPermutationCount,
   generateOrnamentSetSolutions,
   generateRelicSetSolutions,
-  isSetSolutionValid,
 } from 'lib/optimization/relicSetSolver'
 import { zeroCountsBySet } from 'lib/relics/relicFilters'
 import {
@@ -22,47 +20,6 @@ import {
   expect,
   it,
 } from 'vitest'
-
-describe('isSetSolutionValid', () => {
-  it('returns true for valid (1) positions in bitpacked array', () => {
-    const arr = [1, 0, 1, 0]
-    const bitpacked = bitpackBooleanArray(arr)
-    expect(isSetSolutionValid(bitpacked, 0)).toBe(true)
-    expect(isSetSolutionValid(bitpacked, 2)).toBe(true)
-  })
-
-  it('returns false for invalid (0) positions in bitpacked array', () => {
-    const arr = [1, 0, 1, 0]
-    const bitpacked = bitpackBooleanArray(arr)
-    expect(isSetSolutionValid(bitpacked, 1)).toBe(false)
-    expect(isSetSolutionValid(bitpacked, 3)).toBe(false)
-  })
-
-  it('handles indices across multiple packed i32 values', () => {
-    const arr = Array.from({ length: 64 }, () => 0)
-    arr[0] = 1
-    arr[31] = 1
-    arr[32] = 1
-    arr[63] = 1
-    const bitpacked = bitpackBooleanArray(arr)
-
-    expect(isSetSolutionValid(bitpacked, 0)).toBe(true)
-    expect(isSetSolutionValid(bitpacked, 31)).toBe(true)
-    expect(isSetSolutionValid(bitpacked, 32)).toBe(true)
-    expect(isSetSolutionValid(bitpacked, 63)).toBe(true)
-    expect(isSetSolutionValid(bitpacked, 15)).toBe(false)
-    expect(isSetSolutionValid(bitpacked, 47)).toBe(false)
-  })
-
-  it('handles indices above the signed i32 range', () => {
-    const index = 216 ** 4 - 1
-    const packedIndex = Math.floor(index / 32)
-    const bitpacked: number[] = []
-    bitpacked[packedIndex] = 1 << (index & 31)
-
-    expect(isSetSolutionValid(bitpacked, index)).toBe(true)
-  })
-})
 
 describe('computeValidPermutationCount', () => {
   function makeForm(overrides: Partial<Form> = {}): Form {

--- a/src/lib/optimization/relicSetSolver.test.ts
+++ b/src/lib/optimization/relicSetSolver.test.ts
@@ -53,6 +53,15 @@ describe('isSetSolutionValid', () => {
     expect(isSetSolutionValid(bitpacked, 15)).toBe(false)
     expect(isSetSolutionValid(bitpacked, 47)).toBe(false)
   })
+
+  it('handles indices above the signed i32 range', () => {
+    const index = 216 ** 4 - 1
+    const packedIndex = Math.floor(index / 32)
+    const bitpacked: number[] = []
+    bitpacked[packedIndex] = 1 << (index & 31)
+
+    expect(isSetSolutionValid(bitpacked, index)).toBe(true)
+  })
 })
 
 describe('computeValidPermutationCount', () => {

--- a/src/lib/optimization/relicSetSolver.ts
+++ b/src/lib/optimization/relicSetSolver.ts
@@ -367,26 +367,6 @@ export function enumerateValidQuadsD4(
   return out
 }
 
-export function bitpackBooleanArray(arr: number[]) {
-  const paddedLength = Math.ceil(arr.length / 32) * 32
-  const result: number[] = []
-  for (let i = 0; i < paddedLength; i += 32) {
-    let packedValue = 0
-    for (let j = 0; j < 32; j++) {
-      const val = i + j < arr.length ? arr[i + j] : 0
-      packedValue |= val << j
-    }
-    result.push(packedValue >>> 0)
-  }
-  return result
-}
-
-export function isSetSolutionValid(bitpackedArray: number[], index: number): boolean {
-  const packedIndex = index >>> 5
-  const bitIndex = index & 31
-  return ((bitpackedArray[packedIndex] >> bitIndex) & 1) === 1
-}
-
 const permutator = (inputArr: number[]) => {
   const result: number[][] = []
 

--- a/src/lib/optimization/relicSetSolver.ts
+++ b/src/lib/optimization/relicSetSolver.ts
@@ -382,7 +382,7 @@ export function bitpackBooleanArray(arr: number[]) {
 }
 
 export function isSetSolutionValid(bitpackedArray: number[], index: number): boolean {
-  const packedIndex = index >> 5
+  const packedIndex = index >>> 5
   const bitIndex = index & 31
   return ((bitpackedArray[packedIndex] >> bitIndex) & 1) === 1
 }

--- a/src/lib/optimization/setMatchState.test.ts
+++ b/src/lib/optimization/setMatchState.test.ts
@@ -1,14 +1,12 @@
 import { type SetKey } from 'lib/constants/constants'
 import {
-  computeSetMatches,
-  computeSetMatchesInPlace,
-} from 'lib/optimization/calculateStats'
-import {
   ornament2p,
   relic2p,
   relic4p,
 } from 'lib/optimization/setMatching'
 import {
+  computeSetMatches,
+  computeSetMatchesInPlace,
   emptySetMatches,
   NO_SET,
   type MutableSetMatches,

--- a/src/lib/optimization/setMatchState.ts
+++ b/src/lib/optimization/setMatchState.ts
@@ -6,10 +6,8 @@
 // imports every set config, which imports basicStatsArray back - a cycle that leaves
 // WgslStatName undefined at module evaluation time.
 
-// Sentinel meaning "no set matched this slot". Set indices are contiguous registry
-// indices starting at 0 (enforced by assertValidSetConfigList in setConfigRegistry.ts),
-// so a negative value can never collide with a real set. The GPU mirror in
-// lib/gpu/wgsl/structs.wgsl uses 0xFFFFFFFFu, since its fields are u32.
+// Sentinel meaning "no set matched this slot". Registry indices start at 0, so a
+// negative value cannot collide with a real set.
 export const NO_SET = -1
 
 // Explicit match representation for the relic/ornament sets equipped on a build.
@@ -17,9 +15,8 @@ export const NO_SET = -1
 // most one 4-piece set (relic4pSet, which is always equal to relic2pSetA when set).
 // Two ornament slots admit at most one 2-piece set.
 //
-// Every field is either a real set index or NO_SET, so the fields are self-describing
-// and carry no stale values between computations. Read them through the
-// relic2p/relic4p/ornament2p accessors in setMatching.ts.
+// Set-definition code uses the key-based accessors in setMatching.ts. Stat dispatch
+// reads these indices directly after checking NO_SET.
 export type SetMatches = {
   readonly relic2pSetA: number, // NO_SET when unmatched
   readonly relic2pSetB: number, // NO_SET when unmatched
@@ -36,4 +33,61 @@ export function emptySetMatches(): MutableSetMatches {
     relic4pSet: NO_SET,
     ornament2pSet: NO_SET,
   }
+}
+
+export function computeSetMatchesInPlace(
+  target: MutableSetMatches,
+  sets: readonly number[],
+): void {
+  const headSet = sets[0]
+  const handsSet = sets[1]
+  const bodySet = sets[2]
+  const feetSet = sets[3]
+  const planarSet = sets[4]
+  const ropeSet = sets[5]
+
+  if (headSet === handsSet && handsSet === bodySet && bodySet === feetSet) {
+    target.relic2pSetA = headSet
+    target.relic2pSetB = NO_SET
+    target.relic4pSet = headSet
+  } else {
+    target.relic4pSet = NO_SET
+    target.relic2pSetA = NO_SET
+    target.relic2pSetB = NO_SET
+
+    const headRepeats = headSet === handsSet || headSet === bodySet || headSet === feetSet
+    const handsRepeats = handsSet === bodySet || handsSet === feetSet
+    const bodyRepeats = bodySet === feetSet
+    const handsSeenEarlier = handsSet === headSet
+    const bodySeenEarlier = bodySet === headSet || bodySet === handsSet
+
+    // Four relic slots can contain at most two distinct 2-piece matches.
+    if (headRepeats) {
+      target.relic2pSetA = headSet
+    }
+
+    if (handsRepeats && !handsSeenEarlier) {
+      if (target.relic2pSetA === NO_SET) {
+        target.relic2pSetA = handsSet
+      } else {
+        target.relic2pSetB = handsSet
+      }
+    }
+
+    if (bodyRepeats && !bodySeenEarlier) {
+      if (target.relic2pSetA === NO_SET) {
+        target.relic2pSetA = bodySet
+      } else {
+        target.relic2pSetB = bodySet
+      }
+    }
+  }
+
+  target.ornament2pSet = planarSet === ropeSet ? planarSet : NO_SET
+}
+
+export function computeSetMatches(sets: readonly number[]): SetMatches {
+  const target = emptySetMatches()
+  computeSetMatchesInPlace(target, sets)
+  return target
 }

--- a/src/lib/optimization/setMatchState.ts
+++ b/src/lib/optimization/setMatchState.ts
@@ -1,0 +1,39 @@
+// Leaf module: the SetMatches data shape, with no imports.
+//
+// This is deliberately separate from setMatching.ts, which resolves SetKeys through
+// setConfigRegistry. basicStatsArray.ts holds a SetMatches and must be able to construct
+// an empty one; importing setMatching.ts there would pull in setConfigRegistry, which
+// imports every set config, which imports basicStatsArray back - a cycle that leaves
+// WgslStatName undefined at module evaluation time.
+
+// Sentinel meaning "no set matched this slot". Set indices are contiguous registry
+// indices starting at 0 (enforced by assertValidSetConfigList in setConfigRegistry.ts),
+// so a negative value can never collide with a real set. The GPU mirror in
+// lib/gpu/wgsl/structs.wgsl uses 0xFFFFFFFFu, since its fields are u32.
+export const NO_SET = -1
+
+// Explicit match representation for the relic/ornament sets equipped on a build.
+// Four relic slots admit at most two distinct 2-piece sets (relic2pSetA/B) and at
+// most one 4-piece set (relic4pSet, which is always equal to relic2pSetA when set).
+// Two ornament slots admit at most one 2-piece set.
+//
+// Every field is either a real set index or NO_SET, so the fields are self-describing
+// and carry no stale values between computations. Read them through the
+// relic2p/relic4p/ornament2p accessors in setMatching.ts.
+export type SetMatches = {
+  readonly relic2pSetA: number, // NO_SET when unmatched
+  readonly relic2pSetB: number, // NO_SET when unmatched
+  readonly relic4pSet: number, // NO_SET when no 4-piece set; otherwise equals relic2pSetA
+  readonly ornament2pSet: number, // NO_SET when unmatched
+}
+
+export type MutableSetMatches = { -readonly [K in keyof SetMatches]: SetMatches[K] }
+
+export function emptySetMatches(): MutableSetMatches {
+  return {
+    relic2pSetA: NO_SET,
+    relic2pSetB: NO_SET,
+    relic4pSet: NO_SET,
+    ornament2pSet: NO_SET,
+  }
+}

--- a/src/lib/optimization/setMatching.test.ts
+++ b/src/lib/optimization/setMatching.test.ts
@@ -1,0 +1,92 @@
+import { type SetKey } from 'lib/constants/constants'
+import {
+  ornament2p,
+  relic2p,
+  relic4p,
+} from 'lib/optimization/setMatching'
+import {
+  emptySetMatches,
+  type SetMatches,
+} from 'lib/optimization/setMatchState'
+import {
+  OrnamentSetKeyToIndex,
+  RelicSetKeyToIndex,
+} from 'lib/sets/setConfigRegistry'
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest'
+
+// Real setKeys whose registry index is known and stable: RelicSetKeyToIndex/OrnamentSetKeyToIndex
+// preserve insertion order matching the sorted (by info.index) config arrays, so the setKey at
+// position i in Object.keys(...) always has index i.
+const relicKeys = Object.keys(RelicSetKeyToIndex) as SetKey[]
+const ornamentKeys = Object.keys(OrnamentSetKeyToIndex) as SetKey[]
+
+const relicKeyAt = (index: number) => relicKeys[index]
+const ornamentKeyAt = (index: number) => ornamentKeys[index]
+
+function withMatches(overrides: Partial<SetMatches>): SetMatches {
+  return { ...emptySetMatches(), ...overrides }
+}
+
+describe('relic2p', () => {
+  it('returns false for every set when both slots are NO_SET', () => {
+    const matches = emptySetMatches()
+    expect(relic2p(relicKeyAt(0), matches)).toBe(false)
+    expect(relic2p(relicKeyAt(1), matches)).toBe(false)
+  })
+
+  it('matches setA when only setA is populated', () => {
+    const matches = withMatches({ relic2pSetA: 2 })
+    expect(relic2p(relicKeyAt(2), matches)).toBe(true)
+    expect(relic2p(relicKeyAt(3), matches)).toBe(false)
+  })
+
+  it('matches both setA and setB when both slots are populated', () => {
+    const matches = withMatches({ relic2pSetA: 2, relic2pSetB: 3 })
+    expect(relic2p(relicKeyAt(2), matches)).toBe(true)
+    expect(relic2p(relicKeyAt(3), matches)).toBe(true)
+    expect(relic2p(relicKeyAt(4), matches)).toBe(false)
+  })
+})
+
+describe('relic4p', () => {
+  it('returns false when relic4pSet is NO_SET, even if setA equals the queried index', () => {
+    const matches = withMatches({ relic2pSetA: 0 })
+    expect(relic4p(relicKeyAt(0), matches)).toBe(false)
+  })
+
+  it('returns true only for the set held in relic4pSet', () => {
+    const matches = withMatches({ relic2pSetA: 5, relic4pSet: 5 })
+    expect(relic4p(relicKeyAt(5), matches)).toBe(true)
+    expect(relic4p(relicKeyAt(6), matches)).toBe(false)
+  })
+})
+
+describe('ornament2p', () => {
+  it('returns false when ornament2pSet is NO_SET', () => {
+    const matches = emptySetMatches()
+    expect(ornament2p(ornamentKeyAt(1), matches)).toBe(false)
+  })
+
+  it('matches the set held in ornament2pSet', () => {
+    const matches = withMatches({ ornament2pSet: 1 })
+    expect(ornament2p(ornamentKeyAt(1), matches)).toBe(true)
+    expect(ornament2p(ornamentKeyAt(0), matches)).toBe(false)
+  })
+})
+
+describe('capacity: no aliasing between raw index 0 and a hypothetical raw index 32', () => {
+  // The bitmask this replaces stored membership as `1 << setIndex`. Since JS shifts are mod-32,
+  // `1 << 32 === 1 << 0 === 1`, so a 33rd relic set (index 32) would have silently matched index 0.
+  // SetMatches stores raw indices instead of bit positions, so no such aliasing is possible.
+  it('a real setKey at index 0 never matches a match state describing a hypothetical set at raw index 32', () => {
+    const matches = withMatches({ relic2pSetA: 32, relic4pSet: 32, ornament2pSet: 32 })
+
+    expect(relic4p(relicKeyAt(0), matches)).toBe(false)
+    expect(relic2p(relicKeyAt(0), matches)).toBe(false)
+    expect(ornament2p(ornamentKeyAt(0), matches)).toBe(false)
+  })
+})

--- a/src/lib/optimization/setMatching.ts
+++ b/src/lib/optimization/setMatching.ts
@@ -2,6 +2,7 @@ import {
   type SetKey,
   Sets,
 } from 'lib/constants/constants'
+import { type SetMatches } from 'lib/optimization/setMatchState'
 import {
   OrnamentSetKeyToIndex,
   RelicSetKeyToIndex,
@@ -12,16 +13,15 @@ export const SetKeys: Record<SetKey, SetKey> = Object.fromEntries(
   Object.keys(Sets).map((key) => [key, key]),
 ) as Record<SetKey, SetKey>
 
-export type SetCounts = {
-  relicMatch2: number,
-  relicMatch4: number,
-  ornamentMatch2: number,
+export function relic2p(key: SetKey, matches: SetMatches): boolean {
+  const index = RelicSetKeyToIndex[key]
+  return matches.relic2pSetA === index || matches.relic2pSetB === index
 }
 
-export function ornament2p(key: SetKey, sets: SetCounts) {
-  return (sets.ornamentMatch2 >> OrnamentSetKeyToIndex[key]) & 1
+export function relic4p(key: SetKey, matches: SetMatches): boolean {
+  return matches.relic4pSet === RelicSetKeyToIndex[key]
 }
 
-export function relic4p(key: SetKey, sets: SetCounts) {
-  return (sets.relicMatch4 >> RelicSetKeyToIndex[key]) & 1
+export function ornament2p(key: SetKey, matches: SetMatches): boolean {
+  return matches.ornament2pSet === OrnamentSetKeyToIndex[key]
 }

--- a/src/lib/optimization/setSolutionBitset.test.ts
+++ b/src/lib/optimization/setSolutionBitset.test.ts
@@ -1,0 +1,45 @@
+import {
+  bitpackBooleanArray,
+  isSetSolutionValid,
+} from 'lib/optimization/setSolutionBitset'
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest'
+
+describe('isSetSolutionValid', () => {
+  it('returns the value stored at an index', () => {
+    const bitpacked = bitpackBooleanArray([1, 0, 1, 0])
+
+    expect(isSetSolutionValid(bitpacked, 0)).toBe(true)
+    expect(isSetSolutionValid(bitpacked, 1)).toBe(false)
+    expect(isSetSolutionValid(bitpacked, 2)).toBe(true)
+    expect(isSetSolutionValid(bitpacked, 3)).toBe(false)
+  })
+
+  it('handles indices across multiple packed words', () => {
+    const values = Array.from({ length: 64 }, () => 0)
+    values[0] = 1
+    values[31] = 1
+    values[32] = 1
+    values[63] = 1
+    const bitpacked = bitpackBooleanArray(values)
+
+    expect(isSetSolutionValid(bitpacked, 0)).toBe(true)
+    expect(isSetSolutionValid(bitpacked, 31)).toBe(true)
+    expect(isSetSolutionValid(bitpacked, 32)).toBe(true)
+    expect(isSetSolutionValid(bitpacked, 63)).toBe(true)
+    expect(isSetSolutionValid(bitpacked, 15)).toBe(false)
+    expect(isSetSolutionValid(bitpacked, 47)).toBe(false)
+  })
+
+  it('handles indices above the signed i32 range', () => {
+    const index = 216 ** 4 - 1
+    const packedIndex = Math.floor(index / 32)
+    const bitpacked: number[] = []
+    bitpacked[packedIndex] = 1 << (index & 31)
+
+    expect(isSetSolutionValid(bitpacked, index)).toBe(true)
+  })
+})

--- a/src/lib/optimization/setSolutionBitset.ts
+++ b/src/lib/optimization/setSolutionBitset.ts
@@ -1,0 +1,25 @@
+const BITS_PER_WORD = 32
+const WORD_SHIFT = 5
+const BIT_INDEX_MASK = BITS_PER_WORD - 1
+
+export function bitpackBooleanArray(values: readonly number[]): number[] {
+  const paddedLength = Math.ceil(values.length / BITS_PER_WORD) * BITS_PER_WORD
+  const result: number[] = []
+
+  for (let i = 0; i < paddedLength; i += BITS_PER_WORD) {
+    let packedValue = 0
+    for (let j = 0; j < BITS_PER_WORD; j++) {
+      const value = i + j < values.length ? values[i + j] : 0
+      packedValue |= value << j
+    }
+    result.push(packedValue >>> 0)
+  }
+
+  return result
+}
+
+export function isSetSolutionValid(bitpackedArray: readonly number[], index: number): boolean {
+  const packedIndex = index >>> WORD_SHIFT
+  const bitIndex = index & BIT_INDEX_MASK
+  return ((bitpackedArray[packedIndex] >> bitIndex) & 1) === 1
+}

--- a/src/lib/scoring/simScoringUtils.ts
+++ b/src/lib/scoring/simScoringUtils.ts
@@ -423,7 +423,7 @@ function collectPenaltyRecords(
     }
   }
 
-  if (user && configType !== ScoringConfigType.DPS && ornament2p(SetKeys.BrokenKeel, x.c.sets)) {
+  if (user && configType !== ScoringConfigType.DPS && ornament2p(SetKeys.BrokenKeel, x.c.setMatches)) {
     if (x.getSelfValue(StatKey.RES) < 0.30) {
       records.push({ stat: Stats.RES, multiplier: 0 })
     }

--- a/src/lib/sets/ornaments/AmphoreusTheEternalLand.ts
+++ b/src/lib/sets/ornaments/AmphoreusTheEternalLand.ts
@@ -57,7 +57,7 @@ const conditionals: SetConditionals = {
   ],
   gpu: (action: OptimizerAction, context: OptimizerContext) => `
     if (
-      ornament2p(*p_sets, SET_AmphoreusTheEternalLand) >= 1
+      ornament2p(*p_sets, SET_AmphoreusTheEternalLand)
       && setConditionals.enabledAmphoreusTheEternalLand == true
       && ${action.config.hasMemosprite}
       && ${wgslFalse(action.config.teammateSetEffects[Sets.AmphoreusTheEternalLand])}

--- a/src/lib/sets/ornaments/ArcadiaOfWovenDreams.ts
+++ b/src/lib/sets/ornaments/ArcadiaOfWovenDreams.ts
@@ -49,7 +49,7 @@ const conditionals: SetConditionals = {
     )
   },
   gpu: (action: OptimizerAction, context: OptimizerContext) => `
-    if (ornament2p(*p_sets, SET_ArcadiaOfWovenDreams) >= 1) {
+    if (ornament2p(*p_sets, SET_ArcadiaOfWovenDreams)) {
       let arcadiaBuffValue = getArcadiaOfWovenDreamsValue(setConditionals.valueArcadiaOfWovenDreams);
       ${buff.action(AKey.BOOST, 'arcadiaBuffValue').targets(TargetTag.SelfAndMemosprite).wgsl(action, 2)}
     }

--- a/src/lib/sets/ornaments/BelobogOfTheArchitects.ts
+++ b/src/lib/sets/ornaments/BelobogOfTheArchitects.ts
@@ -57,7 +57,7 @@ const BelobogOfTheArchitectsConditional: DynamicConditional = {
   dependsOn: [Stats.EHR],
   chainsTo: [Stats.DEF],
   condition: function(x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) {
-    return ornament2p(SetKeys.BelobogOfTheArchitects, x.c.sets) && x.getActionValueByIndex(StatKey.EHR, SELF_ENTITY_INDEX) >= 0.50
+    return ornament2p(SetKeys.BelobogOfTheArchitects, x.c.setMatches) && x.getActionValueByIndex(StatKey.EHR, SELF_ENTITY_INDEX) >= 0.50
   },
   effect: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
     const baseDef = action.config.selfEntity.baseDef
@@ -72,7 +72,7 @@ const BelobogOfTheArchitectsConditional: DynamicConditional = {
       context,
       `
 if (
-  ornament2p(*p_sets, SET_BelobogOfTheArchitects) >= 1 &&
+  ornament2p(*p_sets, SET_BelobogOfTheArchitects) &&
   (*p_state).BelobogOfTheArchitectsConditional${action.actionIdentifier} == 0.0 &&
   ${containerActionVal(SELF_ENTITY_INDEX, StatKey.EHR, config)} >= 0.50
 ) {

--- a/src/lib/sets/ornaments/BoneCollectionsSereneDemesne.ts
+++ b/src/lib/sets/ornaments/BoneCollectionsSereneDemesne.ts
@@ -58,7 +58,7 @@ const BoneCollectionsSereneDemesneConditional: DynamicConditional = {
   dependsOn: [Stats.HP],
   chainsTo: [Stats.CD],
   condition: function(x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) {
-    return ornament2p(SetKeys.BoneCollectionsSereneDemesne, x.c.sets) && x.getActionValueByIndex(StatKey.HP, SELF_ENTITY_INDEX) >= 5000
+    return ornament2p(SetKeys.BoneCollectionsSereneDemesne, x.c.setMatches) && x.getActionValueByIndex(StatKey.HP, SELF_ENTITY_INDEX) >= 5000
   },
   effect: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
     x.buffDynamic(StatKey.CD, 0.28, action, context, x.targets(TargetTag.SelfAndMemosprite).source(Source.BoneCollectionsSereneDemesne))
@@ -72,7 +72,7 @@ const BoneCollectionsSereneDemesneConditional: DynamicConditional = {
       context,
       `
 if (
-  ornament2p(*p_sets, SET_BoneCollectionsSereneDemesne) >= 1 &&
+  ornament2p(*p_sets, SET_BoneCollectionsSereneDemesne) &&
   (*p_state).BoneCollectionsSereneDemesneConditional${action.actionIdentifier} == 0.0 &&
   ${containerActionVal(SELF_ENTITY_INDEX, StatKey.HP, config)} >= 5000.0
 ) {

--- a/src/lib/sets/ornaments/BrokenKeel.ts
+++ b/src/lib/sets/ornaments/BrokenKeel.ts
@@ -61,7 +61,7 @@ const BrokenKeelConditional: DynamicConditional = {
   dependsOn: [Stats.RES],
   chainsTo: [Stats.CD],
   condition: function(x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) {
-    return ornament2p(SetKeys.BrokenKeel, x.c.sets) && x.getActionValueByIndex(StatKey.RES, SELF_ENTITY_INDEX) >= 0.30
+    return ornament2p(SetKeys.BrokenKeel, x.c.setMatches) && x.getActionValueByIndex(StatKey.RES, SELF_ENTITY_INDEX) >= 0.30
   },
   effect: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
     x.buffDynamic(StatKey.CD, 0.10, action, context, x.targets(TargetTag.FullTeam).source(Source.BrokenKeel))
@@ -76,7 +76,7 @@ const BrokenKeelConditional: DynamicConditional = {
       context,
       `
 if (
-  ornament2p(*p_sets, SET_BrokenKeel) >= 1 &&
+  ornament2p(*p_sets, SET_BrokenKeel) &&
   (*p_state).BrokenKeelConditional${action.actionIdentifier} == 0.0 &&
   ${containerActionVal(SELF_ENTITY_INDEX, StatKey.RES, config)} >= 0.30
 ) {

--- a/src/lib/sets/ornaments/CelestialDifferentiator.ts
+++ b/src/lib/sets/ornaments/CelestialDifferentiator.ts
@@ -56,7 +56,7 @@ const conditionals: SetConditionals = {
   ],
   gpu: (action: OptimizerAction, context: OptimizerContext) => `
     if (
-      ornament2p(*p_sets, SET_CelestialDifferentiator) >= 1
+      ornament2p(*p_sets, SET_CelestialDifferentiator)
       && setConditionals.enabledCelestialDifferentiator == true
       && (*p_c).CD >= 1.20
     ) {

--- a/src/lib/sets/ornaments/CityOfConvergingStars.ts
+++ b/src/lib/sets/ornaments/CityOfConvergingStars.ts
@@ -64,7 +64,7 @@ const conditionals: SetConditionals = {
     },
   }],
   gpu: (action: OptimizerAction, context: OptimizerContext) => `
-    if (ornament2p(*p_sets, SET_CityOfConvergingStars) >= 1) {
+    if (ornament2p(*p_sets, SET_CityOfConvergingStars)) {
       if (setConditionals.valueCityOfConvergingStars == 1 || setConditionals.valueCityOfConvergingStars == 3) {
         ${buff.action(AKey.ATK_P, 0.24).wgsl(action, 2)}
       }

--- a/src/lib/sets/ornaments/CosmicLifeSciencesInstitute.ts
+++ b/src/lib/sets/ornaments/CosmicLifeSciencesInstitute.ts
@@ -39,7 +39,7 @@ const conditionals: SetConditionals = {
     x.buff(StatKey.BOOST, calculateDmgBoost(context), x.source(Source.CosmicLifeSciencesInstitute))
   },
   gpu: (action: OptimizerAction, context: OptimizerContext) => `
-    if (ornament2p(*p_sets, SET_CosmicLifeSciencesInstitute) >= 1) {
+    if (ornament2p(*p_sets, SET_CosmicLifeSciencesInstitute)) {
       ${buff.action(AKey.BOOST, calculateDmgBoost(context)).wgsl(action, 2)}
     }
   `,

--- a/src/lib/sets/ornaments/DuranDynastyOfRunningWolves.ts
+++ b/src/lib/sets/ornaments/DuranDynastyOfRunningWolves.ts
@@ -50,7 +50,7 @@ const conditionals: SetConditionals = {
     }
   },
   gpu: (action: OptimizerAction, context: OptimizerContext) => `
-    if (ornament2p(*p_sets, SET_DuranDynastyOfRunningWolves) >= 1) {
+    if (ornament2p(*p_sets, SET_DuranDynastyOfRunningWolves)) {
       ${buff.hit(HKey.BOOST, `0.05 * f32(setConditionals.valueDuranDynastyOfRunningWolves)`).damageType(DamageTag.FUA).wgsl(action, 2)}
       if (setConditionals.valueDuranDynastyOfRunningWolves >= 5) {
         ${buff.action(AKey.CD, 0.25).wgsl(action, 3)}

--- a/src/lib/sets/ornaments/FallenStarAnchorage.ts
+++ b/src/lib/sets/ornaments/FallenStarAnchorage.ts
@@ -55,7 +55,7 @@ const conditionals: SetConditionals = {
   ],
   gpu: (action: OptimizerAction, context: OptimizerContext) => `
     if (
-      ornament2p(*p_sets, SET_FallenStarAnchorage) >= 1
+      ornament2p(*p_sets, SET_FallenStarAnchorage)
       && setConditionals.enabledFallenStarAnchorage == true
     ) {
       ${buff.action(AKey.CD, 0.32).wgsl(action, 2)}

--- a/src/lib/sets/ornaments/FirmamentFrontlineGlamoth.ts
+++ b/src/lib/sets/ornaments/FirmamentFrontlineGlamoth.ts
@@ -56,7 +56,7 @@ const conditionals: SetConditionals = {
   ],
   gpuTerminal: (action: OptimizerAction, context: OptimizerContext) => `
   if (
-    ornament2p(*p_sets, SET_FirmamentFrontlineGlamoth) >= 1
+    ornament2p(*p_sets, SET_FirmamentFrontlineGlamoth)
     && ${containerActionVal(SELF_ENTITY_INDEX, AKey.SPD, action.config)} >= 135.0
   ) {
     ${buff.action(AKey.BOOST, `select(0.12, 0.18, ${containerActionVal(SELF_ENTITY_INDEX, AKey.SPD, action.config)} >= 160.0)`).wgsl(action, 2)}

--- a/src/lib/sets/ornaments/FleetOfTheAgeless.ts
+++ b/src/lib/sets/ornaments/FleetOfTheAgeless.ts
@@ -61,7 +61,7 @@ const FleetOfTheAgelessConditional: DynamicConditional = {
   dependsOn: [Stats.SPD],
   chainsTo: [Stats.ATK],
   condition: function(x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) {
-    return ornament2p(SetKeys.FleetOfTheAgeless, x.c.sets) && x.getActionValueByIndex(StatKey.SPD, SELF_ENTITY_INDEX) >= 120
+    return ornament2p(SetKeys.FleetOfTheAgeless, x.c.setMatches) && x.getActionValueByIndex(StatKey.SPD, SELF_ENTITY_INDEX) >= 120
   },
   effect: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
     const baseAtk = action.config.selfEntity.baseAtk
@@ -77,7 +77,7 @@ const FleetOfTheAgelessConditional: DynamicConditional = {
       context,
       `
 if (
-  ornament2p(*p_sets, SET_FleetOfTheAgeless) >= 1 &&
+  ornament2p(*p_sets, SET_FleetOfTheAgeless) &&
   (*p_state).FleetOfTheAgelessConditional${action.actionIdentifier} == 0.0 &&
   ${containerActionVal(SELF_ENTITY_INDEX, StatKey.SPD, config)} >= 120.0
 ) {

--- a/src/lib/sets/ornaments/ForgeOfTheKalpagniLantern.ts
+++ b/src/lib/sets/ornaments/ForgeOfTheKalpagniLantern.ts
@@ -55,7 +55,7 @@ const conditionals: SetConditionals = {
   ],
   gpu: (action: OptimizerAction, context: OptimizerContext) => `
     if (
-      ornament2p(*p_sets, SET_ForgeOfTheKalpagniLantern) >= 1
+      ornament2p(*p_sets, SET_ForgeOfTheKalpagniLantern)
       && setConditionals.enabledForgeOfTheKalpagniLantern == true
     ) {
       ${buff.action(AKey.BE, 0.40).wgsl(action, 2)}

--- a/src/lib/sets/ornaments/GiantTreeOfRaptBrooding.ts
+++ b/src/lib/sets/ornaments/GiantTreeOfRaptBrooding.ts
@@ -58,7 +58,7 @@ const GiantTreeOfRaptBrooding135Conditional: DynamicConditional = {
   dependsOn: [Stats.SPD],
   chainsTo: [Stats.OHB],
   condition: function(x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) {
-    return ornament2p(SetKeys.GiantTreeOfRaptBrooding, x.c.sets) && x.getActionValueByIndex(StatKey.SPD, SELF_ENTITY_INDEX) >= 135
+    return ornament2p(SetKeys.GiantTreeOfRaptBrooding, x.c.setMatches) && x.getActionValueByIndex(StatKey.SPD, SELF_ENTITY_INDEX) >= 135
   },
   effect: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
     x.buffDynamic(StatKey.OHB, 0.12, action, context, x.targets(TargetTag.SelfAndMemosprite).source(Source.GiantTreeOfRaptBrooding))
@@ -72,7 +72,7 @@ const GiantTreeOfRaptBrooding135Conditional: DynamicConditional = {
       context,
       `
 if (
-  ornament2p(*p_sets, SET_GiantTreeOfRaptBrooding) >= 1 &&
+  ornament2p(*p_sets, SET_GiantTreeOfRaptBrooding) &&
   (*p_state).GiantTreeOfRaptBrooding135Conditional${action.actionIdentifier} == 0.0 &&
   ${containerActionVal(SELF_ENTITY_INDEX, StatKey.SPD, config)} >= 135.0
 ) {
@@ -91,7 +91,7 @@ const GiantTreeOfRaptBrooding180Conditional: DynamicConditional = {
   dependsOn: [Stats.SPD],
   chainsTo: [Stats.OHB],
   condition: function(x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) {
-    return ornament2p(SetKeys.GiantTreeOfRaptBrooding, x.c.sets) && x.getActionValueByIndex(StatKey.SPD, SELF_ENTITY_INDEX) >= 180
+    return ornament2p(SetKeys.GiantTreeOfRaptBrooding, x.c.setMatches) && x.getActionValueByIndex(StatKey.SPD, SELF_ENTITY_INDEX) >= 180
   },
   effect: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
     x.buffDynamic(StatKey.OHB, 0.08, action, context, x.targets(TargetTag.SelfAndMemosprite).source(Source.GiantTreeOfRaptBrooding))
@@ -105,7 +105,7 @@ const GiantTreeOfRaptBrooding180Conditional: DynamicConditional = {
       context,
       `
 if (
-  ornament2p(*p_sets, SET_GiantTreeOfRaptBrooding) >= 1 &&
+  ornament2p(*p_sets, SET_GiantTreeOfRaptBrooding) &&
   (*p_state).GiantTreeOfRaptBrooding180Conditional${action.actionIdentifier} == 0.0 &&
   ${containerActionVal(SELF_ENTITY_INDEX, StatKey.SPD, config)} >= 180.0
 ) {

--- a/src/lib/sets/ornaments/InertSalsotto.ts
+++ b/src/lib/sets/ornaments/InertSalsotto.ts
@@ -59,7 +59,7 @@ const conditionals: SetConditionals = {
   ],
   gpuTerminal: (action: OptimizerAction, context: OptimizerContext) => `
   if (
-    ornament2p(*p_sets, SET_InertSalsotto) >= 1
+    ornament2p(*p_sets, SET_InertSalsotto)
     && ${containerActionVal(SELF_ENTITY_INDEX, AKey.CR, action.config)} >= 0.50
   ) {
     ${buff.hit(HKey.BOOST, 0.15).damageType(DamageTag.ULT | DamageTag.FUA).wgsl(action, 2)}

--- a/src/lib/sets/ornaments/IzumoGenseiAndTakamaDivineRealm.ts
+++ b/src/lib/sets/ornaments/IzumoGenseiAndTakamaDivineRealm.ts
@@ -59,7 +59,7 @@ const conditionals: SetConditionals = {
   ],
   gpu: (action: OptimizerAction, context: OptimizerContext) => `
     if (
-      ornament2p(*p_sets, SET_IzumoGenseiAndTakamaDivineRealm) >= 1
+      ornament2p(*p_sets, SET_IzumoGenseiAndTakamaDivineRealm)
       && setConditionals.enabledIzumoGenseiAndTakamaDivineRealm == true
     ) {
       ${buff.action(AKey.CR, 0.12).wgsl(action, 2)}

--- a/src/lib/sets/ornaments/PanCosmicCommercialEnterprise.ts
+++ b/src/lib/sets/ornaments/PanCosmicCommercialEnterprise.ts
@@ -58,7 +58,7 @@ const PanCosmicCommercialEnterpriseConditional: DynamicConditional = {
   dependsOn: [Stats.EHR],
   chainsTo: [Stats.ATK],
   condition: function(x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) {
-    return ornament2p(SetKeys.PanCosmicCommercialEnterprise, x.c.sets)
+    return ornament2p(SetKeys.PanCosmicCommercialEnterprise, x.c.setMatches)
   },
   effect: function(x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) {
     const stateValue = action.conditionalState[this.id] || 0
@@ -80,7 +80,7 @@ const PanCosmicCommercialEnterpriseConditional: DynamicConditional = {
       context,
       `
 if (
-  ornament2p(*p_sets, SET_PanCosmicCommercialEnterprise) >= 1
+  ornament2p(*p_sets, SET_PanCosmicCommercialEnterprise)
 ) {
   let stateValue: f32 = (*p_state).PanCosmicCommercialEnterpriseConditional${action.actionIdentifier};
   let buffValue: f32 = min(0.25, 0.25 * ${containerActionVal(SELF_ENTITY_INDEX, StatKey.EHR, config)}) * ${config.selfEntity.baseAtk};

--- a/src/lib/sets/ornaments/PenaconyLandOfTheDreams.ts
+++ b/src/lib/sets/ornaments/PenaconyLandOfTheDreams.ts
@@ -56,7 +56,7 @@ const conditionals: SetConditionals = {
   ],
   gpu: (action: OptimizerAction, context: OptimizerContext) => `
     if (
-      ornament2p(*p_sets, SET_PenaconyLandOfTheDreams) >= 1
+      ornament2p(*p_sets, SET_PenaconyLandOfTheDreams)
       && setConditionals.enabledPenaconyLandOfTheDreams == true
     ) {
       ${buff.action(AKey.BOOST, 0.10).targets(TargetTag.Memosprite).wgsl(action, 2)}

--- a/src/lib/sets/ornaments/PunklordeStageZero.ts
+++ b/src/lib/sets/ornaments/PunklordeStageZero.ts
@@ -57,7 +57,7 @@ const PunklordeStageZeroConditional40: DynamicConditional = {
   dependsOn: [Stats.Elation],
   chainsTo: [Stats.CD],
   condition: function(x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) {
-    return ornament2p(SetKeys.PunklordeStageZero, x.c.sets) && x.getActionValueByIndex(StatKey.ELATION, SELF_ENTITY_INDEX) >= 0.40
+    return ornament2p(SetKeys.PunklordeStageZero, x.c.setMatches) && x.getActionValueByIndex(StatKey.ELATION, SELF_ENTITY_INDEX) >= 0.40
   },
   effect: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
     x.buffDynamic(StatKey.CD, 0.20, action, context, x.source(Source.PunklordeStageZero))
@@ -71,7 +71,7 @@ const PunklordeStageZeroConditional40: DynamicConditional = {
       context,
       `
 if (
-  ornament2p(*p_sets, SET_PunklordeStageZero) >= 1 &&
+  ornament2p(*p_sets, SET_PunklordeStageZero) &&
   (*p_state).PunklordeStageZeroConditional40${action.actionIdentifier} == 0.0 &&
   ${containerActionVal(SELF_ENTITY_INDEX, StatKey.ELATION, config)} >= 0.40
 ) {
@@ -90,7 +90,7 @@ const PunklordeStageZeroConditional80: DynamicConditional = {
   dependsOn: [Stats.Elation],
   chainsTo: [Stats.CD],
   condition: function(x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) {
-    return ornament2p(SetKeys.PunklordeStageZero, x.c.sets) && x.getActionValueByIndex(StatKey.ELATION, SELF_ENTITY_INDEX) >= 0.80
+    return ornament2p(SetKeys.PunklordeStageZero, x.c.setMatches) && x.getActionValueByIndex(StatKey.ELATION, SELF_ENTITY_INDEX) >= 0.80
   },
   effect: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
     x.buffDynamic(StatKey.CD, 0.12, action, context, x.source(Source.PunklordeStageZero))
@@ -104,7 +104,7 @@ const PunklordeStageZeroConditional80: DynamicConditional = {
       context,
       `
 if (
-  ornament2p(*p_sets, SET_PunklordeStageZero) >= 1 &&
+  ornament2p(*p_sets, SET_PunklordeStageZero) &&
   (*p_state).PunklordeStageZeroConditional80${action.actionIdentifier} == 0.0 &&
   ${containerActionVal(SELF_ENTITY_INDEX, StatKey.ELATION, config)} >= 0.80
 ) {

--- a/src/lib/sets/ornaments/RevelryByTheSea.ts
+++ b/src/lib/sets/ornaments/RevelryByTheSea.ts
@@ -61,7 +61,7 @@ const conditionals: SetConditionals = {
     basicP2(WgslStatName.ATK_P, 0.12, RevelryByTheSea),
   ],
   gpuTerminal: (action: OptimizerAction, context: OptimizerContext) => `
-  if (ornament2p(*p_sets, SET_RevelryByTheSea) >= 1) {
+  if (ornament2p(*p_sets, SET_RevelryByTheSea)) {
     if (${containerActionVal(SELF_ENTITY_INDEX, AKey.ATK, action.config)} >= 3600.0) {
       ${buff.hit(HKey.BOOST, 0.24).damageType(DamageTag.DOT).wgsl(action, 3)}
     } else if (${containerActionVal(SELF_ENTITY_INDEX, AKey.ATK, action.config)} >= 2400.0) {

--- a/src/lib/sets/ornaments/RutilantArena.ts
+++ b/src/lib/sets/ornaments/RutilantArena.ts
@@ -59,7 +59,7 @@ const conditionals: SetConditionals = {
   ],
   gpuTerminal: (action: OptimizerAction, context: OptimizerContext) => `
   if (
-    ornament2p(*p_sets, SET_RutilantArena) >= 1
+    ornament2p(*p_sets, SET_RutilantArena)
     && ${containerActionVal(SELF_ENTITY_INDEX, AKey.CR, action.config)} >= 0.70
   ) {
     ${buff.hit(HKey.BOOST, 0.20).damageType(DamageTag.BASIC | DamageTag.SKILL).wgsl(action, 2)}

--- a/src/lib/sets/ornaments/SigoniaTheUnclaimedDesolation.ts
+++ b/src/lib/sets/ornaments/SigoniaTheUnclaimedDesolation.ts
@@ -55,7 +55,7 @@ const conditionals: SetConditionals = {
     basicP2(WgslStatName.CR, 0.04, SigoniaTheUnclaimedDesolation),
   ],
   gpu: (action: OptimizerAction, context: OptimizerContext) => `
-    if (ornament2p(*p_sets, SET_SigoniaTheUnclaimedDesolation) >= 1) {
+    if (ornament2p(*p_sets, SET_SigoniaTheUnclaimedDesolation)) {
       ${buff.action(AKey.CD, `0.04 * f32(setConditionals.valueSigoniaTheUnclaimedDesolation)`).wgsl(action, 2)}
     }
   `,

--- a/src/lib/sets/ornaments/SpaceSealingStation.ts
+++ b/src/lib/sets/ornaments/SpaceSealingStation.ts
@@ -57,7 +57,7 @@ const SpaceSealingStationConditional: DynamicConditional = {
   dependsOn: [Stats.SPD],
   chainsTo: [Stats.ATK],
   condition: function(x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) {
-    return ornament2p(SetKeys.SpaceSealingStation, x.c.sets) && x.getActionValueByIndex(StatKey.SPD, SELF_ENTITY_INDEX) >= 120
+    return ornament2p(SetKeys.SpaceSealingStation, x.c.setMatches) && x.getActionValueByIndex(StatKey.SPD, SELF_ENTITY_INDEX) >= 120
   },
   effect: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
     const baseAtk = action.config.selfEntity.baseAtk
@@ -72,7 +72,7 @@ const SpaceSealingStationConditional: DynamicConditional = {
       context,
       `
 if (
-  ornament2p(*p_sets, SET_SpaceSealingStation) >= 1 &&
+  ornament2p(*p_sets, SET_SpaceSealingStation) &&
   (*p_state).SpaceSealingStationConditional${action.actionIdentifier} == 0.0 &&
   ${containerActionVal(SELF_ENTITY_INDEX, StatKey.SPD, config)} >= 120.0
 ) {

--- a/src/lib/sets/ornaments/TaliaKingdomOfBanditry.ts
+++ b/src/lib/sets/ornaments/TaliaKingdomOfBanditry.ts
@@ -57,7 +57,7 @@ const TaliaKingdomOfBanditryConditional: DynamicConditional = {
   dependsOn: [Stats.SPD],
   chainsTo: [Stats.BE],
   condition: function(x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) {
-    return ornament2p(SetKeys.TaliaKingdomOfBanditry, x.c.sets) && x.getActionValueByIndex(StatKey.SPD, SELF_ENTITY_INDEX) >= 145
+    return ornament2p(SetKeys.TaliaKingdomOfBanditry, x.c.setMatches) && x.getActionValueByIndex(StatKey.SPD, SELF_ENTITY_INDEX) >= 145
   },
   effect: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
     x.buffDynamic(StatKey.BE, 0.20, action, context, x.source(Source.TaliaKingdomOfBanditry))
@@ -71,7 +71,7 @@ const TaliaKingdomOfBanditryConditional: DynamicConditional = {
       context,
       `
 if (
-  ornament2p(*p_sets, SET_TaliaKingdomOfBanditry) >= 1 &&
+  ornament2p(*p_sets, SET_TaliaKingdomOfBanditry) &&
   (*p_state).TaliaKingdomOfBanditryConditional${action.actionIdentifier} == 0.0 &&
   ${containerActionVal(SELF_ENTITY_INDEX, StatKey.SPD, config)} >= 145.0
 ) {

--- a/src/lib/sets/ornaments/TengokuLivestream.ts
+++ b/src/lib/sets/ornaments/TengokuLivestream.ts
@@ -55,7 +55,7 @@ const conditionals: SetConditionals = {
   ],
   gpu: (action: OptimizerAction, context: OptimizerContext) => `
     if (
-      ornament2p(*p_sets, SET_TengokuLivestream) >= 1
+      ornament2p(*p_sets, SET_TengokuLivestream)
       && setConditionals.enabledTengokuLivestream == true
     ) {
       ${buff.action(AKey.CD, 0.32).wgsl(action, 2)}

--- a/src/lib/sets/ornaments/TheWondrousBananAmusementPark.ts
+++ b/src/lib/sets/ornaments/TheWondrousBananAmusementPark.ts
@@ -55,7 +55,7 @@ const conditionals: SetConditionals = {
   ],
   gpu: (action: OptimizerAction, context: OptimizerContext) => `
     if (
-      ornament2p(*p_sets, SET_TheWondrousBananAmusementPark) >= 1
+      ornament2p(*p_sets, SET_TheWondrousBananAmusementPark)
       && setConditionals.enabledTheWondrousBananAmusementPark == true
     ) {
       ${buff.action(AKey.CD, 0.32).wgsl(action, 2)}

--- a/src/lib/sets/relics/AsNavigatorIseeSeesIt.ts
+++ b/src/lib/sets/relics/AsNavigatorIseeSeesIt.ts
@@ -55,7 +55,7 @@ const conditionals: SetConditionals = {
     basicP2(WgslStatName.ATK_P, 0.12, AsNavigatorIseeSeesIt),
   ],
   gpu: (action: OptimizerAction, context: OptimizerContext) => `
-    if (relic4p(*p_sets, SET_AsNavigatorIseeSeesIt) >= 1) {
+    if (relic4p(*p_sets, SET_AsNavigatorIseeSeesIt)) {
       ${buff.hit(HKey.BOOST, `0.18 * f32(setConditionals.valueAsNavigatorIseeSeesIt)`).damageType(DamageTag.SKILL | DamageTag.ULT).wgsl(action, 2)}
     }
   `,

--- a/src/lib/sets/relics/BandOfSizzlingThunder.ts
+++ b/src/lib/sets/relics/BandOfSizzlingThunder.ts
@@ -58,7 +58,7 @@ const conditionals: SetConditionals = {
   ],
   gpu: (action: OptimizerAction, context: OptimizerContext) => `
     if (
-      relic4p(*p_sets, SET_BandOfSizzlingThunder) >= 1
+      relic4p(*p_sets, SET_BandOfSizzlingThunder)
       && setConditionals.enabledBandOfSizzlingThunder == true
     ) {
       ${buff.action(AKey.ATK_P, 0.20).wgsl(action, 2)}

--- a/src/lib/sets/relics/ChampionOfStreetwiseBoxing.ts
+++ b/src/lib/sets/relics/ChampionOfStreetwiseBoxing.ts
@@ -58,7 +58,7 @@ const conditionals: SetConditionals = {
     basicP2(WgslStatName.PHYSICAL_DMG_BOOST, 0.10, ChampionOfStreetwiseBoxing),
   ],
   gpu: (action: OptimizerAction, context: OptimizerContext) => `
-    if (relic4p(*p_sets, SET_ChampionOfStreetwiseBoxing) >= 1) {
+    if (relic4p(*p_sets, SET_ChampionOfStreetwiseBoxing)) {
       ${buff.action(AKey.ATK_P, `0.05 * f32(setConditionals.valueChampionOfStreetwiseBoxing)`).wgsl(action, 2)}
     }
   `,

--- a/src/lib/sets/relics/DivineQueryingMasterSmith.ts
+++ b/src/lib/sets/relics/DivineQueryingMasterSmith.ts
@@ -61,7 +61,7 @@ const conditionals: SetConditionals = {
     basicP2(WgslStatName.HP_P, 0.12, DivineQueryingMasterSmith),
   ],
   gpu: (action: OptimizerAction, context: OptimizerContext) => `
-    if (relic4p(*p_sets, SET_DivineQueryingMasterSmith) >= 1) {
+    if (relic4p(*p_sets, SET_DivineQueryingMasterSmith)) {
       if (setConditionals.valueDivineQueryingMasterSmith >= 1) {
         ${buff.action(AKey.CD_BOOST, 0.28).wgsl(action, 2)}
       }

--- a/src/lib/sets/relics/DivinerOfDistantReach.ts
+++ b/src/lib/sets/relics/DivinerOfDistantReach.ts
@@ -60,7 +60,7 @@ const conditionals: SetConditionals = {
     basicP2(WgslStatName.SPD_P, 0.06, DivinerOfDistantReach),
   ],
   gpu: (action: OptimizerAction, context: OptimizerContext) => `
-    if (relic4p(*p_sets, SET_DivinerOfDistantReach) >= 1) {
+    if (relic4p(*p_sets, SET_DivinerOfDistantReach)) {
       let divinerCrValue = select(0.0, 0.10, (*p_c).SPD >= 120.0) + select(0.0, 0.08, (*p_c).SPD >= 160.0);
       ${buff.action(AKey.CR, 'divinerCrValue').wgsl(action, 2)}
       if (setConditionals.enabledDivinerOfDistantReach == true && ${wgslFalse(action.config.teammateSetEffects[Sets.DivinerOfDistantReach])}) {

--- a/src/lib/sets/relics/EverGloriousMagicalGirl.ts
+++ b/src/lib/sets/relics/EverGloriousMagicalGirl.ts
@@ -64,7 +64,7 @@ const conditionals: SetConditionals = {
     basicP2(WgslStatName.CD, 0.16, EverGloriousMagicalGirl),
   ],
   gpu: (action: OptimizerAction, context: OptimizerContext) => `
-    if (relic4p(*p_sets, SET_EverGloriousMagicalGirl) >= 1) {
+    if (relic4p(*p_sets, SET_EverGloriousMagicalGirl)) {
       ${
     buff.hit(HKey.DEF_PEN, `0.10 + 0.01 * f32(setConditionals.valueEverGloriousMagicalGirl)`).damageType(DamageTag.ELATION).targets(TargetTag.SelfAndMemosprite)
       .wgsl(action, 2)

--- a/src/lib/sets/relics/FiresmithOfLavaForging.ts
+++ b/src/lib/sets/relics/FiresmithOfLavaForging.ts
@@ -60,7 +60,7 @@ const conditionals: SetConditionals = {
     basicP2(WgslStatName.FIRE_DMG_BOOST, 0.10, FiresmithOfLavaForging),
   ],
   gpu: (action: OptimizerAction, context: OptimizerContext) => `
-    if (relic4p(*p_sets, SET_FiresmithOfLavaForging) >= 1) {
+    if (relic4p(*p_sets, SET_FiresmithOfLavaForging)) {
       ${buff.hit(HKey.BOOST, 0.12).damageType(DamageTag.SKILL).wgsl(action, 2)}
       if (setConditionals.enabledFiresmithOfLavaForging == true) {
         ${buff.action(AKey.FIRE_DMG_BOOST, 0.12).wgsl(action, 3)}

--- a/src/lib/sets/relics/GeniusOfBrilliantStars.ts
+++ b/src/lib/sets/relics/GeniusOfBrilliantStars.ts
@@ -55,7 +55,7 @@ const conditionals: SetConditionals = {
     basicP2(WgslStatName.QUANTUM_DMG_BOOST, 0.10, GeniusOfBrilliantStars),
   ],
   gpu: (action: OptimizerAction, context: OptimizerContext) => `
-    if (relic4p(*p_sets, SET_GeniusOfBrilliantStars) >= 1) {
+    if (relic4p(*p_sets, SET_GeniusOfBrilliantStars)) {
       ${buff.action(AKey.DEF_PEN, `select(0.10, 0.20, setConditionals.enabledGeniusOfBrilliantStars == true)`).wgsl(action, 2)}
     }
   `,

--- a/src/lib/sets/relics/GuardOfWutheringSnow.ts
+++ b/src/lib/sets/relics/GuardOfWutheringSnow.ts
@@ -42,7 +42,7 @@ const conditionals: SetConditionals = {
     x.multiplicativeComplement(StatKey.DMG_RED, 0.08, x.source(Source.GuardOfWutheringSnow))
   },
   gpu: (action: OptimizerAction, context: OptimizerContext) => `
-    if (relic2p(*p_sets, SET_GuardOfWutheringSnow) >= 1) {
+    if (relic2p(*p_sets, SET_GuardOfWutheringSnow)) {
       ${buff.actionMultiplicativeComplement(AKey.DMG_RED, 0.08).wgsl(action, 2)}
     }
   `,

--- a/src/lib/sets/relics/HeroOfTriumphantSong.ts
+++ b/src/lib/sets/relics/HeroOfTriumphantSong.ts
@@ -58,7 +58,7 @@ const conditionals: SetConditionals = {
   ],
   gpu: (action: OptimizerAction, context: OptimizerContext) => `
     if (
-      relic4p(*p_sets, SET_HeroOfTriumphantSong) >= 1
+      relic4p(*p_sets, SET_HeroOfTriumphantSong)
       && setConditionals.enabledHeroOfTriumphantSong == true
     ) {
       ${buff.action(AKey.SPD_P, 0.06).wgsl(action, 2)}

--- a/src/lib/sets/relics/HunterOfGlacialForest.ts
+++ b/src/lib/sets/relics/HunterOfGlacialForest.ts
@@ -58,7 +58,7 @@ const conditionals: SetConditionals = {
   ],
   gpu: (action: OptimizerAction, context: OptimizerContext) => `
     if (
-      relic4p(*p_sets, SET_HunterOfGlacialForest) >= 1
+      relic4p(*p_sets, SET_HunterOfGlacialForest)
       && setConditionals.enabledHunterOfGlacialForest == true
     ) {
       ${buff.action(AKey.CD, 0.25).wgsl(action, 2)}

--- a/src/lib/sets/relics/IronCavalryAgainstTheScourge.ts
+++ b/src/lib/sets/relics/IronCavalryAgainstTheScourge.ts
@@ -63,7 +63,7 @@ const conditionals: SetConditionals = {
   ],
   gpuTerminal: (action: OptimizerAction, context: OptimizerContext) => `
   if (
-    relic4p(*p_sets, SET_IronCavalryAgainstTheScourge) >= 1
+    relic4p(*p_sets, SET_IronCavalryAgainstTheScourge)
     && ${containerActionVal(SELF_ENTITY_INDEX, AKey.BE, action.config)} >= 1.50
   ) {
     ${buff.hit(HKey.DEF_PEN, 0.10).damageType(DamageTag.BREAK).wgsl(action, 2)}

--- a/src/lib/sets/relics/KnightOfPurityPalace.ts
+++ b/src/lib/sets/relics/KnightOfPurityPalace.ts
@@ -52,7 +52,7 @@ const conditionals: SetConditionals = {
     basicP2(WgslStatName.DEF_P, 0.15, KnightOfPurityPalace),
   ],
   gpu: (action: OptimizerAction, context: OptimizerContext) => `
-    if (relic4p(*p_sets, SET_KnightOfPurityPalace) >= 1) {
+    if (relic4p(*p_sets, SET_KnightOfPurityPalace)) {
       ${buff.hit(HKey.BOOST, 0.20).outputType(OutputTag.SHIELD).wgsl(action, 2)}
     }
   `,

--- a/src/lib/sets/relics/LongevousDisciple.ts
+++ b/src/lib/sets/relics/LongevousDisciple.ts
@@ -56,7 +56,7 @@ const conditionals: SetConditionals = {
     basicP2(WgslStatName.HP_P, 0.12, LongevousDisciple),
   ],
   gpu: (action: OptimizerAction, context: OptimizerContext) => `
-    if (relic4p(*p_sets, SET_LongevousDisciple) >= 1) {
+    if (relic4p(*p_sets, SET_LongevousDisciple)) {
       ${buff.action(AKey.CR, `0.08 * f32(setConditionals.valueLongevousDisciple)`).wgsl(action, 2)}
     }
   `,

--- a/src/lib/sets/relics/MessengerTraversingHackerspace.ts
+++ b/src/lib/sets/relics/MessengerTraversingHackerspace.ts
@@ -58,7 +58,7 @@ const conditionals: SetConditionals = {
   ],
   gpu: (action: OptimizerAction, context: OptimizerContext) => `
     if (
-      relic4p(*p_sets, SET_MessengerTraversingHackerspace) >= 1
+      relic4p(*p_sets, SET_MessengerTraversingHackerspace)
       && setConditionals.enabledMessengerTraversingHackerspace == true
       && ${wgslFalse(action.config.teammateSetEffects[Sets.MessengerTraversingHackerspace])}
     ) {

--- a/src/lib/sets/relics/MusketeerOfWildWheat.ts
+++ b/src/lib/sets/relics/MusketeerOfWildWheat.ts
@@ -59,7 +59,7 @@ const conditionals: SetConditionals = {
     basicP4(WgslStatName.SPD_P, 0.06, MusketeerOfWildWheat),
   ],
   gpu: (action: OptimizerAction, context: OptimizerContext) => `
-    if (relic4p(*p_sets, SET_MusketeerOfWildWheat) >= 1) {
+    if (relic4p(*p_sets, SET_MusketeerOfWildWheat)) {
       ${buff.hit(HKey.BOOST, 0.10).damageType(DamageTag.BASIC).wgsl(action, 2)}
     }
   `,

--- a/src/lib/sets/relics/PioneerDiverOfDeadWaters.ts
+++ b/src/lib/sets/relics/PioneerDiverOfDeadWaters.ts
@@ -72,9 +72,9 @@ const conditionals: SetConditionals = {
     basicP4(WgslStatName.CR, 0.04, PioneerDiverOfDeadWaters),
   ],
   gpu: (action: OptimizerAction, context: OptimizerContext) => `
-    if (relic2p(*p_sets, SET_PioneerDiverOfDeadWaters) >= 1 && setConditionals.valuePioneerDiverOfDeadWaters >= 0) {
+    if (relic2p(*p_sets, SET_PioneerDiverOfDeadWaters) && setConditionals.valuePioneerDiverOfDeadWaters >= 0) {
       ${buff.action(AKey.BOOST, 0.12).wgsl(action, 2)}
-      if (relic4p(*p_sets, SET_PioneerDiverOfDeadWaters) >= 1) {
+      if (relic4p(*p_sets, SET_PioneerDiverOfDeadWaters)) {
         ${buff.action(AKey.CD_BOOST, `getPioneerSetValue(setConditionals.valuePioneerDiverOfDeadWaters)`).wgsl(action, 3)}
         if (setConditionals.valuePioneerDiverOfDeadWaters > 2) {
           ${buff.action(AKey.CR, 0.04).wgsl(action, 4)}

--- a/src/lib/sets/relics/PoetOfMourningCollapse.ts
+++ b/src/lib/sets/relics/PoetOfMourningCollapse.ts
@@ -64,7 +64,7 @@ const conditionals: SetConditionals = {
     basicP4(WgslStatName.SPD_P, -0.08, PoetOfMourningCollapse),
   ],
   gpu: (action: OptimizerAction, context: OptimizerContext) => `
-    if (relic4p(*p_sets, SET_PoetOfMourningCollapse) >= 1) {
+    if (relic4p(*p_sets, SET_PoetOfMourningCollapse)) {
       let crValue = select(0.0, 0.20, (*p_c).SPD < 110.0) + select(0.0, 0.12, (*p_c).SPD < 95.0);
       ${buff.action(AKey.CR, 'crValue').targets(TargetTag.SelfAndMemosprite).wgsl(action, 2)}
     }

--- a/src/lib/sets/relics/PrisonerInDeepConfinement.ts
+++ b/src/lib/sets/relics/PrisonerInDeepConfinement.ts
@@ -56,7 +56,7 @@ const conditionals: SetConditionals = {
     basicP2(WgslStatName.ATK_P, 0.12, PrisonerInDeepConfinement),
   ],
   gpu: (action: OptimizerAction, context: OptimizerContext) => `
-    if (relic4p(*p_sets, SET_PrisonerInDeepConfinement) >= 1) {
+    if (relic4p(*p_sets, SET_PrisonerInDeepConfinement)) {
       ${buff.action(AKey.DEF_PEN, `0.06 * f32(setConditionals.valuePrisonerInDeepConfinement)`).wgsl(action, 2)}
     }
   `,

--- a/src/lib/sets/relics/SacerdosRelivedOrdeal.ts
+++ b/src/lib/sets/relics/SacerdosRelivedOrdeal.ts
@@ -67,7 +67,7 @@ const conditionals: SetConditionals = {
     basicP2(WgslStatName.SPD_P, 0.06, SacerdosRelivedOrdeal),
   ],
   gpu: (action: OptimizerAction, context: OptimizerContext) => `
-    if (relic4p(*p_sets, SET_SacerdosRelivedOrdeal) >= 1) {
+    if (relic4p(*p_sets, SET_SacerdosRelivedOrdeal)) {
       let sacValue = i32(setConditionals.valueSacerdosRelivedOrdeal);
       if (sacValue == 1 || sacValue == 2) {
         ${buff.action(AKey.CD, `0.18 * f32(setConditionals.valueSacerdosRelivedOrdeal)`).wgsl(action, 2)}

--- a/src/lib/sets/relics/ScholarLostInErudition.ts
+++ b/src/lib/sets/relics/ScholarLostInErudition.ts
@@ -57,7 +57,7 @@ const conditionals: SetConditionals = {
     basicP2(WgslStatName.CR, 0.08, ScholarLostInErudition),
   ],
   gpu: (action: OptimizerAction, context: OptimizerContext) => `
-    if (relic4p(*p_sets, SET_ScholarLostInErudition) >= 1) {
+    if (relic4p(*p_sets, SET_ScholarLostInErudition)) {
       ${buff.hit(HKey.BOOST, 0.20).damageType(DamageTag.SKILL | DamageTag.ULT).wgsl(action, 2)}
       if (setConditionals.enabledScholarLostInErudition == true) {
         ${buff.hit(HKey.BOOST, 0.25).damageType(DamageTag.SKILL).wgsl(action, 3)}

--- a/src/lib/sets/relics/SelfEnshroudedRecluse.ts
+++ b/src/lib/sets/relics/SelfEnshroudedRecluse.ts
@@ -53,9 +53,9 @@ const conditionals: SetConditionals = {
     }
   },
   gpu: (action: OptimizerAction, context: OptimizerContext) => `
-    if (relic2p(*p_sets, SET_SelfEnshroudedRecluse) >= 1) {
+    if (relic2p(*p_sets, SET_SelfEnshroudedRecluse)) {
       ${buff.hit(HKey.BOOST, 0.10).outputType(OutputTag.SHIELD).wgsl(action, 2)}
-      if (relic4p(*p_sets, SET_SelfEnshroudedRecluse) >= 1) {
+      if (relic4p(*p_sets, SET_SelfEnshroudedRecluse)) {
         ${buff.hit(HKey.BOOST, 0.12).outputType(OutputTag.SHIELD).wgsl(action, 3)}
         if (setConditionals.enabledSelfEnshroudedRecluse == true) {
           ${buff.action(AKey.CD, 0.15).targets(TargetTag.FullTeam).wgsl(action, 4)}

--- a/src/lib/sets/relics/TheAshblazingGrandDuke.ts
+++ b/src/lib/sets/relics/TheAshblazingGrandDuke.ts
@@ -52,9 +52,9 @@ const conditionals: SetConditionals = {
     x.buff(StatKey.ATK_P, 0.06 * setConditionals.valueTheAshblazingGrandDuke, x.source(Source.TheAshblazingGrandDuke))
   },
   gpu: (action: OptimizerAction, context: OptimizerContext) => `
-    if (relic2p(*p_sets, SET_TheAshblazingGrandDuke) >= 1) {
+    if (relic2p(*p_sets, SET_TheAshblazingGrandDuke)) {
       ${buff.hit(HKey.BOOST, 0.20).damageType(DamageTag.FUA).wgsl(action, 2)}
-      if (relic4p(*p_sets, SET_TheAshblazingGrandDuke) >= 1) {
+      if (relic4p(*p_sets, SET_TheAshblazingGrandDuke)) {
         ${buff.action(AKey.ATK_P, `0.06 * f32(setConditionals.valueTheAshblazingGrandDuke)`).wgsl(action, 3)}
       }
     }

--- a/src/lib/sets/relics/TheWindSoaringValorous.ts
+++ b/src/lib/sets/relics/TheWindSoaringValorous.ts
@@ -63,7 +63,7 @@ const conditionals: SetConditionals = {
     basicP4(WgslStatName.CR, 0.06, TheWindSoaringValorous),
   ],
   gpu: (action: OptimizerAction, context: OptimizerContext) => `
-    if (relic4p(*p_sets, SET_TheWindSoaringValorous) >= 1) {
+    if (relic4p(*p_sets, SET_TheWindSoaringValorous)) {
       ${buff.hit(HKey.BOOST, `0.36 * f32(setConditionals.enabledTheWindSoaringValorous)`).damageType(DamageTag.ULT).wgsl(action, 2)}
     }
   `,

--- a/src/lib/sets/relics/WarriorGoddessOfSunAndThunder.ts
+++ b/src/lib/sets/relics/WarriorGoddessOfSunAndThunder.ts
@@ -63,7 +63,7 @@ const conditionals: SetConditionals = {
   ],
   gpu: (action: OptimizerAction, context: OptimizerContext) => `
     if (
-      relic4p(*p_sets, SET_WarriorGoddessOfSunAndThunder) >= 1
+      relic4p(*p_sets, SET_WarriorGoddessOfSunAndThunder)
       && setConditionals.enabledWarriorGoddessOfSunAndThunder == true
     ) {
       ${buff.action(AKey.SPD_P, 0.06).wgsl(action, 2)}

--- a/src/lib/sets/relics/WastelanderOfBanditryDesert.ts
+++ b/src/lib/sets/relics/WastelanderOfBanditryDesert.ts
@@ -61,7 +61,7 @@ const conditionals: SetConditionals = {
     basicP2(WgslStatName.IMAGINARY_DMG_BOOST, 0.10, WastelanderOfBanditryDesert),
   ],
   gpu: (action: OptimizerAction, context: OptimizerContext) => `
-    if (relic4p(*p_sets, SET_WastelanderOfBanditryDesert) >= 1) {
+    if (relic4p(*p_sets, SET_WastelanderOfBanditryDesert)) {
       if (setConditionals.valueWastelanderOfBanditryDesert > 0) {
         ${buff.action(AKey.CR_BOOST, 0.10).wgsl(action, 3)}
       }

--- a/src/lib/sets/relics/WatchmakerMasterOfDreamMachinations.ts
+++ b/src/lib/sets/relics/WatchmakerMasterOfDreamMachinations.ts
@@ -59,7 +59,7 @@ const conditionals: SetConditionals = {
   ],
   gpu: (action: OptimizerAction, context: OptimizerContext) => `
     if (
-      relic4p(*p_sets, SET_WatchmakerMasterOfDreamMachinations) >= 1
+      relic4p(*p_sets, SET_WatchmakerMasterOfDreamMachinations)
       && setConditionals.enabledWatchmakerMasterOfDreamMachinations == true
       && ${wgslFalse(action.config.teammateSetEffects[Sets.WatchmakerMasterOfDreamMachinations])}
     ) {

--- a/src/lib/sets/relics/WavestriderCaptain.ts
+++ b/src/lib/sets/relics/WavestriderCaptain.ts
@@ -56,7 +56,7 @@ const conditionals: SetConditionals = {
   ],
   gpu: (action: OptimizerAction, context: OptimizerContext) => `
     if (
-      relic4p(*p_sets, SET_WavestriderCaptain) >= 1
+      relic4p(*p_sets, SET_WavestriderCaptain)
       && setConditionals.enabledWavestriderCaptain == true
     ) {
       ${buff.action(AKey.ATK_P, 0.48).wgsl(action, 2)}

--- a/src/lib/sets/relics/WorldRemakingDeliverer.ts
+++ b/src/lib/sets/relics/WorldRemakingDeliverer.ts
@@ -58,7 +58,7 @@ const conditionals: SetConditionals = {
   ],
   gpu: (action: OptimizerAction, context: OptimizerContext) => `
     if (
-      relic4p(*p_sets, SET_WorldRemakingDeliverer) >= 1
+      relic4p(*p_sets, SET_WorldRemakingDeliverer)
       && setConditionals.enabledWorldRemakingDeliverer == true
     ) {
       ${buff.action(AKey.HP_P, 0.24).targets(TargetTag.SelfAndMemosprite).wgsl(action, 2)}

--- a/src/lib/sets/setConfigRegistry.test.ts
+++ b/src/lib/sets/setConfigRegistry.test.ts
@@ -1,0 +1,145 @@
+import {
+  type Sets,
+  type SetKey,
+  ConditionalDataType,
+} from 'lib/constants/constants'
+import {
+  assertSetConfigCountCapacity,
+  assertValidSetConfigList,
+  assertValidSetConfigRegistry,
+  MAX_ORNAMENT_SET_COUNT,
+  MAX_RELIC_SET_COUNT,
+} from 'lib/sets/setConfigRegistry'
+import { type SetConfig, SetType } from 'types/setConfig'
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest'
+
+function makeConfig(
+  setKey: string,
+  id: string,
+  index: number,
+  setType: SetType = SetType.RELIC,
+): SetConfig {
+  return {
+    id: id as unknown as Sets,
+    setKey: setKey as unknown as SetKey,
+    info: {
+      index,
+      setType,
+      ingameId: String(index),
+      twoPieceStatTag: null,
+    },
+    conditionals: {},
+    display: {
+      conditionalType: ConditionalDataType.BOOLEAN,
+      defaultValue: false,
+    },
+  }
+}
+
+describe('assertValidSetConfigList', () => {
+  it('accepts a list with unique setKeys, unique ids, and contiguous indices from 0', () => {
+    const configs = [
+      makeConfig('KeyA', 'IdA', 0),
+      makeConfig('KeyB', 'IdB', 1),
+      makeConfig('KeyC', 'IdC', 2),
+    ]
+    expect(() => assertValidSetConfigList(configs, 'TEST', SetType.RELIC)).not.toThrow()
+  })
+
+  it('accepts a list regardless of input order, as long as indices are contiguous from 0', () => {
+    const configs = [
+      makeConfig('KeyC', 'IdC', 2),
+      makeConfig('KeyA', 'IdA', 0),
+      makeConfig('KeyB', 'IdB', 1),
+    ]
+    expect(() => assertValidSetConfigList(configs, 'TEST', SetType.RELIC)).not.toThrow()
+  })
+
+  it('rejects a duplicate setKey', () => {
+    const configs = [
+      makeConfig('KeyA', 'IdA', 0),
+      makeConfig('KeyA', 'IdB', 1),
+    ]
+    expect(() => assertValidSetConfigList(configs, 'TEST', SetType.RELIC)).toThrow(/duplicate setKey/)
+  })
+
+  it('rejects a duplicate id', () => {
+    const configs = [
+      makeConfig('KeyA', 'IdA', 0),
+      makeConfig('KeyB', 'IdA', 1),
+    ]
+    expect(() => assertValidSetConfigList(configs, 'TEST', SetType.RELIC)).toThrow(/duplicate id/)
+  })
+
+  it('rejects a duplicate index', () => {
+    const configs = [
+      makeConfig('KeyA', 'IdA', 0),
+      makeConfig('KeyB', 'IdB', 0),
+    ]
+    expect(() => assertValidSetConfigList(configs, 'TEST', SetType.RELIC)).toThrow(/duplicate index/)
+  })
+
+  it('rejects a gap in the index sequence', () => {
+    const configs = [
+      makeConfig('KeyA', 'IdA', 0),
+      makeConfig('KeyB', 'IdB', 1),
+      makeConfig('KeyC', 'IdC', 3),
+    ]
+    expect(() => assertValidSetConfigList(configs, 'TEST', SetType.RELIC)).toThrow(/contiguous from 0/)
+  })
+
+  it('rejects indices that do not start at 0', () => {
+    const configs = [
+      makeConfig('KeyA', 'IdA', 1),
+      makeConfig('KeyB', 'IdB', 2),
+      makeConfig('KeyC', 'IdC', 3),
+    ]
+    expect(() => assertValidSetConfigList(configs, 'TEST', SetType.RELIC)).toThrow(/contiguous from 0/)
+  })
+
+  it('accepts an empty list', () => {
+    expect(() => assertValidSetConfigList([], 'TEST', SetType.RELIC)).not.toThrow()
+  })
+
+  it('rejects a member whose setType does not match its family', () => {
+    const configs = [makeConfig('KeyA', 'IdA', 0, SetType.ORNAMENT)]
+    expect(() => assertValidSetConfigList(configs, 'TEST_RELICS', SetType.RELIC)).toThrow(
+      /has setType 'ornament', expected 'relic'/,
+    )
+  })
+
+})
+
+describe('assertValidSetConfigRegistry', () => {
+  it('rejects a cross-family setKey collision', () => {
+    const relics = [makeConfig('SharedKey', 'RelicId', 0)]
+    const ornaments = [makeConfig('SharedKey', 'OrnamentId', 0, SetType.ORNAMENT)]
+    expect(() => assertValidSetConfigRegistry(relics, ornaments)).toThrow(/duplicate setKey.*across families/)
+  })
+
+  it('rejects a cross-family id collision', () => {
+    const relics = [makeConfig('RelicKey', 'SharedId', 0)]
+    const ornaments = [makeConfig('OrnamentKey', 'SharedId', 0, SetType.ORNAMENT)]
+    expect(() => assertValidSetConfigRegistry(relics, ornaments)).toThrow(/duplicate id.*across families/)
+  })
+})
+
+describe('assertSetConfigCountCapacity', () => {
+  it('accepts the largest counts below a flattened filter length of 2^32', () => {
+    expect(() => assertSetConfigCountCapacity(MAX_RELIC_SET_COUNT, MAX_ORNAMENT_SET_COUNT)).not.toThrow()
+  })
+
+  it('rejects a relic count requiring a flattened filter length of 2^32', () => {
+    expect(() => assertSetConfigCountCapacity(MAX_RELIC_SET_COUNT + 1, 0)).toThrow(/Relic set count 256 exceeds maximum 255/)
+  })
+
+  it('rejects an ornament count requiring a flattened filter length of 2^32', () => {
+    expect(() => assertSetConfigCountCapacity(0, MAX_ORNAMENT_SET_COUNT + 1)).toThrow(
+      /Ornament set count 65536 exceeds maximum 65535/,
+    )
+  })
+})

--- a/src/lib/sets/setConfigRegistry.ts
+++ b/src/lib/sets/setConfigRegistry.ts
@@ -145,6 +145,83 @@ const ALL_ORNAMENT_CONFIGS = [
   CosmicLifeSciencesInstitute,
 ] as const
 
+// Dense filters have N^4 relic entries and N^2 ornament entries. The next counts
+// would require arrays of length 2^32, which JavaScript arrays cannot represent.
+export const MAX_RELIC_SET_COUNT = 255
+export const MAX_ORNAMENT_SET_COUNT = 65_535
+
+export function assertSetConfigCountCapacity(relicCount: number, ornamentCount: number): void {
+  if (relicCount > MAX_RELIC_SET_COUNT) {
+    throw new Error(`Relic set count ${relicCount} exceeds maximum ${MAX_RELIC_SET_COUNT}`)
+  }
+  if (ornamentCount > MAX_ORNAMENT_SET_COUNT) {
+    throw new Error(`Ornament set count ${ornamentCount} exceeds maximum ${MAX_ORNAMENT_SET_COUNT}`)
+  }
+}
+
+// Validates one family before any index-derived structures are constructed.
+export function assertValidSetConfigList(
+  configs: readonly SetConfig[],
+  label: string,
+  expectedSetType: SetType,
+): void {
+  const seenSetKeys = new Set<string>()
+  const seenIds = new Set<string>()
+  const seenIndices = new Set<number>()
+
+  for (const config of configs) {
+    if (config.info.setType !== expectedSetType) {
+      throw new Error(
+        `${label}: setKey '${config.setKey}' has setType '${config.info.setType}', expected '${expectedSetType}'`,
+      )
+    }
+
+    if (seenSetKeys.has(config.setKey)) {
+      throw new Error(`${label}: duplicate setKey '${config.setKey}'`)
+    }
+    seenSetKeys.add(config.setKey)
+
+    if (seenIds.has(config.id)) {
+      throw new Error(`${label}: duplicate id '${config.id}'`)
+    }
+    seenIds.add(config.id)
+
+    if (seenIndices.has(config.info.index)) {
+      throw new Error(`${label}: duplicate index ${config.info.index} (setKey '${config.setKey}')`)
+    }
+    seenIndices.add(config.info.index)
+  }
+
+  const sortedIndices = [...seenIndices].sort((a, b) => a - b)
+  for (let i = 0; i < sortedIndices.length; i++) {
+    if (sortedIndices[i] !== i) {
+      throw new Error(`${label}: indices must be exactly contiguous from 0, got [${sortedIndices.join(', ')}]`)
+    }
+  }
+}
+
+export function assertValidSetConfigRegistry(
+  relicConfigs: readonly SetConfig[],
+  ornamentConfigs: readonly SetConfig[],
+): void {
+  assertValidSetConfigList(relicConfigs, 'ALL_RELIC_CONFIGS', SetType.RELIC)
+  assertValidSetConfigList(ornamentConfigs, 'ALL_ORNAMENT_CONFIGS', SetType.ORNAMENT)
+  assertSetConfigCountCapacity(relicConfigs.length, ornamentConfigs.length)
+
+  const relicSetKeys = new Set(relicConfigs.map((config) => config.setKey))
+  const relicIds = new Set(relicConfigs.map((config) => config.id))
+  for (const config of ornamentConfigs) {
+    if (relicSetKeys.has(config.setKey)) {
+      throw new Error(`Combined set registry: duplicate setKey '${config.setKey}' across families`)
+    }
+    if (relicIds.has(config.id)) {
+      throw new Error(`Combined set registry: duplicate id '${config.id}' across families`)
+    }
+  }
+}
+
+assertValidSetConfigRegistry(ALL_RELIC_CONFIGS, ALL_ORNAMENT_CONFIGS)
+
 const ALL_CONFIGS = [...ALL_RELIC_CONFIGS, ...ALL_ORNAMENT_CONFIGS] as const
 
 type AllConfigItems = (typeof ALL_CONFIGS)[number]

--- a/src/lib/simulations/simulateBuild.ts
+++ b/src/lib/simulations/simulateBuild.ts
@@ -15,7 +15,7 @@ import {
   calculateComputedStats,
   calculateElementalStats,
   calculateRelicStats,
-  calculateSetCounts,
+  computeSetMatches,
 } from 'lib/optimization/calculateStats'
 import { resetConditionalState } from 'lib/optimization/conditionalStateUtils'
 import {
@@ -80,7 +80,7 @@ export function simulateBuild(
 ): SimulateBuildResult {
   // Compute
   let Head: SimulationRelic, Hands: SimulationRelic, Body: SimulationRelic, Feet: SimulationRelic, PlanarSphere: SimulationRelic, LinkRope: SimulationRelic
-  let relicSetIndex: number, ornamentSetIndex: number, sets: number[], setCounts: ReturnType<typeof calculateSetCounts>
+  let relicSetIndex: number, ornamentSetIndex: number, setMatches: ReturnType<typeof computeSetMatches>
 
   if (precomputedSets) {
     Head = relics.Head
@@ -91,8 +91,7 @@ export function simulateBuild(
     LinkRope = relics.LinkRope
     relicSetIndex = precomputedSets.relicSetIndex
     ornamentSetIndex = precomputedSets.ornamentSetIndex
-    sets = precomputedSets.sets
-    setCounts = precomputedSets.setCounts
+    setMatches = precomputedSets.setMatches
   } else {
     extractRelics(relics)
     Head = relics.Head
@@ -105,14 +104,13 @@ export function simulateBuild(
     const computed = precomputeSetState(relics)
     relicSetIndex = computed.relicSetIndex
     ornamentSetIndex = computed.ornamentSetIndex
-    sets = computed.sets
-    setCounts = computed.setCounts
+    setMatches = computed.setMatches
   }
 
   const c = (cachedBasicStatsArrayCore ?? new BasicStatsArrayCore(false)) as BasicStatsArray
-  c.init(relicSetIndex, ornamentSetIndex, setCounts, sets, -1)
+  c.init(relicSetIndex, ornamentSetIndex, setMatches, -1)
 
-  calculateBasicSetEffects(c, context, setCounts, sets)
+  calculateBasicSetEffects(c, context, setMatches)
   calculateRelicStats(c, Head, Hands, Body, Feet, PlanarSphere, LinkRope)
   calculateBaseStats(c, context)
   calculateElementalStats(c, context)
@@ -313,9 +311,9 @@ export function precomputeSetState(relics: SimulationRelicByPart): PrecomputedSe
   const relicSetIndex = encodeRelicSetIndex(setH, setG, setB, setF)
   const ornamentSetIndex = encodeOrnamentSetIndex(setP, setL)
   const sets = [setH, setG, setB, setF, setP, setL]
-  const setCounts = calculateSetCounts(sets)
+  const setMatches = computeSetMatches(sets)
 
-  return { setH, setG, setB, setF, setP, setL, relicSetIndex, ornamentSetIndex, sets, setCounts }
+  return { relicSetIndex, ornamentSetIndex, setMatches }
 }
 
 function extractRelics(relics: SimulationRelicByPart) {

--- a/src/lib/simulations/simulateBuild.ts
+++ b/src/lib/simulations/simulateBuild.ts
@@ -15,7 +15,6 @@ import {
   calculateComputedStats,
   calculateElementalStats,
   calculateRelicStats,
-  computeSetMatches,
 } from 'lib/optimization/calculateStats'
 import { resetConditionalState } from 'lib/optimization/conditionalStateUtils'
 import {
@@ -29,6 +28,10 @@ import {
   getDamageFunction,
 } from 'lib/optimization/engine/damage/damageCalculator'
 import { type TurnAbilityName } from 'lib/optimization/rotation/turnAbilityConfig'
+import {
+  computeSetMatches,
+  type SetMatches,
+} from 'lib/optimization/setMatchState'
 import type {
   SetsOrnaments,
   SetsRelics,
@@ -80,7 +83,7 @@ export function simulateBuild(
 ): SimulateBuildResult {
   // Compute
   let Head: SimulationRelic, Hands: SimulationRelic, Body: SimulationRelic, Feet: SimulationRelic, PlanarSphere: SimulationRelic, LinkRope: SimulationRelic
-  let relicSetIndex: number, ornamentSetIndex: number, setMatches: ReturnType<typeof computeSetMatches>
+  let relicSetIndex: number, ornamentSetIndex: number, setMatches: SetMatches
 
   if (precomputedSets) {
     Head = relics.Head

--- a/src/lib/simulations/statSimulationTypes.ts
+++ b/src/lib/simulations/statSimulationTypes.ts
@@ -5,7 +5,7 @@ import type {
   AbilityKind,
   TurnAbilityName,
 } from 'lib/optimization/rotation/turnAbilityConfig'
-import type { SetCounts } from 'lib/optimization/setMatching'
+import type { SetMatches } from 'lib/optimization/setMatchState'
 import type { SimulationFlags } from 'lib/scoring/simScoringUtils'
 import type {
   SetsOrnaments,
@@ -132,16 +132,9 @@ export type SimulationRelicArrayByPart = {
 }
 
 export type PrecomputedSetState = {
-  setH: number,
-  setG: number,
-  setB: number,
-  setF: number,
-  setP: number,
-  setL: number,
   relicSetIndex: number,
   ornamentSetIndex: number,
-  sets: number[],
-  setCounts: SetCounts,
+  setMatches: SetMatches,
 }
 
 export type BenchmarkSimulationState = {

--- a/src/lib/worker/optimizerWorker.ts
+++ b/src/lib/worker/optimizerWorker.ts
@@ -16,7 +16,7 @@ import {
   calculateComputedStats,
   calculateElementalStats,
   calculateRelicStats,
-  calculateSetCountsInPlace,
+  computeSetMatchesInPlace,
 } from 'lib/optimization/calculateStats'
 import { resetConditionalState } from 'lib/optimization/conditionalStateUtils'
 import {
@@ -30,7 +30,10 @@ import {
   calculateEhp,
   getDamageFunction,
 } from 'lib/optimization/engine/damage/damageCalculator'
-import { type SetCounts } from 'lib/optimization/setMatching'
+import {
+  emptySetMatches,
+  type MutableSetMatches,
+} from 'lib/optimization/setMatchState'
 import {
   SortOption,
   type SortOptionProperties,
@@ -132,7 +135,7 @@ export function optimizerWorker(e: MessageEvent<OptimizerWorkerInput>) {
   const failsRatingFilter = ratingFilter(request, context)
 
   const sets = Array.from<number>({ length: 6 })
-  const setCounts: SetCounts = { relicMatch2: 0, relicMatch4: 0, ornamentMatch2: 0 }
+  const setMatches: MutableSetMatches = emptySetMatches()
 
   for (let col = 0; col < limit; col++) {
     const index = data.skip + col
@@ -168,8 +171,8 @@ export function optimizerWorker(e: MessageEvent<OptimizerWorkerInput>) {
     const ornamentSetIndex = encodeOrnamentSetIndex(setP, setL)
 
     // Exit early if sets don't match
-    const relicValid = ((relicSetSolutions[relicSetIndex >> 5] >> (relicSetIndex & 31)) & 1) === 1
-    const ornamentValid = ((ornamentSetSolutions[ornamentSetIndex >> 5] >> (ornamentSetIndex & 31)) & 1) === 1
+    const relicValid = ((relicSetSolutions[relicSetIndex >>> 5] >> (relicSetIndex & 31)) & 1) === 1
+    const ornamentValid = ((ornamentSetSolutions[ornamentSetIndex >>> 5] >> (ornamentSetIndex & 31)) & 1) === 1
     if (!relicValid || !ornamentValid) {
       continue
     }
@@ -181,10 +184,10 @@ export function optimizerWorker(e: MessageEvent<OptimizerWorkerInput>) {
     sets[4] = setP
     sets[5] = setL
 
-    calculateSetCountsInPlace(setCounts, sets)
-    c.init(relicSetIndex, ornamentSetIndex, setCounts, sets, col)
+    computeSetMatchesInPlace(setMatches, sets)
+    c.init(relicSetIndex, ornamentSetIndex, setMatches, col)
 
-    calculateBasicSetEffects(c, context, setCounts, sets)
+    calculateBasicSetEffects(c, context, setMatches)
     calculateRelicStats(c, head, hands, body, feet, planarSphere, linkRope)
     calculateBaseStats(c, context)
     calculateElementalStats(c, context)

--- a/src/lib/worker/optimizerWorker.ts
+++ b/src/lib/worker/optimizerWorker.ts
@@ -16,7 +16,6 @@ import {
   calculateComputedStats,
   calculateElementalStats,
   calculateRelicStats,
-  computeSetMatchesInPlace,
 } from 'lib/optimization/calculateStats'
 import { resetConditionalState } from 'lib/optimization/conditionalStateUtils'
 import {
@@ -31,9 +30,11 @@ import {
   getDamageFunction,
 } from 'lib/optimization/engine/damage/damageCalculator'
 import {
+  computeSetMatchesInPlace,
   emptySetMatches,
   type MutableSetMatches,
 } from 'lib/optimization/setMatchState'
+import { isSetSolutionValid } from 'lib/optimization/setSolutionBitset'
 import {
   SortOption,
   type SortOptionProperties,
@@ -171,8 +172,8 @@ export function optimizerWorker(e: MessageEvent<OptimizerWorkerInput>) {
     const ornamentSetIndex = encodeOrnamentSetIndex(setP, setL)
 
     // Exit early if sets don't match
-    const relicValid = ((relicSetSolutions[relicSetIndex >>> 5] >> (relicSetIndex & 31)) & 1) === 1
-    const ornamentValid = ((ornamentSetSolutions[ornamentSetIndex >>> 5] >> (ornamentSetIndex & 31)) & 1) === 1
+    const relicValid = isSetSolutionValid(relicSetSolutions, relicSetIndex)
+    const ornamentValid = isSetSolutionValid(ornamentSetSolutions, ornamentSetIndex)
     if (!relicValid || !ornamentValid) {
       continue
     }


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

  - Replace 32-bit set matching with capacity-safe CPU state and generated multiword GPU masks.
  - Add registry validation for set identity, family, index continuity, and filter capacity.
  - Fix high-index solution filtering and preserve set matches across optimizer, scoring, and simulation paths.
  - Add boundary, carry-refresh, state-reuse, serialization, and CPU/GPU parity coverage.

## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [ ] I have added commit messages that are descriptive and meaningful.
- [ ] I have tested the changes locally.
- [ ] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
