### PR TITLE
fix: optimization engine crash cases

### DIFF
--- a/src/lib/gpu/webgpuOptimizer.ts
+++ b/src/lib/gpu/webgpuOptimizer.ts
@@ -26,7 +26,11 @@ import { simulateBuild } from 'lib/simulations/simulateBuild'
 import { type SimulationRelicByPart } from 'lib/simulations/statSimulationTypes'
 import { setSortColumn } from 'lib/stores/gridStore'
 import { gridStore } from 'lib/stores/gridStore'
-import { useOptimizerDisplayStore } from 'lib/stores/optimizerUI/useOptimizerDisplayStore'
+import {
+  isOptimizationRunActive,
+  ownsOptimizationRun,
+  useOptimizerDisplayStore,
+} from 'lib/stores/optimizerUI/useOptimizerDisplayStore'
 import { activateZeroResultSuggestionsModal } from 'lib/tabs/tabOptimizer/OptimizerSuggestionsModal'
 import { OptimizerTabController } from 'lib/tabs/tabOptimizer/optimizerTabController'
 import { type Form } from 'types/form'
@@ -54,7 +58,7 @@ export async function gpuOptimize(props: {
   }
 
   device.onuncapturederror = (event) => {
-    if (useOptimizerDisplayStore.getState().optimizationInProgress) {
+    if (isOptimizationRunActive(request.optimizationId)) {
       useOptimizerDisplayStore.getState().setOptimizationInProgress(false)
       webgpuCrashNotification()
     }
@@ -75,6 +79,12 @@ export async function gpuOptimize(props: {
     globalThis.WEBGPU_DEBUG,
   )
 
+  // Pipeline creation can outlive the run, so release stale resources before dispatch.
+  if (!ownsOptimizationRun(request.optimizationId)) {
+    destroyPipeline(gpuContext)
+    return
+  }
+
   if (gpuContext.DEBUG) {
     Message.warning('Debug mode is ON', 5)
   }
@@ -87,15 +97,17 @@ export async function gpuOptimize(props: {
     permutationsSearched = await runNaiveDispatch(gpuContext)
   }
 
-  if (useOptimizerDisplayStore.getState().optimizationInProgress) {
+  if (isOptimizationRunActive(request.optimizationId)) {
     useOptimizerDisplayStore.getState().setPermutationsSearched(validPermutations)
     useOptimizerDisplayStore.getState().setOptimizerProgress(1)
   }
-  useOptimizerDisplayStore.getState().setOptimizationInProgress(false)
-  useOptimizerDisplayStore.getState().setPermutationsResults(gpuContext.resultsQueue.size())
+  if (ownsOptimizationRun(request.optimizationId)) {
+    useOptimizerDisplayStore.getState().setOptimizationInProgress(false)
+    useOptimizerDisplayStore.getState().setPermutationsResults(gpuContext.resultsQueue.size())
+  }
 
   setTimeout(() => {
-    outputResults(gpuContext)
+    if (ownsOptimizationRun(request.optimizationId)) outputResults(gpuContext)
     destroyPipeline(gpuContext)
   }, 1)
 }
@@ -150,10 +162,12 @@ async function runNaiveDispatch(gpuContext: GpuExecutionContext): Promise<number
     }
 
     if (iteration === WARMUP_ITERATIONS - 1) {
-      useOptimizerDisplayStore.setState({
-        optimizerStartTime: Date.now(),
-        optimizerEndTime: null,
-      })
+      if (ownsOptimizationRun(gpuContext.request.optimizationId)) {
+        useOptimizerDisplayStore.setState({
+          optimizerStartTime: Date.now(),
+          optimizerEndTime: null,
+        })
+      }
       displayOffset = permutationsSearched
     }
 
@@ -167,6 +181,7 @@ async function runNaiveDispatch(gpuContext: GpuExecutionContext): Promise<number
     const progressSnapshot = (iteration + 1) / gpuContext.iterations
     const storeStartTime = useOptimizerDisplayStore.getState().optimizerStartTime
     setTimeout(() => {
+      if (!ownsOptimizationRun(gpuContext.request.optimizationId)) return
       const endTimeToSet = Date.now()
       const msDiff = endTimeToSet - (storeStartTime ?? 0)
 
@@ -184,7 +199,7 @@ async function runNaiveDispatch(gpuContext: GpuExecutionContext): Promise<number
       })
     }, 0)
 
-    if (gpuContext.permutations <= maxPermNumber || !useOptimizerDisplayStore.getState().optimizationInProgress) {
+    if (gpuContext.permutations <= maxPermNumber || !isOptimizationRunActive(gpuContext.request.optimizationId)) {
       gpuContext.cancelled = true
       break
     }
@@ -333,6 +348,7 @@ async function runTupleDispatch(gpuContext: GpuExecutionContext): Promise<number
     const searchedSnapshot = permutationsSearched
     const progressSnapshot = (batch + 1) / totalBatches
     setTimeout(() => {
+      if (!ownsOptimizationRun(gpuContext.request.optimizationId)) return
       useOptimizerDisplayStore.setState({
         optimizerEndTime: Date.now(),
         permutationsResults: gpuContext.resultsQueue.size(),
@@ -341,7 +357,7 @@ async function runTupleDispatch(gpuContext: GpuExecutionContext): Promise<number
       })
     }, 0)
 
-    if (!useOptimizerDisplayStore.getState().optimizationInProgress) {
+    if (!isOptimizationRunActive(gpuContext.request.optimizationId)) {
       gpuContext.cancelled = true
       break
     }
@@ -350,7 +366,7 @@ async function runTupleDispatch(gpuContext: GpuExecutionContext): Promise<number
   // Revisit overflowed batches with tighter threshold
   if (overflowedBatches.length > 0) {
     for (const batchStart of overflowedBatches) {
-      if (!useOptimizerDisplayStore.getState().optimizationInProgress) break
+      if (!isOptimizationRunActive(gpuContext.request.optimizationId)) break
 
       const batchSize = Math.min(BATCH_WGS, gpuContext.assignments.length - batchStart)
       let rawCount: number
@@ -360,7 +376,11 @@ async function runTupleDispatch(gpuContext: GpuExecutionContext): Promise<number
         await gpuContext.compactReadBuffers[0].mapAsync(GPUMapMode.READ)
         const result = processTupleBatch(gpuContext, 0, batchStart, assignments, sizes, localBits, seenIndices)
         rawCount = result.rawCount
-      } while (rawCount > gpuContext.COMPACT_LIMIT && retries++ < 100000)
+      } while (
+        rawCount > gpuContext.COMPACT_LIMIT
+        && retries++ < 100000
+        && isOptimizationRunActive(gpuContext.request.optimizationId)
+      )
     }
   }
 
@@ -466,8 +486,10 @@ async function revisitOverflowedDispatches(
   seenIndices: Set<number>,
   permutationsSearched: number,
 ) {
-  if (overflowedOffsets.length > 0 && useOptimizerDisplayStore.getState().optimizationInProgress) {
+  if (overflowedOffsets.length > 0 && isOptimizationRunActive(gpuContext.request.optimizationId)) {
     for (const overflowOffset of overflowedOffsets) {
+      if (!isOptimizationRunActive(gpuContext.request.optimizationId)) break
+
       let rawCount: number
       let retries = 0
       do {
@@ -481,12 +503,20 @@ async function revisitOverflowedDispatches(
 
         processCompactResults(overflowOffset, count, mappedRange, gpuContext, seenIndices)
         passResult.compactReadBuffer.unmap()
-      } while (rawCount > gpuContext.COMPACT_LIMIT && retries++ < 100000)
+      } while (
+        rawCount > gpuContext.COMPACT_LIMIT
+        && retries++ < 100000
+        && isOptimizationRunActive(gpuContext.request.optimizationId)
+      )
 
       // Update results count but NOT endTime — the main loop's last endTime is the correct final value
       const searchedSnapshot = permutationsSearched
       await new Promise<void>((resolve) =>
         setTimeout(() => {
+          if (!ownsOptimizationRun(gpuContext.request.optimizationId)) {
+            resolve()
+            return
+          }
           const uiState = useOptimizerDisplayStore.getState()
           uiState.setPermutationsResults(gpuContext.resultsQueue.size())
           uiState.setPermutationsSearched(searchedSnapshot)

--- a/src/lib/optimization/optimizer.ts
+++ b/src/lib/optimization/optimizer.ts
@@ -13,6 +13,7 @@ import { getWebgpuDevice } from 'lib/gpu/webgpuDevice'
 import { gpuOptimize } from 'lib/gpu/webgpuOptimizer'
 import { type RelicsByPart } from 'lib/gpu/webgpuTypes'
 import { Message } from 'lib/interactions/message'
+import { webgpuCrashNotification } from 'lib/interactions/notifications'
 import { BasicKey } from 'lib/optimization/basicStatsArray'
 import {
   BufferPacker,
@@ -55,6 +56,7 @@ import { getCharacterById } from 'lib/stores/character/characterStore'
 import { setSortColumn } from 'lib/stores/gridStore'
 import { gridStore } from 'lib/stores/gridStore'
 import {
+  isOptimizationRunActive,
   ownsOptimizationRun,
   useOptimizerDisplayStore,
 } from 'lib/stores/optimizerUI/useOptimizerDisplayStore'
@@ -285,9 +287,9 @@ export const Optimizer = {
           // GPU path won't run and CPU path already skipped — stop optimization
           useOptimizerDisplayStore.getState().setOptimizationInProgress(false)
         } else {
-          void sleep(200).then(() => {
+          return sleep(200).then(() => {
             if (!ownsRun()) return
-            void gpuOptimize({
+            return gpuOptimize({
               device,
               context: context,
               request: request,
@@ -300,9 +302,11 @@ export const Optimizer = {
             })
           })
         }
-      }).catch(() => {
-        // Safety net: if getWebgpuDevice rejects, ensure optimization doesn't stay stuck
+      }).catch((error) => {
+        console.error('WebGPU optimization failed:', error)
+        if (!isOptimizationRunActive(runId)) return
         useOptimizerDisplayStore.getState().setOptimizationInProgress(false)
+        webgpuCrashNotification()
       })
     }
 

--- a/src/lib/optimization/optimizer.ts
+++ b/src/lib/optimization/optimizer.ts
@@ -54,7 +54,10 @@ import { useGlobalStore } from 'lib/stores/app/appStore'
 import { getCharacterById } from 'lib/stores/character/characterStore'
 import { setSortColumn } from 'lib/stores/gridStore'
 import { gridStore } from 'lib/stores/gridStore'
-import { useOptimizerDisplayStore } from 'lib/stores/optimizerUI/useOptimizerDisplayStore'
+import {
+  ownsOptimizationRun,
+  useOptimizerDisplayStore,
+} from 'lib/stores/optimizerUI/useOptimizerDisplayStore'
 import { getRelics } from 'lib/stores/relic/relicStore'
 import {
   activateZeroPermutationsSuggestionsModal,
@@ -73,12 +76,7 @@ import {
   type OptimizerForm,
 } from 'types/form'
 
-// Module-level cancellation flag shared across optimization runs.
-// RACE CONDITION NOTE: If a second optimize() call is triggered before the first finishes,
-// CANCEL is reset to false by the new run while the old run's workers are still in-flight.
-// The old workers will continue running until they complete or the pool is cancelled.
-// The cancel() call sets CANCEL=true and cancels the WorkerPool, which should stop both runs.
-// A per-run cancellation token would be more robust but is not yet implemented.
+// Cancellation stops the current run; ownership checks reject stale callbacks.
 let CANCEL = false
 
 type OptimizerWorkerResult = {
@@ -187,6 +185,12 @@ export const Optimizer = {
   optimize: async function(request: Form) {
     const t = i18next.getFixedT(null, 'optimizerTab', 'ValidationMessages')
 
+    const runId = request.optimizationId
+    const ownsRun = () => ownsOptimizationRun(runId)
+
+    // A newer run may take ownership before this deferred call starts.
+    if (!ownsRun()) return
+
     // Cancel any in-progress optimization before starting a new one
     if (useOptimizerDisplayStore.getState().optimizationInProgress) {
       workerPool.cancelQueue()
@@ -248,6 +252,7 @@ export const Optimizer = {
 
     // Create a special optimization request for the top row, ignoring filters and with a custom callback
     setTimeout(() => {
+      if (!ownsRun()) return
       void calculateCurrentlyEquippedRow(request)
     }, 200)
 
@@ -274,12 +279,14 @@ export const Optimizer = {
 
     if (computeEngine != COMPUTE_ENGINE_CPU) {
       void getWebgpuDevice(true).then((device) => {
+        if (!ownsRun()) return
         if (device == null) {
           Message.error(t('Error.GPUNotAvailable'), 15)
           // GPU path won't run and CPU path already skipped — stop optimization
           useOptimizerDisplayStore.getState().setOptimizationInProgress(false)
         } else {
           void sleep(200).then(() => {
+            if (!ownsRun()) return
             void gpuOptimize({
               device,
               context: context,
@@ -329,7 +336,7 @@ export const Optimizer = {
       }
 
       function dispatchNextRun() {
-        if (CANCEL || nextRunIndex >= runs.length) return
+        if (CANCEL || !ownsRun() || nextRunIndex >= runs.length) return
         const run = runs[nextRunIndex++]
         inProgress++
 
@@ -367,7 +374,7 @@ export const Optimizer = {
           searched += run.runSize
           inProgress--
 
-          if (CANCEL && resultsShown) {
+          if (!ownsRun() || (CANCEL && resultsShown)) {
             releaseBuffer(result.buffer)
             releaseRetryBuffer(taskInput, result.buffer)
             return
@@ -399,7 +406,7 @@ export const Optimizer = {
         }).catch((error) => {
           // Guard against cancellation — cancelQueue() and terminate() reject with
           // WorkerCancelledError. Don't decrement inProgress or create buffers for these.
-          if (error instanceof WorkerCancelledError || CANCEL) return
+          if (error instanceof WorkerCancelledError || CANCEL || !ownsRun()) return
           console.warn('Optimizer worker error:', error)
           inProgress--
           // Buffer is lost when worker dies — create replacement for the pool

--- a/src/lib/stores/optimizerUI/useOptimizerDisplayStore.ts
+++ b/src/lib/stores/optimizerUI/useOptimizerDisplayStore.ts
@@ -111,3 +111,11 @@ export const useOptimizerDisplayStore = createTabAwareStore<OptimizerDisplayStor
   setLightConeSelectModalOpen: (open) => set({ lightConeSelectModalOpen: open }),
   setMenuState: (menuState) => set({ menuState }),
 }))
+
+export function ownsOptimizationRun(runId: string | undefined): boolean {
+  return useOptimizerDisplayStore.getState().optimizationId === runId
+}
+
+export function isOptimizationRunActive(runId: string | undefined): boolean {
+  return useOptimizerDisplayStore.getState().optimizationInProgress && ownsOptimizationRun(runId)
+}


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

- Fix a superseded optimization clearing the loading state and progress of the run that replaced it.
- Fix a superseded optimization publishing its results into the newer run's grid.
- Fix the equipped-build row being calculated from one run's data and displayed using another's, overwriting the newer run's pinned row and selection.
- Fix a superseded optimization cancelling the queued worker tasks belonging to the run that replaced it.
- Fix superseded GPU runs continuing to dispatch work and leaking their compiled pipeline.
- Fix GPU optimization failures being silently discarded, which left the optimizer stuck on a spinner with no error shown.

## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [ ] I have added commit messages that are descriptive and meaningful.
- [ ] I have tested the changes locally.
- [ ] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
