### PR TITLE
fix: various optimizer engine bugs

### DIFF
--- a/src/lib/characterPreview/buffsAnalysis/BuffRow.tsx
+++ b/src/lib/characterPreview/buffsAnalysis/BuffRow.tsx
@@ -7,7 +7,7 @@ import {
   getPrimaryDamageTagColor,
   getStatConfig,
   renderPill,
-  translatedLabel,
+  translatedBuffLabel,
 } from 'lib/characterPreview/buffsAnalysis/buffUtils'
 import {
   DesignContext,
@@ -38,7 +38,7 @@ export function BuffRow({ buff, isLast }: { buff: Buff, isLast: boolean }) {
   const config = getStatConfig(stat)
   const percent = !config?.flat
   const bool = config?.bool
-  const statLabel = translatedLabel(stat, buff.memo)
+  const statLabel = translatedBuffLabel(buff)
 
   let sourceLabel: string
   const source = buff.source

--- a/src/lib/characterPreview/buffsAnalysis/StatSummary.tsx
+++ b/src/lib/characterPreview/buffsAnalysis/StatSummary.tsx
@@ -14,8 +14,9 @@ import {
 import {
   formatBuffValue,
   getStatConfig,
+  isOutputBoost,
   renderPill,
-  translatedLabel,
+  translatedBuffLabel,
 } from 'lib/characterPreview/buffsAnalysis/buffUtils'
 import {
   DesignContext,
@@ -29,7 +30,10 @@ import {
 import { HitDefinitionRows } from 'lib/characterPreview/buffsAnalysis/HitDefinitionDisplay'
 import type { Buff } from 'lib/optimization/basicStatsArray'
 import { AKeyNames } from 'lib/optimization/engine/config/keys'
-import type { DamageTag } from 'lib/optimization/engine/config/tag'
+import {
+  type DamageTag,
+  OutputTag,
+} from 'lib/optimization/engine/config/tag'
 import type { BuffGroups } from 'lib/simulations/combatBuffsAnalysis'
 import { useContext } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -73,7 +77,9 @@ export function collectAllBuffs(buffGroups: BuffGroups): Buff[] {
 }
 
 function getBuffStatKey(buff: Buff): string {
-  return buff.memo ? `memo:${buff.stat}` : buff.stat
+  const memoPrefix = buff.memo ? 'memo:' : ''
+  const outputSuffix = isOutputBoost(buff) ? `:${buff.outputTags ?? OutputTag.DAMAGE}` : ''
+  return `${memoPrefix}${buff.stat}${outputSuffix}`
 }
 
 export function computeStatSums(buffs: Buff[], filter: DamageTag | null): StatSum[] {
@@ -87,7 +93,7 @@ export function computeStatSums(buffs: Buff[], filter: DamageTag | null): StatSu
     if (!metaMap.has(key)) {
       metaMap.set(key, {
         stat: buff.stat,
-        label: translatedLabel(buff.stat, buff.memo),
+        label: translatedBuffLabel(buff),
         percent: !config.flat,
       })
       allContributionsMap.set(key, [])
@@ -116,7 +122,7 @@ export function computeStatSums(buffs: Buff[], filter: DamageTag | null): StatSu
     } else {
       sumMap.set(key, {
         stat: buff.stat,
-        label: translatedLabel(buff.stat, buff.memo),
+        label: translatedBuffLabel(buff),
         total: buff.value,
         count: 1,
         percent: !config.flat,

--- a/src/lib/characterPreview/buffsAnalysis/buffUtils.tsx
+++ b/src/lib/characterPreview/buffsAnalysis/buffUtils.tsx
@@ -4,9 +4,16 @@ import {
   PILL_SIZE,
   TEXT_DIM,
 } from 'lib/characterPreview/buffsAnalysis/designContext'
-import type { AKeyType } from 'lib/optimization/engine/config/keys'
-import type { StatConfigEntry } from 'lib/optimization/engine/config/statsConfig'
-import { newStatsConfig } from 'lib/optimization/engine/config/statsConfig'
+import type { Buff } from 'lib/optimization/basicStatsArray'
+import { type AKeyType } from 'lib/optimization/engine/config/keys'
+import type {
+  SimpleLabel,
+  StatConfigEntry,
+} from 'lib/optimization/engine/config/statsConfig'
+import {
+  getBoostLabel,
+  newStatsConfig,
+} from 'lib/optimization/engine/config/statsConfig'
 import { currentLocale } from 'lib/utils/i18nUtils'
 import { precisionRound } from 'lib/utils/mathUtils'
 import type { ReactElement } from 'react'
@@ -49,7 +56,21 @@ export function translatedLabel(stat: string, isMemo = false): string {
   return labelToString(config.label, isMemo)
 }
 
-export function labelToString(label: StatConfigEntry['label'], isMemo = false) {
+const BOOST_STAT: AKeyType = 'BOOST'
+
+export function isOutputBoost(buff: Buff): boolean {
+  return buff.stat === BOOST_STAT
+}
+
+export function translatedBuffLabel(buff: Buff): string {
+  if (isOutputBoost(buff)) {
+    return labelToString(getBoostLabel(buff.outputTags), buff.memo)
+  }
+
+  return translatedLabel(buff.stat, buff.memo)
+}
+
+export function labelToString(label: SimpleLabel, isMemo = false) {
   if (typeof label === 'string') {
     return isMemo ? i18next.t('MemospriteLabel', { label }) as string : label
   }

--- a/src/lib/conditionals/character/1100/Topaz.ts
+++ b/src/lib/conditionals/character/1100/Topaz.ts
@@ -403,13 +403,13 @@ const scoring = (): ScoringMetadata => ({
 
 const display = {
   imageCenter: {
-    x: 1041,
-    y: 890,
+    x: 1123,
+    y: 849,
     z: 1,
   },
   spineCenter: {
-    x: 1178,
-    y: 886,
+    x: 1207,
+    y: 884,
     z: 1.1,
   },
   showcaseColor: '#bcc0df',

--- a/src/lib/conditionals/character/1400/Hyacine.ts
+++ b/src/lib/conditionals/character/1400/Hyacine.ts
@@ -443,7 +443,7 @@ if (
         type: ConditionalType.ABILITY,
         activation: ConditionalActivation.CONTINUOUS,
         dependsOn: [Stats.SPD],
-        chainsTo: [Stats.OHB],
+        chainsTo: [Stats.OHB, Stats.CD],
         condition: function(x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) {
           const r = action.characterConditionals as Conditionals<typeof content>
 

--- a/src/lib/gpu/injection/displayStats.ts
+++ b/src/lib/gpu/injection/displayStats.ts
@@ -1,0 +1,29 @@
+import { SELF_ENTITY_INDEX } from 'lib/optimization/engine/config/tag'
+import type { ComputedStatsContainerConfig } from 'lib/optimization/engine/container/computedStatsContainer'
+import type { Form } from 'types/form'
+
+export function getDisplayEntityIndex(request: Form, config: ComputedStatsContainerConfig): number {
+  if (request.memoDisplay !== 'memo') return SELF_ENTITY_INDEX
+
+  const memoIndex = config.entitiesArray.findIndex((entity) => entity.memosprite)
+  return memoIndex >= 0 ? memoIndex : SELF_ENTITY_INDEX
+}
+
+export function generateBasicStatExpression(request: Form, config: ComputedStatsContainerConfig, key: string): string {
+  const value = `c.${key}`
+  const entity = config.entitiesArray[getDisplayEntityIndex(request, config)]
+  if (!entity.memosprite) return value
+
+  switch (key) {
+    case 'HP':
+      return `(${entity.memoBaseHpScaling ?? 0} * ${value} + ${entity.memoBaseHpFlat ?? 0})`
+    case 'ATK':
+      return `(${entity.memoBaseAtkScaling ?? 0} * ${value} + ${entity.memoBaseAtkFlat ?? 0})`
+    case 'DEF':
+      return `(${entity.memoBaseDefScaling ?? 0} * ${value} + ${entity.memoBaseDefFlat ?? 0})`
+    case 'SPD':
+      return `(${entity.memoBaseSpdScaling ?? 0} * ${value} + ${entity.memoBaseSpdFlat ?? 0})`
+    default:
+      return value
+  }
+}

--- a/src/lib/gpu/injection/generateWgsl.ts
+++ b/src/lib/gpu/injection/generateWgsl.ts
@@ -1,13 +1,14 @@
 import { Constants } from 'lib/constants/constants'
+import { generateBasicStatExpression } from 'lib/gpu/injection/displayStats'
 import { generateBasicSetEffectsWgsl } from 'lib/gpu/injection/generateBasicSetEffects'
-import { injectComputedStats } from 'lib/gpu/injection/injectComputedStats'
-import { generateDynamicConditionals } from 'lib/gpu/injection/injectConditionals'
-import { injectSettings } from 'lib/gpu/injection/injectSettings'
-import { injectUnrolledActions } from 'lib/gpu/injection/injectUnrolledActions'
 import {
   type GeneratedSetMaskWgsl,
   generateSetMaskWgsl,
 } from 'lib/gpu/injection/generateSetMaskWgsl'
+import { injectComputedStats } from 'lib/gpu/injection/injectComputedStats'
+import { generateDynamicConditionals } from 'lib/gpu/injection/injectConditionals'
+import { injectSettings } from 'lib/gpu/injection/injectSettings'
+import { injectUnrolledActions } from 'lib/gpu/injection/injectUnrolledActions'
 import { generateSetIndexConstants } from 'lib/gpu/injection/setIndexMap'
 import { indent } from 'lib/gpu/injection/wgslUtils'
 import { uniformCompatible } from 'lib/gpu/webgpuDevice'
@@ -57,7 +58,7 @@ export function generateWgsl(context: OptimizerContext, request: Form, relics: R
   wgsl = injectUnrolledActions(wgsl, request, context, gpuParams)
   wgsl = injectConditionalsNew(wgsl, request, context, gpuParams)
   wgsl = injectGpuParams(wgsl, request, context, gpuParams)
-  wgsl = injectBasicFilters(wgsl, request)
+  wgsl = injectBasicFilters(wgsl, request, context)
   wgsl = injectSetFilters(wgsl, request)
   wgsl = injectComputedStats(wgsl)
   wgsl = injectDispatchMode(wgsl, gpuParams, setMasks)
@@ -144,7 +145,7 @@ ${injectedStructs}
 function filterFn(request: Form) {
   return (text: string) => {
     if (text.length === 0) return text
-    const [, , threshold] = text.split(/[><]/).flatMap((x) => x.split('.')).map((x) => x.trim())
+    const threshold = text.split(/[><]/).at(-1)!.trim()
     const min = threshold.includes('min')
     const max = threshold.includes('max')
     const value = request[threshold as keyof Form]
@@ -197,40 +198,42 @@ if (${conditions.join('\n || ')}) {
   )
 }
 
-function injectBasicFilters(wgsl: string, request: Form) {
+function injectBasicFilters(wgsl: string, request: Form, context: OptimizerContext) {
   const sortOption = SortOption[request.resultSort!]
   const sortKey: string = sortOption.key
   const sortOptionComputed = sortOption.isComputedRating
   const filter = filterFn(request)
+  const config = context.defaultActions[context.defaultActions.length - 1].config
+  const stat = (key: string) => generateBasicStatExpression(request, config, key)
 
   // For basic stats, threshold check is here. For computed ratings (COMBO, damage types),
   // threshold check is in generateSortOptionReturn
   let sortString = ''
   if (!sortOptionComputed) {
-    sortString = `c.${sortKey} < threshold`
+    sortString = `${stat(sortKey)} < threshold`
   }
 
   const basicFilters = [
-    filter('c.SPD < minSpd'),
-    filter('c.SPD > maxSpd'),
-    filter('c.HP  < minHp'),
-    filter('c.HP  > maxHp'),
-    filter('c.ATK < minAtk'),
-    filter('c.ATK > maxAtk'),
-    filter('c.DEF < minDef'),
-    filter('c.DEF > maxDef'),
-    filter('c.CR  < minCr'),
-    filter('c.CR  > maxCr'),
-    filter('c.CD  < minCd'),
-    filter('c.CD  > maxCd'),
-    filter('c.EHR < minEhr'),
-    filter('c.EHR > maxEhr'),
-    filter('c.RES < minRes'),
-    filter('c.RES > maxRes'),
-    filter('c.BE  < minBe'),
-    filter('c.BE  > maxBe'),
-    filter('c.ERR < minErr'),
-    filter('c.ERR > maxErr'),
+    filter(`${stat('SPD')} < minSpd`),
+    filter(`${stat('SPD')} > maxSpd`),
+    filter(`${stat('HP')} < minHp`),
+    filter(`${stat('HP')} > maxHp`),
+    filter(`${stat('ATK')} < minAtk`),
+    filter(`${stat('ATK')} > maxAtk`),
+    filter(`${stat('DEF')} < minDef`),
+    filter(`${stat('DEF')} > maxDef`),
+    filter(`${stat('CR')} < minCr`),
+    filter(`${stat('CR')} > maxCr`),
+    filter(`${stat('CD')} < minCd`),
+    filter(`${stat('CD')} > maxCd`),
+    filter(`${stat('EHR')} < minEhr`),
+    filter(`${stat('EHR')} > maxEhr`),
+    filter(`${stat('RES')} < minRes`),
+    filter(`${stat('RES')} > maxRes`),
+    filter(`${stat('BE')} < minBe`),
+    filter(`${stat('BE')} > maxBe`),
+    filter(`${stat('ERR')} < minErr`),
+    filter(`${stat('ERR')} > maxErr`),
     filter(sortString),
   ].filter((str) => str.length > 0).join(' ||\n')
 

--- a/src/lib/gpu/injection/injectUnrolledActions.ts
+++ b/src/lib/gpu/injection/injectUnrolledActions.ts
@@ -4,6 +4,10 @@ import { LightConeConditionalsResolver } from 'lib/conditionals/resolver/lightCo
 import { Constants } from 'lib/constants/constants'
 import type { DynamicConditional } from 'lib/gpu/conditionals/dynamicConditionals'
 import {
+  generateBasicStatExpression,
+  getDisplayEntityIndex,
+} from 'lib/gpu/injection/displayStats'
+import {
   containerActionVal,
   getActionIndex,
   getGlobalRegisterIndexWgsl,
@@ -22,7 +26,6 @@ import {
 } from 'lib/optimization/engine/config/keys'
 import {
   OutputTag,
-  SELF_ENTITY_INDEX,
   TargetTag,
 } from 'lib/optimization/engine/config/tag'
 import { matchesTargetTag } from 'lib/optimization/engine/container/gpuBuffBuilder'
@@ -63,7 +66,12 @@ function generateUnrolledActions(request: Form, context: OptimizerContext, gpuPa
 `
   let functions = ''
   const defaultActionsRecordBuff = context.defaultActions.some(recordsBuffOutput)
-  const abilitySortCompletionIndex = gpuParams.DEBUG ? -1 : getAbilitySortCompletionIndex(request, context)
+  const displayActionIndex = context.defaultActions.length - 1
+  const displayFilters = generateCombatStatFilters(request, context, displayActionIndex)
+  const abilitySortIndex = gpuParams.DEBUG ? -1 : getAbilitySortCompletionIndex(request, context)
+  const abilitySortCompletionIndex = displayFilters && abilitySortIndex >= 0
+    ? Math.max(abilitySortIndex, displayActionIndex)
+    : abilitySortIndex
 
   for (let i = 0; i < context.defaultActions.length; i++) {
     const action = context.defaultActions[i]
@@ -72,14 +80,14 @@ function generateUnrolledActions(request: Form, context: OptimizerContext, gpuPa
     calls += result.actionCall
     functions += result.actionFunction
 
-    if (i === 0) {
-      calls += generateCombatStatFilters(request, context, gpuParams)
+    if (i === displayActionIndex) {
+      calls += displayFilters
     }
 
     // Apply rating filters once every required action is calculated.
     if (i === abilitySortCompletionIndex) {
       calls += generateRatingFilters(request, context)
-      calls += generateSortOptionReturn(request, context)
+      calls += generateSortOptionReturn(request, context, displayActionIndex)
       calls += '    continue;\n'
       return { calls, functions }
     }
@@ -96,7 +104,6 @@ function generateUnrolledActions(request: Form, context: OptimizerContext, gpuPa
 
     calls += result.actionCall
     functions += result.actionFunction
-
   }
 
   if (defaultActionsRecordBuff) {
@@ -105,7 +112,7 @@ function generateUnrolledActions(request: Form, context: OptimizerContext, gpuPa
 
   if (!gpuParams.DEBUG) {
     calls += generateRatingFilters(request, context)
-    calls += generateSortOptionReturn(request, context)
+    calls += generateSortOptionReturn(request, context, displayActionIndex)
   } else {
     calls += generateDebugContainer(context)
     const comboGlobalRegIdx = getGlobalRegisterIndexWgsl(GlobalRegister.COMBO_DMG, context)
@@ -240,33 +247,37 @@ if (slot < COMPACT_LIMIT) {
  * Generates WGSL code to output the result based on the selected sort option.
  * Currently handles: basic stats + COMBO
  */
-function generateSortOptionReturn(request: Form, context: OptimizerContext): string {
+function generateSortOptionReturn(request: Form, context: OptimizerContext, displayActionIndex: number): string {
   const sortOption = SortOption[request.resultSort!]
   const sortKey = sortOption.key
+  const displayAction = context.defaultActions[displayActionIndex]
+  const config = displayAction.config
+  const container = `container${displayActionIndex}`
 
   // Basic stats (not isComputedRating)
   // - statDisplay == 1 (basic mode): use c.{property}
-  // - statDisplay == 0 (combat mode): use container0[stat index]
+  // - statDisplay == 0 (combat mode): use the displayed action container
   if (!sortOption.isComputedRating) {
     const aKey = SortOptionToAKey[sortKey]
     if (aKey === undefined) {
       throw new Error(`GPU sort: no AKey mapping for basic stat '${sortKey}'`)
     }
 
-    const config = context.defaultActions[0].config
-    const statIndex = getActionIndex(SELF_ENTITY_INDEX, aKey, config)
+    const displayEntityIndex = getDisplayEntityIndex(request, config)
+    const statIndex = getActionIndex(displayEntityIndex, aKey, config)
     const boostKey = SortOptionBoostKey[sortKey]
     const boostExpr = boostKey !== undefined
-      ? ` + container0[${getActionIndex(SELF_ENTITY_INDEX, boostKey, config)}]`
+      ? ` + ${container}[${getActionIndex(displayEntityIndex, boostKey, config)}]`
       : ''
+    const basicSortValue = generateBasicStatExpression(request, config, sortKey)
 
     return `
     if (statDisplay == 1) {
-      if (c.${sortKey} > threshold) {
-${writeCompactResult(`c.${sortKey}`)}
+      if (${basicSortValue} > threshold) {
+${writeCompactResult(basicSortValue)}
       }
     } else {
-      let sortValue = container0[${statIndex}]${boostExpr};
+      let sortValue = ${container}[${statIndex}]${boostExpr};
       if (sortValue > threshold) {
 ${writeCompactResult('sortValue')}
       }
@@ -307,9 +318,11 @@ ${writeCompactResult('comboBuff')}
   }
 
   if (sortKey === SortOption.EHP.key) {
+    const displayEntityIndex = getDisplayEntityIndex(request, config)
+    const ehpIndex = getActionIndex(displayEntityIndex, AKey.EHP, config)
     return `
-    if (ehp0 > threshold) {
-${writeCompactResult('ehp0')}
+    if (${container}[${ehpIndex}] > threshold) {
+${writeCompactResult(`${container}[${ehpIndex}]`)}
     }
 `
   }
@@ -662,12 +675,14 @@ function unrollEntityBaseStats(action: OptimizerAction, targetTag: TargetTag = T
 }
 
 /**
- * Generates combat stat filters that execute after the first default action.
+ * Generates combat stat filters for the displayed action.
  * Uses conditional extraction - only extracts stats that have active min/max filters.
  */
-function generateCombatStatFilters(request: Form, context: OptimizerContext, gpuParams: GpuConstants): string {
-  const action = context.defaultActions[0]
+function generateCombatStatFilters(request: Form, context: OptimizerContext, displayActionIndex: number): string {
+  const action = context.defaultActions[displayActionIndex]
   const config = action.config
+  const container = `container${displayActionIndex}`
+  const displayEntityIndex = getDisplayEntityIndex(request, config)
   const isCombatMode = request.statDisplay === 'combat'
 
   const extractions: string[] = []
@@ -686,8 +701,8 @@ function generateCombatStatFilters(request: Form, context: OptimizerContext, gpu
     const hasMax = maxVal < Constants.MAX_INT
 
     if (hasMin || hasMax) {
-      const index = getActionIndex(SELF_ENTITY_INDEX, key, config)
-      extractions.push(`let ${varName} = container0[${index}];`)
+      const index = getActionIndex(displayEntityIndex, key, config)
+      extractions.push(`let ${varName} = ${container}[${index}];`)
       if (hasMin) conditions.push(`${varName} < ${minKey}`)
       if (hasMax) conditions.push(`${varName} > ${maxKey}`)
     }
@@ -707,9 +722,9 @@ function generateCombatStatFilters(request: Form, context: OptimizerContext, gpu
     const hasMax = maxVal < Constants.MAX_INT
 
     if (hasMin || hasMax) {
-      const index = getActionIndex(SELF_ENTITY_INDEX, key, config)
-      const boostIndex = getActionIndex(SELF_ENTITY_INDEX, boostKey, config)
-      extractions.push(`let ${varName} = container0[${index}] + container0[${boostIndex}];`)
+      const index = getActionIndex(displayEntityIndex, key, config)
+      const boostIndex = getActionIndex(displayEntityIndex, boostKey, config)
+      extractions.push(`let ${varName} = ${container}[${index}] + ${container}[${boostIndex}];`)
       if (hasMin) conditions.push(`${varName} < ${minKey}`)
       if (hasMax) conditions.push(`${varName} > ${maxKey}`)
     }
@@ -730,25 +745,25 @@ function generateCombatStatFilters(request: Form, context: OptimizerContext, gpu
 
   // EHP calculation for all entities (needed for filtering or sorting)
   if (context.shaderVariables.needsEhp) {
-    const ehp = generateEhpStatements('container0', action, 'filterEhp')
+    const ehp = generateEhpStatements(container, action, 'filterEhp')
     extractions.push(...ehp.statements)
+    const ehpIndex = getActionIndex(displayEntityIndex, AKey.EHP, config)
 
-    // EHP filtering uses entity 0 (primary character)
-    if (request.minEhp > 0) conditions.push(`${ehp.primaryValue} < minEhp`)
-    if (request.maxEhp < Constants.MAX_INT) conditions.push(`${ehp.primaryValue} > maxEhp`)
+    if (request.minEhp > 0) conditions.push(`${container}[${ehpIndex}] < minEhp`)
+    if (request.maxEhp < Constants.MAX_INT) conditions.push(`${container}[${ehpIndex}] > maxEhp`)
   }
 
   if (extractions.length === 0) return ''
 
   if (conditions.length === 0) {
     return `
-    // Combat stat extractions (after action 0)
+    // Combat stat extractions
     ${extractions.join('\n    ')}
 `
   }
 
   return `
-    // Combat stat filters (after action 0)
+    // Combat stat filters
     ${extractions.join('\n    ')}
     if (
       ${conditions.join(' ||\n      ')}
@@ -760,7 +775,6 @@ function generateCombatStatFilters(request: Form, context: OptimizerContext, gpu
 
 function generateEhpStatements(containerName: string, action: OptimizerAction, variablePrefix: string) {
   const statements: string[] = []
-  let primaryValue = ''
 
   for (let entityIndex = 0; entityIndex < action.config.entitiesLength; entityIndex++) {
     const hpIndex = getActionIndex(entityIndex, AKey.HP, action.config)
@@ -778,8 +792,7 @@ function generateEhpStatements(containerName: string, action: OptimizerAction, v
     statements.push(`let ${dmgRed} = ${containerName}[${dmgRedIndex}];`)
     statements.push(`let ${value} = ${hp} / (1.0 - ${def} / (${def} + 200.0 + 10.0 * f32(enemyLevel))) / (1.0 - ${dmgRed});`)
     statements.push(`${containerName}[${ehpIndex}] = ${value};`)
-    if (entityIndex === 0) primaryValue = value
   }
 
-  return { statements, primaryValue }
+  return { statements }
 }

--- a/src/lib/gpu/injection/injectUnrolledActions.ts
+++ b/src/lib/gpu/injection/injectUnrolledActions.ts
@@ -30,6 +30,7 @@ import {
 } from 'lib/optimization/engine/config/tag'
 import { matchesTargetTag } from 'lib/optimization/engine/container/gpuBuffBuilder'
 import { getDamageFunction } from 'lib/optimization/engine/damage/damageCalculator'
+import { AbilityMeta } from 'lib/optimization/rotation/turnAbilityConfig'
 import type {
   SortOptionKey,
   SortOptionProperties,
@@ -157,6 +158,21 @@ function getAbilitySortCompletionIndex(request: Form, context: OptimizerContext)
 
 function recordsBuffOutput(action: OptimizerAction): boolean {
   return action.hits?.some((hit) => hit.recorded !== false && hit.outputTag === OutputTag.BUFF) ?? false
+}
+
+function getActionOutputWgsl(action: OptimizerAction): string {
+  switch (AbilityMeta[action.actionType].outputTag) {
+    case OutputTag.DAMAGE:
+      return 'comboDmg'
+    case OutputTag.HEAL:
+      return 'comboHeal'
+    case OutputTag.SHIELD:
+      return 'comboShield'
+    case OutputTag.BUFF:
+      return 'comboBuff'
+    default:
+      return '0.0'
+  }
 }
 
 const SortOptionToAKey: Partial<Record<SortOptionKey, AKeyValue>> = {
@@ -423,6 +439,7 @@ function unrollAction(index: number, action: OptimizerAction, context: Optimizer
 
   const damageCalculationWgsl = indent(unrollDamageCalculations(action, context, gpuParams), 1)
   const comboBuffUpdateWgsl = recordsBuffOutput(action) ? '*p_comboBuff = comboBuff;' : ''
+  const actionOutputWgsl = getActionOutputWgsl(action)
 
   //////////
 
@@ -526,8 +543,7 @@ fn unrolledAction${index}(
   *p_comboShield += comboShield;
   ${comboBuffUpdateWgsl}
 
-  // Return total for debug register copy
-  return comboDmg + comboHeal + comboShield + comboBuff;
+  return ${actionOutputWgsl};
 }
   `
   } else {
@@ -599,7 +615,7 @@ fn unrolledAction${index}(
 
   ${comboBuffUpdateWgsl}
 
-  return comboDmg + comboHeal + comboShield + comboBuff;
+  return ${actionOutputWgsl};
 }
   `
   }
@@ -617,8 +633,7 @@ function unrollDamageCalculations(action: OptimizerAction, context: OptimizerCon
   }
 
   if (gpuParams.DEBUG) {
-    // Set action register with total combo damage
-    code += wgslDebugActionRegister(action, context, 'comboDmg + comboHeal + comboShield + comboBuff') + '\n'
+    code += wgslDebugActionRegister(action, context, getActionOutputWgsl(action)) + '\n'
   }
 
   return wgsl`

--- a/src/lib/gpu/injection/injectUnrolledActions.ts
+++ b/src/lib/gpu/injection/injectUnrolledActions.ts
@@ -27,7 +27,10 @@ import {
 } from 'lib/optimization/engine/config/tag'
 import { matchesTargetTag } from 'lib/optimization/engine/container/gpuBuffBuilder'
 import { getDamageFunction } from 'lib/optimization/engine/damage/damageCalculator'
-import type { SortOptionKey } from 'lib/optimization/sortOptions'
+import type {
+  SortOptionKey,
+  SortOptionProperties,
+} from 'lib/optimization/sortOptions'
 import { SortOption } from 'lib/optimization/sortOptions'
 import {
   generateSetCombatWgsl,
@@ -60,6 +63,7 @@ function generateUnrolledActions(request: Form, context: OptimizerContext, gpuPa
 `
   let functions = ''
   const defaultActionsRecordBuff = context.defaultActions.some(recordsBuffOutput)
+  const abilitySortCompletionIndex = gpuParams.DEBUG ? -1 : getAbilitySortCompletionIndex(request, context)
 
   for (let i = 0; i < context.defaultActions.length; i++) {
     const action = context.defaultActions[i]
@@ -72,11 +76,9 @@ function generateUnrolledActions(request: Form, context: OptimizerContext, gpuPa
       calls += generateCombatStatFilters(request, context, gpuParams)
     }
 
-    // For ability-damage sorts (BASIC, SKILL, ULT, etc.), the sort value is fully determined
-    // by this single default action. Threshold-check it and skip all remaining actions.
-    // Note: rating filters for other abilities (e.g., minSkill when sorting by BASIC) are
-    // not enforced since those abilities' damage values are never computed.
-    if (!gpuParams.DEBUG && isAbilitySortAction(request, action)) {
+    // Apply rating filters once every required action is calculated.
+    if (i === abilitySortCompletionIndex) {
+      calls += generateRatingFilters(request, context)
       calls += generateSortOptionReturn(request, context)
       calls += '    continue;\n'
       return { calls, functions }
@@ -102,7 +104,7 @@ function generateUnrolledActions(request: Form, context: OptimizerContext, gpuPa
   }
 
   if (!gpuParams.DEBUG) {
-    calls += generateRatingFilters(request, context, gpuParams)
+    calls += generateRatingFilters(request, context)
     calls += generateSortOptionReturn(request, context)
   } else {
     calls += generateDebugContainer(context)
@@ -122,15 +124,28 @@ function generateUnrolledActions(request: Form, context: OptimizerContext, gpuPa
   return { calls, functions }
 }
 
-function isAbilitySortAction(request: Form, action: OptimizerAction): boolean {
+function getAbilitySortCompletionIndex(request: Form, context: OptimizerContext): number {
   const sortOption = SortOption[request.resultSort!]
-  return !!sortOption?.isComputedRating
-    && sortOption.key !== SortOption.COMBO.key
-    && sortOption.key !== SortOption.COMBO_HEAL.key
-    && sortOption.key !== SortOption.COMBO_SHIELD.key
-    && sortOption.key !== SortOption.COMBO_BUFF.key
-    && sortOption.key !== SortOption.EHP.key
-    && action.actionName === sortOption.key
+  if (
+    !sortOption?.isComputedRating
+    || sortOption.statKey != null
+    || sortOption.globalRegisterIndex != null
+  ) {
+    return -1
+  }
+
+  let completionIndex = context.defaultActions.findIndex((action) => action.actionName === sortOption.key)
+  if (completionIndex < 0) return -1
+
+  for (const filterSortOption of Object.values(SortOption)) {
+    const bounds = getRatingFilterBounds(request, filterSortOption)
+    if (!bounds || (!bounds.hasMin && !bounds.hasMax)) continue
+
+    const actionIndex = context.defaultActions.findIndex((action) => action.actionName === filterSortOption.key)
+    completionIndex = Math.max(completionIndex, actionIndex)
+  }
+
+  return completionIndex
 }
 
 function recordsBuffOutput(action: OptimizerAction): boolean {
@@ -157,28 +172,19 @@ const SortOptionBoostKey: Partial<Record<SortOptionKey, AKeyValue>> = {
   CD: AKey.CD_BOOST,
 }
 
-/**
- * Generates WGSL rating filters (BASIC, SKILL, ULT, etc.) that check dmg{i} variables
- * against user-specified min/max thresholds. Injected after all actions compute but before sort.
- */
-function generateRatingFilters(request: Form, context: OptimizerContext, gpuParams: GpuConstants): string {
+/** Generates active ability rating filters. */
+function generateRatingFilters(request: Form, context: OptimizerContext): string {
   const conditions: string[] = []
 
   for (const sortOption of Object.values(SortOption)) {
-    if (!sortOption.minFilterKey || !sortOption.maxFilterKey) continue
-
-    const minVal = request[sortOption.minFilterKey as keyof Form] as number
-    const maxVal = request[sortOption.maxFilterKey as keyof Form] as number
-    const hasMin = minVal > 0
-    const hasMax = maxVal < Constants.MAX_INT
-
-    if (!hasMin && !hasMax) continue
+    const bounds = getRatingFilterBounds(request, sortOption)
+    if (!bounds || (!bounds.hasMin && !bounds.hasMax)) continue
 
     const actionIndex = context.defaultActions.findIndex((a) => a.actionName === sortOption.key)
     if (actionIndex < 0) continue
 
-    if (hasMin) conditions.push(`dmg${actionIndex} < ${sortOption.minFilterKey}`)
-    if (hasMax) conditions.push(`dmg${actionIndex} > ${sortOption.maxFilterKey}`)
+    if (bounds.hasMin) conditions.push(`dmg${actionIndex} < ${sortOption.minFilterKey}`)
+    if (bounds.hasMax) conditions.push(`dmg${actionIndex} > ${sortOption.maxFilterKey}`)
   }
 
   if (conditions.length === 0) return ''
@@ -191,6 +197,17 @@ function generateRatingFilters(request: Form, context: OptimizerContext, gpuPara
       continue;
     }
 `
+}
+
+function getRatingFilterBounds(request: Form, sortOption: SortOptionProperties) {
+  if (!sortOption.minFilterKey || !sortOption.maxFilterKey) return null
+
+  const minVal = request[sortOption.minFilterKey as keyof Form] as number
+  const maxVal = request[sortOption.maxFilterKey as keyof Form] as number
+  return {
+    hasMin: minVal > 0,
+    hasMax: maxVal < Constants.MAX_INT,
+  }
 }
 
 /**

--- a/src/lib/gpu/tests/webgpuTestUtils.ts
+++ b/src/lib/gpu/tests/webgpuTestUtils.ts
@@ -141,16 +141,6 @@ const StatKeyToStat: Record<number, string> = {
   [StatKey.IMAGINARY_DMG_BOOST]: Stats.Imaginary_DMG,
 }
 
-const ignoredStats: Record<number, boolean> = {
-  [StatKey.PHYSICAL_DMG_BOOST]: true,
-  [StatKey.FIRE_DMG_BOOST]: true,
-  [StatKey.ICE_DMG_BOOST]: true,
-  [StatKey.LIGHTNING_DMG_BOOST]: true,
-  [StatKey.WIND_DMG_BOOST]: true,
-  [StatKey.IMAGINARY_DMG_BOOST]: true,
-  [StatKey.QUANTUM_DMG_BOOST]: true,
-}
-
 const overridePrecision: Record<number, number> = {
   // Flat stats (large values, float precision issues)
   [StatKey.HP]: P_2,
@@ -194,7 +184,6 @@ function arrayDelta(cpuContainer: ComputedStatsContainer, gpuContainer: Computed
 
   // Compare stats array values
   for (let i = 0; i < STATS_LENGTH; i++) {
-    if (ignoredStats[i]) continue
     const statName = statNames[i]
     const precision = overridePrecision[i] ?? P_4
     analyze(statName, cpu[i], gpu[i], precision)

--- a/src/lib/gpu/webgpuDataTransform.ts
+++ b/src/lib/gpu/webgpuDataTransform.ts
@@ -1,8 +1,8 @@
+import { Parts } from 'lib/constants/constants'
 import {
   type GpuExecutionContext,
   type RelicsByPart,
 } from 'lib/gpu/webgpuTypes'
-import { Parts } from 'lib/constants/constants'
 import { BasicKey } from 'lib/optimization/basicStatsArray'
 import {
   type PerSlotSetRanges,
@@ -16,6 +16,14 @@ import {
 } from 'lib/sets/setConfigRegistry'
 import { type StringToNumberMap } from 'types/common'
 import { type Relic } from 'types/relic'
+
+const EMPTY_QUEUE_RESULT_THRESHOLD = -1
+
+export function getGpuResultThreshold(gpuContext: GpuExecutionContext): number {
+  return gpuContext.resultsQueue.size() >= gpuContext.RESULTS_LIMIT
+    ? gpuContext.resultsQueue.topPriority()
+    : EMPTY_QUEUE_RESULT_THRESHOLD
+}
 
 export function generateParamsMatrix(
   offset: number,
@@ -42,7 +50,7 @@ export function generateParamsMatrix(
 
   const permStride = gpuContext.BLOCK_SIZE * gpuContext.CYCLES_PER_INVOCATION
   const permLimit = Math.min(permStride, gpuContext.permutations - offset)
-  const threshold = gpuContext.resultsQueue.size() >= gpuContext.RESULTS_LIMIT ? gpuContext.resultsQueue.topPriority() : 0
+  const threshold = getGpuResultThreshold(gpuContext)
 
   const buf = new ArrayBuffer(32)
   const f32 = new Float32Array(buf)

--- a/src/lib/gpu/webgpuOptimizer.ts
+++ b/src/lib/gpu/webgpuOptimizer.ts
@@ -181,7 +181,7 @@ async function runNaiveDispatch(gpuContext: GpuExecutionContext): Promise<number
     const progressSnapshot = (iteration + 1) / gpuContext.iterations
     const storeStartTime = useOptimizerDisplayStore.getState().optimizerStartTime
     setTimeout(() => {
-      if (!ownsOptimizationRun(gpuContext.request.optimizationId)) return
+      if (!isOptimizationRunActive(gpuContext.request.optimizationId)) return
       const endTimeToSet = Date.now()
       const msDiff = endTimeToSet - (storeStartTime ?? 0)
 

--- a/src/lib/gpu/webgpuOptimizer.ts
+++ b/src/lib/gpu/webgpuOptimizer.ts
@@ -1,5 +1,8 @@
 import { type ComputeEngine } from 'lib/constants/constants'
-import { type WorkgroupEntry } from 'lib/gpu/webgpuDataTransform'
+import {
+  getGpuResultThreshold,
+  type WorkgroupEntry,
+} from 'lib/gpu/webgpuDataTransform'
 import { debugWebgpuOutput } from 'lib/gpu/webgpuDebugger'
 import {
   destroyPipeline,
@@ -259,9 +262,7 @@ export function decodeTupleGlobalIndex(
 }
 
 function submitTupleBatch(gpuContext: GpuExecutionContext, batchStart: number, batchSize: number, bufferIndex: number): void {
-  const threshold = gpuContext.resultsQueue.size() >= gpuContext.RESULTS_LIMIT
-    ? gpuContext.resultsQueue.topPriority()
-    : 0
+  const threshold = getGpuResultThreshold(gpuContext)
   const paramsBuf = new ArrayBuffer(16)
   new Float32Array(paramsBuf)[0] = threshold
   new Uint32Array(paramsBuf, 4)[0] = batchStart

--- a/src/lib/optimization/basicStatsArray.ts
+++ b/src/lib/optimization/basicStatsArray.ts
@@ -5,6 +5,7 @@ import {
 } from 'lib/constants/constants'
 import { type BuffSource } from 'lib/optimization/buffSource'
 import { type AKeyType } from 'lib/optimization/engine/config/keys'
+import { type OutputTag } from 'lib/optimization/engine/config/tag'
 import {
   emptySetMatches,
   type SetMatches,
@@ -17,6 +18,8 @@ export type Buff = {
   source: BuffSource,
   memo?: boolean,
   damageTags?: number,
+  // Basic-stat traces omit hit-level output metadata.
+  outputTags?: OutputTag,
 }
 
 type BasicStatController = {

--- a/src/lib/optimization/engine/config/statsConfig.ts
+++ b/src/lib/optimization/engine/config/statsConfig.ts
@@ -1,4 +1,5 @@
 import { type Namespaces } from 'lib/i18n/i18n'
+import { OutputTag } from 'lib/optimization/engine/config/tag'
 import type Resources from 'types/resources'
 
 interface tInput {
@@ -7,7 +8,7 @@ interface tInput {
   args?: Record<string, string>
 }
 
-interface SimpleLabel extends tInput {}
+export interface SimpleLabel extends tInput {}
 
 export interface StatConfigEntry {
   hit?: boolean
@@ -30,6 +31,12 @@ const optimizerTabMisc = createI18nKey<keyof Prefixed['Misc']>('optimizerTab', `
 const optimizerTabCompositeSuffix = createI18nKey<keyof Prefixed['CompositeLabels']['Suffix']>('optimizerTab', `${keyPrefix}.CompositeLabels.Suffix`)
 const optimizerTabUnconvertible = createI18nKey<keyof Resources['common']['Stats']>('optimizerTab', `${keyPrefix}.Unconvertible`, 'stat')
 const optimizerTabDmgBoost = createI18nKey<keyof Resources['gameData']['Elements']>('optimizerTab', `${keyPrefix}.ElementalDmgBoost`, 'element')
+
+export function getBoostLabel(outputTags?: OutputTag): SimpleLabel {
+  if (outputTags === OutputTag.SHIELD) return optimizerTabMisc('Shield boost')
+  if (outputTags === OutputTag.HEAL) return commonReadableStat('Outgoing Healing Boost')
+  return optimizerTabCompositeSuffix('DMG Boost')
+}
 
 export const newStatsConfig = {
   // ================ Hit Stats ================

--- a/src/lib/optimization/engine/container/computedStatsContainer.ts
+++ b/src/lib/optimization/engine/container/computedStatsContainer.ts
@@ -538,6 +538,7 @@ export class ComputedStatsContainer {
           source: config._source,
           memo: false,
           damageTags: traceDamageTags,
+          outputTags,
         })
       }
       if (hasMemo) {
@@ -548,6 +549,7 @@ export class ComputedStatsContainer {
           source: config._source,
           memo: true,
           damageTags: traceDamageTags,
+          outputTags,
         })
       }
     }

--- a/src/lib/optimization/optimizer.ts
+++ b/src/lib/optimization/optimizer.ts
@@ -264,6 +264,7 @@ export const Optimizer = {
 
     const sortOption = SortOption[request.resultSort!]
     const showMemo = request.memoDisplay === 'memo'
+      && context.defaultActions[context.defaultActions.length - 1].config.entitiesArray.some((entity) => entity.memosprite)
     const gridSortColumn = (request.statDisplay == 'combat'
       ? (showMemo ? sortOption.memoCombatGridColumn : sortOption.combatGridColumn)
       : (showMemo ? sortOption.memoBasicGridColumn : sortOption.basicGridColumn)) as keyof OptimizerDisplayData

--- a/src/lib/optimization/rotation/turnAbilityConfig.ts
+++ b/src/lib/optimization/rotation/turnAbilityConfig.ts
@@ -1,3 +1,4 @@
+import { OutputTag } from 'lib/optimization/engine/config/tag'
 import type { SortOptionKey } from 'lib/optimization/sortOptions'
 
 // =============================================================================
@@ -41,39 +42,37 @@ export enum TurnMarker {
 // ABILITY META CONFIG - Single source of truth
 // =============================================================================
 
-type AbilityCategory = 'damage' | 'heal' | 'shield' | 'buff' | 'null'
-
 interface AbilityMetaEntry {
   label: string
   sortKey?: SortOptionKey // matches SortOption key, undefined = no sort option
-  category: AbilityCategory
+  outputTag: OutputTag | null
 }
 
 export const AbilityMeta = {
-  [AbilityKind.NULL]: { label: 'None', sortKey: undefined, category: 'null' },
-  [AbilityKind.BASIC]: { label: 'Basic', sortKey: 'BASIC', category: 'damage' },
-  [AbilityKind.SKILL]: { label: 'Skill', sortKey: 'SKILL', category: 'damage' },
-  [AbilityKind.ULT]: { label: 'Ult', sortKey: 'ULT', category: 'damage' },
-  [AbilityKind.FUA]: { label: 'Fua', sortKey: 'FUA', category: 'damage' },
-  [AbilityKind.DOT]: { label: 'Dot', sortKey: 'DOT', category: 'damage' },
-  [AbilityKind.BREAK]: { label: 'Break', sortKey: 'BREAK', category: 'damage' },
-  [AbilityKind.MEMO_SKILL]: { label: 'MemoSkill', sortKey: 'MEMO_SKILL', category: 'damage' },
-  [AbilityKind.MEMO_TALENT]: { label: 'MemoTalent', sortKey: 'MEMO_TALENT', category: 'damage' },
-  [AbilityKind.ELATION_SKILL]: { label: 'ElationSkill', sortKey: 'ELATION_SKILL', category: 'damage' },
-  [AbilityKind.UNIQUE]: { label: 'Unique', sortKey: 'UNIQUE', category: 'damage' },
+  [AbilityKind.NULL]: { label: 'None', sortKey: undefined, outputTag: null },
+  [AbilityKind.BASIC]: { label: 'Basic', sortKey: 'BASIC', outputTag: OutputTag.DAMAGE },
+  [AbilityKind.SKILL]: { label: 'Skill', sortKey: 'SKILL', outputTag: OutputTag.DAMAGE },
+  [AbilityKind.ULT]: { label: 'Ult', sortKey: 'ULT', outputTag: OutputTag.DAMAGE },
+  [AbilityKind.FUA]: { label: 'Fua', sortKey: 'FUA', outputTag: OutputTag.DAMAGE },
+  [AbilityKind.DOT]: { label: 'Dot', sortKey: 'DOT', outputTag: OutputTag.DAMAGE },
+  [AbilityKind.BREAK]: { label: 'Break', sortKey: 'BREAK', outputTag: OutputTag.DAMAGE },
+  [AbilityKind.MEMO_SKILL]: { label: 'MemoSkill', sortKey: 'MEMO_SKILL', outputTag: OutputTag.DAMAGE },
+  [AbilityKind.MEMO_TALENT]: { label: 'MemoTalent', sortKey: 'MEMO_TALENT', outputTag: OutputTag.DAMAGE },
+  [AbilityKind.ELATION_SKILL]: { label: 'ElationSkill', sortKey: 'ELATION_SKILL', outputTag: OutputTag.DAMAGE },
+  [AbilityKind.UNIQUE]: { label: 'Unique', sortKey: 'UNIQUE', outputTag: OutputTag.DAMAGE },
 
-  [AbilityKind.BASIC_HEAL]: { label: 'BasicHeal', sortKey: 'BASIC_HEAL', category: 'heal' },
-  [AbilityKind.SKILL_HEAL]: { label: 'SkillHeal', sortKey: 'SKILL_HEAL', category: 'heal' },
-  [AbilityKind.ULT_HEAL]: { label: 'UltHeal', sortKey: 'ULT_HEAL', category: 'heal' },
-  [AbilityKind.FUA_HEAL]: { label: 'FuaHeal', sortKey: 'FUA_HEAL', category: 'heal' },
-  [AbilityKind.TALENT_HEAL]: { label: 'TalentHeal', sortKey: 'TALENT_HEAL', category: 'heal' },
-  [AbilityKind.BASIC_SHIELD]: { label: 'BasicShield', sortKey: 'BASIC_SHIELD', category: 'shield' },
-  [AbilityKind.SKILL_SHIELD]: { label: 'SkillShield', sortKey: 'SKILL_SHIELD', category: 'shield' },
-  [AbilityKind.ULT_SHIELD]: { label: 'UltShield', sortKey: 'ULT_SHIELD', category: 'shield' },
-  [AbilityKind.FUA_SHIELD]: { label: 'FuaShield', sortKey: 'FUA_SHIELD', category: 'shield' },
-  [AbilityKind.TALENT_SHIELD]: { label: 'TalentShield', sortKey: 'TALENT_SHIELD', category: 'shield' },
-  [AbilityKind.BUFF]: { label: 'Buff', sortKey: 'BUFF', category: 'buff' },
-} as const
+  [AbilityKind.BASIC_HEAL]: { label: 'BasicHeal', sortKey: 'BASIC_HEAL', outputTag: OutputTag.HEAL },
+  [AbilityKind.SKILL_HEAL]: { label: 'SkillHeal', sortKey: 'SKILL_HEAL', outputTag: OutputTag.HEAL },
+  [AbilityKind.ULT_HEAL]: { label: 'UltHeal', sortKey: 'ULT_HEAL', outputTag: OutputTag.HEAL },
+  [AbilityKind.FUA_HEAL]: { label: 'FuaHeal', sortKey: 'FUA_HEAL', outputTag: OutputTag.HEAL },
+  [AbilityKind.TALENT_HEAL]: { label: 'TalentHeal', sortKey: 'TALENT_HEAL', outputTag: OutputTag.HEAL },
+  [AbilityKind.BASIC_SHIELD]: { label: 'BasicShield', sortKey: 'BASIC_SHIELD', outputTag: OutputTag.SHIELD },
+  [AbilityKind.SKILL_SHIELD]: { label: 'SkillShield', sortKey: 'SKILL_SHIELD', outputTag: OutputTag.SHIELD },
+  [AbilityKind.ULT_SHIELD]: { label: 'UltShield', sortKey: 'ULT_SHIELD', outputTag: OutputTag.SHIELD },
+  [AbilityKind.FUA_SHIELD]: { label: 'FuaShield', sortKey: 'FUA_SHIELD', outputTag: OutputTag.SHIELD },
+  [AbilityKind.TALENT_SHIELD]: { label: 'TalentShield', sortKey: 'TALENT_SHIELD', outputTag: OutputTag.SHIELD },
+  [AbilityKind.BUFF]: { label: 'Buff', sortKey: 'BUFF', outputTag: OutputTag.BUFF },
+} as const satisfies Record<AbilityKind, AbilityMetaEntry>
 
 // Derived union of all combo option label strings (e.g. 'Basic' | 'Skill' | 'Ult' | ...)
 export type ComboOptionLabel = typeof AbilityMeta[AbilityKind]['label']

--- a/src/lib/sets/ornaments/LushakaTheSunkenSeas.ts
+++ b/src/lib/sets/ornaments/LushakaTheSunkenSeas.ts
@@ -8,9 +8,14 @@ import {
   WgslStatName,
 } from 'lib/optimization/basicStatsArray'
 import { Source } from 'lib/optimization/buffSource'
-import { StatKey } from 'lib/optimization/engine/config/keys'
-import { type ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
 import {
+  HKey,
+  StatKey,
+} from 'lib/optimization/engine/config/keys'
+import { type ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
+import { buff } from 'lib/optimization/engine/container/gpuBuffBuilder'
+import {
+  type OptimizerAction,
   type OptimizerContext,
   type SetConditional,
 } from 'types/optimizer'
@@ -48,6 +53,14 @@ const conditionals: SetConditionals = {
   gpuBasic: () => [
     basicP2(WgslStatName.ERR, 0.05, LushakaTheSunkenSeas),
   ],
+  gpu: (action: OptimizerAction) => `
+    if (
+      ornament2p(*p_sets, SET_LushakaTheSunkenSeas)
+      && setConditionals.enabledLushakaTheSunkenSeas == true
+    ) {
+      ${buff.hit(HKey.BOOST, `0.12 * ${action.config.selfEntity.baseAtk}`).outputBuff(StatKey.ATK).wgsl(action, 2)}
+    }
+  `,
   teammate: [{
     value: Sets.LushakaTheSunkenSeas,
     label: (t) => t('TeammateSets.Lushaka.Text'),

--- a/src/lib/sets/relics/BandOfSizzlingThunder.ts
+++ b/src/lib/sets/relics/BandOfSizzlingThunder.ts
@@ -1,7 +1,6 @@
 import {
   ConditionalDataType,
   Sets,
-  Stats,
 } from 'lib/constants/constants'
 import { basicP2 } from 'lib/gpu/injection/generateBasicSetEffects'
 import {
@@ -43,10 +42,8 @@ const display = {
 } as const satisfies SetDisplay
 
 const conditionals: SetConditionals = {
-  p2c: (c: BasicStatsArray, context: OptimizerContext) => {
-    if (context.elementalDamageType == Stats.Lightning_DMG) {
-      c.LIGHTNING_DMG_BOOST.buff(0.10, Source.BandOfSizzlingThunder)
-    }
+  p2c: (c: BasicStatsArray) => {
+    c.LIGHTNING_DMG_BOOST.buff(0.10, Source.BandOfSizzlingThunder)
   },
   p4x: (x: ComputedStatsContainer, context: OptimizerContext, setConditionals: SetConditional) => {
     if (setConditionals.enabledBandOfSizzlingThunder) {

--- a/src/lib/sets/relics/ChampionOfStreetwiseBoxing.ts
+++ b/src/lib/sets/relics/ChampionOfStreetwiseBoxing.ts
@@ -1,7 +1,6 @@
 import {
   ConditionalDataType,
   Sets,
-  Stats,
 } from 'lib/constants/constants'
 import { basicP2 } from 'lib/gpu/injection/generateBasicSetEffects'
 import {
@@ -46,10 +45,8 @@ const display = {
 } as const satisfies SetDisplay
 
 const conditionals: SetConditionals = {
-  p2c: (c: BasicStatsArray, context: OptimizerContext) => {
-    if (context.elementalDamageType == Stats.Physical_DMG) {
-      c.PHYSICAL_DMG_BOOST.buff(0.10, Source.ChampionOfStreetwiseBoxing)
-    }
+  p2c: (c: BasicStatsArray) => {
+    c.PHYSICAL_DMG_BOOST.buff(0.10, Source.ChampionOfStreetwiseBoxing)
   },
   p4x: (x: ComputedStatsContainer, context: OptimizerContext, setConditionals: SetConditional) => {
     x.buff(StatKey.ATK_P, 0.05 * setConditionals.valueChampionOfStreetwiseBoxing, x.source(Source.ChampionOfStreetwiseBoxing))

--- a/src/lib/sets/relics/EagleOfTwilightLine.ts
+++ b/src/lib/sets/relics/EagleOfTwilightLine.ts
@@ -1,7 +1,6 @@
 import {
   ConditionalDataType,
   Sets,
-  Stats,
 } from 'lib/constants/constants'
 import { basicP2 } from 'lib/gpu/injection/generateBasicSetEffects'
 import {
@@ -9,9 +8,6 @@ import {
   WgslStatName,
 } from 'lib/optimization/basicStatsArray'
 import { Source } from 'lib/optimization/buffSource'
-import {
-  type OptimizerContext,
-} from 'types/optimizer'
 import {
   type SetConditionals,
   type SetConfig,
@@ -33,10 +29,8 @@ const display = {
 } as const satisfies SetDisplay
 
 const conditionals: SetConditionals = {
-  p2c: (c: BasicStatsArray, context: OptimizerContext) => {
-    if (context.elementalDamageType == Stats.Wind_DMG) {
-      c.WIND_DMG_BOOST.buff(0.10, Source.EagleOfTwilightLine)
-    }
+  p2c: (c: BasicStatsArray) => {
+    c.WIND_DMG_BOOST.buff(0.10, Source.EagleOfTwilightLine)
   },
   gpuBasic: () => [
     basicP2(WgslStatName.WIND_DMG_BOOST, 0.10, EagleOfTwilightLine),

--- a/src/lib/sets/relics/FiresmithOfLavaForging.ts
+++ b/src/lib/sets/relics/FiresmithOfLavaForging.ts
@@ -1,7 +1,6 @@
 import {
   ConditionalDataType,
   Sets,
-  Stats,
 } from 'lib/constants/constants'
 import { basicP2 } from 'lib/gpu/injection/generateBasicSetEffects'
 import {
@@ -45,10 +44,8 @@ const display = {
 } as const satisfies SetDisplay
 
 const conditionals: SetConditionals = {
-  p2c: (c: BasicStatsArray, context: OptimizerContext) => {
-    if (context.elementalDamageType == Stats.Fire_DMG) {
-      c.FIRE_DMG_BOOST.buff(0.10, Source.FiresmithOfLavaForging)
-    }
+  p2c: (c: BasicStatsArray) => {
+    c.FIRE_DMG_BOOST.buff(0.10, Source.FiresmithOfLavaForging)
   },
   p4x: (x: ComputedStatsContainer, context: OptimizerContext, setConditionals: SetConditional) => {
     x.buff(StatKey.BOOST, 0.12, x.damageType(DamageTag.SKILL).source(Source.FiresmithOfLavaForging))

--- a/src/lib/sets/relics/GeniusOfBrilliantStars.ts
+++ b/src/lib/sets/relics/GeniusOfBrilliantStars.ts
@@ -1,7 +1,6 @@
 import {
   ConditionalDataType,
   Sets,
-  Stats,
 } from 'lib/constants/constants'
 import { basicP2 } from 'lib/gpu/injection/generateBasicSetEffects'
 import {
@@ -43,10 +42,8 @@ const display = {
 } as const satisfies SetDisplay
 
 const conditionals: SetConditionals = {
-  p2c: (c: BasicStatsArray, context: OptimizerContext) => {
-    if (context.elementalDamageType == Stats.Quantum_DMG) {
-      c.QUANTUM_DMG_BOOST.buff(0.10, Source.GeniusOfBrilliantStars)
-    }
+  p2c: (c: BasicStatsArray) => {
+    c.QUANTUM_DMG_BOOST.buff(0.10, Source.GeniusOfBrilliantStars)
   },
   p4x: (x: ComputedStatsContainer, context: OptimizerContext, setConditionals: SetConditional) => {
     x.buff(StatKey.DEF_PEN, setConditionals.enabledGeniusOfBrilliantStars ? 0.20 : 0.10, x.source(Source.GeniusOfBrilliantStars))

--- a/src/lib/sets/relics/HunterOfGlacialForest.ts
+++ b/src/lib/sets/relics/HunterOfGlacialForest.ts
@@ -1,7 +1,6 @@
 import {
   ConditionalDataType,
   Sets,
-  Stats,
 } from 'lib/constants/constants'
 import { basicP2 } from 'lib/gpu/injection/generateBasicSetEffects'
 import {
@@ -43,10 +42,8 @@ const display = {
 } as const satisfies SetDisplay
 
 const conditionals: SetConditionals = {
-  p2c: (c: BasicStatsArray, context: OptimizerContext) => {
-    if (context.elementalDamageType == Stats.Ice_DMG) {
-      c.ICE_DMG_BOOST.buff(0.10, Source.HunterOfGlacialForest)
-    }
+  p2c: (c: BasicStatsArray) => {
+    c.ICE_DMG_BOOST.buff(0.10, Source.HunterOfGlacialForest)
   },
   p4x: (x: ComputedStatsContainer, context: OptimizerContext, setConditionals: SetConditional) => {
     if (setConditionals.enabledHunterOfGlacialForest) {

--- a/src/lib/sets/relics/PoetOfMourningCollapse.ts
+++ b/src/lib/sets/relics/PoetOfMourningCollapse.ts
@@ -1,7 +1,6 @@
 import {
   ConditionalDataType,
   Sets,
-  Stats,
 } from 'lib/constants/constants'
 import {
   basicP2,
@@ -47,10 +46,8 @@ const display = {
 } as const satisfies SetDisplay
 
 const conditionals: SetConditionals = {
-  p2c: (c: BasicStatsArray, context: OptimizerContext) => {
-    if (context.elementalDamageType == Stats.Quantum_DMG) {
-      c.QUANTUM_DMG_BOOST.buff(0.10, Source.PoetOfMourningCollapse)
-    }
+  p2c: (c: BasicStatsArray) => {
+    c.QUANTUM_DMG_BOOST.buff(0.10, Source.PoetOfMourningCollapse)
   },
   p4c: (c: BasicStatsArray, context: OptimizerContext) => {
     c.SPD_P.buff(-0.08, Source.PoetOfMourningCollapse)

--- a/src/lib/sets/relics/WastelanderOfBanditryDesert.ts
+++ b/src/lib/sets/relics/WastelanderOfBanditryDesert.ts
@@ -1,7 +1,6 @@
 import {
   ConditionalDataType,
   Sets,
-  Stats,
 } from 'lib/constants/constants'
 import { basicP2 } from 'lib/gpu/injection/generateBasicSetEffects'
 import {
@@ -46,10 +45,8 @@ const display = {
 } as const satisfies SetDisplay
 
 const conditionals: SetConditionals = {
-  p2c: (c: BasicStatsArray, context: OptimizerContext) => {
-    if (context.elementalDamageType == Stats.Imaginary_DMG) {
-      c.IMAGINARY_DMG_BOOST.buff(0.10, Source.WastelanderOfBanditryDesert)
-    }
+  p2c: (c: BasicStatsArray) => {
+    c.IMAGINARY_DMG_BOOST.buff(0.10, Source.WastelanderOfBanditryDesert)
   },
   p4x: (x: ComputedStatsContainer, context: OptimizerContext, setConditionals: SetConditional) => {
     x.buff(StatKey.CD_BOOST, 0.20 * (setConditionals.valueWastelanderOfBanditryDesert == 2 ? 1 : 0), x.source(Source.WastelanderOfBanditryDesert))

--- a/src/lib/sets/relics/elementalRelicSets.test.ts
+++ b/src/lib/sets/relics/elementalRelicSets.test.ts
@@ -1,0 +1,48 @@
+import {
+  type SetKey,
+  Stats,
+  type StatsValues,
+} from 'lib/constants/constants'
+import {
+  BasicKey,
+  type BasicStatsArray,
+  BasicStatsArrayCore,
+} from 'lib/optimization/basicStatsArray'
+import { setConfigRegistry } from 'lib/sets/setConfigRegistry'
+import type { OptimizerContext } from 'types/optimizer'
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest'
+
+type ElementalRelicSetCase = {
+  name: string,
+  setKey: SetKey,
+  stat: number,
+  wearerElement: StatsValues,
+}
+
+const cases: ElementalRelicSetCase[] = [
+  { name: 'Band of Sizzling Thunder', setKey: 'BandOfSizzlingThunder', stat: BasicKey.LIGHTNING_DMG_BOOST, wearerElement: Stats.Physical_DMG },
+  { name: 'Champion of Streetwise Boxing', setKey: 'ChampionOfStreetwiseBoxing', stat: BasicKey.PHYSICAL_DMG_BOOST, wearerElement: Stats.Lightning_DMG },
+  { name: 'Eagle of Twilight Line', setKey: 'EagleOfTwilightLine', stat: BasicKey.WIND_DMG_BOOST, wearerElement: Stats.Physical_DMG },
+  { name: 'Firesmith of Lava-Forging', setKey: 'FiresmithOfLavaForging', stat: BasicKey.FIRE_DMG_BOOST, wearerElement: Stats.Physical_DMG },
+  { name: 'Genius of Brilliant Stars', setKey: 'GeniusOfBrilliantStars', stat: BasicKey.QUANTUM_DMG_BOOST, wearerElement: Stats.Physical_DMG },
+  { name: 'Hunter of Glacial Forest', setKey: 'HunterOfGlacialForest', stat: BasicKey.ICE_DMG_BOOST, wearerElement: Stats.Physical_DMG },
+  { name: 'Poet of Mourning Collapse', setKey: 'PoetOfMourningCollapse', stat: BasicKey.QUANTUM_DMG_BOOST, wearerElement: Stats.Physical_DMG },
+  { name: 'Wastelander of Banditry Desert', setKey: 'WastelanderOfBanditryDesert', stat: BasicKey.IMAGINARY_DMG_BOOST, wearerElement: Stats.Physical_DMG },
+]
+
+describe.each(cases)('$name 2-piece effect', ({ setKey, stat, wearerElement }) => {
+  it('adds its elemental damage bonus for an off-element wearer', () => {
+    const c = new BasicStatsArrayCore(false) as BasicStatsArray
+    const context = { elementalDamageType: wearerElement } as OptimizerContext
+    const setConfig = setConfigRegistry.get(setKey)
+
+    c.a[stat] = 0.25
+    setConfig!.conditionals.p2c?.(c, context)
+
+    expect(c.a[stat]).toBeCloseTo(0.35)
+  })
+})

--- a/src/lib/simulations/simulateBuild.ts
+++ b/src/lib/simulations/simulateBuild.ts
@@ -27,7 +27,10 @@ import {
   calculateEhp,
   getDamageFunction,
 } from 'lib/optimization/engine/damage/damageCalculator'
-import { type TurnAbilityName } from 'lib/optimization/rotation/turnAbilityConfig'
+import {
+  AbilityMeta,
+  type TurnAbilityName,
+} from 'lib/optimization/rotation/turnAbilityConfig'
 import {
   computeSetMatches,
   type SetMatches,
@@ -146,6 +149,7 @@ export function simulateBuild(
 
   for (let i = 0; i < context.rotationActions.length; i++) {
     const action = context.rotationActions[i]
+    const actionOutputTag = AbilityMeta[action.actionType].outputTag
     x.setConfig(action.config)
 
     resetConditionalState(action)
@@ -162,7 +166,7 @@ export function simulateBuild(
       rotationBuffSteps!.push({ actionType: action.actionType, snapshot: captureSnapshot(x) })
     }
 
-    let sum = 0
+    let actionOutput = 0
 
     for (let hitIndex = 0; hitIndex < action.hits!.length; hitIndex++) {
       const hit = action.hits![hitIndex]
@@ -174,7 +178,13 @@ export function simulateBuild(
       }
 
       if (hit.recorded !== false) {
-        sum += dmg
+        if (hit.outputTag === actionOutputTag) {
+          if (actionOutputTag === OutputTag.BUFF) {
+            actionOutput = dmg
+          } else {
+            actionOutput += dmg
+          }
+        }
         if (hit.outputTag === OutputTag.DAMAGE) {
           comboDmg += dmg
         } else if (hit.outputTag === OutputTag.HEAL) {
@@ -187,7 +197,7 @@ export function simulateBuild(
       }
     }
 
-    x.setActionRegisterValue(action.registerIndex, sum)
+    x.setActionRegisterValue(action.registerIndex, actionOutput)
   }
 
   let primaryActionStats: PrimaryActionStats | undefined
@@ -200,6 +210,7 @@ export function simulateBuild(
     rotationDamage = []
     for (let i = 0; i < context.defaultActions.length; i++) {
       const action = context.defaultActions[i]
+      const actionOutputTag = AbilityMeta[action.actionType].outputTag
       x.setConfig(action.config)
 
       resetConditionalState(action)
@@ -234,7 +245,7 @@ export function simulateBuild(
         }
       }
 
-      let sum = 0
+      let actionOutput = 0
 
       for (let hitIndex = 0; hitIndex < action.hits!.length; hitIndex++) {
         const hit = action.hits![hitIndex]
@@ -246,14 +257,20 @@ export function simulateBuild(
         }
 
         if (hit.recorded !== false) {
-          sum += dmg
+          if (hit.outputTag === actionOutputTag) {
+            if (actionOutputTag === OutputTag.BUFF) {
+              actionOutput = dmg
+            } else {
+              actionOutput += dmg
+            }
+          }
           if (hit.outputTag === OutputTag.BUFF) {
             comboBuff = dmg
           }
         }
       }
 
-      x.setActionRegisterValue(action.registerIndex, sum)
+      x.setActionRegisterValue(action.registerIndex, actionOutput)
     }
 
     calculateEhp(x, context)

--- a/src/lib/simulations/tests/simTestUtils.ts
+++ b/src/lib/simulations/tests/simTestUtils.ts
@@ -14,6 +14,7 @@ import {
   GlobalRegister,
   StatKey,
 } from 'lib/optimization/engine/config/keys'
+import { OutputTag } from 'lib/optimization/engine/config/tag'
 import { AbilityMeta } from 'lib/optimization/rotation/turnAbilityConfig'
 import { StatCalculator } from 'lib/relics/statCalculator'
 import {
@@ -237,13 +238,13 @@ export function collectResults(input: TestInput) {
     for (const [abilityKind, dmg] of Object.entries(actionDamage)) {
       const meta = AbilityMeta[abilityKind as keyof typeof AbilityMeta]
 
-      if (meta?.category === 'heal') {
+      if (meta?.outputTag === OutputTag.HEAL) {
         healValue += dmg ?? 0
-      } else if (meta?.category === 'shield') {
+      } else if (meta?.outputTag === OutputTag.SHIELD) {
         shieldValue += dmg ?? 0
-      } else if (meta?.category === 'buff') {
+      } else if (meta?.outputTag === OutputTag.BUFF) {
         buffValue += dmg ?? 0
-      } else if (meta?.category === 'damage') {
+      } else if (meta?.outputTag === OutputTag.DAMAGE) {
         nameCombatResults[`${abilityKind}_DMG`] = precisionRound(dmg ?? 0, 7)
       }
     }

--- a/src/lib/stores/optimizerForm/optimizerFormStoreActions.ts
+++ b/src/lib/stores/optimizerForm/optimizerFormStoreActions.ts
@@ -1,5 +1,6 @@
 import { CharacterConditionalsResolver } from 'lib/conditionals/resolver/characterConditionalsResolver'
 import { LightConeConditionalsResolver } from 'lib/conditionals/resolver/lightConeConditionalsResolver'
+import { DEFAULT_MEMO_DISPLAY, PathNames } from 'lib/constants/constants'
 import { generateConditionalResolverMetadata } from 'lib/optimization/combo/comboInitializers'
 import type { SetConditionals } from 'lib/optimization/combo/comboTypes'
 import { getGameMetadata } from 'lib/state/gameMetadata'
@@ -80,6 +81,11 @@ export function computeLoadForm(form: Form): OptimizerRequestState {
   const merged = mergeDefinedValues({ ...defaults }, converted)
   if (converted.setConditionals && defaults.setConditionals) {
     merged.setConditionals = { ...defaults.setConditionals, ...converted.setConditionals }
+  }
+
+  const characterMetadata = merged.characterId ? getGameMetadata().characters?.[merged.characterId] : undefined
+  if (characterMetadata?.path !== PathNames.Remembrance) {
+    merged.memoDisplay = DEFAULT_MEMO_DISPLAY
   }
 
   mergeConditionalDefaults(merged, form)

--- a/src/lib/tabs/tabOptimizer/optimizerForm/components/CharacterSelectorDisplay.tsx
+++ b/src/lib/tabs/tabOptimizer/optimizerForm/components/CharacterSelectorDisplay.tsx
@@ -7,6 +7,7 @@ import { CharacterConditionalsResolver } from 'lib/conditionals/resolver/charact
 import { Stats } from 'lib/constants/constants'
 import { Hint } from 'lib/interactions/hint'
 import { getAKeyName } from 'lib/optimization/engine/config/keys'
+import { OutputTag } from 'lib/optimization/engine/config/tag'
 import {
   type AbilityKind,
   AbilityMeta,
@@ -126,8 +127,8 @@ export function CharacterSelectorDisplay() {
           // @ts-ignore - BUFF key is handled above, not in i18n
           : t(`SortOptions.${sortOption.key}`)
 
-        const category = AbilityMeta[action as AbilityKind]?.category
-        if (category === 'buff') {
+        const outputTag = AbilityMeta[action as AbilityKind]?.outputTag
+        if (outputTag === OutputTag.BUFF) {
           optimizationOptions.push({ value: sortOption.key, label: label as string })
         } else {
           abilityOptions.push({ value: sortOption.key, label: label as string })

--- a/src/lib/worker/optimizerWorker.ts
+++ b/src/lib/worker/optimizerWorker.ts
@@ -32,6 +32,7 @@ import {
   calculateEhp,
   getDamageFunction,
 } from 'lib/optimization/engine/damage/damageCalculator'
+import { AbilityMeta } from 'lib/optimization/rotation/turnAbilityConfig'
 import {
   computeSetMatchesInPlace,
   emptySetMatches,
@@ -139,6 +140,8 @@ export function optimizerWorker(e: MessageEvent<OptimizerWorkerInput>) {
   const failsBasicStatsFilter = basicStatsFilter(request, memoEntity)
   const failsEhpFilter = ehpFilter(request, displayEntityIndex)
   const failsRatingFilter = ratingFilter(request, context)
+  const rotationActionOutputTags = context.rotationActions.map((action) => AbilityMeta[action.actionType].outputTag)
+  const defaultActionOutputTags = context.defaultActions.map((action) => AbilityMeta[action.actionType].outputTag)
 
   const sets = Array.from<number>({ length: 6 })
   const setMatches: MutableSetMatches = emptySetMatches()
@@ -214,6 +217,7 @@ export function optimizerWorker(e: MessageEvent<OptimizerWorkerInput>) {
     // Calculate rotation actions for combo damage
     for (let i = 0; i < context.rotationActions.length; i++) {
       const action = context.rotationActions[i]
+      const actionOutputTag = rotationActionOutputTags[i]
       x.setConfig(action.config)
       resetConditionalState(action)
 
@@ -222,32 +226,38 @@ export function optimizerWorker(e: MessageEvent<OptimizerWorkerInput>) {
       calculateComputedStats(x, action, context)
       calculateBaseMultis(x, action, context)
 
-      let sum = 0
+      let actionOutput = 0
       for (let hitIndex = 0; hitIndex < action.hits!.length; hitIndex++) {
         const hit = action.hits![hitIndex]
         const dmg = getDamageFunction(hit.damageFunctionType).apply(x, action, hitIndex, context)
         x.setHitRegisterValue(hit.registerIndex, dmg)
 
-        // Accumulate recorded hits by output tag
         if (hit.recorded !== false) {
-          sum += dmg
-          if (hit.outputTag == OutputTag.DAMAGE) {
+          if (hit.outputTag === actionOutputTag) {
+            if (actionOutputTag === OutputTag.BUFF) {
+              actionOutput = dmg
+            } else {
+              actionOutput += dmg
+            }
+          }
+          if (hit.outputTag === OutputTag.DAMAGE) {
             comboDmg += dmg
-          } else if (hit.outputTag == OutputTag.HEAL) {
+          } else if (hit.outputTag === OutputTag.HEAL) {
             comboHeal += dmg
-          } else if (hit.outputTag == OutputTag.SHIELD) {
+          } else if (hit.outputTag === OutputTag.SHIELD) {
             comboShield += dmg
-          } else if (hit.outputTag == OutputTag.BUFF) {
+          } else if (hit.outputTag === OutputTag.BUFF) {
             comboBuff = dmg
           }
         }
       }
-      x.setActionRegisterValue(action.registerIndex, sum)
+      x.setActionRegisterValue(action.registerIndex, actionOutput)
     }
 
     // Calculate default actions for display stats and store in registers
     for (let i = 0; i < context.defaultActions.length; i++) {
       const action = context.defaultActions[i]
+      const actionOutputTag = defaultActionOutputTags[i]
       x.setConfig(action.config)
       resetConditionalState(action)
 
@@ -256,20 +266,26 @@ export function optimizerWorker(e: MessageEvent<OptimizerWorkerInput>) {
       calculateComputedStats(x, action, context)
       calculateBaseMultis(x, action, context)
 
-      let sum = 0
+      let actionOutput = 0
       for (let hitIndex = 0; hitIndex < action.hits!.length; hitIndex++) {
         const hit = action.hits![hitIndex]
         const dmg = getDamageFunction(hit.damageFunctionType).apply(x, action, hitIndex, context)
         x.setHitRegisterValue(hit.registerIndex, dmg)
 
         if (hit.recorded !== false) {
-          sum += dmg
-          if (hit.outputTag == OutputTag.BUFF) {
+          if (hit.outputTag === actionOutputTag) {
+            if (actionOutputTag === OutputTag.BUFF) {
+              actionOutput = dmg
+            } else {
+              actionOutput += dmg
+            }
+          }
+          if (hit.outputTag === OutputTag.BUFF) {
             comboBuff = dmg
           }
         }
       }
-      x.setActionRegisterValue(action.registerIndex, sum)
+      x.setActionRegisterValue(action.registerIndex, actionOutput)
     }
 
     calculateEhp(x, context)

--- a/src/lib/worker/optimizerWorker.ts
+++ b/src/lib/worker/optimizerWorker.ts
@@ -24,7 +24,10 @@ import {
   type StatKeyValue,
 } from 'lib/optimization/engine/config/keys'
 import { OutputTag } from 'lib/optimization/engine/config/tag'
-import { ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
+import {
+  ComputedStatsContainer,
+  type OptimizerEntity,
+} from 'lib/optimization/engine/container/computedStatsContainer'
 import {
   calculateEhp,
   getDamageFunction,
@@ -102,10 +105,7 @@ export function optimizerWorker(e: MessageEvent<OptimizerWorkerInput>) {
   const combatDisplay = request.statDisplay === 'combat'
   const baseDisplay = !combatDisplay
   const memoDisplay = request.memoDisplay === 'memo'
-  const summonerDisplay = !memoDisplay
   let passCount = 0
-
-  const { failsBasicThresholdFilter, failsComputedThresholdFilter } = generateResultMinFilter(request, context)
 
   initializeContextConditionals(context)
 
@@ -117,12 +117,11 @@ export function optimizerWorker(e: MessageEvent<OptimizerWorkerInput>) {
   // Initialize arrays once with maximum size (performance optimization)
   x.initializeArrays(context.maxContainerArrayLength, context)
 
-  // Find memosprite entity index from first default action
+  const displayConfig = context.defaultActions[context.defaultActions.length - 1]?.config
   let memospriteEntityIndex = -1
-  if (context.defaultActions.length > 0) {
-    const firstAction = context.defaultActions[0]
-    for (let i = 1; i < firstAction.config.entitiesLength; i++) {
-      const entity = firstAction.config.entitiesArray[i]
+  if (displayConfig) {
+    for (let i = 0; i < displayConfig.entitiesLength; i++) {
+      const entity = displayConfig.entitiesArray[i]
       if (entity.memosprite) {
         memospriteEntityIndex = i
         break
@@ -130,9 +129,15 @@ export function optimizerWorker(e: MessageEvent<OptimizerWorkerInput>) {
     }
   }
 
+  const displayEntityIndex = (memoDisplay && memospriteEntityIndex >= 0) ? memospriteEntityIndex : 0
+  const memoEntity = memoDisplay && memospriteEntityIndex >= 0 && displayConfig
+    ? displayConfig.entitiesArray[memospriteEntityIndex]
+    : undefined
+  const { failsBasicThresholdFilter, failsComputedThresholdFilter } = generateResultMinFilter(request, context, displayEntityIndex, memoEntity)
+
   const failsCombatStatsFilter = combatStatsFilter(request)
-  const failsBasicStatsFilter = basicStatsFilter(request)
-  const failsEhpFilter = ehpFilter(request)
+  const failsBasicStatsFilter = basicStatsFilter(request, memoEntity)
+  const failsEhpFilter = ehpFilter(request, displayEntityIndex)
   const failsRatingFilter = ratingFilter(request, context)
 
   const sets = Array.from<number>({ length: 6 })
@@ -194,7 +199,7 @@ export function optimizerWorker(e: MessageEvent<OptimizerWorkerInput>) {
     calculateElementalStats(c, context)
 
     // Exit early on base display filters failing
-    if (baseDisplay && summonerDisplay && (failsBasicThresholdFilter(c.a) || failsBasicStatsFilter(c))) {
+    if (baseDisplay && (failsBasicThresholdFilter(c.a) || failsBasicStatsFilter(c))) {
       continue
     }
 
@@ -274,9 +279,6 @@ export function optimizerWorker(e: MessageEvent<OptimizerWorkerInput>) {
     x.setGlobalRegisterValue(GlobalRegister.COMBO_SHIELD, comboShield)
     x.setGlobalRegisterValue(GlobalRegister.COMBO_BUFF, comboBuff)
 
-    // Display mode filtering using entity-aware filters
-    const displayEntityIndex = (memoDisplay && memospriteEntityIndex >= 0) ? memospriteEntityIndex : 0
-
     // Combat stats filtering
     if (combatDisplay && failsCombatStatsFilter(x, displayEntityIndex)) {
       continue
@@ -312,9 +314,41 @@ function addBasicConditionIfNeeded(
   statKey: StatKeyValue,
   min: number,
   max: number,
+  transform?: BasicStatTransform,
 ) {
-  if (min !== 0 || max !== Constants.MAX_INT) {
+  if (min === 0 && max === Constants.MAX_INT) return
+
+  if (!transform) {
     conditions.push((c) => c.a[statKey] < min || c.a[statKey] > max)
+    return
+  }
+
+  const [scale, flat] = transform
+  conditions.push((c) => {
+    const value = scale * c.a[statKey] + flat
+    return value < min || value > max
+  })
+}
+
+type BasicStatTransform = readonly [scale: number, flat: number]
+
+function getMemoBasicStatTransform(
+  statKey: number,
+  memoEntity?: OptimizerEntity,
+): BasicStatTransform | undefined {
+  if (!memoEntity) return undefined
+
+  switch (statKey) {
+    case StatKey.HP:
+      return [memoEntity.memoBaseHpScaling ?? 0, memoEntity.memoBaseHpFlat ?? 0]
+    case StatKey.ATK:
+      return [memoEntity.memoBaseAtkScaling ?? 0, memoEntity.memoBaseAtkFlat ?? 0]
+    case StatKey.DEF:
+      return [memoEntity.memoBaseDefScaling ?? 0, memoEntity.memoBaseDefFlat ?? 0]
+    case StatKey.SPD:
+      return [memoEntity.memoBaseSpdScaling ?? 0, memoEntity.memoBaseSpdFlat ?? 0]
+    default:
+      return undefined
   }
 }
 
@@ -349,19 +383,22 @@ function addCombatBoostedConditionIfNeeded(
   }
 }
 
-function basicStatsFilter(request: Form) {
+function basicStatsFilter(request: Form, memoEntity?: OptimizerEntity) {
   const conditions: ((c: BasicStatsArray) => boolean)[] = []
+  const add = (statKey: StatKeyValue, min: number, max: number) => {
+    addBasicConditionIfNeeded(conditions, statKey, min, max, getMemoBasicStatTransform(statKey, memoEntity))
+  }
 
-  addBasicConditionIfNeeded(conditions, StatKey.HP, request.minHp, request.maxHp)
-  addBasicConditionIfNeeded(conditions, StatKey.ATK, request.minAtk, request.maxAtk)
-  addBasicConditionIfNeeded(conditions, StatKey.DEF, request.minDef, request.maxDef)
-  addBasicConditionIfNeeded(conditions, StatKey.SPD, request.minSpd, request.maxSpd)
-  addBasicConditionIfNeeded(conditions, StatKey.CR, request.minCr, request.maxCr)
-  addBasicConditionIfNeeded(conditions, StatKey.CD, request.minCd, request.maxCd)
-  addBasicConditionIfNeeded(conditions, StatKey.EHR, request.minEhr, request.maxEhr)
-  addBasicConditionIfNeeded(conditions, StatKey.RES, request.minRes, request.maxRes)
-  addBasicConditionIfNeeded(conditions, StatKey.BE, request.minBe, request.maxBe)
-  addBasicConditionIfNeeded(conditions, StatKey.ERR, request.minErr, request.maxErr)
+  add(StatKey.HP, request.minHp, request.maxHp)
+  add(StatKey.ATK, request.minAtk, request.maxAtk)
+  add(StatKey.DEF, request.minDef, request.maxDef)
+  add(StatKey.SPD, request.minSpd, request.maxSpd)
+  add(StatKey.CR, request.minCr, request.maxCr)
+  add(StatKey.CD, request.minCd, request.maxCd)
+  add(StatKey.EHR, request.minEhr, request.maxEhr)
+  add(StatKey.RES, request.minRes, request.maxRes)
+  add(StatKey.BE, request.minBe, request.maxBe)
+  add(StatKey.ERR, request.minErr, request.maxErr)
 
   return (c: BasicStatsArray) => conditions.some((condition) => condition(c))
 }
@@ -383,7 +420,7 @@ function combatStatsFilter(request: Form) {
   return (x: ComputedStatsContainer, entityIndex: number) => conditions.some((condition) => condition(x, entityIndex))
 }
 
-function ehpFilter(request: Form) {
+function ehpFilter(request: Form, displayEntityIndex: number) {
   const minEhp = request.minEhp
   const maxEhp = request.maxEhp
 
@@ -392,7 +429,7 @@ function ehpFilter(request: Form) {
   }
 
   return (x: ComputedStatsContainer) => {
-    const ehp = x.a[StatKey.EHP]
+    const ehp = x.getActionValueByIndex(StatKey.EHP, displayEntityIndex)
     return ehp < minEhp || ehp > maxEhp
   }
 }
@@ -426,15 +463,24 @@ function ratingFilter(request: Form, context: OptimizerContext) {
 
 // Returns threshold filters that skip builds whose sort value is below the rising min floor.
 // Basic stats can be checked before simulation (early exit), computed ratings only after.
-function generateResultMinFilter(request: Form, context: OptimizerContext) {
+function generateResultMinFilter(
+  request: Form,
+  context: OptimizerContext,
+  displayEntityIndex: number,
+  memoEntity?: OptimizerEntity,
+) {
   const threshold = request.resultMinFilter
   const sortOption = SortOption[request.resultSort!] as SortOptionProperties
   const pass = () => false
 
   if (!sortOption.isComputedRating) {
     const key = BasicKey[sortOption.key as BasicKeyType]
+    const transform = getMemoBasicStatTransform(key, memoEntity)
+    const getValue = transform
+      ? (c: Float32Array) => transform[0] * c[key] + transform[1]
+      : (c: Float32Array) => c[key]
     return {
-      failsBasicThresholdFilter: (c: Float32Array) => c[key] < threshold,
+      failsBasicThresholdFilter: (c: Float32Array) => getValue(c) < threshold,
       failsComputedThresholdFilter: pass,
     }
   }
@@ -443,7 +489,7 @@ function generateResultMinFilter(request: Form, context: OptimizerContext) {
 
   if (sortOption.statKey != null) {
     const statKey = sortOption.statKey
-    getComputedValue = (x) => x.a[statKey]
+    getComputedValue = (x) => x.getActionValueByIndex(statKey, displayEntityIndex)
   } else if (sortOption.globalRegisterIndex != null) {
     const globalRegisterIndex = sortOption.globalRegisterIndex
     getComputedValue = (x) => x.getGlobalRegisterValue(globalRegisterIndex)


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

 - Fix GPU optimizer filters for ability ratings, memosprite stats, EHP, and result thresholds.
  - Fix GPU progress reporting using an incorrect final permutation count.
  - Keep damage, healing, shielding, and buff outputs separated in optimizer ratings and simulations.
  - Fix healing and shielding boosts appearing and aggregating as DMG Boost in buff analysis.
  - Align Lushaka and Hyacine conditional calculations across optimizer paths.
  - Fix elemental 2-piece relic bonuses applying incorrectly to off-element damage on CPU.
  - Adjust Topaz's portrait positioning.
## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [ ] I have added commit messages that are descriptive and meaningful.
- [ ] I have tested the changes locally.
- [ ] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
