### PR TITLE
feat: add average potential view to relic scorer

### DIFF
--- a/public/locales/en_US/hint.yaml
+++ b/public/locales/en_US/hint.yaml
@@ -121,6 +121,7 @@ RelicInsights:
     'Buckets' looks at how perfect this relic could be (with the best possible upgrade rolls) for each character, and buckets them into percentages.<1/>If you hover over a character portrait you'll
     see the new stats and/or rolls necessary to reach the max potential of this relic.<3/>⚠️ Relics with missing substats may have misleadingly high buckets, as best-case upgrade analysis assumes the
     best new substat per character.
+  p4: Use the Maximum / Average toggle to switch between the best possible upgrade rolls and the projected average potential at the relic's maximum level.
   p3: "Top 10 takes the top 10 characters that this relic could be best for, and shows the range of \"% perfection\" upgrading this relic could result in."
 RelicLocation:
   Title: Relic Location

--- a/public/locales/en_US/hint.yaml
+++ b/public/locales/en_US/hint.yaml
@@ -121,8 +121,8 @@ RelicInsights:
     'Buckets' looks at how perfect this relic could be (with the best possible upgrade rolls) for each character, and buckets them into percentages.<1/>If you hover over a character portrait you'll
     see the new stats and/or rolls necessary to reach the max potential of this relic.<3/>⚠️ Relics with missing substats may have misleadingly high buckets, as best-case upgrade analysis assumes the
     best new substat per character.
-  p4: Use the Maximum / Average toggle to switch between the best possible upgrade rolls and the projected average potential at the relic's maximum level.
   p3: "Top 10 takes the top 10 characters that this relic could be best for, and shows the range of \"% perfection\" upgrading this relic could result in."
+  p4: Use the Maximum / Average toggle to switch between the best possible upgrade rolls and the projected average potential at the relic's maximum level.
 RelicLocation:
   Title: Relic Location
   p1: When a relic is selected in the grid, its position in the ingame inventory is displayed here.

--- a/public/locales/en_US/relicsTab.yaml
+++ b/public/locales/en_US/relicsTab.yaml
@@ -178,6 +178,9 @@ Toolbar:
     PlotAll: Show all characters
     PlotCustom: Show custom characters
     PlotOwned: Show owned characters
+  PotentialOptions:
+    Maximum: Maximum
+    Average: Average
   EditRelic: Edit relic
   DeleteRelic:
     ButtonText: Delete relic
@@ -189,3 +192,4 @@ RelicInsights:
   NewStats: 'New stats: '
   UpgradedStats: 'Upgraded stats: '
   AvgPotential: 'Average potential: '
+  MaxPotential: 'Maximum potential: '

--- a/src/lib/interactions/hint.tsx
+++ b/src/lib/interactions/hint.tsx
@@ -427,6 +427,7 @@ export const Hint = {
               ⚠️ Relics with missing substats may have misleadingly high buckets, as best-case upgrade analysis assumes the best new substat per character.
             </Trans>
           </p>
+          <p>{t('p4') /* Use the Maximum / Average toggle to switch between maximum and average potential. */}</p>
           <p>
             {
               t(

--- a/src/lib/tabs/tabRelics/bottomDock/BottomToolbar.tsx
+++ b/src/lib/tabs/tabRelics/bottomDock/BottomToolbar.tsx
@@ -65,8 +65,8 @@ export function BottomToolbarRight() {
   ], [t])
 
   const potentialOptions = useMemo(() => [
-    { value: String(BucketPotentialMode.Maximum), label: t('PotentialOptions.Maximum') },
-    { value: String(BucketPotentialMode.Average), label: t('PotentialOptions.Average') },
+    { value: BucketPotentialMode.Maximum, label: t('PotentialOptions.Maximum') },
+    { value: BucketPotentialMode.Average, label: t('PotentialOptions.Average') },
   ], [t])
 
   return (
@@ -115,8 +115,8 @@ export function BottomToolbarRight() {
         {insightsMode === RelicInsights.Buckets && (
           <SegmentedControl
             size='xs'
-            value={String(bucketPotentialMode)}
-            onChange={(value) => setBucketPotentialMode(Number(value) as BucketPotentialMode)}
+            value={bucketPotentialMode}
+            onChange={setBucketPotentialMode}
             data={potentialOptions}
             styles={{ label: { height: 22 } }}
             style={{ width: 160 }}

--- a/src/lib/tabs/tabRelics/bottomDock/BottomToolbar.tsx
+++ b/src/lib/tabs/tabRelics/bottomDock/BottomToolbar.tsx
@@ -18,6 +18,7 @@ import { useScannerState } from 'lib/tabs/tabImport/ScannerWebsocketClient'
 import { RelicLocator } from 'lib/tabs/tabRelics/RelicLocator'
 import { RelicsTabController } from 'lib/tabs/tabRelics/relicsTabController'
 import {
+  BucketPotentialMode,
   InsightCharacters,
   RelicInsights,
   useRelicsTabStore,
@@ -35,13 +36,15 @@ export function BottomToolbarLeft() {
 }
 
 export function BottomToolbarRight() {
-  const { selectedRelicsIds, insightsMode, setInsightsMode, insightsCharacters, setInsightsCharacters } = useRelicsTabStore(
+  const { selectedRelicsIds, insightsMode, setInsightsMode, insightsCharacters, setInsightsCharacters, bucketPotentialMode, setBucketPotentialMode, } = useRelicsTabStore(
     useShallow((s) => ({
       selectedRelicsIds: s.selectedRelicsIds,
       insightsMode: s.insightsMode,
       setInsightsMode: s.setInsightsMode,
       insightsCharacters: s.insightsCharacters,
       setInsightsCharacters: s.setInsightsCharacters,
+      bucketPotentialMode: s.bucketPotentialMode,
+      setBucketPotentialMode: s.setBucketPotentialMode,
     })),
   )
 
@@ -59,6 +62,11 @@ export function BottomToolbarRight() {
     { value: String(InsightCharacters.All), label: t('PlotOptions.PlotAll') },
     { value: String(InsightCharacters.Custom), label: t('PlotOptions.PlotCustom') },
     { value: String(InsightCharacters.Owned), label: t('PlotOptions.PlotOwned') },
+  ], [t])
+
+  const potentialOptions = useMemo(() => [
+    { value: String(BucketPotentialMode.Maximum), label: t('PotentialOptions.Maximum') },
+    { value: String(BucketPotentialMode.Average), label: t('PotentialOptions.Average') },
   ], [t])
 
   return (
@@ -103,6 +111,17 @@ export function BottomToolbarRight() {
         >
           {t('EditRelic')}
         </Button>
+        {/* This setting only changes portrait placement in the Buckets chart. */}
+        {insightsMode === RelicInsights.Buckets && (
+          <SegmentedControl
+            size='xs'
+            value={String(bucketPotentialMode)}
+            onChange={(value) => setBucketPotentialMode(Number(value) as BucketPotentialMode)}
+            data={potentialOptions}
+            styles={{ label: { height: 22 } }}
+            style={{ width: 160 }}
+          />
+        )}
       </Group>
 
       <Group gap={5}>

--- a/src/lib/tabs/tabRelics/relicInsightsPanel/BucketsPanel.test.ts
+++ b/src/lib/tabs/tabRelics/relicInsightsPanel/BucketsPanel.test.ts
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+import {
+  getBucketIndex,
+  getBucketPotential,
+} from 'lib/tabs/tabRelics/relicInsightsPanel/BucketsPanel'
+import { BucketPotentialMode } from 'lib/tabs/tabRelics/useRelicsTabStore'
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest'
+
+const score = {
+  bestPct: 53,
+  averagePct: 45,
+}
+
+describe('BucketsPanel potential modes', () => {
+  it('uses maximum potential for maximum mode', () => {
+    expect(getBucketPotential(score, BucketPotentialMode.Maximum)).toBe(53)
+    expect(getBucketIndex(score, BucketPotentialMode.Maximum)).toBe(5)
+  })
+
+  it('uses average potential for average mode', () => {
+    expect(getBucketPotential(score, BucketPotentialMode.Average)).toBe(45)
+    expect(getBucketIndex(score, BucketPotentialMode.Average)).toBe(4)
+  })
+
+  it('clamps values to the available bucket range', () => {
+    expect(getBucketIndex({ bestPct: -1, averagePct: -1 }, BucketPotentialMode.Maximum)).toBe(0)
+    expect(getBucketIndex({ bestPct: 100, averagePct: 100 }, BucketPotentialMode.Maximum)).toBe(9)
+  })
+
+  it('places exact multiples of ten in the next bucket', () => {
+    expect(getBucketIndex({ bestPct: 9.99, averagePct: 9.99 }, BucketPotentialMode.Maximum)).toBe(0)
+    expect(getBucketIndex({ bestPct: 10, averagePct: 10 }, BucketPotentialMode.Maximum)).toBe(1)
+  })
+})

--- a/src/lib/tabs/tabRelics/relicInsightsPanel/BucketsPanel.tsx
+++ b/src/lib/tabs/tabRelics/relicInsightsPanel/BucketsPanel.tsx
@@ -3,9 +3,12 @@ import {
   OpenCloseIDs,
   setOpen,
 } from 'lib/hooks/useOpenClose'
+import type { PotentialResult } from 'lib/relics/scoring/types'
 import { Assets } from 'lib/rendering/assets'
 import { useGlobalStore } from 'lib/stores/app/appStore'
 import { type PanelProps } from 'lib/tabs/tabRelics/relicInsightsPanel/RelicInsightsPanel'
+import { BucketPotentialMode } from 'lib/tabs/tabRelics/useRelicsTabStore'
+import { precisionRound } from 'lib/utils/mathUtils'
 import { memo } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
@@ -28,10 +31,16 @@ type DataPoint = {
   y: number,
   name: Score['name'],
   id: Score['id'],
+  potential: number,
+  potentialMode: BucketPotentialMode,
   bestAdded: Score['score']['meta']['bestAddedStats'],
   bestUpgraded: Score['score']['meta']['bestUpgradedStats'],
   imgWidth: number,
   imgHeight: number,
+}
+
+type BucketsPanelProps = PanelProps & {
+  potentialMode: BucketPotentialMode,
 }
 
 const DEFAULT_WIDTH = 1222
@@ -42,7 +51,7 @@ const IMG_HEIGHT_NORMAL = 39
 const IMG_WIDTH_COMPACT = 20
 const IMG_HEIGHT_COMPACT = 30
 
-export const BucketsPanel = memo(({ scores, width: propWidth, height: propHeight }: PanelProps) => {
+export const BucketsPanel = memo(({ scores, width: propWidth, height: propHeight, potentialMode }: BucketsPanelProps) => {
   const chartWidth = propWidth ?? DEFAULT_WIDTH
   const chartHeight = propHeight ?? DEFAULT_HEIGHT
   const compact = chartHeight < 250
@@ -54,7 +63,7 @@ export const BucketsPanel = memo(({ scores, width: propWidth, height: propHeight
   for (let i = 0; i < 10; i++) buckets[i] = []
 
   scores.forEach((score) => {
-    const bucketIndex = Math.min(9, Math.max(0, Math.floor(score.score.bestPct / 10)))
+    const bucketIndex = getBucketIndex(score.score, potentialMode)
     buckets[bucketIndex].push(score)
   })
 
@@ -77,6 +86,8 @@ export const BucketsPanel = memo(({ scores, width: propWidth, height: propHeight
       y: bucketIdx,
       name: score.name,
       id: score.id,
+      potential: getBucketPotential(score.score, potentialMode),
+      potentialMode,
       bestAdded: score.score.meta.bestAddedStats,
       bestUpgraded: score.score.meta.bestUpgradedStats,
       imgWidth,
@@ -158,6 +169,8 @@ function TooltipContent(props: TooltipContentProps) {
   const { t } = useTranslation('relicsTab', { keyPrefix: 'RelicInsights' })
 
   const data = payload?.[0]?.payload
+  if (!data) return null
+
   return (
     <div
       style={{
@@ -172,24 +185,44 @@ function TooltipContent(props: TooltipContentProps) {
       }}
     >
       <div style={{ marginBottom: 5 }}>
-        <u>{data?.name}</u>
+        <u>{data.name}</u>
       </div>
       <div>
-        {data?.bestUpgraded?.length !== 0 && (
-          <>
-            <>{t('UpgradedStats')}</>
-            <>{data?.bestUpgraded?.join(' / ')}</>
-          </>
-        )}
+        {data.potentialMode === BucketPotentialMode.Average ? t('AvgPotential') : t('MaxPotential')}
+        {precisionRound(data.potential, 1)}%
       </div>
-      <div>
-        {data?.bestAdded?.length !== 0 && (
-          <>
-            <>{t('NewStats')}</>
-            <>{data?.bestAdded?.join(' / ')}</>
-          </>
-        )}
-      </div>
+      {data.potentialMode === BucketPotentialMode.Maximum && (
+        <>
+          <div>
+            {data.bestUpgraded?.length > 0 && (
+              <>
+                <>{t('UpgradedStats')}</>
+                <>{data.bestUpgraded.join(' / ')}</>
+              </>
+            )}
+          </div>
+          <div>
+            {data.bestAdded?.length > 0 && (
+              <>
+                <>{t('NewStats')}</>
+                <>{data.bestAdded.join(' / ')}</>
+              </>
+            )}
+          </div>
+        </>
+      )}
     </div>
   )
+}
+
+type BucketPotential = Pick<PotentialResult, 'averagePct' | 'bestPct'>
+
+export function getBucketPotential(score: BucketPotential, mode: BucketPotentialMode): number {
+  return mode === BucketPotentialMode.Average ? score.averagePct : score.bestPct
+}
+
+export function getBucketIndex(score: BucketPotential, mode: BucketPotentialMode): number {
+  const potential = getBucketPotential(score, mode)
+  // The chart has ten rows, so 100% remains in the highest 90%+ bucket.
+  return Math.min(9, Math.max(0, Math.floor(potential / 10)))
 }

--- a/src/lib/tabs/tabRelics/relicInsightsPanel/BucketsPanel.tsx
+++ b/src/lib/tabs/tabRelics/relicInsightsPanel/BucketsPanel.tsx
@@ -8,7 +8,7 @@ import { Assets } from 'lib/rendering/assets'
 import { useGlobalStore } from 'lib/stores/app/appStore'
 import { type PanelProps } from 'lib/tabs/tabRelics/relicInsightsPanel/RelicInsightsPanel'
 import { BucketPotentialMode } from 'lib/tabs/tabRelics/useRelicsTabStore'
-import { precisionRound } from 'lib/utils/mathUtils'
+import { truncate10ths } from 'lib/utils/mathUtils'
 import { memo } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
@@ -189,7 +189,7 @@ function TooltipContent(props: TooltipContentProps) {
       </div>
       <div>
         {data.potentialMode === BucketPotentialMode.Average ? t('AvgPotential') : t('MaxPotential')}
-        {precisionRound(data.potential, 1)}%
+        {truncate10ths(data.potential)}%
       </div>
       {data.potentialMode === BucketPotentialMode.Maximum && (
         <>

--- a/src/lib/tabs/tabRelics/relicInsightsPanel/RelicInsightsPanel.tsx
+++ b/src/lib/tabs/tabRelics/relicInsightsPanel/RelicInsightsPanel.tsx
@@ -13,6 +13,7 @@ import { BucketsPanel } from 'lib/tabs/tabRelics/relicInsightsPanel/BucketsPanel
 import { EstbpCard } from 'lib/tabs/tabRelics/relicInsightsPanel/Estbp'
 import { Top10Panel } from 'lib/tabs/tabRelics/relicInsightsPanel/Top10Panel'
 import {
+  type BucketPotentialMode,
   InsightCharacters,
   RelicInsights,
   useRelicsTabStore,
@@ -27,10 +28,11 @@ import type { CharacterId } from 'types/character'
 import { useShallow } from 'zustand/react/shallow'
 
 export const RelicInsightsPanel = memo(function RelicInsightsPanel() {
-  const { insightsCharacters, insightsMode, selectedRelicId, excludedRelicPotentialCharacters } = useRelicsTabStore(
+  const { insightsCharacters, insightsMode, bucketPotentialMode, selectedRelicId, excludedRelicPotentialCharacters } = useRelicsTabStore(
     useShallow((s) => ({
       insightsCharacters: s.insightsCharacters,
       insightsMode: s.insightsMode,
+      bucketPotentialMode: s.bucketPotentialMode,
       selectedRelicId: s.selectedRelicId,
       excludedRelicPotentialCharacters: s.excludedRelicPotentialCharacters,
     })),
@@ -73,17 +75,17 @@ export const RelicInsightsPanel = memo(function RelicInsightsPanel() {
     return <div style={{ width: '100%', overflow: 'hidden' }} />
   }
 
-  return <RelicInsightsPanelContent scores={scores} insightsMode={insightsMode} />
+  return <RelicInsightsPanelContent scores={scores} insightsMode={insightsMode} bucketPotentialMode={bucketPotentialMode} />
 })
 
-function RelicInsightsPanelContent({ scores, insightsMode }: { scores: Score[], insightsMode: RelicInsights }) {
+function RelicInsightsPanelContent({ scores, insightsMode, bucketPotentialMode, }: { scores: Score[], insightsMode: RelicInsights, bucketPotentialMode: BucketPotentialMode, }) {
   return (
     <div style={{ width: '100%', overflow: 'hidden' }}>
       <DeferCreate>
         {(() => {
           switch (insightsMode) {
             case RelicInsights.Buckets:
-              return <BucketsPanel scores={scores} width={INSIGHTS_PANEL_WIDTH} />
+              return <BucketsPanel scores={scores} width={INSIGHTS_PANEL_WIDTH} potentialMode={bucketPotentialMode} />
             case RelicInsights.Top10:
               return <Top10Panel scores={scores} width={INSIGHTS_PANEL_WIDTH} />
             case RelicInsights.ESTBP:

--- a/src/lib/tabs/tabRelics/useRelicsTabStore.test.ts
+++ b/src/lib/tabs/tabRelics/useRelicsTabStore.test.ts
@@ -6,6 +6,7 @@ import {
   Sets,
 } from 'lib/constants/constants'
 import {
+  BucketPotentialMode,
   InsightCharacters,
   RelicInsights,
   useRelicsTabStore,
@@ -62,6 +63,7 @@ describe('useRelicsTabStore', () => {
       expect(state().excludedRelicPotentialCharacters).toEqual([])
       expect(state().insightsMode).toBe(RelicInsights.Buckets)
       expect(state().insightsCharacters).toBe(InsightCharacters.Custom)
+      expect(state().bucketPotentialMode).toBe(BucketPotentialMode.Maximum)
       expect(state().valueColumns).toHaveLength(7)
       expect(state().filters).toEqual(emptyFilters)
     })
@@ -158,6 +160,11 @@ describe('useRelicsTabStore', () => {
       state().setInsightsCharacters(InsightCharacters.All)
       expect(state().insightsMode).toBe(RelicInsights.Top10)
       expect(state().insightsCharacters).toBe(InsightCharacters.All)
+    })
+
+    it('setBucketPotentialMode updates the bucket potential mode', () => {
+      state().setBucketPotentialMode(BucketPotentialMode.Average)
+      expect(state().bucketPotentialMode).toBe(BucketPotentialMode.Average)
     })
   })
 })

--- a/src/lib/tabs/tabRelics/useRelicsTabStore.ts
+++ b/src/lib/tabs/tabRelics/useRelicsTabStore.ts
@@ -36,6 +36,13 @@ export enum InsightCharacters {
   Owned,
 }
 
+// Represents the score used to place characters in the Buckets chart.
+// This does not affect Top 10 or EST TBP, which have their own presentation logic.
+export enum BucketPotentialMode {
+  Maximum,
+  Average,
+}
+
 const defaultState: RelicsTabStateValues = {
   focusCharacter: null,
   selectedRelicId: null,
@@ -61,6 +68,8 @@ const defaultState: RelicsTabStateValues = {
     mainStat: [],
     subStat: [],
   },
+  // Preserve the current maximum-potential behavior by default.
+  bucketPotentialMode: BucketPotentialMode.Maximum,
   insightsMode: RelicInsights.Buckets,
   insightsCharacters: InsightCharacters.Custom,
 }
@@ -74,6 +83,7 @@ interface RelicsTabStateValues {
   filters: RelicTabFilters
   insightsMode: RelicInsights
   insightsCharacters: InsightCharacters
+  bucketPotentialMode: BucketPotentialMode
 }
 
 interface RelicsTabStateActions {
@@ -88,6 +98,8 @@ interface RelicsTabStateActions {
 
   setInsightsMode: (mode: RelicInsights) => void
   setInsightsCharacters: (mode: InsightCharacters) => void
+
+  setBucketPotentialMode: (mode: RelicsTabStateValues['bucketPotentialMode']) => void
 }
 
 type RelicsTabState = RelicsTabStateActions & RelicsTabStateValues
@@ -115,6 +127,7 @@ const useRelicsTabStore = createTabAwareStore<RelicsTabState>((set, get) => ({
 
   setInsightsMode: (insightsMode) => set({ insightsMode }),
   setInsightsCharacters: (insightsCharacters) => set({ insightsCharacters }),
+  setBucketPotentialMode: (bucketPotentialMode) => set({ bucketPotentialMode }),
 }))
 
 export { useRelicsTabStore }

--- a/src/types/resources.d.ts
+++ b/src/types/resources.d.ts
@@ -5926,7 +5926,8 @@ export default interface Resources {
       "Title": "Relic Insight",
       "p1": "When a relic is selected in the table above, you can choose an analysis to view a plot of.",
       "p2": "'Buckets' looks at how perfect this relic could be (with the best possible upgrade rolls) for each character, and buckets them into percentages.<1/>If you hover over a character portrait you'll see the new stats and/or rolls necessary to reach the max potential of this relic.<3/>⚠️ Relics with missing substats may have misleadingly high buckets, as best-case upgrade analysis assumes the best new substat per character.",
-      "p3": "Top 10 takes the top 10 characters that this relic could be best for, and shows the range of \"% perfection\" upgrading this relic could result in."
+      "p3": "Top 10 takes the top 10 characters that this relic could be best for, and shows the range of \"% perfection\" upgrading this relic could result in.",
+      "p4": "Use the Maximum / Average toggle to switch between the best possible upgrade rolls and the projected average potential at the relic's maximum level."
     },
     "RelicLocation": {
       "Title": "Relic Location",
@@ -7847,6 +7848,7 @@ export default interface Resources {
     },
     "RelicInsights": {
       "AvgPotential": "Average potential: ",
+      "MaxPotential": "Maximum potential: ",
       "NewStats": "New stats: ",
       "UpgradedStats": "Upgraded stats: "
     },
@@ -7868,6 +7870,10 @@ export default interface Resources {
         "PlotAll": "Show all characters",
         "PlotCustom": "Show custom characters",
         "PlotOwned": "Show owned characters"
+      },
+      "PotentialOptions": {
+        "Average": "Average",
+        "Maximum": "Maximum"
       },
       "RelicLocator": {
         "Filter": "Auto filter rows",


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

- Added a Maximum/Average potential selector to the relic scorer's Buckets view.
- Changed the bucket chart to use maximum/average potential based on the selected mode.
- Kept Maximum as the default mode and limited the selector to the Buckets view.
- Kept upgrade suggestions limited to Maximum mode because they describe the best-case upgrade path.
- Added localized labels and help text for the new scoring modes.
- Added tests covering the bucket score selection and relic insight mode state.

## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

- Closes #1079

## Testing

- Manually verified that the selector is visible in the Buckets view and hidden in the Top 10 and EST TBP views.
- Manually verified switching between Maximum and Average updates the bucket results.
- Ran `npx vitest --no-watch --pool=forks`.
- Ran `npm run typecheck`
- Ran `npm run lint`
- Ran `npm run build`
- Ran `npm test` (Playwright).


## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [x] I have added commit messages that are descriptive and meaningful.
- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->

### Updated help text

<img width="2880" height="1404" alt="image" src="https://github.com/user-attachments/assets/bd59cc9d-5589-488a-a78f-b6d2afcc5980" />

### Maximum potential

<img width="2880" height="1408" alt="image" src="https://github.com/user-attachments/assets/22f14e80-3020-44a6-95a3-d9f62b3d26cc" />

### Average potential

<img width="2880" height="1398" alt="image" src="https://github.com/user-attachments/assets/bdcee2f7-d1bb-4723-b7fa-4043cdcf9ed1" />
