### PR TITLE
fix: various conditional audit fixes

### DIFF
--- a/src/lib/conditionals/character/1000/KafkaB1.ts
+++ b/src/lib/conditionals/character/1000/KafkaB1.ts
@@ -269,25 +269,48 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
     },
 
     finalizeCalculations: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
-      const r = action.characterConditionals as Conditionals<typeof content>
-
-      // Trace: EHR >= 75% grants +100% base ATK
-      const ehrValue = x.getActionValueByIndex(StatKey.EHR, SELF_ENTITY_INDEX)
-      if (r.ehrBasedBuff && ehrValue >= 0.75) {
-        x.buff(StatKey.ATK, 1.00 * context.baseATK, x.source(SOURCE_TRACE))
-      }
-
       boostAshblazingAtkContainer(x, action, getHitMulti(action, context))
     },
     newGpuFinalizeCalculations: (action: OptimizerAction, context: OptimizerContext) => {
-      const r = action.characterConditionals as Conditionals<typeof content>
+      return gpuBoostAshblazingAtkContainer(getHitMulti(action, context), action)
+    },
 
-      return wgsl`
-if (${wgslTrue(r.ehrBasedBuff)} && ${containerActionVal(SELF_ENTITY_INDEX, StatKey.EHR, action.config)} >= 0.75) {
+    dynamicConditionals: [
+      {
+        id: 'KafkaSelfEhrConditional',
+        type: ConditionalType.ABILITY,
+        activation: ConditionalActivation.SINGLE,
+        dependsOn: [Stats.EHR],
+        chainsTo: [Stats.ATK],
+        condition: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
+          const r = action.characterConditionals as Conditionals<typeof content>
+          return r.ehrBasedBuff && x.getActionValueByIndex(StatKey.EHR, SELF_ENTITY_INDEX) >= 0.75
+        },
+        effect: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => {
+          x.buffDynamic(StatKey.ATK, 1.00 * context.baseATK, action, context, x.source(SOURCE_TRACE))
+        },
+        gpu: function(action: OptimizerAction, context: OptimizerContext) {
+          const r = action.characterConditionals as Conditionals<typeof content>
+          const stateKey = `${this.id}${action.actionIdentifier}`
+
+          return newConditionalWgslWrapper(
+            this,
+            action,
+            context,
+            wgsl`
+if (
+  ${wgslTrue(r.ehrBasedBuff)} &&
+  (*p_state).${stateKey} == 0.0 &&
+  ${containerActionVal(SELF_ENTITY_INDEX, StatKey.EHR, action.config)} >= 0.75
+) {
+  (*p_state).${stateKey} = 1.0;
   ${buff.action(AKey.ATK, `1.00 * baseATK`).wgsl(action)}
 }
-      ` + gpuBoostAshblazingAtkContainer(getHitMulti(action, context), action)
-    },
+            `,
+          )
+        },
+      },
+    ],
 
     teammateDynamicConditionals: [
       {
@@ -295,7 +318,7 @@ if (${wgslTrue(r.ehrBasedBuff)} && ${containerActionVal(SELF_ENTITY_INDEX, StatK
         type: ConditionalType.ABILITY,
         activation: ConditionalActivation.SINGLE,
         dependsOn: [Stats.EHR],
-        chainsTo: [],
+        chainsTo: [Stats.ATK],
         condition: function(x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) {
           return x.getActionValueByIndex(StatKey.EHR, SELF_ENTITY_INDEX) >= 0.75
         },
@@ -307,7 +330,7 @@ if (${wgslTrue(r.ehrBasedBuff)} && ${containerActionVal(SELF_ENTITY_INDEX, StatK
 
           const ehrValue = x.getActionValueByIndex(StatKey.EHR, SELF_ENTITY_INDEX)
           if (ehrValue >= 0.75) {
-            x.buff(StatKey.ATK, 1.00 * context.baseATK, x.source(SOURCE_TRACE))
+            x.buffDynamic(StatKey.ATK, 1.00 * context.baseATK, action, context, x.source(SOURCE_TRACE))
           }
         },
         gpu: function(action: OptimizerAction, context: OptimizerContext) {

--- a/src/lib/conditionals/character/1300/Sunday.ts
+++ b/src/lib/conditionals/character/1300/Sunday.ts
@@ -37,6 +37,7 @@ import {
   TargetTag,
 } from 'lib/optimization/engine/config/tag'
 import { type ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
+import { buff } from 'lib/optimization/engine/container/gpuBuffBuilder'
 import {
   AbilityKind,
   NULL_TURN_ABILITY_NAME,
@@ -408,8 +409,8 @@ if (cr > 1.00) {
   let stateValue: f32 = (*p_state).${this.id}${action.actionIdentifier};
 
   (*p_state).${this.id}${action.actionIdentifier} = buffValue;
-  ${p_containerActionVal(SELF_ENTITY_INDEX, StatKey.UNCONVERTIBLE_CD_BUFF, config)} += buffValue - stateValue;
-  ${p_containerActionVal(SELF_ENTITY_INDEX, StatKey.CD, config)} += buffValue - stateValue;
+  ${buff.action(StatKey.UNCONVERTIBLE_CD_BUFF, 'buffValue - stateValue').wgsl(action)}
+  ${buff.action(StatKey.CD, 'buffValue - stateValue').wgsl(action)}
 }
 `,
           )

--- a/src/lib/conditionals/character/1400/Hysilens.ts
+++ b/src/lib/conditionals/character/1400/Hysilens.ts
@@ -384,7 +384,7 @@ const conditionals = (e: Eidolon, withContent: boolean): CharacterConditionalsCo
 
       return `
 if (${wgslTrue(r.ehrToDmg)}) {
-  let dmgBuff = min(0.90, 0.15 * floorSafe((${containerActionVal(SELF_ENTITY_INDEX, StatKey.EHR, action.config)} - 0.60) / 0.10));
+  let dmgBuff = max(0.0, min(0.90, 0.15 * floorSafe((${containerActionVal(SELF_ENTITY_INDEX, StatKey.EHR, action.config)} - 0.60) / 0.10)));
   ${buff.action(AKey.BOOST, 'dmgBuff').wgsl(action)}
 }
 ` + gpuBoostUltAshblazingAtk(action, ultHitMulti(context))

--- a/src/lib/conditionals/lightcone/4star/ItsShowtime.ts
+++ b/src/lib/conditionals/lightcone/4star/ItsShowtime.ts
@@ -14,6 +14,7 @@ import { Source } from 'lib/optimization/buffSource'
 import { StatKey } from 'lib/optimization/engine/config/keys'
 import { SELF_ENTITY_INDEX } from 'lib/optimization/engine/config/tag'
 import { type ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
+import { buff } from 'lib/optimization/engine/container/gpuBuffBuilder'
 import { wrappedFixedT } from 'lib/utils/i18nUtils'
 import { precisionRound } from 'lib/utils/mathUtils'
 import { type LightConeConditionalsController } from 'types/conditionals'
@@ -82,7 +83,7 @@ if (
   ${containerActionVal(SELF_ENTITY_INDEX, StatKey.EHR, action.config)} >= 0.80
 ) {
   (*p_state).ItsShowtimeConversionConditional${action.actionIdentifier} = 1.0;
-  ${containerActionVal(SELF_ENTITY_INDEX, StatKey.ATK, action.config)} += ${sValuesAtkBuff[s]} * baseATK;
+  ${buff.action(StatKey.ATK, `${sValuesAtkBuff[s]} * baseATK`).wgsl(action)}
 }
     `,
           )

--- a/src/lib/conditionals/lightcone/5star/SailingTowardsASecondLife.ts
+++ b/src/lib/conditionals/lightcone/5star/SailingTowardsASecondLife.ts
@@ -17,6 +17,7 @@ import {
   SELF_ENTITY_INDEX,
 } from 'lib/optimization/engine/config/tag'
 import { type ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
+import { buff } from 'lib/optimization/engine/container/gpuBuffBuilder'
 import { wrappedFixedT } from 'lib/utils/i18nUtils'
 import { precisionRound } from 'lib/utils/mathUtils'
 import { type LightConeConditionalsController } from 'types/conditionals'
@@ -96,7 +97,7 @@ if (
   ${containerActionVal(SELF_ENTITY_INDEX, StatKey.BE, action.config)} >= 1.50
 ) {
   (*p_state).SailingTowardsASecondLifeConditional${action.actionIdentifier} = 1.0;
-  ${containerActionVal(SELF_ENTITY_INDEX, StatKey.SPD, action.config)} += ${sValuesSpdBuff[s]} * baseSPD;
+  ${buff.action(StatKey.SPD, `${sValuesSpdBuff[s]} * baseSPD`).wgsl(action)}
 }
     `,
           )

--- a/src/lib/conditionals/lightcone/5star/YetHopeIsPriceless.ts
+++ b/src/lib/conditionals/lightcone/5star/YetHopeIsPriceless.ts
@@ -75,7 +75,7 @@ const conditionals = (s: SuperImpositionLevel, withContent: boolean): LightConeC
       const cdValue = x.getActionValueByIndex(StatKey.CD, SELF_ENTITY_INDEX)
       x.buff(
         StatKey.BOOST,
-        (r.fuaDmgBoost) ? sValuesFuaDmg[s] * Math.min(4, floorSafe((cdValue - 1.20) / 0.20)) : 0,
+        (r.fuaDmgBoost) ? sValuesFuaDmg[s] * Math.max(0, Math.min(4, floorSafe((cdValue - 1.20) / 0.20))) : 0,
         x.damageType(DamageTag.FUA).source(SOURCE_LC),
       )
     },
@@ -85,7 +85,7 @@ const conditionals = (s: SuperImpositionLevel, withContent: boolean): LightConeC
       return wgsl`
 if (${wgslTrue(r.fuaDmgBoost)}) {
   let cdValue = ${containerActionVal(SELF_ENTITY_INDEX, StatKey.CD, action.config)};
-  let fuaDmgBuff = ${sValuesFuaDmg[s]} * min(4.0, floorSafe((cdValue - 1.20) / 0.20));
+  let fuaDmgBuff = ${sValuesFuaDmg[s]} * max(0.0, min(4.0, floorSafe((cdValue - 1.20) / 0.20)));
   ${buff.hit(HKey.BOOST, 'fuaDmgBuff').damageType(DamageTag.FUA).wgsl(action)}
 }
     `

--- a/src/lib/optimization/calculateDamage.ts
+++ b/src/lib/optimization/calculateDamage.ts
@@ -1,3 +1,4 @@
+import { evaluateTerminalSetConditionals } from 'lib/optimization/calculateStats'
 import { type ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
 import {
   type OptimizerAction,
@@ -8,7 +9,9 @@ export function calculateBaseMultis(x: ComputedStatsContainer, action: Optimizer
   const lightConeController = context.lightConeController
   const characterController = context.characterController
 
-  // TODO
   if (lightConeController.finalizeCalculations) lightConeController.finalizeCalculations(x, action, context)
   if (characterController.finalizeCalculations) characterController.finalizeCalculations(x, action, context)
+
+  // Set requirements must include stat buffs applied during finalization.
+  evaluateTerminalSetConditionals(x, x.a, x.c.setMatches, action, context)
 }

--- a/src/lib/optimization/calculateStats.ts
+++ b/src/lib/optimization/calculateStats.ts
@@ -119,7 +119,6 @@ export function calculateComputedStats(x: ComputedStatsContainer, action: Optimi
   applyPercentStats(x, a, context)
   evaluateDynamicSetConditionals(x, matches, action, context)
   evaluateDynamicConditionals(x, action, context)
-  evaluateTerminalSetConditionals(x, a, matches, action, context)
 
   return x
 }

--- a/src/lib/optimization/rotation/preprocessor/preprocessCharacters.ts
+++ b/src/lib/optimization/rotation/preprocessor/preprocessCharacters.ts
@@ -39,10 +39,10 @@ export class CastoricePreprocessor extends AbilityPreprocessorBase {
     let memoDmgStacks = this.state.memoDmgStacks
 
     if (kind == AbilityKind.MEMO_SKILL) {
-      const value = memoDmgStacks + 1
+      const value = Math.min(6, memoDmgStacks + 1)
       setComboNumberCategoryCharacterActivation(comboState, 'memoDmgStacks', index, value)
       setComboNumberCategoryCharacterActivation(comboState, 'memoSkillEnhances', index, Math.min(3, value))
-      memoDmgStacks = Math.min(6, memoDmgStacks + 1)
+      memoDmgStacks = value
     } else if (kind == AbilityKind.MEMO_TALENT) {
       setComboNumberCategoryCharacterActivation(comboState, 'memoDmgStacks', index, memoDmgStacks)
       setComboNumberCategoryCharacterActivation(comboState, 'memoSkillEnhances', index, 1)

--- a/src/lib/optimization/rotation/preprocessor/preprocessTeammate.ts
+++ b/src/lib/optimization/rotation/preprocessor/preprocessTeammate.ts
@@ -57,6 +57,7 @@ class CerydraPeeragePreprocessor extends TeammateAbilityPreprocessorBase {
 
   private incrementStacks() {
     this.state.stacks = Math.min(8, this.state.stacks + 1)
+    if (this.state.stacks >= 6) this.state.peerageActive = true
   }
 
   private resetStacks() {

--- a/src/lib/relics/estTbp/estTbp.ts
+++ b/src/lib/relics/estTbp/estTbp.ts
@@ -8,6 +8,7 @@ import {
   getRollQualityDistribution,
   thresholdProbability,
 } from 'lib/relics/estTbp/convolution'
+import { RelicRollGrader } from 'lib/relics/relicRollGrader'
 import { precisionRound } from 'lib/utils/mathUtils'
 import { clone } from 'lib/utils/objectUtils'
 import type { Relic } from 'types/relic'
@@ -18,6 +19,9 @@ export function scoreTbp(preRelic: Relic, weights: { [stat: string]: number }): 
     relic.enhance += 3
     relic.substats.push(s)
   })
+  if (relic.previewSubstats.length > 0) {
+    RelicRollGrader.calculateRelicSubstatRolls(relic)
+  }
   // Round away the floating point errors from weight products
   const scoreToBeat = precisionRound(simpleSubstatScoreOfRelic(relic, weights))
 

--- a/src/lib/relics/relicUtils.ts
+++ b/src/lib/relics/relicUtils.ts
@@ -50,10 +50,16 @@ function normalizeSubstatValue(stat: string, value: number): number {
 export function hashRelic(relic: Relic) {
   const substatValues: number[] = []
   const substatStats: string[] = []
+  const previewSubstatValues: number[] = []
+  const previewSubstatStats: string[] = []
 
   for (const substat of relic.substats) {
     substatValues.push(normalizeSubstatValue(substat.stat, substat.value))
     substatStats.push(substat.stat)
+  }
+  for (const substat of relic.previewSubstats) {
+    previewSubstatValues.push(normalizeSubstatValue(substat.stat, substat.value))
+    previewSubstatStats.push(substat.stat)
   }
   const hashObject = {
     part: relic.part,
@@ -64,6 +70,8 @@ export function hashRelic(relic: Relic) {
     mainValue: Math.floor(relic.main.value),
     substatValues,
     substatStats,
+    previewSubstatValues,
+    previewSubstatStats,
   }
 
   return objectHash(hashObject)

--- a/src/lib/relics/relicUtils.ts
+++ b/src/lib/relics/relicUtils.ts
@@ -50,16 +50,10 @@ function normalizeSubstatValue(stat: string, value: number): number {
 export function hashRelic(relic: Relic) {
   const substatValues: number[] = []
   const substatStats: string[] = []
-  const previewSubstatValues: number[] = []
-  const previewSubstatStats: string[] = []
 
   for (const substat of relic.substats) {
     substatValues.push(normalizeSubstatValue(substat.stat, substat.value))
     substatStats.push(substat.stat)
-  }
-  for (const substat of relic.previewSubstats) {
-    previewSubstatValues.push(normalizeSubstatValue(substat.stat, substat.value))
-    previewSubstatStats.push(substat.stat)
   }
   const hashObject = {
     part: relic.part,
@@ -70,8 +64,6 @@ export function hashRelic(relic: Relic) {
     mainValue: Math.floor(relic.main.value),
     substatValues,
     substatStats,
-    previewSubstatValues,
-    previewSubstatStats,
   }
 
   return objectHash(hashObject)

--- a/src/lib/scoring/simScoringUtils.ts
+++ b/src/lib/scoring/simScoringUtils.ts
@@ -20,7 +20,6 @@ import {
   ornament2p,
   SetKeys,
 } from 'lib/optimization/setMatching'
-import { StatCalculator } from 'lib/relics/statCalculator'
 import type { SimulationSets } from 'lib/scoring/dpsScore'
 import { SCORING_CONFIG_REGISTRY } from 'lib/scoring/scoringConfig'
 import type { SimulationStatUpgrade } from 'lib/simulations/scoringUpgrades'
@@ -32,7 +31,6 @@ import type {
 import type { TeammateSetUpgrade } from 'lib/simulations/teammateUpgradeGrouping'
 import { renderThousandsK } from 'lib/utils/i18nUtils'
 import { precisionRound } from 'lib/utils/mathUtils'
-import { isFlat } from 'lib/utils/statUtils'
 import type { Form } from 'types/form'
 import type {
   DBMetadataCharacter,
@@ -405,18 +403,8 @@ function collectPenaltyRecords(
       if (user) {
         records.push({ stat: stat as StatsValues, multiplier: 0 })
       }
-    } else if (isFlat(stat)) {
-      const multiplier = (Math.min(1, statValue / threshold) + 1) / 2
-      if (precisionRound(multiplier) < 1) {
-        records.push({ stat: stat as StatsValues, multiplier })
-      }
     } else {
-      const multiplier = Math.min(
-        1,
-        1
-          - (threshold - statValue)
-            / StatCalculator.getMaxedSubstatValue(stat as SubStats, 1.0),
-      )
+      const multiplier = (Math.min(1, statValue / threshold) + 1) / 2
       if (precisionRound(multiplier) < 1) {
         records.push({ stat: stat as StatsValues, multiplier })
       }

--- a/src/lib/sets/ornaments/BelobogOfTheArchitects.ts
+++ b/src/lib/sets/ornaments/BelobogOfTheArchitects.ts
@@ -10,10 +10,7 @@ import {
   newConditionalWgslWrapper,
 } from 'lib/gpu/conditionals/dynamicConditionals'
 import { basicP2 } from 'lib/gpu/injection/generateBasicSetEffects'
-import {
-  containerActionVal,
-  p_containerActionVal,
-} from 'lib/gpu/injection/injectUtils'
+import { containerActionVal } from 'lib/gpu/injection/injectUtils'
 import {
   type BasicStatsArray,
   WgslStatName,
@@ -22,6 +19,7 @@ import { Source } from 'lib/optimization/buffSource'
 import { StatKey } from 'lib/optimization/engine/config/keys'
 import { SELF_ENTITY_INDEX } from 'lib/optimization/engine/config/tag'
 import { type ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
+import { buff } from 'lib/optimization/engine/container/gpuBuffBuilder'
 import {
   ornament2p,
   SetKeys,
@@ -77,7 +75,7 @@ if (
   ${containerActionVal(SELF_ENTITY_INDEX, StatKey.EHR, config)} >= 0.50
 ) {
   (*p_state).BelobogOfTheArchitectsConditional${action.actionIdentifier} = 1.0;
-  ${p_containerActionVal(SELF_ENTITY_INDEX, StatKey.DEF, config)} += 0.15 * ${config.selfEntity.baseDef};
+  ${buff.action(StatKey.DEF, 0.15 * config.selfEntity.baseDef).wgsl(action)}
 }
     `,
     )

--- a/src/lib/sets/ornaments/PanCosmicCommercialEnterprise.ts
+++ b/src/lib/sets/ornaments/PanCosmicCommercialEnterprise.ts
@@ -10,10 +10,7 @@ import {
   newConditionalWgslWrapper,
 } from 'lib/gpu/conditionals/dynamicConditionals'
 import { basicP2 } from 'lib/gpu/injection/generateBasicSetEffects'
-import {
-  containerActionVal,
-  p_containerActionVal,
-} from 'lib/gpu/injection/injectUtils'
+import { containerActionVal } from 'lib/gpu/injection/injectUtils'
 import {
   type BasicStatsArray,
   WgslStatName,
@@ -22,6 +19,7 @@ import { Source } from 'lib/optimization/buffSource'
 import { StatKey } from 'lib/optimization/engine/config/keys'
 import { SELF_ENTITY_INDEX } from 'lib/optimization/engine/config/tag'
 import { type ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
+import { buff } from 'lib/optimization/engine/container/gpuBuffBuilder'
 import {
   ornament2p,
   SetKeys,
@@ -86,7 +84,7 @@ if (
   let buffValue: f32 = min(0.25, 0.25 * ${containerActionVal(SELF_ENTITY_INDEX, StatKey.EHR, config)}) * ${config.selfEntity.baseAtk};
 
   (*p_state).PanCosmicCommercialEnterpriseConditional${action.actionIdentifier} = buffValue;
-  ${p_containerActionVal(SELF_ENTITY_INDEX, StatKey.ATK, config)} += buffValue - stateValue;
+  ${buff.action(StatKey.ATK, 'buffValue - stateValue').wgsl(action)}
 }
     `,
     )

--- a/src/lib/sets/ornaments/PunklordeStageZero.ts
+++ b/src/lib/sets/ornaments/PunklordeStageZero.ts
@@ -10,10 +10,7 @@ import {
   newConditionalWgslWrapper,
 } from 'lib/gpu/conditionals/dynamicConditionals'
 import { basicP2 } from 'lib/gpu/injection/generateBasicSetEffects'
-import {
-  containerActionVal,
-  p_containerActionVal,
-} from 'lib/gpu/injection/injectUtils'
+import { containerActionVal } from 'lib/gpu/injection/injectUtils'
 import {
   type BasicStatsArray,
   WgslStatName,
@@ -22,6 +19,7 @@ import { Source } from 'lib/optimization/buffSource'
 import { StatKey } from 'lib/optimization/engine/config/keys'
 import { SELF_ENTITY_INDEX } from 'lib/optimization/engine/config/tag'
 import { type ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
+import { buff } from 'lib/optimization/engine/container/gpuBuffBuilder'
 import {
   ornament2p,
   SetKeys,
@@ -76,7 +74,7 @@ if (
   ${containerActionVal(SELF_ENTITY_INDEX, StatKey.ELATION, config)} >= 0.40
 ) {
   (*p_state).PunklordeStageZeroConditional40${action.actionIdentifier} = 1.0;
-  ${p_containerActionVal(SELF_ENTITY_INDEX, StatKey.CD, config)} += 0.20;
+  ${buff.action(StatKey.CD, 0.20).wgsl(action)}
 }
     `,
     )
@@ -109,7 +107,7 @@ if (
   ${containerActionVal(SELF_ENTITY_INDEX, StatKey.ELATION, config)} >= 0.80
 ) {
   (*p_state).PunklordeStageZeroConditional80${action.actionIdentifier} = 1.0;
-  ${p_containerActionVal(SELF_ENTITY_INDEX, StatKey.CD, config)} += 0.12;
+  ${buff.action(StatKey.CD, 0.12).wgsl(action)}
 }
     `,
     )

--- a/src/lib/sets/ornaments/SpaceSealingStation.ts
+++ b/src/lib/sets/ornaments/SpaceSealingStation.ts
@@ -10,10 +10,7 @@ import {
   newConditionalWgslWrapper,
 } from 'lib/gpu/conditionals/dynamicConditionals'
 import { basicP2 } from 'lib/gpu/injection/generateBasicSetEffects'
-import {
-  containerActionVal,
-  p_containerActionVal,
-} from 'lib/gpu/injection/injectUtils'
+import { containerActionVal } from 'lib/gpu/injection/injectUtils'
 import {
   type BasicStatsArray,
   WgslStatName,
@@ -22,6 +19,7 @@ import { Source } from 'lib/optimization/buffSource'
 import { StatKey } from 'lib/optimization/engine/config/keys'
 import { SELF_ENTITY_INDEX } from 'lib/optimization/engine/config/tag'
 import { type ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
+import { buff } from 'lib/optimization/engine/container/gpuBuffBuilder'
 import {
   ornament2p,
   SetKeys,
@@ -77,7 +75,7 @@ if (
   ${containerActionVal(SELF_ENTITY_INDEX, StatKey.SPD, config)} >= 120.0
 ) {
   (*p_state).SpaceSealingStationConditional${action.actionIdentifier} = 1.0;
-  ${p_containerActionVal(SELF_ENTITY_INDEX, StatKey.ATK, config)} += 0.12 * ${config.selfEntity.baseAtk};
+  ${buff.action(StatKey.ATK, 0.12 * config.selfEntity.baseAtk).wgsl(action)}
 }
     `,
     )

--- a/src/lib/sets/ornaments/TaliaKingdomOfBanditry.ts
+++ b/src/lib/sets/ornaments/TaliaKingdomOfBanditry.ts
@@ -10,10 +10,7 @@ import {
   newConditionalWgslWrapper,
 } from 'lib/gpu/conditionals/dynamicConditionals'
 import { basicP2 } from 'lib/gpu/injection/generateBasicSetEffects'
-import {
-  containerActionVal,
-  p_containerActionVal,
-} from 'lib/gpu/injection/injectUtils'
+import { containerActionVal } from 'lib/gpu/injection/injectUtils'
 import {
   type BasicStatsArray,
   WgslStatName,
@@ -22,6 +19,7 @@ import { Source } from 'lib/optimization/buffSource'
 import { StatKey } from 'lib/optimization/engine/config/keys'
 import { SELF_ENTITY_INDEX } from 'lib/optimization/engine/config/tag'
 import { type ComputedStatsContainer } from 'lib/optimization/engine/container/computedStatsContainer'
+import { buff } from 'lib/optimization/engine/container/gpuBuffBuilder'
 import {
   ornament2p,
   SetKeys,
@@ -76,7 +74,7 @@ if (
   ${containerActionVal(SELF_ENTITY_INDEX, StatKey.SPD, config)} >= 145.0
 ) {
   (*p_state).TaliaKingdomOfBanditryConditional${action.actionIdentifier} = 1.0;
-  ${p_containerActionVal(SELF_ENTITY_INDEX, StatKey.BE, config)} += 0.20;
+  ${buff.action(StatKey.BE, 0.20).wgsl(action)}
 }
     `,
     )

--- a/src/lib/sets/ornaments/TheWondrousBananAmusementPark.ts
+++ b/src/lib/sets/ornaments/TheWondrousBananAmusementPark.ts
@@ -46,7 +46,7 @@ const conditionals: SetConditionals = {
     c.CD.buff(0.16, Source.TheWondrousBananAmusementPark)
   },
   p2x: (x: ComputedStatsContainer, context: OptimizerContext, setConditionals: SetConditional) => {
-    if (setConditionals.enabledTheWondrousBananAmusementPark) {
+    if (x.config.hasSummons && setConditionals.enabledTheWondrousBananAmusementPark) {
       x.buff(StatKey.CD, 0.32, x.source(Source.TheWondrousBananAmusementPark))
     }
   },
@@ -57,6 +57,7 @@ const conditionals: SetConditionals = {
     if (
       ornament2p(*p_sets, SET_TheWondrousBananAmusementPark)
       && setConditionals.enabledTheWondrousBananAmusementPark == true
+      && ${action.config.hasSummons}
     ) {
       ${buff.action(AKey.CD, 0.32).wgsl(action, 2)}
     }

--- a/src/lib/sets/relics/WatchmakerMasterOfDreamMachinations.ts
+++ b/src/lib/sets/relics/WatchmakerMasterOfDreamMachinations.ts
@@ -12,6 +12,7 @@ import {
 import { Source } from 'lib/optimization/buffSource'
 import {
   AKey,
+  HKey,
   StatKey,
 } from 'lib/optimization/engine/config/keys'
 import { TargetTag } from 'lib/optimization/engine/config/tag'
@@ -64,6 +65,7 @@ const conditionals: SetConditionals = {
       && ${wgslFalse(action.config.teammateSetEffects[Sets.WatchmakerMasterOfDreamMachinations])}
     ) {
       ${buff.action(AKey.BE, 0.30).targets(TargetTag.FullTeam).wgsl(action, 2)}
+      ${buff.hit(HKey.BOOST, 0.30).outputBuff(StatKey.BE).wgsl(action, 2)}
     }
   `,
   teammate: [{

--- a/src/lib/simulations/tests/customBenchmark/benchmarkOrchestrator.test.ts
+++ b/src/lib/simulations/tests/customBenchmark/benchmarkOrchestrator.test.ts
@@ -107,7 +107,7 @@ test('Black Swan B1 benchmark 0 captain', async () => {
       mains: testMains(Stats.ATK_P, Stats.ATK_P, Stats.Wind_DMG, Stats.ATK_P),
       stats: testStatSpread(),
     }),
-    7510289.308226261,
+    7507882.612300571,
     8310382.031654682,
   )
 }, TIMEOUT)

--- a/src/lib/tabs/tabOptimizer/optimizerForm/OptimizerForm.tsx
+++ b/src/lib/tabs/tabOptimizer/optimizerForm/OptimizerForm.tsx
@@ -142,8 +142,10 @@ const LightConeConditionalDisplayWrapper = memo(function LightConeConditionalDis
     }, metadata)
     const controller = LightConeConditionalsResolver.get(conditionalResolverMetadata)
     const defaults = { ...controller.defaults() }
-    const lightConeForm = getCharacterById(charId)?.form.lightConeConditionals || {}
-    mergeDefinedValues(defaults, lightConeForm)
+    const savedForm = getCharacterById(charId)?.form
+    if (savedForm?.lightCone === lcId) {
+      mergeDefinedValues(defaults, savedForm.lightConeConditionals)
+    }
 
     useOptimizerRequestStore.getState().setLightConeConditionals(defaults)
   }, [lcId, superimposition, charId])

--- a/src/lib/tabs/tabOptimizer/optimizerForm/OptimizerForm.tsx
+++ b/src/lib/tabs/tabOptimizer/optimizerForm/OptimizerForm.tsx
@@ -130,7 +130,7 @@ const LightConeConditionalDisplayWrapper = memo(function LightConeConditionalDis
   const superimposition = useOptimizerRequestStore((s) => s.lightConeSuperimposition)
   const charId = useOptimizerRequestStore((s) => s.characterId)
 
-  // Hook into light cone changes to set defaults
+  // Restore settings on character or cone changes, preserving live edits when superimposition changes.
   useEffect(() => {
     if (!charId || !lcId) return
 
@@ -138,7 +138,7 @@ const LightConeConditionalDisplayWrapper = memo(function LightConeConditionalDis
       characterId: charId,
       characterEidolon: 0, // Assuming eidolon is not needed for light cone metadata
       lightCone: lcId,
-      lightConeSuperimposition: superimposition,
+      lightConeSuperimposition: useOptimizerRequestStore.getState().lightConeSuperimposition,
     }, metadata)
     const controller = LightConeConditionalsResolver.get(conditionalResolverMetadata)
     const defaults = { ...controller.defaults() }
@@ -148,7 +148,7 @@ const LightConeConditionalDisplayWrapper = memo(function LightConeConditionalDis
     }
 
     useOptimizerRequestStore.getState().setLightConeConditionals(defaults)
-  }, [lcId, superimposition, charId])
+  }, [lcId, charId, metadata])
 
   return (
     <Flex direction='column' justify='space-between' style={{ height: '100%', marginBottom: 8 }}>

--- a/src/lib/worker/estTbpWorkerRunner.ts
+++ b/src/lib/worker/estTbpWorkerRunner.ts
@@ -88,5 +88,9 @@ export function handleWork(relic: Relic, weights: Record<string, number>): Promi
 }
 
 function hashRun(relic: Relic, weights: Record<string, number>): string {
-  return objectHash({ relic: hashRelic(relic), weights: objectHash(weights) })
+  const previewSubstats = relic.previewSubstats.map((substat) => ({
+    stat: substat.stat,
+    value: substat.value,
+  }))
+  return objectHash({ relic: hashRelic(relic), previewSubstats, weights: objectHash(weights) })
 }

--- a/src/types/conditionals.ts
+++ b/src/types/conditionals.ts
@@ -65,8 +65,8 @@ export interface ConditionalsController {
   newCalculateBasicEffects?: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => void
   newGpuCalculateBasicEffects?: (action: OptimizerAction, context: OptimizerContext) => string
 
-  // Multipliers that can be evaluated after all stat modifications are complete
-  // No changes to stats should occur at this stage
+  // A finalizer reads finished combat stats and prepares damage modifiers.
+  // It must not change shared combat stats or trigger further stat conversions.
   finalizeCalculations?: (x: ComputedStatsContainer, action: OptimizerAction, context: OptimizerContext) => void
 
   // WGSL implementation of finalizeCalculations to run on GPU


### PR DESCRIPTION
# Pull Request

<!-- When the PR is ready for review, send a note in the dev channel -->

## Description

<!-- Please provide a brief description of the changes made in this pull request.
List out: Added, Changed, Fixed, etc as appropriate -->

  - Preserve light cone conditionals when changing superimposition and prevent settings from leaking between different
    light cones.

  - Fix combat calculation order for set thresholds and Kafka’s EHR-based ATK buff.
  - Fix missing GPU buffs for pets, Watchmaker, Sunday E6, five ornaments, and two light cones.
  - Prevent threshold effects from producing negative bonuses and make breakpoint scoring consistent.
  - Fix Estimated Trailblaze Power results when preview substats change.
  - Cap Castorice’s memo stacks and reactivate Cerydra’s Peerage after rebuilding six stacks.

## Related Issue

<!-- If this pull request is related to any issue, please mention it here. For example, Closes #1 will tag the issue with this PR-->

-

## Checklist

<!-- Please check all the boxes below by replacing the space with an x. -->

- [ ] I have added commit messages that are descriptive and meaningful.
- [ ] I have tested the changes locally.
- [ ] I have reviewed the code changes.

## Screenshots

<!-- If the changes include any visual updates, please provide screenshots here. -->
