### PR TITLE
fix: optimization tab display issues, sunday e6 bug

### DIFF
--- a/src/lib/conditionals/character/1300/Sunday.ts
+++ b/src/lib/conditionals/character/1300/Sunday.ts
@@ -315,7 +315,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
           const memoUnconvertibleCr = x.getActionValueByIndex(StatKey.UNCONVERTIBLE_CR_BUFF, memoIndex)
 
           const stateValue = action.conditionalState[this.id] || 0
-          const buffValue = floorSafe((memoCr - memoUnconvertibleCr - 1.00) / 0.01) * 2.00 * 0.01
+          const buffValue = Math.max(0, floorSafe((memoCr - memoUnconvertibleCr - 1.00) / 0.01) * 2.00 * 0.01)
 
           action.conditionalState[this.id] = buffValue
           x.buffDynamic(StatKey.UNCONVERTIBLE_CD_BUFF, buffValue - stateValue, action, context, x.targets(TargetTag.Memosprite).source(SOURCE_E6))
@@ -347,7 +347,7 @@ let cr = ${containerActionVal(memoIndex, StatKey.CR, config)};
 let unconvertibleCr = ${containerActionVal(memoIndex, StatKey.UNCONVERTIBLE_CR_BUFF, config)};
 
 if (cr > 1.00) {
-  let buffValue: f32 = floorSafe((cr - unconvertibleCr - 1.00) / 0.01) * 2.00 * 0.01;
+  let buffValue: f32 = max(0.0, floorSafe((cr - unconvertibleCr - 1.00) / 0.01) * 2.00 * 0.01);
   let stateValue: f32 = (*p_state).${this.id}${action.actionIdentifier};
 
   (*p_state).${this.id}${action.actionIdentifier} = buffValue;
@@ -377,7 +377,7 @@ if (cr > 1.00) {
           const unconvertibleCr = x.getActionValueByIndex(StatKey.UNCONVERTIBLE_CR_BUFF, SELF_ENTITY_INDEX)
 
           const stateValue = action.conditionalState[this.id] || 0
-          const buffValue = floorSafe((cr - unconvertibleCr - 1.00) / 0.01) * 2.00 * 0.01
+          const buffValue = Math.max(0, floorSafe((cr - unconvertibleCr - 1.00) / 0.01) * 2.00 * 0.01)
 
           action.conditionalState[this.id] = buffValue
           x.buffDynamic(StatKey.UNCONVERTIBLE_CD_BUFF, buffValue - stateValue, action, context, x.source(SOURCE_E6))
@@ -404,7 +404,7 @@ let cr = ${containerActionVal(SELF_ENTITY_INDEX, StatKey.CR, config)};
 let unconvertibleCr = ${containerActionVal(SELF_ENTITY_INDEX, StatKey.UNCONVERTIBLE_CR_BUFF, config)};
 
 if (cr > 1.00) {
-  let buffValue: f32 = floorSafe((cr - unconvertibleCr - 1.00) / 0.01) * 2.00 * 0.01;
+  let buffValue: f32 = max(0.0, floorSafe((cr - unconvertibleCr - 1.00) / 0.01) * 2.00 * 0.01);
   let stateValue: f32 = (*p_state).${this.id}${action.actionIdentifier};
 
   (*p_state).${this.id}${action.actionIdentifier} = buffValue;

--- a/src/lib/optimization/combo/comboInitializers.ts
+++ b/src/lib/optimization/combo/comboInitializers.ts
@@ -199,7 +199,9 @@ function mergeTeammate(baseTeammate: ComboTeammate | null, updateTeammate: Combo
   if (!baseTeammate || !updateTeammate) return
   if (baseTeammate.metadata.characterId !== updateTeammate.metadata.characterId) return
   mergeConditionals(baseTeammate.characterConditionals, updateTeammate.characterConditionals)
-  mergeConditionals(baseTeammate.lightConeConditionals, updateTeammate.lightConeConditionals)
+  if (baseTeammate.metadata.lightCone === updateTeammate.metadata.lightCone) {
+    mergeConditionals(baseTeammate.lightConeConditionals, updateTeammate.lightConeConditionals)
+  }
   mergeConditionals(baseTeammate.relicSetConditionals, updateTeammate.relicSetConditionals)
   mergeConditionals(baseTeammate.ornamentSetConditionals, updateTeammate.ornamentSetConditionals)
 }

--- a/src/lib/optimization/rotation/actionTransform.test.ts
+++ b/src/lib/optimization/rotation/actionTransform.test.ts
@@ -7,8 +7,13 @@ import {
 import { initializeComboState } from 'lib/optimization/combo/comboInitializers'
 import type { ComboNumberConditional } from 'lib/optimization/combo/comboTypes'
 import { generateContext } from 'lib/optimization/context/calculateContext'
+import { StatKey } from 'lib/optimization/engine/config/keys'
 import { newTransformStateActions } from 'lib/optimization/rotation/actionTransform'
 import { ComboType } from 'lib/optimization/rotation/comboType'
+import {
+  DEFAULT_BUFF,
+  NULL_TURN_ABILITY_NAME,
+} from 'lib/optimization/rotation/turnAbilityConfig'
 import { initializeContextConditionals } from 'lib/simulations/contextConditionals'
 import { generateFullDefaultForm } from 'lib/simulations/utils/benchmarkForm'
 import { Metadata } from 'lib/state/metadataInitializer'
@@ -109,4 +114,15 @@ describe('teammate dynamic conditionals are registered exactly once', () => {
     expectSundayConditionals(context.rotationActions)
     expectSundayConditionals(context.defaultActions)
   })
+})
+
+test('advanced rotation buff actions preserve their display stat', () => {
+  const form = generateFullDefaultForm('1101', '21003', 6, 5)
+  form.comboType = ComboType.ADVANCED
+  form.comboTurnAbilities = [NULL_TURN_ABILITY_NAME, DEFAULT_BUFF]
+
+  const context = generateContext(form)
+  const buffAction = context.rotationActions[0]
+
+  expect(buffAction.buffStat).toBe(StatKey.CD)
 })

--- a/src/lib/optimization/rotation/actionTransform.ts
+++ b/src/lib/optimization/rotation/actionTransform.ts
@@ -79,6 +79,9 @@ export function newTransformStateActions(comboState: ComboState, request: Form, 
 
       action.actionType = actionKind
       action.hits = actionDef.hits as Hit[]
+      if (action.hits?.[0]?.damageFunctionType === DamageFunctionType.Buff) {
+        action.buffStat = (action.hits[0] as BuffHitDefinition).buffStat
+      }
 
       for (const modifier of context.actionModifiers) {
         const self = buildModifierContext(action, modifier)

--- a/src/lib/tabs/tabOptimizer/analysis/DamageSplitsChart.tsx
+++ b/src/lib/tabs/tabOptimizer/analysis/DamageSplitsChart.tsx
@@ -249,14 +249,13 @@ function CustomTooltip({ active, payload, bars }: { active?: boolean, payload?: 
 export function DamageSplitsChart({ data }: { data: DamageSplitEntry[] }) {
   const { t } = useTranslation('optimizerTab')
   const { rows, bars, legendItems } = useMemo(() => flattenData(data, t), [data, t])
+  const chartHeight = Math.max(200, rows.length * BAR_HEIGHT + CHART_PADDING)
+  const maxTotal = useMemo(() => Math.max(0, ...rows.map((r) => r.total)), [rows])
+  const renderBarLabel = useMemo(() => createBarLabelRenderer(maxTotal), [maxTotal])
 
   if (rows.length === 0) {
     return null
   }
-
-  const chartHeight = Math.max(200, rows.length * BAR_HEIGHT + CHART_PADDING)
-  const maxTotal = useMemo(() => Math.max(...rows.map((r) => r.total)), [rows])
-  const renderBarLabel = useMemo(() => createBarLabelRenderer(maxTotal), [maxTotal])
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }} className='pre-font'>

--- a/src/lib/tabs/tabOptimizer/analysis/StatsDiffCard.tsx
+++ b/src/lib/tabs/tabOptimizer/analysis/StatsDiffCard.tsx
@@ -1,6 +1,5 @@
 import { showcaseOutlineLight } from 'lib/characterPreview/CharacterPreviewComponents'
 import {
-  COMBO_DMG_STAT,
   getStatRenderValues,
   StatRow,
   StatRowDivider,
@@ -9,12 +8,18 @@ import { StatText } from 'lib/characterPreview/StatText'
 import type { StatsValues } from 'lib/constants/constants'
 import { Stats } from 'lib/constants/constants'
 import {
-  GlobalRegister,
+  type AKeyValue,
   StatKey,
 } from 'lib/optimization/engine/config/keys'
 import type { ComputedStatsObjectExternal } from 'lib/optimization/engine/container/computedStatsContainer'
+import { SortOption } from 'lib/optimization/sortOptions'
 import { Assets } from 'lib/rendering/assets'
 import { DEFAULT_LC_IMAGE_OFFSET } from 'lib/rendering/lcImageTransform'
+import {
+  resolveComboLabel,
+  SCORING_CONFIG_REGISTRY,
+} from 'lib/scoring/scoringConfig'
+import { formatSimScore } from 'lib/scoring/simScoringUtils'
 import { getGameMetadata } from 'lib/state/gameMetadata'
 import type { OptimizerResultAnalysis } from 'lib/tabs/tabOptimizer/analysis/expandedDataPanelController'
 import classes from 'lib/tabs/tabOptimizer/analysis/StatsDiffCard.module.css'
@@ -32,6 +37,7 @@ import {
 import { isFlat } from 'lib/utils/statUtils'
 import { useTranslation } from 'react-i18next'
 import iconClasses from 'style/icons.module.css'
+import { ScoringConfigType } from 'types/metadata'
 
 const baseCardHeight = 429
 const extraRowHeight = 27
@@ -69,14 +75,24 @@ function StatDiffSummary({ analysis }: { analysis: OptimizerResultAnalysis }) {
   oldStats[analysis.elementalDmgValue] += analysis.oldX.getSelfValue(StatKey.BOOST)
   newStats[analysis.elementalDmgValue] += analysis.newX.getSelfValue(StatKey.BOOST)
 
-  // COMBO_DMG is stored in global registers, inject for display
-  const oldCombo = analysis.oldX.getGlobalRegisterValue(GlobalRegister.COMBO_DMG)
-  const newCombo = analysis.newX.getGlobalRegisterValue(GlobalRegister.COMBO_DMG)
+  const comboConfigType = getComboConfigType(analysis)
+  const comboConfig = SCORING_CONFIG_REGISTRY[comboConfigType]
+  const oldCombo = analysis.oldX.getGlobalRegisterValue(comboConfig.comboRegister)
+  const newCombo = analysis.newX.getGlobalRegisterValue(comboConfig.comboRegister)
+  const buffStat = comboConfigType === ScoringConfigType.BUFFER
+    ? analysis.context.rotationActions.find((action) => action.buffStat != null)?.buffStat
+      ?? analysis.context.defaultActions.find((action) => action.buffStat != null)?.buffStat
+    : undefined
 
   return (
     <StatText style={{ width: '100%' }}>
       <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
-        <ComboDiffRow oldValue={oldCombo} newValue={newCombo} />
+        <ComboDiffRow
+          oldValue={oldCombo}
+          newValue={newCombo}
+          configType={comboConfigType}
+          buffStat={buffStat}
+        />
         <DiffRow oldStats={oldStats} newStats={newStats} stat={Stats.HP} />
         <DiffRow oldStats={oldStats} newStats={newStats} stat={Stats.ATK} />
         <DiffRow oldStats={oldStats} newStats={newStats} stat={Stats.DEF} />
@@ -95,22 +111,50 @@ function StatDiffSummary({ analysis }: { analysis: OptimizerResultAnalysis }) {
   )
 }
 
-function ComboDiffRow({ oldValue, newValue }: {
+function getComboConfigType(analysis: OptimizerResultAnalysis): ScoringConfigType {
+  switch (analysis.request.resultSort) {
+    case SortOption.COMBO_BUFF.key:
+      return ScoringConfigType.BUFFER
+    case SortOption.COMBO_HEAL.key:
+      return ScoringConfigType.HEAL
+    case SortOption.COMBO_SHIELD.key:
+      return ScoringConfigType.SHIELD
+  }
+
+  const activeConfig = [
+    ScoringConfigType.DPS,
+    ScoringConfigType.BUFFER,
+    ScoringConfigType.HEAL,
+    ScoringConfigType.SHIELD,
+  ].find((configType) => {
+    const register = SCORING_CONFIG_REGISTRY[configType].comboRegister
+    return analysis.oldX.getGlobalRegisterValue(register) !== 0
+      || analysis.newX.getGlobalRegisterValue(register) !== 0
+  })
+
+  return activeConfig ?? ScoringConfigType.DPS
+}
+
+function ComboDiffRow({ oldValue, newValue, configType, buffStat }: {
   oldValue: number,
   newValue: number,
+  configType: ScoringConfigType,
+  buffStat?: AKeyValue,
 }) {
-  const { t } = useTranslation('common')
-  const { valueDisplay: oldDisplay } = getStatRenderValues(oldValue, oldValue, COMBO_DMG_STAT, false)
-  const { valueDisplay: newDisplay } = getStatRenderValues(newValue, newValue, COMBO_DMG_STAT, false)
+  useTranslation()
+  const config = SCORING_CONFIG_REGISTRY[configType]
+  const label = resolveComboLabel(config, buffStat)
+  const oldDisplay = formatSimScore(oldValue, buffStat, 1, config.thousands)
+  const newDisplay = formatSimScore(newValue, buffStat, 1, config.thousands)
 
   return (
     <div style={{ display: 'flex', gap: 12, alignItems: 'center' }}>
       <div className={classes.oldStatColumn}>
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', fontSize: 16 }}>
           <img src={Assets.getStatIcon('simScore')} className={iconClasses.statIconSpaced} />
-          {t('ReadableStats.simScore')}
+          {label}
           <StatRowDivider />
-          <RenderValue value={oldDisplay} stat={COMBO_DMG_STAT} />
+          {oldDisplay}
         </div>
       </div>
 
@@ -119,10 +163,15 @@ function ComboDiffRow({ oldValue, newValue }: {
       </span>
 
       <div className={classes.newValueColumn} style={{ display: 'flex', justifyContent: 'flex-end' }}>
-        <RenderValue value={newDisplay} stat={COMBO_DMG_STAT} />
+        {newDisplay}
       </div>
 
-      <DiffRender oldValue={oldValue} newValue={newValue} stat={COMBO_DMG_STAT} />
+      <ComboDiffRender
+        oldValue={oldValue}
+        newValue={newValue}
+        configType={configType}
+        buffStat={buffStat}
+      />
     </div>
   )
 }
@@ -161,28 +210,52 @@ function DiffRow({ oldStats, newStats, stat }: {
   )
 }
 
-function RenderValue({ value, stat, comboDiff }: { value: string | number, stat: StatsValues | typeof COMBO_DMG_STAT, comboDiff?: boolean }) {
-  const { t } = useTranslation('common')
-  if (stat === COMBO_DMG_STAT) {
-    return value + (comboDiff ? '%' : t('ThousandsSuffix'))
-  } else if (isFlat(stat)) {
+function RenderValue({ value, stat }: { value: string | number, stat: StatsValues }) {
+  if (isFlat(stat)) {
     return value
   }
   return value + '%'
 }
 
-function DiffRender({ oldValue, newValue, stat }: { oldValue: number, newValue: number, stat: StatsValues | typeof COMBO_DMG_STAT }) {
+function ComboDiffRender({ oldValue, newValue, configType, buffStat }: {
+  oldValue: number,
+  newValue: number,
+  configType: ScoringConfigType,
+  buffStat?: AKeyValue,
+}) {
+  if (oldValue === newValue) return null
+
+  const config = SCORING_CONFIG_REGISTRY[configType]
+  const increase = newValue > oldValue
+  const absoluteDiff = Math.abs(newValue - oldValue)
+  const valueDisplay = configType === ScoringConfigType.DPS
+    ? oldValue === 0 ? null : `${precisionRound(Math.abs(newValue / oldValue - 1) * 100, 1)}%`
+    : formatSimScore(absoluteDiff, buffStat, 1, config.thousands)
+
+  if (valueDisplay == null) return null
+
+  return (
+    <div style={{ display: 'flex', color: arrowColor(increase), width: 90, gap: 10, justifyContent: 'flex-end', alignItems: 'center' }}>
+      {valueDisplay}
+      <span className={classes.arrowIcon}>
+        {arrowDirection(increase)}
+      </span>
+    </div>
+  )
+}
+
+function DiffRender({ oldValue, newValue, stat }: { oldValue: number, newValue: number, stat: StatsValues }) {
   if (visualDiff(newValue, oldValue, stat) === 0) return null
 
   const increase = newValue > oldValue
   const diff = increase ? visualDiff(newValue, oldValue, stat) : -visualDiff(newValue, oldValue, stat)
   const icon = arrowDirection(increase)
   const color = arrowColor(increase)
-  const { valueDisplay } = getStatDiffRenderValues(diff, diff, stat)
+  const { valueDisplay } = getStatRenderValues(diff, diff, stat)
 
   return (
     <div style={{ display: 'flex', color: color, width: 90, gap: 10, justifyContent: 'flex-end', alignItems: 'center' }}>
-      <RenderValue value={valueDisplay} stat={stat} comboDiff={true} />
+      <RenderValue value={valueDisplay} stat={stat} />
       <span className={classes.arrowIcon}>
         {icon}
       </span>
@@ -190,25 +263,11 @@ function DiffRender({ oldValue, newValue, stat }: { oldValue: number, newValue: 
   )
 }
 
-function getStatDiffRenderValues(statValue: number, customValue: number, stat: StatsValues | typeof COMBO_DMG_STAT) {
-  if (stat === COMBO_DMG_STAT) {
-    const valueDisplay = `${truncate10ths(precisionRound(customValue ?? 0)).toFixed(1)}`
-    const value1000thsPrecision = precisionRound(customValue).toFixed(3)
-    return {
-      valueDisplay,
-      value1000thsPrecision,
-    }
-  }
-  return getStatRenderValues(statValue, customValue, stat)
-}
-
-function visualDiff(n1: number, n2: number, stat: StatsValues | typeof COMBO_DMG_STAT) {
+function visualDiff(n1: number, n2: number, stat: StatsValues) {
   if (stat === Stats.SPD) {
     return precisionRound(truncate10ths(n1) - truncate10ths(n2))
   } else if (isFlat(stat)) {
     return precisionRound(Math.floor(n1) - Math.floor(n2))
-  } else if (stat === COMBO_DMG_STAT) {
-    return precisionRound((n1 / n2 - 1) * 100)
   } else {
     return precisionRound(truncate1000ths(n1) - truncate1000ths(n2))
   }

--- a/src/lib/tabs/tabOptimizer/optimizerForm/components/TeammateCard.tsx
+++ b/src/lib/tabs/tabOptimizer/optimizerForm/components/TeammateCard.tsx
@@ -97,7 +97,6 @@ export const TeammateCard = memo(function TeammateCard({ index, dbMetadata }: {
               value={teammateCharacterId ?? null}
               onChange={(id) => {
                 if (id) {
-                  useOptimizerRequestStore.getState().setTeammateField(index, 'characterId', id)
                   updateTeammate({ [`teammate${index}` as TeammateProperty]: { characterId: id } })
                 } else {
                   updateTeammate({ [`teammate${index}` as TeammateProperty]: { characterId: null } })
@@ -196,7 +195,6 @@ export const TeammateCard = memo(function TeammateCard({ index, dbMetadata }: {
               value={teammateLightConeId ?? null}
               onChange={(id) => {
                 if (id) {
-                  useOptimizerRequestStore.getState().setTeammateField(index, 'lightCone', id)
                   updateTeammate({ [`teammate${index}` as TeammateProperty]: { lightCone: id } })
                 } else {
                   updateTeammate({ [`teammate${index}` as TeammateProperty]: { lightCone: null } })

--- a/src/lib/tabs/tabOptimizer/optimizerForm/components/teammate/updateTeammate.ts
+++ b/src/lib/tabs/tabOptimizer/optimizerForm/components/teammate/updateTeammate.ts
@@ -23,18 +23,28 @@ export function updateTeammate(changedValues: Partial<Form>) {
   if (updatedTeammate.lightCone) {
     const store = useOptimizerRequestStore.getState()
     const teammate = store.teammates[teammateIndex]
+    if (!teammate.characterId) return
+    const lightConeChanged = teammate.lightCone !== updatedTeammate.lightCone
 
-    const lcDefaults = resolveLcDefaults(teammate as any, getGameMetadata(), true)
-    if (!lcDefaults) return
+    const lcDefaults = resolveLcDefaults({
+      characterId: teammate.characterId,
+      characterEidolon: teammate.characterEidolon,
+      lightCone: updatedTeammate.lightCone,
+      lightConeSuperimposition: teammate.lightConeSuperimposition,
+    }, getGameMetadata(), true)
+    const lightConeConditionals = lightConeChanged
+      ? { ...lcDefaults }
+      : { ...lcDefaults, ...teammate.lightConeConditionals }
 
-    const mergedConditionals = { ...lcDefaults, ...teammate.lightConeConditionals }
-    useOptimizerRequestStore.getState().setTeammateField(teammateIndex, 'lightConeConditionals', mergedConditionals)
+    store.setTeammateField(teammateIndex, 'lightCone', updatedTeammate.lightCone)
+    store.setTeammateField(teammateIndex, 'lightConeConditionals', lightConeConditionals)
   } else if (updatedTeammate.characterId) {
     const teammateCharacterId = updatedTeammate.characterId
 
     const store = useOptimizerRequestStore.getState()
     const currentTeammate = store.teammates[teammateIndex]
     const teammateCharacter = getCharacterById(teammateCharacterId)
+    const characterChanged = currentTeammate.characterId !== teammateCharacterId
 
     let lightCone = currentTeammate.lightCone
     let lightConeSuperimposition = currentTeammate.lightConeSuperimposition
@@ -59,14 +69,14 @@ export function updateTeammate(changedValues: Partial<Form>) {
       characterEidolon: characterEidolon,
     })
 
-    let characterConditionalsValues = currentTeammate.characterConditionals
-    if (charController.teammateDefaults) {
-      characterConditionalsValues = { ...charController.teammateDefaults(), ...characterConditionalsValues }
-    }
+    const characterDefaults = charController.teammateDefaults?.()
+    const characterConditionalsValues = characterChanged
+      ? { ...characterDefaults }
+      : { ...characterDefaults, ...currentTeammate.characterConditionals }
 
-    let lightConeConditionalsValues = currentTeammate.lightConeConditionals
-    if (lightCone) {
-      const lcDefaults = resolveLcDefaults(
+    const lightConeChanged = currentTeammate.lightCone !== lightCone
+    const lcDefaults = lightCone
+      ? resolveLcDefaults(
         {
           characterId: teammateCharacterId,
           characterEidolon,
@@ -76,10 +86,10 @@ export function updateTeammate(changedValues: Partial<Form>) {
         getGameMetadata(),
         true,
       )
-      if (lcDefaults) {
-        lightConeConditionalsValues = { ...lcDefaults, ...lightConeConditionalsValues }
-      }
-    }
+      : undefined
+    const lightConeConditionalsValues = lightConeChanged
+      ? { ...lcDefaults }
+      : { ...lcDefaults, ...currentTeammate.lightConeConditionals }
 
     useOptimizerRequestStore.getState().setTeammate(teammateIndex, {
       characterId: teammateCharacterId,


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

- Fix Sunday E6 from subtracting CRIT DMG when converted CRIT Rate is below zero.
  - Fix teammate character and Light Cone changes retaining incompatible conditional settings.
  - Fix Advanced rotation buffs losing percentage and flat-stat display metadata.
  - Improve optimization analysis with Combo Buff, Heal, and Shield metrics, rounded deltas, and stable empty damage charts.

## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [ ] I have added commit messages that are descriptive and meaningful.
- [ ] I have tested the changes locally.
- [ ] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
