### PR TITLE
feat: update wgsl unit tests

### DIFF
--- a/src/lib/gpu/injection/generateWgsl.debug.test.ts
+++ b/src/lib/gpu/injection/generateWgsl.debug.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+import { generateWgsl } from 'lib/gpu/injection/generateWgsl'
+import {
+  addE6S5Teammate,
+} from 'lib/gpu/tests/webgpuTestGenerator'
+import { generateTestRelics } from 'lib/gpu/tests/webgpuTestUtils'
+import { generateContext } from 'lib/optimization/context/calculateContext'
+import { SortOption } from 'lib/optimization/sortOptions'
+import { generateFullDefaultForm } from 'lib/simulations/utils/benchmarkForm'
+import { Metadata } from 'lib/state/metadataInitializer'
+import { normalizeForm } from 'lib/stores/optimizerForm/optimizerFormConversions'
+import type { GpuConstants } from 'lib/gpu/webgpuTypes'
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest'
+
+Metadata.initialize()
+
+const DEBUG_GPU_CONSTANTS = {
+  WORKGROUP_SIZE: 256,
+  BLOCK_SIZE: 16_384,
+  CYCLES_PER_INVOCATION: 256,
+  RESULTS_LIMIT: 1_024,
+  COMPACT_LIMIT: 4_096,
+  DEBUG: true,
+  TUPLE_MODE: false,
+} satisfies GpuConstants
+
+describe('WebGPU debug shader output', () => {
+  it('matches the CPU last-default-action container and preserves every other register', () => {
+    const request = normalizeForm(generateFullDefaultForm('1005b1', '23001', 6, 5))
+    request.resultSort = SortOption.COMBO.key
+    addE6S5Teammate(request, 0, '8008', '21051')
+    addE6S5Teammate(request, 1, '1225', '23035')
+    addE6S5Teammate(request, 2, '1309', '23026')
+
+    const context = generateContext(request)
+    const wgsl = generateWgsl(context, request, generateTestRelics(), DEBUG_GPU_CONSTANTS)
+    const lastDefaultIndex = context.defaultActions.length - 1
+
+    expect(lastDefaultIndex).toBeGreaterThan(0)
+    expect(wgsl).toContain(`var debugContainer: array<f32, ${context.maxContainerArrayLength}> = container${lastDefaultIndex};`)
+    expect(wgsl).toContain('debugEhp0Value')
+
+    for (let i = 0; i < context.defaultActions.length + context.rotationActions.length; i++) {
+      const registerCopy = `Copy action ${i} registers to debug container`
+      if (i === lastDefaultIndex) {
+        expect(wgsl).not.toContain(registerCopy)
+      } else {
+        expect(wgsl).toContain(registerCopy)
+      }
+    }
+  })
+
+  it('matches CPU last-recorded semantics for combo buff output', () => {
+    const request = normalizeForm(generateFullDefaultForm('1313', '23000', 6, 5))
+    request.resultSort = SortOption.COMBO_BUFF.key
+
+    const context = generateContext(request)
+    const wgsl = generateWgsl(context, request, generateTestRelics(), DEBUG_GPU_CONSTANTS)
+
+    expect(wgsl).toContain('let defaultComboBuff = comboBuff;')
+    expect(wgsl).toContain('comboBuff = defaultComboBuff;')
+    expect(wgsl).toContain('*p_comboBuff = comboBuff;')
+    expect(wgsl).not.toContain('*p_comboBuff += comboBuff;')
+  })
+})

--- a/src/lib/gpu/injection/injectUnrolledActions.ts
+++ b/src/lib/gpu/injection/injectUnrolledActions.ts
@@ -21,6 +21,7 @@ import {
   GlobalRegister,
 } from 'lib/optimization/engine/config/keys'
 import {
+  OutputTag,
   SELF_ENTITY_INDEX,
   TargetTag,
 } from 'lib/optimization/engine/config/tag'
@@ -58,6 +59,7 @@ function generateUnrolledActions(request: Form, context: OptimizerContext, gpuPa
     var comboBuff: f32 = 0;
 `
   let functions = ''
+  const defaultActionsRecordBuff = context.defaultActions.some(recordsBuffOutput)
 
   for (let i = 0; i < context.defaultActions.length; i++) {
     const action = context.defaultActions[i]
@@ -68,12 +70,6 @@ function generateUnrolledActions(request: Form, context: OptimizerContext, gpuPa
 
     if (i === 0) {
       calls += generateCombatStatFilters(request, context, gpuParams)
-    }
-
-    if (gpuParams.DEBUG) {
-      calls += i === 0
-        ? `\n    var debugContainer: array<f32, ${context.maxContainerArrayLength}> = container0;\n\n`
-        : generateRegisterCopy(i, action, context)
     }
 
     // For ability-damage sorts (BASIC, SKILL, ULT, etc.), the sort value is fully determined
@@ -87,6 +83,10 @@ function generateUnrolledActions(request: Form, context: OptimizerContext, gpuPa
     }
   }
 
+  if (defaultActionsRecordBuff) {
+    calls += '    let defaultComboBuff = comboBuff;\n'
+  }
+
   for (let i = 0; i < context.rotationActions.length; i++) {
     const action = context.rotationActions[i]
     const actionIndex = context.defaultActions.length + i
@@ -95,15 +95,17 @@ function generateUnrolledActions(request: Form, context: OptimizerContext, gpuPa
     calls += result.actionCall
     functions += result.actionFunction
 
-    if (gpuParams.DEBUG) {
-      calls += generateRegisterCopy(actionIndex, action, context)
-    }
+  }
+
+  if (defaultActionsRecordBuff) {
+    calls += '    comboBuff = defaultComboBuff;\n'
   }
 
   if (!gpuParams.DEBUG) {
     calls += generateRatingFilters(request, context, gpuParams)
     calls += generateSortOptionReturn(request, context)
   } else {
+    calls += generateDebugContainer(context)
     const comboGlobalRegIdx = getGlobalRegisterIndexWgsl(GlobalRegister.COMBO_DMG, context)
     const healGlobalRegIdx = getGlobalRegisterIndexWgsl(GlobalRegister.COMBO_HEAL, context)
     const shieldGlobalRegIdx = getGlobalRegisterIndexWgsl(GlobalRegister.COMBO_SHIELD, context)
@@ -129,6 +131,10 @@ function isAbilitySortAction(request: Form, action: OptimizerAction): boolean {
     && sortOption.key !== SortOption.COMBO_BUFF.key
     && sortOption.key !== SortOption.EHP.key
     && action.actionName === sortOption.key
+}
+
+function recordsBuffOutput(action: OptimizerAction): boolean {
+  return action.hits?.some((hit) => hit.recorded !== false && hit.outputTag === OutputTag.BUFF) ?? false
 }
 
 const SortOptionToAKey: Partial<Record<SortOptionKey, AKeyValue>> = {
@@ -331,6 +337,32 @@ function generateRegisterCopy(actionIndex: number, action: OptimizerAction, cont
   return code
 }
 
+function generateDebugContainer(context: OptimizerContext): string {
+  const debugActionIndex = context.defaultActions.length - 1
+  const debugAction = context.defaultActions[debugActionIndex]
+  if (!debugAction) throw new Error('WebGPU debug output requires at least one default action')
+
+  let code = `
+    // Match simulateBuild
+    var debugContainer: array<f32, ${context.maxContainerArrayLength}> = container${debugActionIndex};
+`
+
+  if (context.shaderVariables.needsEhp) {
+    const { statements } = generateEhpStatements('debugContainer', debugAction, 'debugEhp')
+    code += `    ${statements.join('\n    ')}\n`
+  }
+
+  for (let i = 0; i < context.defaultActions.length; i++) {
+    if (i !== debugActionIndex) code += generateRegisterCopy(i, context.defaultActions[i], context)
+  }
+  for (let i = 0; i < context.rotationActions.length; i++) {
+    const actionIndex = context.defaultActions.length + i
+    code += generateRegisterCopy(actionIndex, context.rotationActions[i], context)
+  }
+
+  return code
+}
+
 // dprint-ignore
 function unrollAction(index: number, action: OptimizerAction, context: OptimizerContext, gpuParams: GpuConstants, isRotationAction: boolean) {
   const characterConditionals: CharacterConditionalsController = CharacterConditionalsResolver.get(context)
@@ -360,6 +392,7 @@ function unrollAction(index: number, action: OptimizerAction, context: Optimizer
   //////////
 
   const damageCalculationWgsl = indent(unrollDamageCalculations(action, context, gpuParams), 1)
+  const comboBuffUpdateWgsl = recordsBuffOutput(action) ? '*p_comboBuff = comboBuff;' : ''
 
   //////////
 
@@ -461,7 +494,7 @@ fn unrolledAction${index}(
   *p_comboDmg += comboDmg;
   *p_comboHeal += comboHeal;
   *p_comboShield += comboShield;
-  *p_comboBuff += comboBuff;
+  ${comboBuffUpdateWgsl}
 
   // Return total for debug register copy
   return comboDmg + comboHeal + comboShield + comboBuff;
@@ -534,7 +567,7 @@ fn unrolledAction${index}(
 
   ${damageCalculationWgsl}
 
-  *p_comboBuff += comboBuff;
+  ${comboBuffUpdateWgsl}
 
   return comboDmg + comboHeal + comboShield + comboBuff;
 }
@@ -680,24 +713,12 @@ function generateCombatStatFilters(request: Form, context: OptimizerContext, gpu
 
   // EHP calculation for all entities (needed for filtering or sorting)
   if (context.shaderVariables.needsEhp) {
-    for (let entityIndex = 0; entityIndex < config.entitiesLength; entityIndex++) {
-      const hpIndex = getActionIndex(entityIndex, AKey.HP, config)
-      const defIndex = getActionIndex(entityIndex, AKey.DEF, config)
-      const dmgRedIndex = getActionIndex(entityIndex, AKey.DMG_RED, config)
-      const ehpIndex = getActionIndex(entityIndex, AKey.EHP, config)
-
-      extractions.push(`let ehpHp${entityIndex} = container0[${hpIndex}];`)
-      extractions.push(`let ehpDef${entityIndex} = container0[${defIndex}];`)
-      extractions.push(`let ehpDmgRed${entityIndex} = container0[${dmgRedIndex}];`)
-      extractions.push(
-        `let ehp${entityIndex} = ehpHp${entityIndex} / (1.0 - ehpDef${entityIndex} / (ehpDef${entityIndex} + 200.0 + 10.0 * f32(enemyLevel))) / (1.0 - ehpDmgRed${entityIndex});`,
-      )
-      extractions.push(`container0[${ehpIndex}] = ehp${entityIndex};`)
-    }
+    const ehp = generateEhpStatements('container0', action, 'filterEhp')
+    extractions.push(...ehp.statements)
 
     // EHP filtering uses entity 0 (primary character)
-    if (request.minEhp > 0) conditions.push(`ehp0 < minEhp`)
-    if (request.maxEhp < Constants.MAX_INT) conditions.push(`ehp0 > maxEhp`)
+    if (request.minEhp > 0) conditions.push(`${ehp.primaryValue} < minEhp`)
+    if (request.maxEhp < Constants.MAX_INT) conditions.push(`${ehp.primaryValue} > maxEhp`)
   }
 
   if (extractions.length === 0) return ''
@@ -718,4 +739,30 @@ function generateCombatStatFilters(request: Form, context: OptimizerContext, gpu
       continue;
     }
 `
+}
+
+function generateEhpStatements(containerName: string, action: OptimizerAction, variablePrefix: string) {
+  const statements: string[] = []
+  let primaryValue = ''
+
+  for (let entityIndex = 0; entityIndex < action.config.entitiesLength; entityIndex++) {
+    const hpIndex = getActionIndex(entityIndex, AKey.HP, action.config)
+    const defIndex = getActionIndex(entityIndex, AKey.DEF, action.config)
+    const dmgRedIndex = getActionIndex(entityIndex, AKey.DMG_RED, action.config)
+    const ehpIndex = getActionIndex(entityIndex, AKey.EHP, action.config)
+    const suffix = `${variablePrefix}${entityIndex}`
+    const hp = `${suffix}Hp`
+    const def = `${suffix}Def`
+    const dmgRed = `${suffix}DmgRed`
+    const value = `${suffix}Value`
+
+    statements.push(`let ${hp} = ${containerName}[${hpIndex}];`)
+    statements.push(`let ${def} = ${containerName}[${defIndex}];`)
+    statements.push(`let ${dmgRed} = ${containerName}[${dmgRedIndex}];`)
+    statements.push(`let ${value} = ${hp} / (1.0 - ${def} / (${def} + 200.0 + 10.0 * f32(enemyLevel))) / (1.0 - ${dmgRed});`)
+    statements.push(`${containerName}[${ehpIndex}] = ${value};`)
+    if (entityIndex === 0) primaryValue = value
+  }
+
+  return { statements, primaryValue }
 }

--- a/src/lib/gpu/tests/webgpuTestGenerator.ts
+++ b/src/lib/gpu/tests/webgpuTestGenerator.ts
@@ -9,11 +9,15 @@ import { Hyacine } from 'lib/conditionals/character/1400/Hyacine'
 import { Hysilens } from 'lib/conditionals/character/1400/Hysilens'
 import { PermansorTerrae } from 'lib/conditionals/character/1400/PermansorTerrae'
 import { Phainon } from 'lib/conditionals/character/1400/Phainon'
+import { AventurineWaveflair } from 'lib/conditionals/character/1500/AventurineWaveflair'
+import { RobinSummeretto } from 'lib/conditionals/character/1500/RobinSummeretto'
 import { AThanklessCoronation } from 'lib/conditionals/lightcone/5star/AThanklessCoronation'
 import { EpochEtchedInGoldenBlood } from 'lib/conditionals/lightcone/5star/EpochEtchedInGoldenBlood'
 import { LiesAflutterInTheWind } from 'lib/conditionals/lightcone/5star/LiesAflutterInTheWind'
 import { LifeShouldBeCastToFlames } from 'lib/conditionals/lightcone/5star/LifeShouldBeCastToFlames'
 import { MayRainbowsRemainInTheSky } from 'lib/conditionals/lightcone/5star/MayRainbowsRemainInTheSky'
+import { RiseAndSing } from 'lib/conditionals/lightcone/5star/RiseAndSing'
+import { SummerRidesTheSurf } from 'lib/conditionals/lightcone/5star/SummerRidesTheSurf'
 import { TheHellWhereIdealsBurn } from 'lib/conditionals/lightcone/5star/TheHellWhereIdealsBurn'
 import { ThisLoveForever } from 'lib/conditionals/lightcone/5star/ThisLoveForever'
 import { ThoughWorldsApart } from 'lib/conditionals/lightcone/5star/ThoughWorldsApart'
@@ -140,6 +144,8 @@ const baseCharacterLightConeMappings: Array<{ characterId: CharacterId, lightCon
   { characterId: Evernight.id, lightConeId: ToEvernightsStars.id },
   { characterId: PermansorTerrae.id, lightConeId: ThoughWorldsApart.id },
   { characterId: Cyrene.id, lightConeId: ThisLoveForever.id },
+  { characterId: RobinSummeretto.id, lightConeId: RiseAndSing.id },
+  { characterId: AventurineWaveflair.id, lightConeId: SummerRidesTheSurf.id },
   { characterId: '8001', lightConeId: basicLc }, // Trailblazer
   { characterId: '8002', lightConeId: basicLc }, // Trailblazer
   { characterId: '8003', lightConeId: basicLc }, // Trailblazer

--- a/src/lib/gpu/tests/webgpuTestGenerator.ts
+++ b/src/lib/gpu/tests/webgpuTestGenerator.ts
@@ -62,18 +62,19 @@ const cache: {
 }
 
 const basicLc = '23001' // In the Night
+const kafkaId: CharacterId = '1005b1'
 const baseCharacterLightConeMappings: Array<{ characterId: CharacterId, lightConeId: LightConeId }> = [
   { characterId: '1001', lightConeId: basicLc }, // March 7th
   { characterId: '1002', lightConeId: basicLc }, // Dan Heng
   { characterId: '1003', lightConeId: '23000' }, // Himeko
-  { characterId: '1004', lightConeId: '23004' }, // Welt
-  { characterId: '1005', lightConeId: '23006' }, // Kafka
-  { characterId: '1006', lightConeId: '23007' }, // Silver Wolf
+  { characterId: '1004b1', lightConeId: '23004' }, // Welt
+  { characterId: kafkaId, lightConeId: '23006' }, // Kafka
+  { characterId: '1006b1', lightConeId: '23007' }, // Silver Wolf
   { characterId: '1008', lightConeId: basicLc }, // Arlan
   { characterId: '1009', lightConeId: basicLc }, // Asta
   { characterId: '1013', lightConeId: basicLc }, // Herta
   { characterId: '1101', lightConeId: '23003' }, // Bronya
-  { characterId: '1102', lightConeId: '23001' }, // Seele
+  { characterId: '1102b1', lightConeId: '23001' }, // Seele
   { characterId: '1103', lightConeId: basicLc }, // Serval
   { characterId: '1104', lightConeId: '23005' }, // Gepard
   { characterId: '1105', lightConeId: basicLc }, // Natasha
@@ -88,18 +89,18 @@ const baseCharacterLightConeMappings: Array<{ characterId: CharacterId, lightCon
   { characterId: '1202', lightConeId: basicLc }, // Tingyun
   { characterId: '1203', lightConeId: '23008' }, // Luocha
   { characterId: '1204', lightConeId: '23010' }, // Jing Yuan
-  { characterId: '1205', lightConeId: '23009' }, // Blade
+  { characterId: '1205b1', lightConeId: '23009' }, // Blade
   { characterId: '1206', lightConeId: basicLc }, // Sushang
   { characterId: '1207', lightConeId: basicLc }, // Yukong
   { characterId: '1208', lightConeId: '23011' }, // Fu Xuan
   { characterId: '1209', lightConeId: '23012' }, // Yanqing
   { characterId: '1210', lightConeId: basicLc }, // Guinaifen
   { characterId: '1211', lightConeId: '23013' }, // Bailu
-  { characterId: '1212', lightConeId: '23014' }, // Jingliu
+  { characterId: '1212b1', lightConeId: '23014' }, // Jingliu
   { characterId: '1213', lightConeId: '23015' }, // Dan Heng • Imbibitor Lunae
   { characterId: '1214', lightConeId: basicLc }, // Xueyi
   { characterId: '1215', lightConeId: basicLc }, // Hanya
-  { characterId: '1217', lightConeId: '23017' }, // Huohuo
+  { characterId: '1217b1', lightConeId: '23017' }, // Huohuo
   { characterId: '1218', lightConeId: '23029' }, // Jiaoqiu
   { characterId: '1220', lightConeId: '23031' }, // Feixiao
   { characterId: '1221', lightConeId: '23030' }, // Yunli
@@ -111,11 +112,11 @@ const baseCharacterLightConeMappings: Array<{ characterId: CharacterId, lightCon
   { characterId: '1303', lightConeId: '23019' }, // Ruan Mei
   { characterId: '1304', lightConeId: '23023' }, // Aventurine
   { characterId: '1305', lightConeId: '23020' }, // Dr. Ratio
-  { characterId: '1306', lightConeId: '23021' }, // Sparkle
-  { characterId: '1307', lightConeId: '23022' }, // Black Swan
+  { characterId: '1306b1', lightConeId: '23021' }, // Sparkle
+  { characterId: '1307b1', lightConeId: '23022' }, // Black Swan
   { characterId: '1308', lightConeId: '23024' }, // Acheron
   { characterId: '1309', lightConeId: '23026' }, // Robin
-  { characterId: '1310', lightConeId: '23025' }, // Firefly
+  { characterId: '1310b1', lightConeId: '23025' }, // Firefly
   { characterId: '1312', lightConeId: basicLc }, // Misha
   { characterId: '1314', lightConeId: '23028' }, // Jade
   { characterId: '1315', lightConeId: '23027' }, // Boothill
@@ -190,7 +191,7 @@ export function generateE6E5Tests(device: GPUDevice) {
 
 export function generateStarLcTests(device: GPUDevice, star: number) {
   // Use Kafka since she has DOT and FUA
-  const characterId = '1005'
+  const characterId = kafkaId
   const metadataLightCones = Object.values(cache.metadata.lightCones)
   const lightCones = metadataLightCones.filter((lc: DBMetadataLightCone) => lc.rarity === star)
   const tests: WebgpuTest[] = []
@@ -205,7 +206,7 @@ export function generateStarLcTests(device: GPUDevice, star: number) {
 
 export function generateOrnamentSetTests(device: GPUDevice) {
   // Use Kafka since she has DOT and FUA
-  const characterId = '1005'
+  const characterId = kafkaId
   const lightConeId = basicLc
   const tests: WebgpuTest[] = []
 
@@ -222,7 +223,7 @@ export function generateOrnamentSetTests(device: GPUDevice) {
 
 export function generateRelicSetTests(device: GPUDevice) {
   // Use Kafka since she has DOT and FUA
-  const characterId = '1005'
+  const characterId = kafkaId
   const lightConeId = basicLc
   const tests: WebgpuTest[] = []
 

--- a/src/lib/gpu/tests/webgpuTestUtils.ts
+++ b/src/lib/gpu/tests/webgpuTestUtils.ts
@@ -12,10 +12,10 @@ import type { RelicsByPart } from 'lib/gpu/webgpuTypes'
 import { generateContext } from 'lib/optimization/context/calculateContext'
 import {
   AKeyNames,
+  GlobalRegister,
   StatKey,
 } from 'lib/optimization/engine/config/keys'
 import { STATS_LENGTH } from 'lib/optimization/engine/config/statsConfig'
-import { OutputTag } from 'lib/optimization/engine/config/tag'
 import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
 import { SortOption } from 'lib/optimization/sortOptions'
 import type { AugmentedStats } from 'lib/relics/relicAugmenter'
@@ -26,6 +26,7 @@ import {
 import { simulateBuild } from 'lib/simulations/simulateBuild'
 import type { SimulationRelicByPart } from 'lib/simulations/statSimulationTypes'
 import type { Form } from 'types/form'
+import type { CharacterId } from 'types/character'
 import type { OptimizerContext } from 'types/optimizer'
 
 export async function runTestRequest(request: Form, relics: RelicsByPart, device: GPUDevice) {
@@ -50,8 +51,9 @@ export async function runTestRequest(request: Form, relics: RelicsByPart, device
   )
 
   const passResult = generateExecutionPass(gpuContext, 0)
-  await passResult.gpuReadBuffer.mapAsync(GPUMapMode.READ, 0, 10000)
-  const arrayBuffer = passResult.gpuReadBuffer.getMappedRange(0, 10000)
+  const resultByteLength = Float32Array.BYTES_PER_ELEMENT * context.maxContainerArrayLength
+  await passResult.gpuReadBuffer.mapAsync(GPUMapMode.READ, 0, resultByteLength)
+  const arrayBuffer = passResult.gpuReadBuffer.getMappedRange(0, resultByteLength)
   const array = new Float32Array(arrayBuffer)
 
   const relicsByPart = {
@@ -198,46 +200,14 @@ function arrayDelta(cpuContainer: ComputedStatsContainer, gpuContainer: Computed
     analyze(statName, cpu[i], gpu[i], precision)
   }
 
-  // Compare register values for COMBO damage (sum of rotation action registers)
-  // Also extract HEAL and SHIELD values from hit registers based on outputTag
-  let cpuCombo = 0
-  let gpuCombo = 0
-  let cpuHeal = 0
-  let gpuHeal = 0
-  let cpuShield = 0
-  let gpuShield = 0
-  let cpuBuff = 0
-  let gpuBuff = 0
-
-  for (const action of context.rotationActions) {
-    cpuCombo += cpuContainer.getActionRegisterValue(action.registerIndex)
-    gpuCombo += gpuContainer.getActionRegisterValue(action.registerIndex)
-
-    if (action.hits) {
-      for (const hit of action.hits) {
-        const cpuHitValue = cpuContainer.getHitRegisterValue(hit.registerIndex)
-        const gpuHitValue = gpuContainer.getHitRegisterValue(hit.registerIndex)
-        if (hit.outputTag === OutputTag.HEAL) {
-          cpuHeal += cpuHitValue
-          gpuHeal += gpuHitValue
-        } else if (hit.outputTag === OutputTag.SHIELD) {
-          cpuShield += cpuHitValue
-          gpuShield += gpuHitValue
-        }
-      }
-    }
-  }
-
-  for (const action of context.defaultActions) {
-    if (action.hits) {
-      for (const hit of action.hits) {
-        if (hit.outputTag === OutputTag.BUFF) {
-          cpuBuff = cpuContainer.getHitRegisterValue(hit.registerIndex)
-          gpuBuff = gpuContainer.getHitRegisterValue(hit.registerIndex)
-        }
-      }
-    }
-  }
+  const cpuCombo = cpuContainer.getGlobalRegisterValue(GlobalRegister.COMBO_DMG)
+  const gpuCombo = gpuContainer.getGlobalRegisterValue(GlobalRegister.COMBO_DMG)
+  const cpuHeal = cpuContainer.getGlobalRegisterValue(GlobalRegister.COMBO_HEAL)
+  const gpuHeal = gpuContainer.getGlobalRegisterValue(GlobalRegister.COMBO_HEAL)
+  const cpuShield = cpuContainer.getGlobalRegisterValue(GlobalRegister.COMBO_SHIELD)
+  const gpuShield = gpuContainer.getGlobalRegisterValue(GlobalRegister.COMBO_SHIELD)
+  const cpuBuff = cpuContainer.getGlobalRegisterValue(GlobalRegister.COMBO_BUFF)
+  const gpuBuff = gpuContainer.getGlobalRegisterValue(GlobalRegister.COMBO_BUFF)
 
   analyze('COMBO_REGISTER', cpuCombo, gpuCombo, getDynamicComboPrecision(Math.max(cpuCombo, gpuCombo)))
   analyze('HEAL_REGISTER', cpuHeal, gpuHeal, P_2)
@@ -293,7 +263,9 @@ export function uncondenseRelics(relicsByPart: RelicsByPart) {
   return relicsByPart
 }
 
-// Jingliu base build +25% CR for crit sets
+const jingliuId: CharacterId = '1212b1'
+
+// Jingliu build +25% CR for crit sets
 export function generateTestRelics() {
   const condensedRelics = {
     Head: [
@@ -307,7 +279,7 @@ export function generateTestRelics() {
           value: 705.6,
         },
         id: 'cd85c14c-a662-4413-a149-a379e6d538d3',
-        equippedBy: '1212',
+        equippedBy: jingliuId,
         condensedStats: [
           [StatKey.CR, 0.11016 + 0.25],
           [StatKey.CD, 0.10368],
@@ -334,7 +306,7 @@ export function generateTestRelics() {
           value: 352.8,
         },
         id: '798657c8-5c5c-4b44-9c5f-f5f094414289',
-        equippedBy: '1212',
+        equippedBy: jingliuId,
         condensedStats: [
           [StatKey.HP_P, 0.03456],
           [StatKey.SPD, 4],
@@ -361,7 +333,7 @@ export function generateTestRelics() {
           value: 64.8,
         },
         id: 'b3376a19-62f9-489e-80e6-8f98335af158',
-        equippedBy: '1212',
+        equippedBy: jingliuId,
         condensedStats: [
           [StatKey.HP, 114.31138],
           [StatKey.ATK_P, 0.07344],
@@ -388,7 +360,7 @@ export function generateTestRelics() {
           value: 25.032,
         },
         id: '92c53d06-80d0-43a8-b896-2feeda419674',
-        equippedBy: '1212',
+        equippedBy: jingliuId,
         condensedStats: [
           [StatKey.ATK, 21.16877],
           [StatKey.ATK_P, 0.11664],
@@ -415,7 +387,7 @@ export function generateTestRelics() {
           value: 38.8803,
         },
         id: '80abbd56-b1a0-4587-a349-754c33627217',
-        equippedBy: '1212',
+        equippedBy: jingliuId,
         condensedStats: [
           [StatKey.DEF, 74.09071],
           [StatKey.CR, 0.05508],
@@ -442,7 +414,7 @@ export function generateTestRelics() {
           value: 43.2,
         },
         id: 'c521dc03-6c6e-45ef-9933-811367312441',
-        equippedBy: '1212',
+        equippedBy: jingliuId,
         condensedStats: [
           [StatKey.HP, 80.44134],
           [StatKey.CR, 0.08424],

--- a/src/lib/gpu/webgpuInternals.test.ts
+++ b/src/lib/gpu/webgpuInternals.test.ts
@@ -1,0 +1,32 @@
+// @vitest-environment jsdom
+import {
+  getResultBindGroupEntries,
+  getResultMatrixBufferSize,
+} from 'lib/gpu/webgpuInternals'
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest'
+
+const buffer = {} as GPUBuffer
+
+describe('WebGPU result buffer layout', () => {
+  it('binds the debug results array and valid permutation counter', () => {
+    const entries = getResultBindGroupEntries(true, buffer, buffer, buffer, buffer)
+
+    expect(entries.map((entry) => entry.binding)).toEqual([0, 3])
+  })
+
+  it('binds the release compaction buffers and valid permutation counter', () => {
+    const entries = getResultBindGroupEntries(false, buffer, buffer, buffer, buffer)
+
+    expect(entries.map((entry) => entry.binding)).toEqual([1, 2, 3])
+  })
+
+  it('sizes debug output by the full container stride', () => {
+    expect(getResultMatrixBufferSize(true, 16_384, 97)).toBe(6_356_992)
+    expect(getResultMatrixBufferSize(true, 16_384, 257)).toBe(16_842_752)
+    expect(getResultMatrixBufferSize(false, 16_384, 257)).toBe(4)
+  })
+})

--- a/src/lib/gpu/webgpuInternals.ts
+++ b/src/lib/gpu/webgpuInternals.ts
@@ -88,12 +88,11 @@ export async function initializeGpuPipeline(
 
   // Params buffer: 16 bytes for tuple mode (threshold + batchOffset + padding), 32 bytes for naive (8 floats)
   const paramsMatrixBufferSize = TUPLE_MODE ? 16 : Float32Array.BYTES_PER_ELEMENT * 8
-  const resultMatrixBufferSize = Float32Array.BYTES_PER_ELEMENT * BLOCK_SIZE * CYCLES_PER_INVOCATION
-  // Only DEBUG mode needs the full results buffer
-  const resultBufferSize = DEBUG ? resultMatrixBufferSize : 4
+  // DEBUG writes one full stats container per invocation. Release mode does not use this buffer.
+  const resultMatrixBufferSize = getResultMatrixBufferSize(DEBUG, BLOCK_SIZE, context.maxContainerArrayLength)
   const resultMatrixBuffers: [GPUBuffer, GPUBuffer] = [
-    device.createBuffer({ size: resultBufferSize, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC }),
-    device.createBuffer({ size: resultBufferSize, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC }),
+    device.createBuffer({ size: resultMatrixBufferSize, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC }),
+    device.createBuffer({ size: resultMatrixBufferSize, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC }),
   ]
   const paramsMatrixBuffer = device.createBuffer({
     size: paramsMatrixBufferSize,
@@ -200,23 +199,19 @@ export async function initializeGpuPipeline(
   const bindGroups2: [GPUBindGroup, GPUBindGroup] = [0, 1].map((i) =>
     device.createBindGroup({
       layout: computePipeline.getBindGroupLayout(2),
-      entries: (
-        DEBUG
-          ? [
-            { binding: 0, resource: { buffer: resultMatrixBuffers[i] } },
-          ]
-          : [
-            { binding: 1, resource: { buffer: compactCountBuffers[i] } },
-            { binding: 2, resource: { buffer: compactResultsBuffers[i] } },
-            { binding: 3, resource: { buffer: validCountBuffers[i] } },
-          ]
+      entries: getResultBindGroupEntries(
+        DEBUG,
+        resultMatrixBuffers[i],
+        compactCountBuffers[i],
+        compactResultsBuffers[i],
+        validCountBuffers[i],
       ),
     })
   ) as [GPUBindGroup, GPUBindGroup]
 
   const gpuReadBuffers: [GPUBuffer, GPUBuffer] = [
-    device.createBuffer({ size: resultBufferSize, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ }),
-    device.createBuffer({ size: resultBufferSize, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ }),
+    device.createBuffer({ size: resultMatrixBufferSize, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ }),
+    device.createBuffer({ size: resultMatrixBufferSize, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ }),
   ]
 
   const iterations = Math.ceil(permutations / BLOCK_SIZE / CYCLES_PER_INVOCATION)
@@ -286,10 +281,8 @@ export function submitGpuDispatch(gpuContext: GpuExecutionContext, paramsData: A
 
   const commandEncoder = device.createCommandEncoder()
 
-  if (!gpuContext.DEBUG) {
-    commandEncoder.clearBuffer(compactCountBuffer, 0, 4)
-    commandEncoder.clearBuffer(validCountBuffer, 0, 4)
-  }
+  commandEncoder.clearBuffer(validCountBuffer, 0, 4)
+  if (!gpuContext.DEBUG) commandEncoder.clearBuffer(compactCountBuffer, 0, 4)
 
   const passEncoder = commandEncoder.beginComputePass()
   passEncoder.setPipeline(gpuContext.computePipeline)
@@ -325,6 +318,29 @@ export function generateExecutionPass(gpuContext: GpuExecutionContext, offset: n
     gpuReadBuffer: gpuContext.gpuReadBuffers[bufferIndex],
     compactReadBuffer: gpuContext.compactReadBuffers[bufferIndex],
   }
+}
+
+export function getResultMatrixBufferSize(debug: boolean, blockSize: number, containerLength: number): number {
+  return debug ? Float32Array.BYTES_PER_ELEMENT * blockSize * containerLength : 4
+}
+
+export function getResultBindGroupEntries(
+  debug: boolean,
+  resultMatrixBuffer: GPUBuffer,
+  compactCountBuffer: GPUBuffer,
+  compactResultsBuffer: GPUBuffer,
+  validCountBuffer: GPUBuffer,
+): GPUBindGroupEntry[] {
+  return debug
+    ? [
+      { binding: 0, resource: { buffer: resultMatrixBuffer } },
+      { binding: 3, resource: { buffer: validCountBuffer } },
+    ]
+    : [
+      { binding: 1, resource: { buffer: compactCountBuffer } },
+      { binding: 2, resource: { buffer: compactResultsBuffer } },
+      { binding: 3, resource: { buffer: validCountBuffer } },
+    ]
 }
 
 async function generatePipeline(device: GPUDevice, wgsl: string) {

--- a/src/lib/optimization/engine/container/computedStatsContainer.ts
+++ b/src/lib/optimization/engine/container/computedStatsContainer.ts
@@ -167,12 +167,12 @@ export class ComputedStatsContainerConfig {
   public entityStride: number // actionStatsLength + (hitsLength * hitStatsLength)
   public arrayLength: number
 
-  // Register layout: [Stats...][Action Registers][Global Registers][Hit Registers]
+  // Register layout: [Stats...][Action Registers][Hit Registers][Global Registers]
   public registersOffset: number // Where registers start in array
   public actionRegistersLength: number // Number of action registers
   public globalRegistersLength: number // Number of global registers (e.g., COMBO_DMG)
   public hitRegistersLength: number // Number of hit registers
-  public totalRegistersLength: number // action + global + hit registers
+  public totalRegistersLength: number // action + hit + global registers
 
   public actionBuffIndices: Record<number, number[]> // Cached indices for actionBuff/actionSet
   public entityBaseOffsets: Record<number, number[]> // Per-TargetTag entity base offsets for loop-flipped stat writes

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -102,7 +102,7 @@ export default defineConfig({
   test: {
     environment: 'node',
     slowTestThreshold: 500,
-    exclude: ['node_modules/**', 'tests/**'],
+    exclude: ['node_modules/**', 'tests/**', 'plans/**'],
     execArgv: ['--no-webstorage'],
   },
   worker: {


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->
- Fix WebGPU parity tests reporting zero for every GPU value, caused by an incomplete debug bind group that made the dispatch fail before running.
- Fix debug result buffer sizing, which was dimensioned as scalar scores rather than full stat containers and would have overflowed for characters with larger containers.
- Fix GPU debug output snapshotting a different combat action than the CPU reference, so parity now compares like for like.
- Fix combo buff totals accumulating across actions instead of taking the last recorded value.
- Update the GPU and CPU comparison to read combo, heal, shield, and buff totals directly from their global registers instead of re-summing per-action values.
- Update WebGPU test characters from deprecated pre-Novaflare kits to their current versions, covering ten characters that were silently testing outdated implementations.
- Add Robin Summeretto and Aventurine Waveflair to WebGPU parity test coverage.
- Add regression tests for debug shader generation and result buffer layout.
- Fix a register layout comment that contradicted the actual ordering used by the accessors.
- Update the test runner to exclude the plans directory from test discovery.
## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [ ] I have added commit messages that are descriptive and meaningful.
- [ ] I have tested the changes locally.
- [ ] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
